### PR TITLE
Font on risks boxes is fixed

### DIFF
--- a/Clients/src/presentation/components/Risks/index.tsx
+++ b/Clients/src/presentation/components/Risks/index.tsx
@@ -3,58 +3,101 @@ import { SxProps, Stack, Typography, useTheme } from "@mui/material";
 import { FC } from "react";
 import { RiskData } from "../../mocks/projects/project-overview.data";
 
-const Risks: FC<RiskData & {sx?: SxProps<Theme> | undefined}> = (
-    { veryHighRisks, highRisks, mediumRisks, lowRisks, veryLowRisks, sx }
-) => {
-    const theme = useTheme();
+const Risks: FC<RiskData & { sx?: SxProps<Theme> | undefined }> = ({
+  veryHighRisks,
+  highRisks,
+  mediumRisks,
+  lowRisks,
+  veryLowRisks,
+  sx,
+}) => {
+  const theme = useTheme();
 
-    const styles = {
-        stack: {
-            border: `1px solid ${theme.palette.border.light}`,
-            borderRadius: 2,
-            backgroundColor: theme.palette.background.main,
-            minWidth: 532,
-            width: "fit-content"
-        },
-        stackItem: {
-            p: "15px", 
-            position: "relative",
-            width: 124,
-            "&:after": { 
-                content: `""`, 
-                position: "absolute", 
-                backgroundColor: "#EEEEEE", 
-                top: "13px", right: 0, 
-                width: "1px", 
-                height: "43px"
-            } 
-        }
-    }
+  const styles = {
+    stack: {
+      border: `1px solid ${theme.palette.border.light}`,
+      borderRadius: 2,
+      backgroundColor: theme.palette.background.main,
+      minWidth: 532,
+      width: "fit-content",
+    },
+    stackItem: {
+      p: "15px",
+      position: "relative",
+      width: 124,
+      "&:after": {
+        content: `""`,
+        position: "absolute",
+        backgroundColor: "#EEEEEE",
+        top: "13px",
+        right: 0,
+        width: "1px",
+        height: "43px",
+      },
+    },
+    stackItemText: {
+      fontSize: "13px",
+    },
+  };
 
-    return (
-        <Stack direction="row" justifyContent="space-between" sx={{...styles.stack, ...sx}}>
-            <Stack sx={styles.stackItem}>
-                <Typography sx={{color: "#C63622"}}>Very high risks</Typography>
-                <Typography sx={{color: theme.palette.text.secondary}}>{veryHighRisks}</Typography>
-            </Stack>
-            <Stack sx={styles.stackItem}>
-                <Typography sx={{color: "#D68B61"}}>High risks</Typography>
-                <Typography sx={{color: theme.palette.text.secondary}}>{highRisks}</Typography>
-            </Stack>
-            <Stack sx={styles.stackItem}>
-                <Typography sx={{color: "#D6B971"}}>Medium risks</Typography>
-                <Typography sx={{color: theme.palette.text.secondary}}>{mediumRisks}</Typography>
-            </Stack>
-            <Stack sx={styles.stackItem}>
-                <Typography sx={{color: "#B8D39C"}}>Low risks</Typography>
-                <Typography sx={{color: theme.palette.text.secondary}}>{lowRisks}</Typography>
-            </Stack>
-            <Stack sx={{p: "15px", width: 124}}>
-                <Typography sx={{color: "#52AB43"}}>Very low risks</Typography>
-                <Typography sx={{color: theme.palette.text.secondary}}>{veryLowRisks}</Typography>
-            </Stack>
-        </Stack>
-    );
-}
+  return (
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+      sx={{ ...styles.stack, ...sx }}
+    >
+      <Stack sx={styles.stackItem}>
+        <Typography sx={{ color: "#C63622", ...styles.stackItemText }}>
+          Very high risks
+        </Typography>
+        <Typography
+          sx={{ color: theme.palette.text.secondary, ...styles.stackItemText }}
+        >
+          {veryHighRisks}
+        </Typography>
+      </Stack>
+      <Stack sx={styles.stackItem}>
+        <Typography sx={{ color: "#D68B61", ...styles.stackItemText }}>
+          High risks
+        </Typography>
+        <Typography
+          sx={{ color: theme.palette.text.secondary, ...styles.stackItemText }}
+        >
+          {highRisks}
+        </Typography>
+      </Stack>
+      <Stack sx={styles.stackItem}>
+        <Typography sx={{ color: "#D6B971", ...styles.stackItemText }}>
+          Medium risks
+        </Typography>
+        <Typography
+          sx={{ color: theme.palette.text.secondary, ...styles.stackItemText }}
+        >
+          {mediumRisks}
+        </Typography>
+      </Stack>
+      <Stack sx={styles.stackItem}>
+        <Typography sx={{ color: "#B8D39C", ...styles.stackItemText }}>
+          Low risks
+        </Typography>
+        <Typography
+          sx={{ color: theme.palette.text.secondary, ...styles.stackItemText }}
+        >
+          {lowRisks}
+        </Typography>
+      </Stack>
+      <Stack sx={{ p: "15px", width: 124 }}>
+        <Typography sx={{ color: "#52AB43", ...styles.stackItemText }}>
+          Very low risks
+        </Typography>
+        <Typography
+          sx={{ color: theme.palette.text.secondary, ...styles.stackItemText }}
+        >
+          {veryLowRisks}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+};
 
 export default Risks;

--- a/Clients/src/presentation/pages/Home/index.tsx
+++ b/Clients/src/presentation/pages/Home/index.tsx
@@ -1,9 +1,9 @@
-import { Box, Button, Stack, Typography, useTheme } from "@mui/material";
+import { Box, Stack, Typography, useTheme } from "@mui/material";
 import ProjectCard, { ProjectCardProps } from "../../components/ProjectCard";
 import { mockProjects } from "../../mocks/dashboard/project.data";
 import { NoProjectBox, StyledStack, styles } from "./styles";
 import dashboardData from "../../mocks/dashboard/dashboard.data";
-import emptyState from "../../assets/imgs/empty-state.svg"
+import emptyState from "../../assets/imgs/empty-state.svg";
 import Popup from "../../components/Popup";
 import CreateProjectForm from "../../components/CreateProjectForm";
 import { useNavigate } from "react-router-dom";
@@ -25,9 +25,18 @@ const Home = ({ projects = mockProjects }: HomeProps) => {
   const navigate = useNavigate();
   const { complianceStatus, riskStatus } = dashboardData;
   const complianceMetrics = [
-    { title: "Completed requirements", value: `${complianceStatus.assessmentCompletionRate}%` },
-    { title: "Completed assessments", value: complianceStatus.completedAssessments },
-    { title: "Assessment completion rate", value: `${complianceStatus.completedRequirementsPercentage}%` },
+    {
+      title: "Completed requirements",
+      value: `${complianceStatus.assessmentCompletionRate}%`,
+    },
+    {
+      title: "Completed assessments",
+      value: complianceStatus.completedAssessments,
+    },
+    {
+      title: "Assessment completion rate",
+      value: `${complianceStatus.completedRequirementsPercentage}%`,
+    },
   ];
   const riskMetrics = [
     { title: "Acceptable risks", value: riskStatus.acceptableRisks },
@@ -37,7 +46,11 @@ const Home = ({ projects = mockProjects }: HomeProps) => {
 
   const MetricSection = ({ title, metrics }: MetricSectionProps) => (
     <>
-      <Typography variant="h2" component="div" sx={{pb: 8.5, mt: 17, ...styles.title}}>
+      <Typography
+        variant="h2"
+        component="div"
+        sx={{ pb: 8.5, mt: 17, ...styles.title }}
+      >
         {title}
       </Typography>
       <Stack direction="row" justifyContent="space-between" spacing={15}>
@@ -56,7 +69,13 @@ const Home = ({ projects = mockProjects }: HomeProps) => {
       <Box sx={{ display: "flex", justifyContent: "center" }}>
         <img src={emptyState} alt="Empty project state" />
       </Box>
-      <Typography sx={{ textAlign: "center", mt: 13.5, color: theme.palette.text.tertiary }}>
+      <Typography
+        sx={{
+          textAlign: "center",
+          mt: 13.5,
+          color: theme.palette.text.tertiary,
+        }}
+      >
         You have no projects, yet. Click on the "New Project" button to start
         one.
       </Typography>
@@ -69,9 +88,9 @@ const Home = ({ projects = mockProjects }: HomeProps) => {
         <Typography variant="h1" component="div" sx={styles.title}>
           Projects overview
         </Typography>
-        <Popup 
-          popupId="create-project-popup" 
-          popupContent={<CreateProjectForm/>} 
+        <Popup
+          popupId="create-project-popup"
+          popupContent={<CreateProjectForm />}
           openPopupButtonName="New project"
           actionButtonName="Create project"
           popupTitle="Create new project"
@@ -83,7 +102,7 @@ const Home = ({ projects = mockProjects }: HomeProps) => {
         <>
           <Stack direction="row" justifyContent="space-between" spacing={15}>
             {projects.map((item: ProjectCardProps) => (
-                <ProjectCard key={item.id} {...item} />
+              <ProjectCard key={item.id} {...item} />
             ))}
           </Stack>
           <MetricSection


### PR DESCRIPTION
Font size is changed to `13px` for those boxes now.

![Screenshot (178)](https://github.com/user-attachments/assets/7b0c15cf-207f-4789-94ff-0ea2f409b574)

![Screenshot (177)](https://github.com/user-attachments/assets/9deed582-0227-4e2e-afbf-43ed11d63a9c)

![Screenshot (176)](https://github.com/user-attachments/assets/654861b0-55c9-4170-9e5c-42f6ff5099b1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced formatting and readability of the `Risks` and `Home` components.
	- Introduced new text styling for risk categories to ensure consistent appearance.
	- Reformatted arrays and component properties for improved clarity.

- **Chores**
	- Removed unused import statements to streamline the `Home` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->