### PR TITLE
Adjust sidebar from being overlapped by body content

### DIFF
--- a/Clients/src/presentation/containers/Dashboard/index.css
+++ b/Clients/src/presentation/containers/Dashboard/index.css
@@ -11,7 +11,11 @@
   max-width: 230px;
   top: 0;
   left: 0;
-  z-index: 100;
+  z-index: 1;
+}
+
+.base-Popup-root{
+  z-index: 2;
 }
 
 .home-layout > div {

--- a/Clients/src/presentation/containers/Dashboard/index.css
+++ b/Clients/src/presentation/containers/Dashboard/index.css
@@ -11,6 +11,7 @@
   max-width: 230px;
   top: 0;
   left: 0;
+  z-index: 100;
 }
 
 .home-layout > div {


### PR DESCRIPTION
## Describe your changes
- Give sidebar z-index to prevent overlapped by body content 

![verifywise-sidbar-fixed](https://github.com/user-attachments/assets/3b0bfa1b-80bb-4f8c-9ba1-7f617cdfd733)

## Issue number

Mention the issue number(s) this PR addresses (#418).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated z-index for the dashboard sidebar to improve layout visibility and prevent potential overlapping issues.
	- Introduced a new class `.base-Popup-root` to enhance element layering within the layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->