### PR TITLE
Move validateForm and passwordChecks to separate file(validations/formValidation)

### DIFF
--- a/Clients/src/application/validations/formValidation.ts
+++ b/Clients/src/application/validations/formValidation.ts
@@ -1,0 +1,123 @@
+import { checkStringValidation } from "./stringValidation";
+
+// Constants
+const PASSWORD_REGEX = /[!@#$%^&*(),.?":{}|<>]/;
+// Validation constants
+const VALIDATION_RULES = {
+  NAME: { min: 3, max: 50 },
+  PASSWORD: { min: 8, max: 16 },
+  EMAIL: { min: 0, max: 128 },
+} as const;
+
+// Define the shape of form values
+export interface FormValues {
+  name?: string;
+  surname?: string;
+  email?: string;
+  password: string;
+  confirmPassword: string;
+}
+
+// Define the shape of form errors
+export interface FormErrors {
+  name?: string;
+  surname?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+}
+
+interface ValidationResult {
+  isFormValid: boolean;
+  errors: FormErrors;
+}
+
+interface PasswordValidationResult {
+  length: boolean;
+  specialChar: boolean;
+}
+
+/**
+ * Validates form input values
+ * @param values Form values to validate
+ * @returns Validation result containing isFormValid flag and any errors
+ */
+// Function to validate the entire form
+export const validateForm = ( values: FormValues ): ValidationResult => {
+  const newErrors: FormErrors = {};
+
+  // Validate name
+  if (values.name) {
+    const name = checkStringValidation(
+      "Name",
+      values.name,
+      VALIDATION_RULES.NAME.min,
+      VALIDATION_RULES.NAME.max
+    );
+    if (!name.accepted) {
+      newErrors.name = name.message;
+    }
+  }
+
+  // Validate surname
+  if (values.surname) {
+    const surname = checkStringValidation(
+      "Surname",
+      values.surname,
+      VALIDATION_RULES.NAME.min,
+      VALIDATION_RULES.NAME.max
+    );
+    if (!surname.accepted) {
+    newErrors.surname = surname.message;
+    }
+  }
+
+  // Validate email
+  if (values.email) {
+    const email = checkStringValidation(
+      "Email",
+      values.email,
+      VALIDATION_RULES.EMAIL.min,
+      VALIDATION_RULES.EMAIL.max,
+      false,
+      false,
+      false,
+      false,
+      "email"
+    );
+    if (!email.accepted) {
+      newErrors.email = email.message;
+    }
+  }
+
+  // Validate password
+  const password = checkStringValidation(
+    "Password",
+    values.password,
+    VALIDATION_RULES.PASSWORD.min,
+    VALIDATION_RULES.PASSWORD.max,
+    true,
+    true,
+    true,
+    true,
+    "password"
+  );
+  if (!password.accepted) {
+    newErrors.password = password.message;
+  }
+
+  // Confirm password validation
+  if (values.password !== values.confirmPassword) {
+    newErrors.confirmPassword = "Passwords do not match";
+  }
+
+  return { isFormValid: Object.keys(newErrors).length === 0, errors: newErrors }; // Return true if no errors exist
+};
+
+// Function to check Password based on the password input
+export const validatePassword = (values: FormValues): PasswordValidationResult => {
+  return {
+    length: values.password.length >= VALIDATION_RULES.PASSWORD.min,
+    specialChar: PASSWORD_REGEX.test(values.password),
+  };
+};

--- a/Clients/src/presentation/pages/Authentication/RegisterUser/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/RegisterUser/index.tsx
@@ -1,19 +1,12 @@
 import { Button, Stack, Typography, useTheme } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Check from "../../../components/Checks";
 import Field from "../../../components/Inputs/Field";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import { useNavigate } from "react-router-dom";
-
-// Define the shape of form values
-interface FormValues {
-  name: string;
-  surname: string;
-  password: string;
-  confirmPassword: string;
-}
+import { validatePassword, validateForm } from "../../../../application/validations/formValidation";
+import type { FormValues, FormErrors } from "../../../../application/validations/formValidation";
 
 // Initial state for form values
 const initialState: FormValues = {
@@ -23,31 +16,14 @@ const initialState: FormValues = {
   confirmPassword: "",
 };
 
-// Define the shape of form errors
-interface FormErrors {
-  name?: string;
-  surname?: string;
-  password?: string;
-  confirmPassword?: string;
-}
-
-// Define the shape for password validation checks
-interface PasswordChecks {
-  length: boolean;
-  specialChar: boolean;
-}
-
 const RegisterUser: React.FC = () => {
   const navigate = useNavigate();
   // State for form values
   const [values, setValues] = useState<FormValues>(initialState);
   // State for form errors
   const [errors, setErrors] = useState<FormErrors>({});
-  // State for password validation checks
-  const [passwordChecks, setPasswordChecks] = useState<PasswordChecks>({
-    length: false,
-    specialChar: false,
-  });
+  // Password checks based on the password input
+  const passwordChecks = validatePassword(values);
 
   // Handle input field changes
   const handleChange =
@@ -55,67 +31,19 @@ const RegisterUser: React.FC = () => {
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setValues({ ...values, [prop]: event.target.value });
       setErrors({ ...errors, [prop]: "" });
-    };
-
-  // Effect to update password checks based on the password input
-  useEffect(() => {
-    setPasswordChecks({
-      length: values.password.length >= 8,
-      specialChar: /[!@#$%^&*(),.?":{}|<>]/.test(values.password),
-    });
-  }, [values.password]);
-
-  // Function to validate the entire form
-  const validateForm = (): boolean => {
-    const newErrors: FormErrors = {};
-
-    // Validate name
-    const name = checkStringValidation("Name", values.name, 3, 50);
-    if (!name.accepted) {
-      newErrors.name = name.message;
-    }
-
-    // Validate surname
-    const surname = checkStringValidation("Surname", values.surname, 3, 50);
-    if (!surname.accepted) {
-      newErrors.surname = surname.message;
-    }
-
-    // Validate password
-    const password = checkStringValidation(
-      "Password",
-      values.password,
-      8,
-      16,
-      true,
-      true,
-      true,
-      true,
-      "password"
-    );
-    if (!password.accepted) {
-      newErrors.password = password.message;
-    }
-
-    // Confirm password validation
-    if (values.password !== values.confirmPassword) {
-      newErrors.confirmPassword = "Passwords do not match";
-    }
-
-    // Update state with any new errors
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0; // Return true if no errors exist
   };
 
   // Handle form submission
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (validateForm()) {
+    const { isFormValid, errors } = validateForm(values);
+    if (!isFormValid) {
+      setErrors(errors);
+    } else {
       console.log("Form submitted:", values);
       // Reset form after successful submission
       setValues(initialState);
       setErrors({});
-      setPasswordChecks({ length: false, specialChar: false });
       navigate("/login");
     }
   };

--- a/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Stack, Typography, useTheme } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Check from "../../../components/Checks";
 import Field from "../../../components/Inputs/Field";
@@ -7,25 +7,9 @@ import Field from "../../../components/Inputs/Field";
 import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
 import { ReactComponent as Lock } from "../../../assets/icons/lock.svg";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import { useNavigate } from "react-router-dom";
-
-// Define the shape of form values
-interface FormValues {
-  password: string;
-  confirmPassword: string;
-}
-
-interface FormErrors {
-  password?: string;
-  confirmPassword?: string;
-}
-
-// Define the shape for password validation checks
-interface PasswordChecks {
-  length: boolean;
-  specialChar: boolean;
-}
+import { validatePassword, validateForm } from "../../../../application/validations/formValidation";
+import type { FormValues, FormErrors } from "../../../../application/validations/formValidation";
 
 // Initial state for form values
 const initialState: FormValues = {
@@ -39,11 +23,8 @@ const SetNewPassword: React.FC = () => {
   const [values, setValues] = useState<FormValues>(initialState);
   // State for form errors
   const [errors, setErrors] = useState<FormErrors>({});
-  // State for password validation checks
-  const [passwordChecks, setPasswordChecks] = useState<PasswordChecks>({
-    length: false,
-    specialChar: false,
-  });
+  // Password checks based on the password input
+  const passwordChecks = validatePassword(values);
 
   // Handle input field changes
   const handleChange =
@@ -53,53 +34,18 @@ const SetNewPassword: React.FC = () => {
       setErrors({ ...errors, [prop]: "" });
     };
 
-  // Effect to update password checks based on the password input
-  useEffect(() => {
-    setPasswordChecks({
-      length: values.password.length >= 8,
-      specialChar: /[!@#$%^&*(),.?":{}|<>]/.test(values.password),
-    });
-  }, [values.password]);
-
-  // Function to validate the entire form
-  const validateForm = (): boolean => {
-    const newErrors: FormErrors = {};
-
-    // Validate password
-    const password = checkStringValidation(
-      "Password",
-      values.password,
-      8,
-      16,
-      true,
-      true,
-      true,
-      true,
-      "password"
-    );
-    if (!password.accepted) {
-      newErrors.password = password.message;
-    }
-
-    // Confirm password validation
-    if (values.password !== values.confirmPassword) {
-      newErrors.confirmPassword = "Passwords do not match";
-    }
-
-    // Update state with any new errors
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0; // Return true if no errors exist
-  };
 
   // Handle form submission
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (validateForm()) {
+    const { isFormValid, errors } = validateForm(values);
+    if (!isFormValid) {
+      setErrors(errors);
+    } else {
       console.log("Form submitted:", values);
       // Reset form after successful submission
       setValues(initialState);
       setErrors({});
-      setPasswordChecks({ length: false, specialChar: false });
     }
   };
 


### PR DESCRIPTION
The function `validateForm` has been duplicated across several files. To enhance code reusability, we can move it to a separate file and call it whenever it's needed.

Additionally, `passwordChecks` is currently being synchronized using `useEffect`. Since this approach is no longer recommended for syncing states in React (https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state), we could create a separate method for this purpose so that it can also be reused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced comprehensive form validation for user input, including password checks.
	- Added structured validation interfaces for form values and errors.

- **Bug Fixes**
	- Improved error handling during form submission based on new validation logic.

- **Refactor**
	- Streamlined validation logic in the `RegisterAdmin`, `RegisterUser`, and `SetNewPassword` components by removing unnecessary state management and using validation functions directly.
	- Updated the `validateForm` function to accept input values and return validation results instead of managing internal state.

- **Chores**
	- Removed unused imports related to previous validation methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->