### PR TITLE
Project risk popup scroll

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
@@ -1,6 +1,5 @@
 import { FC, useState, useCallback, useMemo, lazy, Suspense, Dispatch, SetStateAction } from "react";
 import {
-  Button,
   Divider,
   SelectChangeEvent,
   Stack,
@@ -12,6 +11,7 @@ import { RISK_LABELS } from "../../RiskLevel/constants";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import selectValidation from "../../../../application/validations/selectValidation";
 import { MitigationFormValues } from "../interface";
+import styles from "../styles.module.css";
 
 // Lazy load components
 const Select = lazy(() => import("../../Inputs/Select"));
@@ -299,7 +299,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
           />
         </Suspense>
       )}
-      <Stack component="form" onSubmit={handleSubmit}>
+      <Stack component="form" onSubmit={handleSubmit} className={styles.popupBody}>
         <Stack sx={{ flexDirection: "row", columnGap: 12.5, mb: 8 }}>
           <Stack sx={{ rowGap: 8.5 }}>
             <Suspense fallback={<div>Loading...</div>}>
@@ -363,17 +363,19 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
           </Stack>
           <Stack sx={{ rowGap: 8.5 }}>
             <Suspense fallback={<div>Loading...</div>}>
-              <DatePicker
-                label="Start date"
-                date={mitigationValues.deadline ? dayjs(mitigationValues.deadline) : null}
-                handleDateChange={(e) => handleDateChange("deadline", e)}
-                sx={{
-                  width: 130,
-                  "& input": { width: 85 },
-                }}
-                isRequired
-                error={errors.deadline}
-              />
+              <Stack style={{ minWidth: "303px" }}>
+                <DatePicker
+                  label="Start date"
+                  date={mitigationValues.deadline ? dayjs(mitigationValues.deadline) : null}
+                  handleDateChange={(e) => handleDateChange("deadline", e)}
+                  sx={{
+                    width: 130,
+                    "& input": { width: 85 },
+                  }}
+                  isRequired
+                  error={errors.deadline}
+                />
+              </Stack>
             </Suspense>
             <Suspense fallback={<div>Loading...</div>}>
               <FileUpload onClose={() => {}} uploadProps={{}} open={false} />
@@ -460,7 +462,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
             isOptional
           />
         </Suspense>
-        <Button
+        {/* <Button
           type="submit"
           variant="contained"
           disableRipple={
@@ -480,7 +482,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
           }}
         >
           Save
-        </Button>
+        </Button> */}
       </Stack>
     </Stack>
   );

--- a/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
@@ -8,9 +8,7 @@ import {
 } from "@mui/material";
 import dayjs, { Dayjs } from "dayjs";
 import { RISK_LABELS } from "../../RiskLevel/constants";
-import { checkStringValidation } from "../../../../application/validations/stringValidation";
-import selectValidation from "../../../../application/validations/selectValidation";
-import { MitigationFormValues } from "../interface";
+import { MitigationFormValues, MitigationFormErrors } from "../interface";
 import styles from "../styles.module.css";
 
 // Lazy load components
@@ -21,38 +19,10 @@ const FileUpload = lazy(() => import("../../Modals/FileUpload"));
 const RiskLevel = lazy(() => import("../../RiskLevel"));
 const Alert = lazy(() => import("../../Alert"));
 
-// export interface MitigationFormValues {
-//   mitigationStatus: number;
-//   mitigationPlan: string;
-//   currentRiskLevel: number;
-//   implementationStrategy: string;
-//   deadline: string;
-//   doc: string;
-//   likelihood: Likelihood;
-//   riskSeverity: Severity;
-//   approver: number;
-//   approvalStatus: number;
-//   dateOfAssessment: string;
-//   recommendations: string;
-// }
-
 interface MitigationSectionProps {
-  closePopup: () => void;
   mitigationValues: MitigationFormValues;
   setMitigationValues: Dispatch<SetStateAction<MitigationFormValues>>;
-}
-
-interface FormErrors {
-  mitigationStatus?: string;
-  mitigationPlan?: string;
-  currentRiskLevel?: string;
-  implementationStrategy?: string;
-  deadline?: string;
-  doc?: string;
-  approver?: string;
-  approvalStatus?: string;
-  dateOfAssessment?: string;
-  recommendations?: string;
+  migitateErrors: MitigationFormErrors;
 }
 
 export enum MitigationStatus {
@@ -113,10 +83,10 @@ export enum MitigationStatus {
  * @requires selectValidation
  * @requires dayjs
  */
-const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationValues, setMitigationValues }) => {
+const MitigationSection: FC<MitigationSectionProps> = ({ mitigationValues, setMitigationValues, migitateErrors }) => {
   const theme = useTheme();
   // const [values, setValues] = useState<MitigationFormValues>(initialState);
-  const [errors, setErrors] = useState<FormErrors>({});
+  const [errors, setErrors] = useState<MitigationFormErrors>({});
   const [alert, setAlert] = useState<{
     variant: "success" | "info" | "warning" | "error";
     title?: string;
@@ -155,94 +125,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
         setErrors((prevErrors) => ({ ...prevErrors, [prop]: "" }));
       },
     []
-  );
-
-  const validateForm = useCallback((): boolean => {
-    const newErrors: FormErrors = {};
-
-    const mitigationPlan = checkStringValidation(
-      "Mitigation plan",
-      mitigationValues.mitigationPlan,
-      1,
-      1024
-    );
-    if (!mitigationPlan.accepted) {
-      newErrors.mitigationPlan = mitigationPlan.message;
-    }
-    const implementationStrategy = checkStringValidation(
-      "Implementation strategy",
-      mitigationValues.implementationStrategy,
-      1,
-      1024
-    );
-    if (!implementationStrategy.accepted) {
-      newErrors.implementationStrategy = implementationStrategy.message;
-    }
-    const recommendations = checkStringValidation(
-      "Recommendations",
-      mitigationValues.recommendations,
-      1,
-      1024
-    );
-    if (!recommendations.accepted) {
-      newErrors.recommendations = recommendations.message;
-    }
-    const deadline = checkStringValidation(
-      "Recommendations",
-      mitigationValues.deadline,
-      1
-    );
-    if (!deadline.accepted) {
-      newErrors.deadline = deadline.message;
-    }
-    const dateOfAssessment = checkStringValidation(
-      "Recommendations",
-      mitigationValues.dateOfAssessment,
-      1
-    );
-    if (!dateOfAssessment.accepted) {
-      newErrors.dateOfAssessment = dateOfAssessment.message;
-    }
-    const mitigationStatus = selectValidation(
-      "Mitigation status",
-      mitigationValues.mitigationStatus
-    );
-    if (!mitigationStatus.accepted) {
-      newErrors.mitigationStatus = mitigationStatus.message;
-    }
-    const currentRiskLevel = selectValidation(
-      "Current risk level",
-      mitigationValues.currentRiskLevel
-    );
-    if (!currentRiskLevel.accepted) {
-      newErrors.currentRiskLevel = currentRiskLevel.message;
-    }
-    const approver = selectValidation("Approver", mitigationValues.approver);
-    if (!approver.accepted) {
-      newErrors.approver = approver.message;
-    }
-    const approvalStatus = selectValidation(
-      "Approval status",
-      mitigationValues.approvalStatus
-    );
-    if (!approvalStatus.accepted) {
-      newErrors.approvalStatus = approvalStatus.message;
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  }, [mitigationValues]);
-
-  const handleSubmit = useCallback(
-    async (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      if (validateForm()) {
-        //request to the backend
-        closePopup();
-      }
-    },
-    [validateForm, closePopup]
-  );
+  );  
 
   const mitigationStatusItems = useMemo(
     () => [
@@ -299,7 +182,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
           />
         </Suspense>
       )}
-      <Stack component="form" onSubmit={handleSubmit} className={styles.popupBody}>
+      <Stack component="form" className={styles.popupBody}>
         <Stack sx={{ flexDirection: "row", columnGap: 12.5, mb: 8 }}>
           <Stack sx={{ rowGap: 8.5 }}>
             <Suspense fallback={<div>Loading...</div>}>
@@ -315,7 +198,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
                   backgroundColor: theme.palette.background.main,
                 }}
                 isRequired
-                error={errors.mitigationStatus}
+                error={migitateErrors.mitigationStatus}
               />
             </Suspense>
             <Suspense fallback={<div>Loading...</div>}>
@@ -327,7 +210,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
                 onChange={handleOnTextFieldChange("mitigationPlan")}
                 sx={{ backgroundColor: theme.palette.background.main }}
                 isRequired
-                error={errors.mitigationPlan}
+                error={migitateErrors.mitigationPlan}
               />
             </Suspense>
           </Stack>
@@ -345,7 +228,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
                   backgroundColor: theme.palette.background.main,
                 }}
                 isRequired
-                error={errors.currentRiskLevel}
+                error={migitateErrors.currentRiskLevel}
               />
             </Suspense>
             <Suspense fallback={<div>Loading...</div>}>
@@ -357,7 +240,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
                 onChange={handleOnTextFieldChange("implementationStrategy")}
                 sx={{ backgroundColor: theme.palette.background.main }}
                 isRequired
-                error={errors.implementationStrategy}
+                error={migitateErrors.implementationStrategy}
               />
             </Suspense>
           </Stack>
@@ -373,7 +256,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
                     "& input": { width: 85 },
                   }}
                   isRequired
-                  error={errors.deadline}
+                  error={migitateErrors.deadline}
                 />
               </Stack>
             </Suspense>
@@ -416,7 +299,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
                 backgroundColor: theme.palette.background.main,
               }}
               isRequired
-              error={errors.approver}
+              error={migitateErrors.approver}
             />
           </Suspense>
           <Suspense fallback={<div>Loading...</div>}>
@@ -432,7 +315,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
                 backgroundColor: theme.palette.background.main,
               }}
               isRequired
-              error={errors.approvalStatus}
+              error={migitateErrors.approvalStatus}
             />
           </Suspense>
           <Suspense fallback={<div>Loading...</div>}>
@@ -447,7 +330,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
                 "& input": { width: 85 },
               }}
               isRequired
-              error={errors.dateOfAssessment}
+              error={migitateErrors.dateOfAssessment}
             />
           </Suspense>
         </Stack>
@@ -462,27 +345,6 @@ const MitigationSection: FC<MitigationSectionProps> = ({ closePopup, mitigationV
             isOptional
           />
         </Suspense>
-        {/* <Button
-          type="submit"
-          variant="contained"
-          disableRipple={
-            theme.components?.MuiButton?.defaultProps?.disableRipple
-          }
-          sx={{
-            borderRadius: 2,
-            maxHeight: 34,
-            textTransform: "inherit",
-            backgroundColor: "#4C7DE7",
-            boxShadow: "none",
-            border: "1px solid #175CD3",
-            ml: "auto",
-            mr: 0,
-            mt: "30px",
-            "&:hover": { boxShadow: "none" },
-          }}
-        >
-          Save
-        </Button> */}
       </Stack>
     </Stack>
   );

--- a/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
@@ -8,30 +8,16 @@ import {
 import { FC, useState, useCallback, Suspense, Dispatch, SetStateAction } from "react";
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
-import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import Alert from "../../Alert";
-import selectValidation from "../../../../application/validations/selectValidation";
 import React from "react";
-import { RiskFormValues } from "../interface";
+import { RiskFormValues, RiskFormErrors } from "../interface";
 
 const RiskLevel = React.lazy(() => import("../../RiskLevel"));
 
 interface RiskSectionProps {
-  closePopup: () => void;
   riskValues: RiskFormValues;
   setRiskValues: Dispatch<SetStateAction<RiskFormValues>>;
-}
-
-interface FormErrors {
-  riskName?: string;
-  actionOwner?: string;
-  aiLifecyclePhase?: string;
-  riskDescription?: string;
-  riskCategory?: string;
-  potentialImpact?: string;
-  assessmentMapping?: string;
-  controlsMapping?: string;
-  reviewNotes?: string;
+  riskErrors: RiskFormErrors;
 }
 
 /**
@@ -63,10 +49,10 @@ interface FormErrors {
  * @example
  * <RiskSection closePopup={closePopupFunction} status="new" />
  */
-const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValues }) => {
+const RiskSection: FC<RiskSectionProps> = ({ riskValues, setRiskValues, riskErrors }) => {
   const theme = useTheme();
   // const [values, setValues] = useState<RiskFormValues>(initialState);
-  const [errors, setErrors] = useState<FormErrors>({});
+  const [errors, setErrors] = useState<RiskFormErrors>({});
   const [alert, setAlert] = useState<{
     variant: "success" | "info" | "warning" | "error";
     title?: string;
@@ -97,68 +83,6 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
     []
   );
 
-  const validateForm = useCallback((): boolean => {
-    const newErrors: FormErrors = {};
-
-    const riskName = checkStringValidation("Risk name", riskValues.riskName, 3, 50);
-    if (!riskName.accepted) {
-      newErrors.riskName = riskName.message;
-    }
-    const riskDescription = checkStringValidation(
-      "Risk description",
-      riskValues.riskDescription,
-      1,
-      256
-    );
-    if (!riskDescription.accepted) {
-      newErrors.riskDescription = riskDescription.message;
-    }
-    const potentialImpact = checkStringValidation(
-      "Potential impact",
-      riskValues.potentialImpact,
-      1,
-      256
-    );
-    if (!potentialImpact.accepted) {
-      newErrors.potentialImpact = potentialImpact.message;
-    }
-    const reviewNotes = checkStringValidation(
-      "Review notes",
-      riskValues.reviewNotes,
-      0,
-      1024
-    );
-    if (!reviewNotes.accepted) {
-      newErrors.reviewNotes = reviewNotes.message;
-    }
-    const actionOwner = selectValidation("Action owner", riskValues.actionOwner);
-    if (!actionOwner.accepted) {
-      newErrors.actionOwner = actionOwner.message;
-    }
-    const aiLifecyclePhase = selectValidation(
-      "AI lifecycle phase",
-      riskValues.aiLifecyclePhase
-    );
-    if (!aiLifecyclePhase.accepted) {
-      newErrors.aiLifecyclePhase = aiLifecyclePhase.message;
-    }
-    const riskCategory = selectValidation("Risk category", riskValues.riskCategory);
-    if (!riskCategory.accepted) {
-      newErrors.riskCategory = riskCategory.message;
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0; // Return true if no errors exist
-  }, [riskValues]);
-
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (validateForm()) {
-      //request to the backend      
-      closePopup();
-    }
-  };
-
   return (
     <Stack>
       {alert && (
@@ -173,7 +97,6 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
       <Stack
         className="AddNewRiskForm"
         component="form"
-        onSubmit={handleSubmit}
       >
         <Stack sx={{ width: "100%", mb: 10 }}>
           <Stack sx={{ gap: 8.5 }}>
@@ -199,7 +122,7 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
                   width: "325px",
                 }}
                 isRequired
-                error={errors.riskName}
+                error={riskErrors.riskName}
               />
               <Select
                 id="action-owner-input"
@@ -213,7 +136,7 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
                   { _id: 3, name: "Owner 3" },
                 ]}
                 isRequired
-                error={errors.actionOwner}
+                error={riskErrors.actionOwner}
                 sx={{
                   width: "325px",
                 }}
@@ -230,7 +153,7 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
                   { _id: 3, name: "Phase 3" },
                 ]}
                 isRequired
-                error={errors.aiLifecyclePhase}
+                error={riskErrors.aiLifecyclePhase}
                 sx={{
                   width: "325px",
                 }}
@@ -255,7 +178,7 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
                   value={riskValues.riskDescription}
                   onChange={handleOnTextFieldChange("riskDescription")}
                   isRequired
-                  error={errors.riskDescription}
+                  error={riskErrors.riskDescription}
                   sx={{
                     width: "325px",
                   }}
@@ -272,7 +195,7 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
                     { _id: 3, name: "Category 3" },
                   ]}
                   isRequired
-                  error={errors.riskCategory}
+                  error={riskErrors.riskCategory}
                   sx={{
                     width: "325px",
                   }}
@@ -286,7 +209,7 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
                 value={riskValues.potentialImpact}
                 onChange={handleOnTextFieldChange("potentialImpact")}
                 isRequired
-                error={errors.potentialImpact}
+                error={riskErrors.potentialImpact}
                 sx={{
                   width: "670px",
                   height: "120px",
@@ -330,34 +253,9 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValu
               },
             }}
             isOptional
-            error={errors.reviewNotes}
+            error={riskErrors.reviewNotes}
           />
         </Stack>
-        {/* <Button
-          type="submit"
-          variant="contained"
-          disableRipple={
-            theme.components?.MuiButton?.defaultProps?.disableRipple
-          }
-          sx={{
-            borderRadius: 2,
-            maxHeight: 34,
-            textTransform: "inherit",
-            backgroundColor: "#4C7DE7",
-            boxShadow: "none",
-            border: "1px solid #175CD3",
-            ml: "auto",
-            mr: 0,
-            mt: "30px",
-            "&:hover": { boxShadow: "none" },
-          }}
-        >
-          {status === "new" ? (
-            <Typography>Save</Typography>
-          ) : (
-            <Typography>Update</Typography>
-          )}
-        </Button> */}
       </Stack>
     </Stack>
   );

--- a/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
@@ -3,7 +3,6 @@ import {
   Divider,
   Typography,
   useTheme,
-  Button,
   SelectChangeEvent,
 } from "@mui/material";
 import { FC, useState, useCallback, Suspense, Dispatch, SetStateAction } from "react";
@@ -19,7 +18,6 @@ const RiskLevel = React.lazy(() => import("../../RiskLevel"));
 
 interface RiskSectionProps {
   closePopup: () => void;
-  status: string;
   riskValues: RiskFormValues;
   setRiskValues: Dispatch<SetStateAction<RiskFormValues>>;
 }
@@ -65,7 +63,7 @@ interface FormErrors {
  * @example
  * <RiskSection closePopup={closePopupFunction} status="new" />
  */
-const RiskSection: FC<RiskSectionProps> = ({ closePopup, status, riskValues, setRiskValues }) => {
+const RiskSection: FC<RiskSectionProps> = ({ closePopup, riskValues, setRiskValues }) => {
   const theme = useTheme();
   // const [values, setValues] = useState<RiskFormValues>(initialState);
   const [errors, setErrors] = useState<FormErrors>({});
@@ -335,7 +333,7 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, status, riskValues, set
             error={errors.reviewNotes}
           />
         </Stack>
-        <Button
+        {/* <Button
           type="submit"
           variant="contained"
           disableRipple={
@@ -359,7 +357,7 @@ const RiskSection: FC<RiskSectionProps> = ({ closePopup, status, riskValues, set
           ) : (
             <Typography>Update</Typography>
           )}
-        </Button>
+        </Button> */}
       </Stack>
     </Stack>
   );

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -7,6 +7,9 @@ import "./styles.module.css";
 import { Likelihood, Severity } from "../RiskLevel/constants";
 import { RiskFormValues, RiskFormErrors, MitigationFormValues, MitigationFormErrors } from "./interface";
 
+import { checkStringValidation } from "../../../application/validations/stringValidation";
+import selectValidation from "../../../application/validations/selectValidation";
+
 const RiskSection = lazy(() => import("./RisksSection"));
 const MitigationSection = lazy(() => import("./MitigationSection"));
 
@@ -69,6 +72,8 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
   const disableRipple =
     theme.components?.MuiButton?.defaultProps?.disableRipple;
   
+  const [riskErrors, setRiskErrors] = useState<RiskFormErrors>({});
+  const [migitateErrors, setMigitateErrors] = useState<MitigationFormErrors>({});
   const [riskValues, setRiskValues] = useState<RiskFormValues>(riskInitialState);
   const [mitigationValues, setMitigationValues] = useState<MitigationFormValues>(mitigationInitialState);
   const [value, setValue] = useState("risks");
@@ -90,6 +95,142 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
     }),
     []
   );
+
+  const validateForm = useCallback((): boolean => {
+    const newErrors: RiskFormErrors = {};
+    const newMitigationErrors: MitigationFormErrors = {};
+
+    const riskName = checkStringValidation("Risk name", riskValues.riskName, 3, 50);
+    if (!riskName.accepted) {
+      newErrors.riskName = riskName.message;
+    }
+    const riskDescription = checkStringValidation(
+      "Risk description",
+      riskValues.riskDescription,
+      1,
+      256
+    );
+    if (!riskDescription.accepted) {
+      newErrors.riskDescription = riskDescription.message;
+    }
+    const potentialImpact = checkStringValidation(
+      "Potential impact",
+      riskValues.potentialImpact,
+      1,
+      256
+    );
+    if (!potentialImpact.accepted) {
+      newErrors.potentialImpact = potentialImpact.message;
+    }
+    const reviewNotes = checkStringValidation(
+      "Review notes",
+      riskValues.reviewNotes,
+      0,
+      1024
+    );
+    if (!reviewNotes.accepted) {
+      newErrors.reviewNotes = reviewNotes.message;
+    }
+    const actionOwner = selectValidation("Action owner", riskValues.actionOwner);
+    if (!actionOwner.accepted) {
+      newErrors.actionOwner = actionOwner.message;
+    }
+    const aiLifecyclePhase = selectValidation(
+      "AI lifecycle phase",
+      riskValues.aiLifecyclePhase
+    );
+    if (!aiLifecyclePhase.accepted) {
+      newErrors.aiLifecyclePhase = aiLifecyclePhase.message;
+    }
+    const riskCategory = selectValidation("Risk category", riskValues.riskCategory);
+    if (!riskCategory.accepted) {
+      newErrors.riskCategory = riskCategory.message;
+    }
+
+    const mitigationPlan = checkStringValidation(
+      "Mitigation plan",
+      mitigationValues.mitigationPlan,
+      1,
+      1024
+    );
+    if (!mitigationPlan.accepted) {
+      newMitigationErrors.mitigationPlan = mitigationPlan.message;
+    }
+    const implementationStrategy = checkStringValidation(
+      "Implementation strategy",
+      mitigationValues.implementationStrategy,
+      1,
+      1024
+    );
+    if (!implementationStrategy.accepted) {
+      newMitigationErrors.implementationStrategy = implementationStrategy.message;
+    }
+    // const recommendations = checkStringValidation(
+    //   "Recommendations",
+    //   mitigationValues.recommendations,
+    //   1,
+    //   1024
+    // );
+    // if (!recommendations.accepted) {
+    //   newMitigationErrors.recommendations = recommendations.message;
+    // }
+    const deadline = checkStringValidation(
+      "Deadline",
+      mitigationValues.deadline,
+      1
+    );
+    if (!deadline.accepted) {
+      newMitigationErrors.deadline = deadline.message;
+    }
+    const dateOfAssessment = checkStringValidation(
+      "Date Of Assessment",
+      mitigationValues.dateOfAssessment,
+      1
+    );
+    if (!dateOfAssessment.accepted) {
+      newMitigationErrors.dateOfAssessment = dateOfAssessment.message;
+    }
+    const mitigationStatus = selectValidation(
+      "Mitigation status",
+      mitigationValues.mitigationStatus
+    );
+    if (!mitigationStatus.accepted) {
+      newMitigationErrors.mitigationStatus = mitigationStatus.message;
+    }
+    const currentRiskLevel = selectValidation(
+      "Current risk level",
+      mitigationValues.currentRiskLevel
+    );
+    if (!currentRiskLevel.accepted) {
+      newMitigationErrors.currentRiskLevel = currentRiskLevel.message;
+    }
+    const approver = selectValidation("Approver", mitigationValues.approver);
+    if (!approver.accepted) {
+      newMitigationErrors.approver = approver.message;
+    }
+    const approvalStatus = selectValidation(
+      "Approval status",
+      mitigationValues.approvalStatus
+    );
+    if (!approvalStatus.accepted) {
+      newMitigationErrors.approvalStatus = approvalStatus.message;
+    }
+
+    setMigitateErrors(newMitigationErrors);
+    setRiskErrors(newErrors);
+
+    return Object.keys(newErrors).length === 0 && Object.keys(newMitigationErrors).length === 0;  // Return true if no errors exist    
+  }, [riskValues, mitigationValues]);
+
+  const riskFormSubmitHandler = () => {
+    // check forms validate    
+    if(validateForm()){
+      // call backend 
+      closePopup();
+    }else{
+      console.log('validation fails')
+    }
+  }
 
   return (
     <Stack>
@@ -119,15 +260,16 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
         </Box>
         <Suspense fallback={<div>Loading...</div>}>
           <TabPanel value="risks" sx={{ p: "24px 0 0" }}>
-            <RiskSection closePopup={closePopup} riskValues={riskValues} setRiskValues={setRiskValues}/>
+            <RiskSection riskValues={riskValues} setRiskValues={setRiskValues} riskErrors={riskErrors}/>
           </TabPanel>
           <TabPanel value="mitigation" sx={{ p: "24px 0 0" }}>
-            <MitigationSection closePopup={closePopup} mitigationValues={mitigationValues} setMitigationValues={setMitigationValues} />
+            <MitigationSection mitigationValues={mitigationValues} setMitigationValues={setMitigationValues} migitateErrors={migitateErrors} />
           </TabPanel>
         </Suspense>
         <Box sx={{ display: 'flex'}}>
           <Button
-            type="button"            
+            type="submit" 
+            onClick={riskFormSubmitHandler}           
             variant="contained"
             disableRipple={
               theme.components?.MuiButton?.defaultProps?.disableRipple

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -1,11 +1,11 @@
 import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
-import { Box, Stack, Tab, useTheme } from "@mui/material";
+import { Box, Stack, Tab, useTheme, Typography, Button } from "@mui/material";
 import { FC, useState, useCallback, useMemo, lazy, Suspense } from "react";
-import "./styles.css";
+import "./styles.module.css";
 import { Likelihood, Severity } from "../RiskLevel/constants";
-import { RiskFormValues, MitigationFormValues } from "./interface";
+import { RiskFormValues, RiskFormErrors, MitigationFormValues, MitigationFormErrors } from "./interface";
 
 const RiskSection = lazy(() => import("./RisksSection"));
 const MitigationSection = lazy(() => import("./MitigationSection"));
@@ -119,12 +119,39 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
         </Box>
         <Suspense fallback={<div>Loading...</div>}>
           <TabPanel value="risks" sx={{ p: "24px 0 0" }}>
-            <RiskSection closePopup={closePopup} status={popupStatus} riskValues={riskValues} setRiskValues={setRiskValues} />
+            <RiskSection closePopup={closePopup} riskValues={riskValues} setRiskValues={setRiskValues}/>
           </TabPanel>
           <TabPanel value="mitigation" sx={{ p: "24px 0 0" }}>
             <MitigationSection closePopup={closePopup} mitigationValues={mitigationValues} setMitigationValues={setMitigationValues} />
           </TabPanel>
         </Suspense>
+        <Box sx={{ display: 'flex'}}>
+          <Button
+            type="button"            
+            variant="contained"
+            disableRipple={
+              theme.components?.MuiButton?.defaultProps?.disableRipple
+            }
+            sx={{
+              borderRadius: 2,
+              maxHeight: 34,
+              textTransform: "inherit",
+              backgroundColor: "#4C7DE7",
+              boxShadow: "none",
+              border: "1px solid #175CD3",
+              ml: "auto",
+              mr: 0,
+              mt: "30px",
+              "&:hover": { boxShadow: "none" },
+            }}
+          >
+            {popupStatus === "new" ? (
+              <Typography>Save</Typography>
+            ) : (
+              <Typography>Update</Typography>
+            )}
+          </Button>
+        </Box>
       </TabContext>
     </Stack>
   );

--- a/Clients/src/presentation/components/AddNewRiskForm/interface.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/interface.tsx
@@ -15,6 +15,18 @@ export interface RiskFormValues {
     reviewNotes: string;
 }
 
+export interface RiskFormErrors {
+    riskName?: string;
+    actionOwner?: string;
+    aiLifecyclePhase?: string;
+    riskDescription?: string;
+    riskCategory?: string;
+    potentialImpact?: string;
+    assessmentMapping?: string;
+    controlsMapping?: string;
+    reviewNotes?: string;
+}
+
 export interface MitigationFormValues {
     mitigationStatus: number;
     mitigationPlan: string;
@@ -29,3 +41,16 @@ export interface MitigationFormValues {
     dateOfAssessment: string;
     recommendations: string;
 }
+
+export interface MitigationFormErrors {
+    mitigationStatus?: string;
+    mitigationPlan?: string;
+    currentRiskLevel?: string;
+    implementationStrategy?: string;
+    deadline?: string;
+    doc?: string;
+    approver?: string;
+    approvalStatus?: string;
+    dateOfAssessment?: string;
+    recommendations?: string;
+  }

--- a/Clients/src/presentation/components/AddNewRiskForm/interface.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/interface.tsx
@@ -53,4 +53,4 @@ export interface MitigationFormErrors {
     approvalStatus?: string;
     dateOfAssessment?: string;
     recommendations?: string;
-  }
+}

--- a/Clients/src/presentation/components/AddNewRiskForm/styles.css
+++ b/Clients/src/presentation/components/AddNewRiskForm/styles.css
@@ -1,7 +1,0 @@
-#add-new-risk-popup {
-    padding: 3% 0;
-    align-items: flex-start!important;
-}
-/* #add-new-risk-popup > div {
-    height: 100%
-} */

--- a/Clients/src/presentation/components/AddNewRiskForm/styles.module.css
+++ b/Clients/src/presentation/components/AddNewRiskForm/styles.module.css
@@ -1,0 +1,17 @@
+#add-new-risk-popup {
+    padding: 3% 0;
+    align-items: flex-start!important;
+}
+.popupBody{
+    overflow: auto; 
+    height: calc(100vh - 309px);
+    /* height: 572.08px; */
+}
+.popupBody::-webkit-scrollbar-track {
+    box-shadow: inset 0 0 3px transparent; 
+    border-radius: 8px;
+}
+/* #add-new-risk-popup > div {
+    height: 100%
+} */
+


### PR DESCRIPTION
## Describe your changes

- Display scroll at mitigation tab 
- Combine "save" button in the main risk form component, previously there were two "save" functions written for each tab in risk-section component and mitigation-section component
- Add form validation in the main risk form component to validate both risk and mitigation forms 

https://github.com/user-attachments/assets/3e16bbfe-a748-453c-a0d3-17b0e5774bef

## Issue number

Mention the issue number(s) this PR addresses (#472 ).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced form validation for Risk and Mitigation sections
  - Added comprehensive error handling for form inputs

- **Improvements**
  - Refined error management across Risk and Mitigation form components
  - Updated form submission process with more robust validation
  - Improved user feedback for form errors

- **Changes**
  - Removed `closePopup` functionality from some components
  - Restructured error state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->