### PR TITLE
039 Nov 5 Add Swagger for Subrequirement Evidences

### DIFF
--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -1677,6 +1677,314 @@ paths:
                 error:
                   type: object
 
+  /subrequirementEvidence:
+    get:
+      tags: [subrequirementEvidence]
+      security:
+        - JWTAuth: []
+      responses:
+        "200":
+          description: list of all subrequirement evidences
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: ok
+                  data:
+                    type: array
+                    items:
+                      $ref: "#components/schemas/SubRequirementEvidence"
+        "204":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: no content
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    post:
+      tags: [subrequirementEvidence]
+      security:
+        - JWTAuth: []
+      requestBody:
+        description: body of the new subrequirement evidences
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subrequirement_id:
+                  type: integer
+                  example: 1
+                document_name:
+                  type: string
+                  example: "Compliance Report"
+                document_type:
+                  type: string
+                  example: "PDF"
+                file_path:
+                  type: string
+                  example: "/documents/compliance_report.pdf"
+                upload_date:
+                  type: string
+                  format: date-time
+                  example: "2023-01-15T00:00:00.000Z"
+                uploader_id:
+                  type: integer
+                  example: 1
+                description:
+                  type: string
+                  example: "Annual compliance report for 2023"
+                status:
+                  type: string
+                  example: "Reviewed"
+                last_reviewed:
+                  type: string
+                  format: date-time
+                  example: "2023-02-01T00:00:00.000Z"
+                reviewer_id:
+                  type: integer
+                  example: 2
+                reviewer_comments:
+                  type: string
+                  example: "Report is complete and meets all requirements."
+        required: true
+      responses:
+        "201":
+          description: created subrequirement evidences
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: created
+                data:
+                  type: object
+                  $ref: "#components/schemas/SubRequirementEvidence"
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+        "503":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: service unavailable
+                error:
+                  type: object
+  /subrequirementEvidence/{id}:
+    get:
+      tags: [subrequirementEvidence]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the subrequirement evidences
+      responses:
+        "200":
+          description: subrequirement evidences
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: ok
+                  data:
+                    $ref: "#components/schemas/SubRequirementEvidence"
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    put:
+      tags: [subrequirementEvidence]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the subrequirement evidences
+      requestBody:
+        description: body of the new subrequirement evidences
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subrequirement_id:
+                  type: integer
+                  example: 1
+                document_name:
+                  type: string
+                  example: "Compliance Report"
+                document_type:
+                  type: string
+                  example: "PDF"
+                file_path:
+                  type: string
+                  example: "/documents/compliance_report.pdf"
+                upload_date:
+                  type: string
+                  format: date-time
+                  example: "2023-01-15T00:00:00.000Z"
+                uploader_id:
+                  type: integer
+                  example: 1
+                description:
+                  type: string
+                  example: "Annual compliance report for 2023"
+                status:
+                  type: string
+                  example: "Reviewed"
+                last_reviewed:
+                  type: string
+                  format: date-time
+                  example: "2023-02-01T00:00:00.000Z"
+                reviewer_id:
+                  type: integer
+                  example: 2
+                reviewer_comments:
+                  type: string
+                  example: "Report is complete and meets all requirements."
+        required: true
+      responses:
+        "202":
+          description: subrequirement evidences
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: accepted
+                  data:
+                    $ref: "#components/schemas/SubRequirementEvidence"
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+    delete:
+      tags: [subrequirementEvidence]
+      security:
+        - JWTAuth: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: id of the subrequirement evidences to delete
+      responses:
+        "202":
+          description: subrequirement evidences
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: accepted
+                  data:
+                    type: boolean
+                    example: true
+        "404":
+          description: no content to display
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: not found
+                data:
+                  type: object
+        "500":
+          description: internal server error
+          content:
+            application/json:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: internal server error
+                error:
+                  type: object
+
 components:
   securitySchemes:
     JWTAuth:
@@ -1841,3 +2149,44 @@ components:
         required:
           type: boolean
           example: true
+    SubRequirementEvidence:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        subrequirement_id:
+          type: integer
+          example: 1
+        document_name:
+          type: string
+          example: "Compliance Report"
+        document_type:
+          type: string
+          example: "PDF"
+        file_path:
+          type: string
+          example: "/documents/compliance_report.pdf"
+        upload_date:
+          type: string
+          format: date-time
+          example: "2023-01-15T00:00:00.000Z"
+        uploader_id:
+          type: integer
+          example: 1
+        description:
+          type: string
+          example: "Annual compliance report for 2023"
+        status:
+          type: string
+          example: "Reviewed"
+        last_reviewed:
+          type: string
+          format: date-time
+          example: "2023-02-01T00:00:00.000Z"
+        reviewer_id:
+          type: integer
+          example: 2
+        reviewer_comments:
+          type: string
+          example: "Report is complete and meets all requirements."

--- a/Servers/utils/subrequirementEvidence.util.ts
+++ b/Servers/utils/subrequirementEvidence.util.ts
@@ -6,7 +6,7 @@ export const getAllSubrequirementEvidencesQuery = async (): Promise<
 > => {
   console.log("getAllSubrequirementEvidences");
   const subrequirementEvidences = await pool.query(
-    "SELECT * FROM subrequirement_evidences"
+    "SELECT * FROM subrequirementevidences"
   );
   return subrequirementEvidences.rows;
 };
@@ -16,7 +16,7 @@ export const getSubrequirementEvidenceByIdQuery = async (
 ): Promise<SubrequirementEvidence | null> => {
   console.log("getSubrequirementEvidenceById", id);
   const result = await pool.query(
-    "SELECT * FROM subrequirement_evidences WHERE id = $1",
+    "SELECT * FROM subrequirementevidences WHERE id = $1",
     [id]
   );
   return result.rows.length ? result.rows[0] : null;
@@ -27,7 +27,7 @@ export const createNewSubrequirementEvidenceQuery = async (
 ): Promise<SubrequirementEvidence> => {
   console.log("createNewSubrequirementEvidence", subrequirementEvidence);
   const result = await pool.query(
-    `INSERT INTO subrequirement_evidences (
+    `INSERT INTO subrequirementevidences (
       subrequirement_id, document_name, document_type, file_path, upload_date, 
       uploader_id, description, status, last_reviewed, reviewer_id, reviewer_comments
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING *`,
@@ -55,7 +55,7 @@ export const updateSubrequirementEvidenceByIdQuery = async (
   console.log("updateSubrequirementEvidenceById", id, subrequirementEvidence);
   const fields = [];
   const values = [];
-  let query = "UPDATE subrequirement_evidences SET ";
+  let query = "UPDATE subrequirementevidences SET ";
 
   if (subrequirementEvidence.subrequirement_id) {
     fields.push("subrequirement_id = $1");
@@ -125,7 +125,7 @@ export const deleteSubrequirementEvidenceByIdQuery = async (
 ): Promise<SubrequirementEvidence | null> => {
   console.log("deleteSubrequirementEvidenceById", id);
   const result = await pool.query(
-    "DELETE FROM subrequirement_evidences WHERE id = $1 RETURNING *",
+    "DELETE FROM subrequirementevidences WHERE id = $1 RETURNING *",
     [id]
   );
   return result.rows.length ? result.rows[0] : null;


### PR DESCRIPTION
- Added Swagger YAML for subrequirement evidences
- Fixed controller for subrequirement evidences

Affected Issue: #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new API endpoints for managing subrequirement evidences:
		- **GET** `/subrequirementEvidence` - Retrieve all subrequirement evidences.
		- **POST** `/subrequirementEvidence` - Create a new subrequirement evidence.
		- **GET** `/subrequirementEvidence/{id}` - Retrieve a specific subrequirement evidence by ID.
		- **PUT** `/subrequirementEvidence/{id}` - Update an existing subrequirement evidence.
		- **DELETE** `/subrequirementEvidence/{id}` - Remove a subrequirement evidence by ID.
	- Added schema definition for `SubRequirementEvidence` to define its structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->