### PR TITLE
Add delete modal backdrop and disable click on it

### DIFF
--- a/Clients/src/presentation/components/Modals/InviteUser/index.tsx
+++ b/Clients/src/presentation/components/Modals/InviteUser/index.tsx
@@ -40,7 +40,12 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({
   };
 
   return (
-    <Modal open={isOpen} onClose={() => setIsOpen(false)}>
+    <Modal open={isOpen}
+    onClose={(_event, reason) => {
+      if (reason !== 'backdropClick') {
+          setIsOpen(false);
+      }
+    }}>
       <Stack
         gap={theme.spacing(2)}
         color={theme.palette.text.secondary}

--- a/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
@@ -17,17 +17,13 @@ import {
   useTheme,
   SelectChangeEvent,
   TablePagination,
-  Dialog,
-  DialogTitle,
-  DialogContentText,
-  DialogContent,
-  DialogActions,
 } from "@mui/material";
 import Trashbin from "../../../../presentation/assets/icons/trash-01.svg";
 import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
 import TablePaginationActions from "../../../components/TablePagination";
 import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import InviteUserModal from "../../../components/Modals/InviteUser";
+import DualButtonModal from "../../../vw-v2-components/Dialogs/DualButtonModal";
 
 // Enum for roles
 enum Role {
@@ -336,58 +332,23 @@ const TeamManagement: React.FC = (): JSX.Element => {
             </Table>
           </TableContainer>
 
-          <Dialog
-            open={open}
-            onClose={handleClose}
-            sx={{
-              maxWidth: "440px",
-              position: "absolute",
-              top: "50%",
-              left: "50%",
-              padding: "32px",
-              transform: "translate(-50%, -50%)",
-              "& .MuiDialog-paper": {
-                borderRadius: "8px",
-                boxShadow: "0 0px 0px rgba(0, 0, 0, 0.1)",
-                backgroundColor: "white",
-                padding: "32px",
-                margin: "0px",
-              },
-              "& .MuiBackdrop-root": {
-                backgroundColor: "rgba(0, 0, 0, 0)",
-              },
-              "& .css-7znkgh-MuiModal-root-MuiDialog-root": {
-                backgroundColor: "rgba(0, 0, 0, 0)",
-              },
-              "& .MuiDialog-container": {
-                backgroundColor: "rgba(0, 0, 0, 0)",
-              },
-            }}
-          >
-            <DialogTitle
-              sx={{ color: "#344054", fontSize: "16px", paddingBottom: "13px" }}
-            >
-              Confirm Delete
-            </DialogTitle>
-            <DialogContent>
-              <DialogContentText sx={{ color: "#344054", fontSize: "13px" }}>
-                Are you sure you want to delete this team member? This action
-                cannot be undone.
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions sx={{ padding: "0px 0px" }}>
-              <Button onClick={handleClose} sx={{ color: "black" }}>
-                Cancel
-              </Button>
-              <Button
-                onClick={confirmDelete}
-                sx={{ backgroundColor: "#DB504A", height: "32px" }}
-                variant="contained"
-              >
-                Delete
-              </Button>
-            </DialogActions>
-          </Dialog>
+          {open && (
+            <DualButtonModal
+              title="Confirm Delete"
+              body={
+                <Typography fontSize={13}>
+                  Are you sure you want to delete your account? This action is
+                  permanent and cannot be undone.
+                </Typography>
+              }
+              cancelText="Cancel"
+              proceedText="Delete"
+              onCancel={handleClose}
+              onProceed={confirmDelete}
+              proceedButtonColor="error"
+              proceedButtonVariant="contained"
+            />
+          )}
 
           <TablePagination
             count={dashboardValues.vendors.length}


### PR DESCRIPTION
## Describe your changes

- Add delete modal backdrop and disable click on the modal's backdrop for team member.

https://github.com/user-attachments/assets/8c97fb06-8a00-4b0c-939d-13aec8737393

## Issue number

Mention the issue number(s) this PR addresses (#527 ).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced modal interaction to prevent accidental closures
	- Replaced team member deletion confirmation dialog with a more specialized modal component

- **Improvements**
	- Updated modal closing behavior to improve user experience
	- Refined deletion confirmation process with clearer messaging about permanent actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->