### PR TITLE
Justify project modal textfield height

### DIFF
--- a/Clients/src/presentation/components/CreateProjectForm/index.tsx
+++ b/Clients/src/presentation/components/CreateProjectForm/index.tsx
@@ -364,7 +364,6 @@ const CreateProjectForm: FC<CreateProjectFormProps> = ({ closePopup, setIsNewPro
                 value={values.goal}
                 onChange={handleOnTextFieldChange("goal")}
                 sx={{
-                  height: 101,
                   backgroundColor: theme.palette.background.main,
                 }}
                 isRequired

--- a/Clients/src/presentation/components/Inputs/Field/index.css
+++ b/Clients/src/presentation/components/Inputs/Field/index.css
@@ -40,7 +40,7 @@
 
 .field-description .MuiFormControl-root .MuiInputBase-root .MuiInputBase-input {
   padding: 0;
-  max-height: 53px;
+  /* max-height: 53px; */
 }
 
 .field-description .MuiFormControl-root .MuiInputBase-root {

--- a/Clients/src/presentation/components/Inputs/Field/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Field/index.tsx
@@ -149,7 +149,7 @@ const Field = forwardRef(
           autoComplete={autoComplete}
           placeholder={placeholder}
           multiline={type === "description"}
-          rows={type === "description" ? 4 : 1}
+          rows={type === "description" ? 5 : 1}
           value={value}
           onInput={onInput}
           onChange={onChange}


### PR DESCRIPTION
## Describe your changes

- Remove max-height style from css.
- Display text-field height according to Figma design. 

<img width="972" alt="Screenshot 2025-01-13 at 10 12 30 AM" src="https://github.com/user-attachments/assets/7bb51daa-8677-4493-b3eb-0bf831434168" />

## Issue number

Mention the issue number(s) this PR addresses (#432).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
	- Modified the "Goal" input field in the Create Project Form to have more flexible height
	- Increased the number of rows for description-type input fields from 4 to 5
	- Removed maximum height restriction for input elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->