### PR TITLE
037 Nov 5 Add Swagger for Section

### DIFF
--- a/Servers/controllers/section.ctrl.ts
+++ b/Servers/controllers/section.ctrl.ts
@@ -69,18 +69,33 @@ export async function getSectionById(req: Request, res: Response): Promise<any> 
 
 export async function createSection(req: Request, res: Response): Promise<any> {
   try {
-    const { name, description } = req.body;
+    const {
+      assessment_tracker_id,
+      name,
+      total_questions,
+      completed_questions
+    } = req.body;
 
-    if (!name || !description) {
+    if (
+      !assessment_tracker_id ||
+      !name ||
+      !total_questions ||
+      !completed_questions
+    ) {
       return res
         .status(400)
         .json(
-          STATUS_CODE[400]({ message: "name and description are required" })
+          STATUS_CODE[400]({ message: "assessment_tracker_id, name, total_questions and completed_questions are required" })
         );
     }
 
     if (MOCK_DATA_ON === "true") {
-      const newSection = createMockSection({ name, description });
+      const newSection = createMockSection({
+      assessment_tracker_id,
+      name,
+      total_questions,
+      completed_questions
+    });
 
       if (newSection) {
         return res.status(201).json(STATUS_CODE[201](newSection));
@@ -88,7 +103,12 @@ export async function createSection(req: Request, res: Response): Promise<any> {
 
       return res.status(503).json(STATUS_CODE[503]({}));
     } else {
-      const newSection = await createNewSectionQuery({ name, description });
+      const newSection = await createNewSectionQuery({
+      assessment_tracker_id,
+      name,
+      total_questions,
+      completed_questions
+    });
 
       if (newSection) {
         return res.status(201).json(STATUS_CODE[201](newSection));
@@ -108,18 +128,33 @@ export async function updateSectionById(
   console.log("updateSectionById");
   try {
     const sectionId = parseInt(req.params.id);
-    const { name, description } = req.body;
+    const {
+      assessment_tracker_id,
+      name,
+      total_questions,
+      completed_questions
+    } = req.body;
 
-    if (!name || !description) {
+    if (
+      !assessment_tracker_id ||
+      !name ||
+      !total_questions ||
+      !completed_questions
+    ) {
       return res
         .status(400)
         .json(
-          STATUS_CODE[400]({ message: "name and description are required" })
+          STATUS_CODE[400]({ message: "assessment_tracker_id, name, total_questions and completed_questions are required" })
         );
     }
 
     if (MOCK_DATA_ON === "true") {
-      const updatedSection = updateMockSectionById(sectionId, { name, description });
+      const updatedSection = updateMockSectionById(sectionId, {
+        assessment_tracker_id,
+        name,
+        total_questions,
+        completed_questions
+      });
 
       if (updatedSection) {
         return res.status(202).json(STATUS_CODE[202](updatedSection));
@@ -128,8 +163,10 @@ export async function updateSectionById(
       return res.status(404).json(STATUS_CODE[404]({}));
     } else {
       const updatedSection = await updateSectionByIdQuery(sectionId, {
+        assessment_tracker_id,
         name,
-        description,
+        total_questions,
+        completed_questions
       });
 
       if (updatedSection) {

--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -1933,6 +1933,268 @@ paths:
                 error:
                   type: object
 
+  /sections:
+    get:
+      tags: [sections]
+      security:
+        - JWTAuth: []
+      responses:
+        "200":
+          description: list of all sections
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: ok
+                  data:
+                    type: array
+                    items:
+                      $ref: "#components/schemas/Section"
+        "204":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: no content
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    post:
+      tags: [sections]
+      security:
+        - JWTAuth: []
+      requestBody:
+        description: body of the new section
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                assessment_tracker_id:
+                  type: integer
+                  example: 1
+                name:
+                  type: string
+                  example: "Network Security"
+                total_questions:
+                  type: integer
+                  example: 20
+                completed_questions:
+                  type: integer
+                  example: 20
+        required: true
+      responses:
+        "201":
+          description: created section
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: created
+                data:
+                  type: object
+                  $ref: "#components/schemas/Section"
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+        "503":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: service unavailable
+                error:
+                  type: object
+  /sections/{id}:
+    get:
+      tags: [sections]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the section
+      responses:
+        "200":
+          description: section
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: ok
+                  data:
+                    $ref: "#components/schemas/Section"
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    put:
+      tags: [sections]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the section
+      requestBody:
+        description: body of the new section
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                assessment_tracker_id:
+                  type: integer
+                  example: 1
+                name:
+                  type: string
+                  example: "Network Security"
+                total_questions:
+                  type: integer
+                  example: 20
+                completed_questions:
+                  type: integer
+                  example: 20
+        required: true
+      responses:
+        "202":
+          description: section
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: accepted
+                  data:
+                    $ref: "#components/schemas/Section"
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    delete:
+      tags: [sections]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the section to delete
+      responses:
+        "202":
+          description: section
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: accepted
+                  data:
+                    type: boolean
+                    example: true
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+
 components:
   securitySchemes:
     JWTAuth:
@@ -2115,3 +2377,21 @@ components:
         evidence:
           type: string
           example: "Evidence for question 101"
+    Section:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        assessment_tracker_id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: "Network Security"
+        total_questions:
+          type: integer
+          example: 20
+        completed_questions:
+          type: integer
+          example: 20

--- a/Servers/utils/section.util.ts
+++ b/Servers/utils/section.util.ts
@@ -14,40 +14,55 @@ export const getSectionByIdQuery = async (id: number): Promise<Section | null> =
 };
 
 export const createNewSectionQuery = async (section: {
-  name: string;
-  description: string;
+  assessment_tracker_id: number
+  name: string
+  total_questions: number
+  completed_questions: number
 }): Promise<Section> => {
   console.log("createNewSection", section);
   const result = await pool.query(
-    "INSERT INTO sections (name, description) VALUES ($1, $2) RETURNING *",
-    [section.name, section.description]
+    "INSERT INTO sections (assessment_tracker_id, name, total_questions, completed_questions) VALUES ($1, $2, $3, $4) RETURNING *",
+    [section.assessment_tracker_id, section.name, section.total_questions, section.completed_questions]
   );
   return result.rows[0];
 };
 
 export const updateSectionByIdQuery = async (
   id: number,
-  section: { name?: string; description?: string }
+  section: {
+    assessment_tracker_id?: number
+    name?: string
+    total_questions?: number
+    completed_questions?: number
+  }
 ): Promise<Section | null> => {
   console.log("updateSectionById", id, section);
   const fields = [];
   const values = [];
   let query = "UPDATE sections SET ";
 
-  if (section.name) {
-    fields.push("name = $1");
-    values.push(section.name);
+  if(section.assessment_tracker_id) {
+    fields.push("assessment_tracker_id = $1")
+    values.push(section.assessment_tracker_id)
   }
-  if (section.description) {
-    fields.push("description = $2");
-    values.push(section.description);
+  if(section.name) {
+    fields.push("name = $2")
+    values.push(section.name)
+  }
+  if(section.total_questions) {
+    fields.push("total_questions = $3")
+    values.push(section.total_questions)
+  }
+  if(section.completed_questions) {
+    fields.push("completed_questions = $4")
+    values.push(section.completed_questions)
   }
 
   if (fields.length === 0) {
     throw new Error("No fields to update");
   }
 
-  query += fields.join(", ") + " WHERE id = $3 RETURNING *";
+  query += fields.join(", ") + " WHERE id = $5 RETURNING *";
   values.push(id);
 
   const result = await pool.query(query, values);


### PR DESCRIPTION
- Added Swagger YAML for sections
- Fixed controller for sections

Affected Issue: #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new API endpoints for managing sections: 
		- GET /sections
		- POST /sections
		- GET /sections/{id}
		- PUT /sections/{id}
		- DELETE /sections/{id}
	- Expanded parameters for creating and updating sections to include `assessment_tracker_id`, `total_questions`, and `completed_questions`.

- **Bug Fixes**
	- Improved error handling for missing parameters in section creation and updates.

- **Documentation**
	- Added a new schema definition for `Section` in the API documentation to clarify the required properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->