### PR TITLE
050 Nov 29: Use DB for the API calls instead of mock data

### DIFF
--- a/Servers/controllers/assessment.ctrl.ts
+++ b/Servers/controllers/assessment.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Assessment } from "../models/assessment.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllAssessments(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const assessments = getAllMockAssessments();
 
       if (assessments) {
@@ -52,7 +52,7 @@ export async function getAssessmentById(
   try {
     const assessmentId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const assessment = getMockAssessmentById(assessmentId);
 
       if (assessment) {
@@ -91,7 +91,7 @@ export async function createAssessment(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const createdAssessment = createMockAssessment(newAssessment);
 
       if (createdAssessment) {
@@ -131,7 +131,7 @@ export async function updateAssessmentById(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const assessment = updateMockAssessmentById(
         assessmentId,
         updatedAssessment
@@ -166,7 +166,7 @@ export async function deleteAssessmentById(
   try {
     const assessmentId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedAssessment = deleteMockAssessmentById(assessmentId);
 
       if (deletedAssessment) {

--- a/Servers/controllers/control.ctrl.ts
+++ b/Servers/controllers/control.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Control } from "../models/control.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllControls(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const controls = getAllMockControls();
 
       if (controls) {
@@ -52,7 +52,7 @@ export async function getControlById(
   try {
     const controlId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const control = getMockControlById(controlId);
 
       if (control) {
@@ -87,7 +87,7 @@ export async function createControl(req: Request, res: Response): Promise<any> {
       implementationDetails: string;
     } = req.body;
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const control = createMockControl(newControl);
 
       if (control) {
@@ -126,7 +126,7 @@ export async function updateControlById(
       implementationDetails: string;
     } = req.body;
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const control = updateMockControlById(controlId, updatedControl);
 
       if (control) {
@@ -155,7 +155,7 @@ export async function deleteControlById(
   try {
     const controlId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const control = deleteMockControlById(controlId);
 
       if (control) {

--- a/Servers/controllers/project.ctrl.ts
+++ b/Servers/controllers/project.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Project } from "../models/project.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllProjects(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const projects = getAllMockProjects();
 
       if (projects) {
@@ -52,7 +52,7 @@ export async function getProjectById(
   try {
     const projectId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const project = getMockProjectById(projectId);
 
       if (project) {
@@ -96,7 +96,7 @@ export async function createProject(req: Request, res: Response): Promise<any> {
         );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const createdProject = createMockProject(newProject);
 
       if (createdProject) {
@@ -144,7 +144,7 @@ export async function updateProjectById(
         );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const project = updateMockProjectById(projectId, updatedProject);
 
       if (project) {
@@ -173,7 +173,7 @@ export async function deleteProjectById(
   try {
     const projectId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedProject = deleteMockProjectById(projectId);
 
       if (deletedProject) {

--- a/Servers/controllers/projectRisks.ctrl.ts
+++ b/Servers/controllers/projectRisks.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { ProjectRisk } from "../models/projectRisk.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllProjectRisks(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const projectRisks = getAllMockProjectRisks();
 
       if (projectRisks) {
@@ -52,7 +52,7 @@ export async function getProjectRiskById(
   try {
     const projectRiskId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const projectRisk = getMockProjectRiskById(projectRiskId);
 
       if (projectRisk) {
@@ -107,7 +107,7 @@ export async function createProjectRisk(
       date_of_assessment: Date;
     } = req.body;
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const newProjectRisk = createMockProjectRisk(projectRisk);
 
       if (newProjectRisk) {
@@ -163,7 +163,7 @@ export async function updateProjectRiskById(
       date_of_assessment: Date;
     }> = req.body;
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const updatedProjectRisk = updateMockProjectRiskById(
         projectRiskId,
         projectRisk
@@ -198,7 +198,7 @@ export async function deleteProjectRiskById(
   try {
     const projectRiskId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedProjectRisk = deleteMockProjectRiskById(projectRiskId);
 
       if (deletedProjectRisk) {

--- a/Servers/controllers/projectScope.ctrl.ts
+++ b/Servers/controllers/projectScope.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { ProjectScope } from "../models/projectScope.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllProjectScopes(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const projectScopes = getAllMockProjectScopes();
 
       if (projectScopes) {
@@ -52,7 +52,7 @@ export async function getProjectScopeById(
   try {
     const projectScopeId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const projectScope = getMockProjectScopeById(projectScopeId);
 
       if (projectScope) {
@@ -91,7 +91,7 @@ export async function createProjectScope(
       technologyDocumentation: string;
     };
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const createdProjectScope = createMockProjectScope(projectScope);
 
       if (createdProjectScope) {
@@ -131,7 +131,7 @@ export async function updateProjectScopeById(
       technologyDocumentation: string;
     };
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const updatedProjectScope = updateMockProjectScopeById(
         projectScopeId,
         projectScope
@@ -166,7 +166,7 @@ export async function deleteProjectScopeById(
   try {
     const projectScopeId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedProjectScope = deleteMockProjectScopeById(projectScopeId);
 
       if (deletedProjectScope) {

--- a/Servers/controllers/question.ctrl.ts
+++ b/Servers/controllers/question.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Question } from "../models/question.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllQuestions(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const questions = getAllMockQuestions();
 
       if (questions) {
@@ -52,7 +52,7 @@ export async function getQuestionById(
   try {
     const questionId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const question = getMockQuestionById(questionId);
 
       if (question) {
@@ -104,7 +104,7 @@ export async function createQuestion(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const createdQuestion = createMockQuestion(newQuestion);
 
       if (createdQuestion) {
@@ -157,7 +157,7 @@ export async function updateQuestionById(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const question = updateMockQuestionById(questionId, updatedQuestion);
 
       if (question) {
@@ -189,7 +189,7 @@ export async function deleteQuestionById(
   try {
     const questionId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedQuestion = deleteMockQuestionById(questionId);
 
       if (deletedQuestion) {

--- a/Servers/controllers/role.ctrl.ts
+++ b/Servers/controllers/role.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Role } from "../models/role.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllRoles(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const roles = getAllMockRoles();
 
       if (roles) {
@@ -52,7 +52,7 @@ export async function getRoleById(
   try {
     const roleId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const role = getMockRoleById(roleId);
 
       if (role) {
@@ -91,7 +91,7 @@ export async function createRole(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const createdRole = createMockRole(newRole);
 
       if (createdRole) {
@@ -131,7 +131,7 @@ export async function updateRoleById(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const role = updateMockRoleById(
         roleId,
         updatedRole
@@ -166,7 +166,7 @@ export async function deleteRoleById(
   try {
     const roleId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedRole = deleteMockRoleById(roleId);
 
       if (deletedRole) {

--- a/Servers/controllers/subcontrol.ctrl.ts
+++ b/Servers/controllers/subcontrol.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Subcontrol } from "../models/subcontrol.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllSubcontrols(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const subcontrols = getAllMockSubcontrols();
 
       if (subcontrols) {
@@ -52,7 +52,7 @@ export async function getSubcontrolById(
   try {
     const subcontrolId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const subcontrol = getMockSubcontrolById(subcontrolId);
 
       if (subcontrol) {
@@ -93,7 +93,7 @@ export async function createNewSubcontrol(
       feedback: string;
     } = req.body;
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const newSubcontrol = createMockSubcontrol(subcontrol);
 
       if (newSubcontrol) {
@@ -135,7 +135,7 @@ export async function updateSubcontrolById(
       feedback: string;
     }> = req.body;
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const updatedSubcontrol = updateMockSubcontrolById(
         subcontrolId,
         subcontrol
@@ -170,7 +170,7 @@ export async function deleteSubcontrolById(
   try {
     const subcontrolId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedSubcontrol = deleteMockSubcontrolById(subcontrolId);
 
       if (deletedSubcontrol) {

--- a/Servers/controllers/subtopic.ctrl.ts
+++ b/Servers/controllers/subtopic.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Subtopic } from "../models/subtopic.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllSubtopics(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const subtopics = getAllMockSubtopics();
 
       if (subtopics) {
@@ -52,7 +52,7 @@ export async function getSubtopicById(
   try {
     const subtopicId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const subtopic = getMockSubtopicById(subtopicId);
 
       if (subtopic) {
@@ -79,7 +79,7 @@ export async function createNewSubtopic(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const subtopic = createMockSubtopic(req.body);
 
       if (subtopic) {
@@ -108,7 +108,7 @@ export async function updateSubtopicById(
   try {
     const subtopicId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const subtopic = updateMockSubtopicById(subtopicId, req.body);
 
       if (subtopic) {
@@ -137,7 +137,7 @@ export async function deleteSubtopicById(
   try {
     const subtopicId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const subtopic = deleteMockSubtopicById(subtopicId);
 
       if (subtopic) {

--- a/Servers/controllers/topic.ctrl.ts
+++ b/Servers/controllers/topic.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Topic } from "../models/topic.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -20,7 +20,7 @@ import {
 
 export async function getAllTopics(req: Request, res: Response): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const topics = getAllMockTopics();
 
       if (topics) {
@@ -46,7 +46,7 @@ export async function getTopicById(req: Request, res: Response): Promise<any> {
   try {
     const topicId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const topic = getMockTopicById(topicId);
 
       if (topic) {
@@ -79,7 +79,7 @@ export async function createNewTopic(
       title: string;
     } = req.body;
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const topic = createMockTopic(newTopic);
 
       if (topic) {
@@ -112,7 +112,7 @@ export async function updateTopicById(
       title: string;
     } = req.body;
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const topic = updateMockTopicById(topicId, updatedTopic);
 
       if (topic) {
@@ -141,7 +141,7 @@ export async function deleteTopicById(
   try {
     const topicId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const topic = deleteMockTopicById(topicId);
 
       if (topic) {

--- a/Servers/controllers/vendor.ctrl.ts
+++ b/Servers/controllers/vendor.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { Vendor } from "../models/vendor.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -20,7 +20,7 @@ import {
 
 export async function getAllVendors(req: Request, res: Response): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const vendors = getAllMockVendors();
 
       if (vendors) {
@@ -46,7 +46,7 @@ export async function getVendorById(req: Request, res: Response): Promise<any> {
   try {
     const vendorId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const vendor = getMockVendorById(vendorId);
 
       if (vendor) {
@@ -101,7 +101,7 @@ export async function createVendor(req: Request, res: Response): Promise<any> {
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const createdVendor = createMockVendor(newVendor);
 
       if (createdVendor) {
@@ -160,7 +160,7 @@ export async function updateVendorById(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const vendor = updateMockVendorById(vendorId, updatedVendor);
 
       if (vendor) {
@@ -189,7 +189,7 @@ export async function deleteVendorById(
   try {
     const vendorId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedVendor = deleteMockVendorById(vendorId);
 
       if (deletedVendor) {

--- a/Servers/controllers/vendorRisk.ctrl.ts
+++ b/Servers/controllers/vendorRisk.ctrl.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { VendorRisk } from "../models/vendorRisk.model";
-const MOCK_DATA_ON = true;
+const MOCK_DATA_ON = process.env.MOCK_DATA_ON;
 
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
@@ -23,7 +23,7 @@ export async function getAllVendorRisks(
   res: Response
 ): Promise<any> {
   try {
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const vendorRisks = getAllMockVendorRisks();
 
       if (vendorRisks) {
@@ -52,7 +52,7 @@ export async function getVendorRiskById(
   try {
     const vendorRiskId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const vendorRisk = getMockVendorRiskById(vendorRiskId);
 
       if (vendorRisk) {
@@ -104,7 +104,7 @@ export async function createVendorRisk(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const createdVendorRisk = createMockVendorRisk(newVendorRisk);
 
       if (createdVendorRisk) {
@@ -157,7 +157,7 @@ export async function updateVendorRiskById(
       );
     }
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const vendorRisk = updateMockVendorRiskById(
         vendorRiskId,
         updatedVendorRisk
@@ -192,7 +192,7 @@ export async function deleteVendorRiskById(
   try {
     const vendorRiskId = parseInt(req.params.id);
 
-    if (MOCK_DATA_ON === true) {
+    if (MOCK_DATA_ON === "true") {
       const deletedVendorRisk = deleteMockVendorRiskById(vendorRiskId);
 
       if (deletedVendorRisk) {

--- a/Servers/mocks/question.mock.data.ts
+++ b/Servers/mocks/question.mock.data.ts
@@ -19,7 +19,7 @@ export const questions: Question[] = [
       "What business problem does the AI system solve, and what are its capabilities? What other techniques were considered before deciding to use AI to address this problem?",
     answerType: "Long text",
     evidenceFileRequired: false,
-    hint: "It's important to provide transparent information about why you are choosing a high-risk AI system, including a mapping of key stages within the project and an assessment of resources and capabilities within your team or organization.",
+    hint: "It''s important to provide transparent information about why you are choosing a high-risk AI system, including a mapping of key stages within the project and an assessment of resources and capabilities within your team or organization.",
     isRequired: true,
     priorityLevel: "high priority",
   },


### PR DESCRIPTION
- Removed the static use of `MOCK_DATA_ON=true` in every controller
- Now the `MOCK_DATA_ON` will depend on the value set in the `.env` file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced configurability for mock data usage by retrieving the `MOCK_DATA_ON` value from environment variables across various controllers.

- **Bug Fixes**
  - Corrected a typographical error in the hint property of a question in the mock data.

These changes improve the flexibility of the application in different deployment environments while ensuring accurate mock data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->