### PR TITLE
Remove back and save buttons in the vendors page

### DIFF
--- a/Clients/src/presentation/components/IconButton/index.tsx
+++ b/Clients/src/presentation/components/IconButton/index.tsx
@@ -1,3 +1,11 @@
+/**
+ * IconButton component that renders a custom-styled Material-UI IconButton with a settings icon.
+ * It includes a dropdown menu with options to edit or remove a vendor, and modals for adding or removing vendors.
+ *
+ * @component
+ * @returns {JSX.Element} The rendered IconButton component with associated dropdown menu and modals.
+ */
+
 import {
   Menu,
   MenuItem,
@@ -13,11 +21,36 @@ const IconButton = () => {
   const theme = useTheme();
   const [anchorEl, setAnchorEl] = useState(null);
   const [actions, setActions] = useState({});
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpenRemoveVendorModal, setIsOpenRemoveVendorModal] = useState(false);
+  const [isOpenAddNewVendorModal, setIsOpenAddNewVendorModal] = useState(false);
   const [value, setValue] = useState("1");
 
+  const dropDownStyle = {
+    width: 190,
+    "& ul": { p: theme.spacing(2.5) },
+    "& li": {
+      m: 0,
+      fontSize: 13,
+      "& .MuiTouchRipple-root": {
+        display: "none",
+      },
+    },
+    "& li:hover": { borderRadius: 4 },
+    "& li:last-of-type": {
+      color: theme.palette.error.main,
+    },
+    boxShadow: theme.boxShadow,
+  };
+
+  /**
+   * Handles the opening of a menu by preventing the default event behavior,
+   * stopping event propagation, setting the anchor element, and updating the actions state.
+   *
+   * @param {any} id - The identifier associated with the menu item.
+   * @param {any} event - The event object triggered by the user interaction.
+   * @param {any} url - The URL associated with the menu item.
+   */
   const openMenu = (event: any, id: any, url: any) => {
-    console.log("open menu");
     event.preventDefault();
     event.stopPropagation();
     setAnchorEl(event.currentTarget);
@@ -25,92 +58,141 @@ const IconButton = () => {
     console.log(actions);
   };
 
-  const openRemove = (e: any) => {
-    closeMenu(e);
-    setIsOpen(true);
-  };
+  /**
+   * Handles the action of opening the "Remove Vendor" dialog by closing the dropdown menu
+   * and setting the state to open the remove vendor modal.
+   *
+   * @param {React.MouseEvent} e - The click event that triggers the function.
+   */
+  function openRemoveVendor(e: React.MouseEvent) {
+    closeDropDownMenu(e);
+    setIsOpenRemoveVendorModal(true);
+  }
 
-  const handleChange = (_: React.SyntheticEvent, newValue: string) => {
+  /**
+   * Handles the change event for a component, updating the state with the new value.
+   *
+   * @param {React.SyntheticEvent} _ - The synthetic event object.
+   * @param {string} newValue - The new value to set in the state.
+   */
+  function handleChange(_: React.SyntheticEvent, newValue: string) {
     setValue(newValue);
-  };
+  }
 
-  const openAddNewVendor = () => {
-    setIsOpen(true);
-  };
+  /**
+   * Handles the action of opening the "Add New Vendor" dialog by setting the state to open the add new vendor modal.
+   */
+  function openAddNewVendor() {
+    setIsOpenAddNewVendorModal(true);
+  }
 
-  const closeMenu = (e: any) => {
+  /**
+   * Handles the closing of the dropdown menu by stopping event propagation
+   * and setting the anchor element to null.
+   *
+   * @param {React.SyntheticEvent} e - The event object triggered by the user interaction.
+   */
+  function closeDropDownMenu(e: React.SyntheticEvent) {
     e.stopPropagation();
     setAnchorEl(null);
-  };
+  }
+
+  /**
+   * A dropdown list of options rendered as a Material-UI Menu component.
+   *
+   * @constant
+   * @type {JSX.Element}
+   *
+   * @param {HTMLElement} anchorEl - The HTML element used to set the position of the dropdown menu.
+   * @param {boolean} open - Boolean value indicating whether the dropdown menu is open.
+   * @param {function} onClose - Function to handle the closing of the dropdown menu.
+   * @param {object} slotProps - Additional properties for customizing the dropdown menu.
+   * @param {object} slotProps.paper - Custom styles for the dropdown menu paper.
+   * @param {object} slotProps.paper.sx - Custom styles applied to the dropdown menu.
+   * @param {function} openAddNewVendor - Function to handle the action of opening the "Add New Vendor" dialog.
+   * @param {function} openRemoveVendor - Function to handle the action of opening the "Remove Vendor" dialog.
+   *
+   * @returns {JSX.Element} The rendered dropdown menu with "Edit" and "Remove" options.
+   */
+  const dropDownListOfOptions: JSX.Element = (
+    <Menu
+      anchorEl={anchorEl}
+      open={Boolean(anchorEl)}
+      onClose={(e: React.SyntheticEvent) => closeDropDownMenu(e)}
+      slotProps={{
+        paper: {
+          sx: dropDownStyle,
+        },
+      }}
+    >
+      <MenuItem
+        onClick={() => {
+          openAddNewVendor();
+        }}
+      >
+        Edit
+      </MenuItem>
+      <MenuItem
+        onClick={(e) => {
+          e.stopPropagation();
+          openRemoveVendor(e);
+        }}
+      >
+        Remove
+      </MenuItem>
+    </Menu>
+  );
+
+  /**
+   * Custom IconButton component styled as settings button.
+   *
+   * @constant
+   * @type {JSX.Element}
+   * @description This component renders a Material-UI IconButton with custom styles and behavior.
+   * It disables the ripple effect if specified in the theme, removes the outline on focus,
+   * and sets the stroke color of the SVG path to a custom color from the theme palette.
+   * The button's onClick event handler stops the event propagation and opens a menu with specified parameters.
+   *
+   * @param {React.MouseEvent} event - The click event.
+   * @param {string} someId - The ID to be used when opening the menu.
+   * @param {string} someUrl - The URL to be used when opening the menu.
+   *
+   * @returns {JSX.Element} A styled IconButton component with a settings icon.
+   */
+  const customIconButtonAsSettings: JSX.Element = (
+    <MuiIconButton
+      disableRipple={
+        theme.components?.MuiIconButton?.defaultProps?.disableRipple
+      }
+      sx={{
+        "&:focus": {
+          outline: "none",
+        },
+        "& svg path": {
+          stroke: theme.palette.other.icon,
+        },
+      }}
+      onClick={(event) => {
+        event.stopPropagation();
+        openMenu(event, "someId", "someUrl");
+      }}
+    >
+      <Setting />
+    </MuiIconButton>
+  );
 
   return (
     <>
-      <MuiIconButton
-        disableRipple={
-          theme.components?.MuiIconButton?.defaultProps?.disableRipple
-        }
-        sx={{
-          "&:focus": {
-            outline: "none",
-          },
-          "& svg path": {
-            stroke: theme.palette.other.icon,
-          },
-        }}
-        onClick={(event) => {
-          event.stopPropagation();
-          openMenu(event, "someId", "someUrl");
-        }}
-      >
-        <Setting />
-      </MuiIconButton>
-
-      <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={(e) => closeMenu(e)}
-        slotProps={{
-          paper: {
-            sx: {
-              width: 190,
-              "& ul": { p: theme.spacing(2.5) },
-              "& li": {
-                m: 0,
-                fontSize: 13,
-                "& .MuiTouchRipple-root": {
-                  display: "none",
-                },
-              },
-              "& li:hover": { borderRadius: 4 },
-              "& li:last-of-type": {
-                color: theme.palette.error.main,
-              },
-              boxShadow: theme.boxShadow,
-            },
-          },
-        }}
-      >
-        <MenuItem
-          onClick={() => {
-            openAddNewVendor();
-          }}
-        >
-          Edit
-        </MenuItem>
-        <MenuItem
-          onClick={(e) => {
-            e.stopPropagation();
-            openRemove(e);
-          }}
-        >
-          Remove
-        </MenuItem>
-      </Menu>
-      <BasicModal isOpen={isOpen} setIsOpen={() => setIsOpen(false)} />
+      {customIconButtonAsSettings}
+      {dropDownListOfOptions}
+      <BasicModal
+        isOpen={isOpenRemoveVendorModal}
+        setIsOpen={() => setIsOpenRemoveVendorModal(false)}
+      />
       <AddNewVendor
-        isOpen={isOpen}
+        isOpen={isOpenAddNewVendorModal}
         handleChange={handleChange}
-        setIsOpen={() => setIsOpen(false)}
+        setIsOpen={() => setIsOpenAddNewVendorModal(false)}
         value={value}
       />
     </>

--- a/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
+++ b/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
@@ -1,3 +1,22 @@
+/**
+ * TableWithPlaceholder component renders a table with a placeholder image when no data is provided.
+ * It displays a table header and a body populated with rows from the provided data.
+ *
+ * @component
+ * @param {Object} props - The properties object.
+ * @param {Array} props.data - The array of data objects to be displayed in the table. Defaults to listOfVendors.
+ * @returns {JSX.Element} The rendered TableWithPlaceholder component.
+ *
+ * @example
+ * // Example usage of TableWithPlaceholder
+ * const data = [
+ *   { name: "Vendor A", type: "Type 1", assignee: "John Doe", status: "Active", risk: "Low", review_date: "2023-01-01" },
+ *   { name: "Vendor B", type: "Type 2", assignee: "Jane Smith", status: "Inactive", risk: "High", review_date: "2023-02-01" }
+ * ];
+ *
+ * <TableWithPlaceholder data={data} />
+ */
+
 import {
   Table,
   TableBody,
@@ -11,23 +30,121 @@ import {
 import Placeholder from "../../../assets/imgs/table placeholder 1.png";
 import listOfVendors from "../../../mocks/vendors.data";
 import IconButton from "../../IconButton";
-import AddNewVendor from "../../Modals/NewVendor";
-import { useState } from "react";
 
-function TableWithPlaceholder({ data = listOfVendors }) {
+/**
+ * An array of strings representing the titles of the table columns.
+ * The columns include:
+ * - "name": The name of the item.
+ * - "type": The type of the item.
+ * - "assignee": The person assigned to the item.
+ * - "status": The current status of the item.
+ * - "risk": The risk level associated with the item.
+ * - "review date": The date when the item was last reviewed.
+ * - "": An empty string for a column with no title.
+ */
+const titleOfTableColumns = [
+  "name",
+  "type",
+  "assignee",
+  "status",
+  "risk",
+  "review date",
+  "",
+];
+
+const TableWithPlaceholder = ({ data = listOfVendors }) => {
   const theme = useTheme();
-
-  const [isOpen, setIsOpen] = useState(false);
-  const [value, setValue] = useState("1");
-
-  const handleChange = (_: React.SyntheticEvent, newValue: string) => {
-    setValue(newValue);
-  };
 
   const cellStyle = { fontSize: 13, paddingY: theme.spacing(6) };
 
+  /**
+   * Renders the table header with specified styles and column titles.
+   *
+   * @constant
+   * @type {JSX.Element}
+   *
+   * @remarks
+   * The table header is styled with a light background color and uppercase text.
+   * Each column title is styled with a specific color, font weight, and padding.
+   *
+   * @param {Array<string>} titleOfTableColumns - An array of strings representing the titles of the table columns.
+   *
+   * @returns {JSX.Element} The table header component.
+   */
+  const tableHeader: JSX.Element = (
+    <TableHead
+      sx={{
+        backgroundColor: "#FAFAFA",
+      }}
+    >
+      <TableRow
+        sx={{
+          textTransform: "uppercase",
+          borderBottom: "1px solid #EEEEEE",
+        }}
+      >
+        {titleOfTableColumns.map((cell, index) => (
+          <TableCell
+            style={{
+              color: "#a1afc6",
+              fontWeight: 400,
+              paddingLeft: "16px",
+            }}
+            key={index}
+          >
+            {cell}
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+
+  /**
+   * Renders the body of a table with rows populated from the provided data.
+   * Each row displays various properties of the data object such as name, type, assignee, status, risk, and review date.
+   * An IconButton is also rendered in the last cell of each row.
+   *
+   * @constant
+   * @type {JSX.Element}
+   * @param {Array} data - The array of data objects to be displayed in the table.
+   * @param {Object} row - The individual data object representing a row in the table.
+   * @param {number} index - The index of the current row in the data array.
+   * @param {Object} row.name - The name property of the data object.
+   * @param {Object} row.type - The type property of the data object.
+   * @param {Object} row.assignee - The assignee property of the data object.
+   * @param {Object} row.status - The status property of the data object.
+   * @param {Object} row.risk - The risk property of the data object.
+   * @param {Object} row.review_date - The review date property of the data object.
+   * @param {Object} cellStyle - The style object applied to each TableCell.
+   * @returns {JSX.Element} The rendered table body with rows.
+   */
+  const tableBody: JSX.Element = (
+    <TableBody>
+      {data &&
+        data.map((row, index) => (
+          <TableRow
+            key={index}
+            sx={{
+              textTransform: "capitalize",
+              borderBottom: "1px solid #EEEEEE",
+            }}
+          >
+            <TableCell sx={cellStyle}>{row.name}</TableCell>
+            <TableCell sx={cellStyle}>{row.type}</TableCell>
+            <TableCell sx={cellStyle}>{row.assignee}</TableCell>
+            <TableCell sx={cellStyle}>{row.status}</TableCell>
+            <TableCell sx={cellStyle}>{row.risk}</TableCell>
+            <TableCell sx={cellStyle}>{row.review_date}</TableCell>
+            <TableCell sx={cellStyle}>
+              <IconButton />
+            </TableCell>
+          </TableRow>
+        ))}
+    </TableBody>
+  );
+
   return (
-    <TableContainer style={{}}>
+    <TableContainer>
       <Table
         sx={{
           border: "1px solid #EEEEEE",
@@ -37,61 +154,8 @@ function TableWithPlaceholder({ data = listOfVendors }) {
           },
         }}
       >
-        <TableHead
-          sx={{
-            backgroundColor: "#FAFAFA",
-          }}
-        >
-          <TableRow
-            sx={{
-              textTransform: "uppercase",
-              borderBottom: "1px solid #EEEEEE",
-            }}
-          >
-            {[
-              "name",
-              "type",
-              "assignee",
-              "status",
-              "risk",
-              "review date",
-              "",
-            ].map((cell, index) => (
-              <TableCell
-                style={{
-                  color: "#a1afc6",
-                  fontWeight: 400,
-                  paddingLeft: "16px",
-                }}
-                key={index}
-              >
-                {cell}
-              </TableCell>
-            ))}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {data &&
-            data.map((row, index) => (
-              <TableRow
-                key={index}
-                sx={{
-                  textTransform: "capitalize",
-                  borderBottom: "1px solid #EEEEEE",
-                }}
-              >
-                <TableCell sx={cellStyle}>{row.name}</TableCell>
-                <TableCell sx={cellStyle}>{row.type}</TableCell>
-                <TableCell sx={cellStyle}>{row.assignee}</TableCell>
-                <TableCell sx={cellStyle}>{row.status}</TableCell>
-                <TableCell sx={cellStyle}>{row.risk}</TableCell>
-                <TableCell sx={cellStyle}>{row.review_date}</TableCell>
-                <TableCell sx={cellStyle}>
-                  <IconButton />
-                </TableCell>
-              </TableRow>
-            ))}
-        </TableBody>
+        {tableHeader}
+        {tableBody}
       </Table>
       {!data && (
         <div
@@ -109,14 +173,8 @@ function TableWithPlaceholder({ data = listOfVendors }) {
           <img src={Placeholder} alt="Placeholder" />
         </div>
       )}
-      <AddNewVendor
-        isOpen={isOpen}
-        handleChange={handleChange}
-        setIsOpen={() => setIsOpen(false)}
-        value={value}
-      />
     </TableContainer>
   );
-}
+};
 
 export default TableWithPlaceholder;

--- a/Clients/src/presentation/pages/Vendors/index.tsx
+++ b/Clients/src/presentation/pages/Vendors/index.tsx
@@ -1,5 +1,4 @@
 import { Button, Stack, Typography, useTheme } from "@mui/material";
-import { ReactComponent as Back } from "../../assets/icons/left-arrow-long.svg";
 import "./index.css";
 import TableWithPlaceholder from "../../components/Table/WithPlaceholder";
 import { useState } from "react";
@@ -22,40 +21,6 @@ const Vendors = () => {
   return (
     <div className="vendors-page">
       <Stack gap={theme.spacing(10)}>
-        <Stack
-          justifyContent={"space-between"}
-          display={"flex"}
-          flexDirection={"row"}
-          marginBottom={theme.spacing(6)}
-        >
-          <Button
-            disableRipple={
-              theme.components?.MuiButton?.defaultProps?.disableRipple
-            }
-            variant="contained"
-            color="inherit"
-            sx={{
-              width: 100,
-              height: 30,
-              gap: 6,
-              fontSize: 13,
-              boxShadow: "none",
-              backgroundColor: "#F5F5F5",
-              borderRadius: "4px",
-              border: "1px solid #EBEBEB",
-              alignItems: "center",
-              "&:hover": {
-                backgroundColor: "#F5F5F5",
-                boxShadow: "none",
-              },
-              textTransform: "capitalize",
-            }}
-            onClick={() => console.log("Back button")}
-          >
-            <Back />
-            Back
-          </Button>
-        </Stack>
         <Stack>
           <Typography fontSize={16} color="#1A1919" fontWeight={600}>
             Vendors list
@@ -97,34 +62,6 @@ const Vendors = () => {
           </Button>
         </Stack>
         <TableWithPlaceholder />
-        <Stack
-          sx={{
-            alignItems: "flex-end",
-          }}
-        >
-          <Button
-            disableRipple={
-              theme.components?.MuiButton?.defaultProps?.disableRipple
-            }
-            variant="contained"
-            sx={{
-              width: 150,
-              height: 34,
-              fontSize: 13,
-              textTransform: "capitalize",
-              backgroundColor: "#4C7DE7",
-              boxShadow: "none",
-              borderRadius: "4px",
-              border: "1px solid #175CD3",
-              "&:hover": {
-                boxShadow: "none",
-              },
-            }}
-            onClick={() => console.log("Save button")}
-          >
-            Save
-          </Button>
-        </Stack>
       </Stack>
       <AddNewVendor
         isOpen={isOpen}


### PR DESCRIPTION
Addressing the issue #60 

![Screenshot (162)](https://github.com/user-attachments/assets/6af4f0bb-ce86-4204-b6a0-f6af4343e68d)


_I've also done some code refactor on this page in this pr._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `TableWithPlaceholder` component that displays a placeholder image when no data is available.
	- Enhanced modal handling for "Remove Vendor" and "Add New Vendor" with distinct state management.

- **Bug Fixes**
	- Improved dropdown menu functionality and styling for better user experience.

- **Documentation**
	- Added detailed comments and usage examples for the new `TableWithPlaceholder` component. 

- **Refactor**
	- Streamlined code structure for modal management and table rendering. 
	- Removed unnecessary state management in the `Vendors` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->