### PR TITLE
033 Nov 5 Add Swagger for Question Evidence

### DIFF
--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -1462,9 +1462,6 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: integer
-                  example: 1
                 section_id:
                   type: integer
                   example: 1
@@ -1578,9 +1575,6 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: integer
-                  example: 1
                 section_id:
                   type: integer
                   example: 1
@@ -1643,6 +1637,268 @@ paths:
       responses:
         "202":
           description: compliance tracker
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: accepted
+                  data:
+                    type: boolean
+                    example: true
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+
+  /questionEvidence:
+    get:
+      tags: [questionEvidence]
+      security:
+        - JWTAuth: []
+      responses:
+        "200":
+          description: list of all question evidences
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: ok
+                  data:
+                    type: array
+                    items:
+                      $ref: "#components/schemas/QuestionEvidence"
+        "204":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: no content
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    post:
+      tags: [questionEvidence]
+      security:
+        - JWTAuth: []
+      requestBody:
+        description: body of the new question evidence
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                question_id:
+                  type: integer
+                  example: 1
+                section_id:
+                  type: integer
+                  example: 1
+                assessment_review:
+                  type: string
+                  example: "Review for question 101"
+                evidence:
+                  type: string
+                  example: "Evidence for question 101"
+        required: true
+      responses:
+        "201":
+          description: created question evidence
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: created
+                data:
+                  type: object
+                  $ref: "#components/schemas/QuestionEvidence"
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+        "503":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: service unavailable
+                error:
+                  type: object
+  /questionEvidence/{id}:
+    get:
+      tags: [questionEvidence]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the question evidence
+      responses:
+        "200":
+          description: question evidence
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: ok
+                  data:
+                    $ref: "#components/schemas/QuestionEvidence"
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    put:
+      tags: [questionEvidence]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the question evidence
+      requestBody:
+        description: body of the new question evidence
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                question_id:
+                  type: integer
+                  example: 1
+                section_id:
+                  type: integer
+                  example: 1
+                assessment_review:
+                  type: string
+                  example: "Review for question 101"
+                evidence:
+                  type: string
+                  example: "Evidence for question 101"
+        required: true
+      responses:
+        "202":
+          description: question evidence
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: accepted
+                  data:
+                    $ref: "#components/schemas/QuestionEvidence"
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    delete:
+      tags: [questionEvidence]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the question evidence to delete
+      responses:
+        "202":
+          description: question evidence
           content:
             application/json:
               schema:
@@ -1841,3 +2097,21 @@ components:
         required:
           type: boolean
           example: true
+    QuestionEvidence:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        question_id:
+          type: integer
+          example: 1
+        section_id:
+          type: integer
+          example: 1
+        assessment_review:
+          type: string
+          example: "Review for question 101"
+        evidence:
+          type: string
+          example: "Evidence for question 101"

--- a/Servers/utils/questionEvidence.util.ts
+++ b/Servers/utils/questionEvidence.util.ts
@@ -6,7 +6,7 @@ export const getAllQuestionEvidencesQuery = async (): Promise<
 > => {
   console.log("getAllQuestionEvidences");
   const questionEvidences = await pool.query(
-    "SELECT * FROM question_evidences"
+    "SELECT * FROM questionevidences"
   );
   return questionEvidences.rows;
 };
@@ -16,7 +16,7 @@ export const getQuestionEvidenceByIdQuery = async (
 ): Promise<QuestionEvidence | null> => {
   console.log("getQuestionEvidenceById", id);
   const result = await pool.query(
-    "SELECT * FROM question_evidences WHERE id = $1",
+    "SELECT * FROM questionevidences WHERE id = $1",
     [id]
   );
   return result.rows.length ? result.rows[0] : null;
@@ -30,7 +30,7 @@ export const createNewQuestionEvidenceQuery = async (questionEvidence: {
 }): Promise<QuestionEvidence> => {
   console.log("createNewQuestionEvidence", questionEvidence);
   const result = await pool.query(
-    "INSERT INTO question_evidences (question_id, section_id, assessment_review, evidence) VALUES ($1, $2, $3, $4) RETURNING *",
+    "INSERT INTO questionevidences (question_id, section_id, assessment_review, evidence) VALUES ($1, $2, $3, $4) RETURNING *",
     [
       questionEvidence.question_id,
       questionEvidence.section_id,
@@ -53,7 +53,7 @@ export const updateQuestionEvidenceByIdQuery = async (
   console.log("updateQuestionEvidenceById", id, questionEvidence);
   const fields = [];
   const values = [];
-  let query = "UPDATE question_evidences SET ";
+  let query = "UPDATE questionevidences SET ";
 
   if (questionEvidence.question_id) {
     fields.push("question_id = $1");
@@ -88,7 +88,7 @@ export const deleteQuestionEvidenceByIdQuery = async (
 ): Promise<boolean> => {
   console.log("deleteQuestionEvidenceById", id);
   const result = await pool.query(
-    "DELETE FROM question_evidences WHERE id = $1 RETURNING id",
+    "DELETE FROM questionevidences WHERE id = $1 RETURNING id",
     [id]
   );
   return result.rowCount !== null && result.rowCount > 0;


### PR DESCRIPTION
- Added Swagger YAML for question evidence

- Fixed controller for question evidence

Affected Issue: #155 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint `/questionEvidence` for managing question evidence with methods for creating, retrieving, updating, and deleting entries.
	- Added a new schema definition for `QuestionEvidence` detailing its properties.

- **Bug Fixes**
	- Updated database queries to reflect the new table name `questionevidences`, ensuring accurate data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->