### PR TITLE
004 oct 13 removing effects dashboard project pages

### DIFF
--- a/Clients/src/presentation/components/CreateProjectForm/index.tsx
+++ b/Clients/src/presentation/components/CreateProjectForm/index.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from 'react';
-import { Box, Stack, useTheme } from '@mui/material';
+import { Stack, useTheme } from '@mui/material';
 import Select from "../Inputs/Select";
 import DatePicker from '../Inputs/Datepicker';
 import Field from '../Inputs/Field';
@@ -27,7 +27,7 @@ const CreateProjectForm: FC = () => {
         sx={{ width: "130px", 
           "& input": { width: "85px" }
       }} />
-      <Box sx={{ display: "grid", gridTemplateColumns: "1fr", columnGap: 20, rowGap: 9.5, marginTop: "16px" }}>
+      <Stack sx={{ display: "grid", gridTemplateColumns: "1fr", columnGap: 20, rowGap: 9.5, marginTop: "16px" }}>
          <Select
           id="risk-classification-input"
           label="AI risk classification"
@@ -54,10 +54,10 @@ const CreateProjectForm: FC = () => {
           ]}
           sx={{ width: "350px", backgroundColor: theme.palette.background.main }}
         />
-      </Box>
-      <Box sx={{ marginTop: "16px" }}>
+      </Stack>
+      <Stack sx={{ marginTop: "16px" }}>
         <Field id="goal-input" label="Goal" type="description" sx={{ height: 101, backgroundColor: theme.palette.background.main }} />
-      </Box>
+      </Stack>
     </Stack>
   )
 }

--- a/Clients/src/presentation/components/Inputs/Datepicker/index.css
+++ b/Clients/src/presentation/components/Inputs/Datepicker/index.css
@@ -15,3 +15,25 @@
 .mui-date-picker > .MuiFormLabel-root {
   font-size: 13px;
 }
+
+.mui-date-picker .MuiTouchRipple-root, 
+.MuiPickersPopper-root .MuiTouchRipple-root,
+.MuiPickersDay-root.Mui-selected .MuiTouchRipple-root { 
+  display: none
+}
+
+.MuiPickersCalendarHeader-switchViewButton:hover,
+.MuiPickersArrowSwitcher-button:hover,
+.MuiPickersDay-root:hover,
+.Mui-selected:hover {
+  background-color: transparent!important;
+}
+
+.MuiPickersPopper-root .Mui-selected {
+  background-color: #1570EF!important;
+}
+
+.MuiPickersPopper-root .Mui-selected:hover {
+  color: #fff!important;
+  background-color: #1570EF!important;
+} 

--- a/Clients/src/presentation/components/Inputs/Datepicker/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Datepicker/index.tsx
@@ -3,7 +3,6 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DatePicker as MuiDatePicker } from "@mui/x-date-pickers/DatePicker";
 import "./index.css";
-import { Opacity } from "@mui/icons-material";
 
 interface DatePickerProps {
   label?: string;

--- a/Clients/src/presentation/components/Inputs/Datepicker/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Datepicker/index.tsx
@@ -3,6 +3,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { DatePicker as MuiDatePicker } from "@mui/x-date-pickers/DatePicker";
 import "./index.css";
+import { Opacity } from "@mui/icons-material";
 
 interface DatePickerProps {
   label?: string;
@@ -24,15 +25,18 @@ const DatePicker = ({
     <Stack
       sx={{
         "& fieldset": {
-          borderColor: theme.palette.border,
+          borderColor: theme.palette.border.dark,
           borderRadius: theme.shape.borderRadius
         },
         "&:not(:has(.Mui-disabled)):not(:has(.input-error)) .MuiOutlinedInput-root:hover:not(:has(input:focus)):not(:has(textarea:focus)) fieldset":
           {
-            borderColor: theme.palette.border,
+            borderColor: theme.palette.border.dark,
           },
         "&:has(.input-error) .MuiOutlinedInput-root fieldset": {
           borderColor: theme.palette.error.text,
+        },
+        ".Mui-focused .MuiOutlinedInput-notchedOutline": {
+          border: `1px solid ${theme.palette.border.dark}!important`
         },
       }}
     >

--- a/Clients/src/presentation/components/Inputs/Field/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Field/index.tsx
@@ -100,6 +100,9 @@ const Field = forwardRef(
           "&:has(.input-error) .MuiOutlinedInput-root fieldset": {
             borderColor: theme.palette.error.text,
           },
+          ".Mui-focused .MuiOutlinedInput-notchedOutline": {
+            border: `1px solid ${theme.palette.border.dark}!important`
+          },
           width: width,
         }}
       >

--- a/Clients/src/presentation/components/Inputs/Select/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Select/index.tsx
@@ -58,7 +58,12 @@ const Select: React.FC<SelectProps> = ({
   };
 
   return (
-    <Stack gap={theme.spacing(2)} className="select-wrapper">
+    <Stack gap={theme.spacing(2)} className="select-wrapper" 
+      sx={{
+        ".Mui-focused .MuiOutlinedInput-notchedOutline": {
+          border: `1px solid ${theme.palette.border.dark}!important`
+        }
+      }}>
       {label && (
         <Typography
           component="h3"
@@ -87,12 +92,12 @@ const Select: React.FC<SelectProps> = ({
                 fontSize: 13,
                 color: theme.palette.text.primary,
                 "&:hover": {
-                  backgroundColor: theme.palette.action.hover,
+                  backgroundColor: "transparent",
                 },
                 "&.Mui-selected": {
-                  backgroundColor: theme.palette.action.selected,
+                  backgroundColor: "transparent",
                   "&:hover": {
-                    backgroundColor: theme.palette.action.selected,
+                    backgroundColor: "transparent",
                   },
                 },
                 "& .MuiTouchRipple-root": {

--- a/Clients/src/presentation/components/Popup/index.tsx
+++ b/Clients/src/presentation/components/Popup/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Box, Typography, useTheme } from "@mui/material";
+import { Button, Typography, useTheme, Stack } from "@mui/material";
 import { ClearIcon } from "@mui/x-date-pickers/icons";
 import React from "react";
 import { FC } from "react";
@@ -86,7 +86,7 @@ const Popup: FC<PopupProps> = ({
                 alignItems: "center",
                 justifyContent: "center"
             }}>
-                <Box sx={styles.popupContent}>
+                <Stack sx={styles.popupContent}>
                     <Typography variant="h1" component="div" sx={{ color: "#344054", fontSize: 16, fontWeight: 600, mb: 3.5 }}>
                         {popupTitle}
                     </Typography>
@@ -100,7 +100,7 @@ const Popup: FC<PopupProps> = ({
                     <Button variant="contained" disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple} sx={styles.actionButton}>
                         {actionButtonName}
                     </Button>
-                </Box>
+                </Stack>
             </BasePopup>
         </div>
     )


### PR DESCRIPTION
Removed effects from Create Project popup. 
Changed Box to Stack for Popup component and Create Project form component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling and interaction feedback for the DatePicker, Select, and Field components.
	- Streamlined layout management in the CreateProjectForm and Popup components by using Stack instead of Box.

- **Bug Fixes**
	- Improved visual feedback for focused and hover states across various input components.

- **Style**
	- Updated CSS for better visibility and interaction on date picker elements, including hover and selected states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->