### PR TITLE
086 Jan 31: Send `assessment_id` when sending Projects

### DIFF
--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -4409,6 +4409,9 @@ components:
         last_updated_by:
           type: integer
           example: 1
+        assessment_id:
+          type: integer
+          example: 1
     ProjectRisk:
       type: object
       properties:

--- a/Servers/utils/project.utils.ts
+++ b/Servers/utils/project.utils.ts
@@ -4,6 +4,10 @@ import pool from "../database/db";
 export const getAllProjectsQuery = async (): Promise<Project[]> => {
   console.log("getAllProjects");
   const projects = await pool.query("SELECT * FROM projects");
+  for (let project of projects.rows) {
+    const assessment = await pool.query(`SELECT id FROM assessments WHERE project_id = $1`, [project.id])
+    project["assessment_id"] = assessment.rows[0].id
+  }
   return projects.rows;
 };
 
@@ -12,7 +16,11 @@ export const getProjectByIdQuery = async (
 ): Promise<Project | null> => {
   console.log("getProjectById", id);
   const result = await pool.query("SELECT * FROM projects WHERE id = $1", [id]);
-  return result.rows.length ? result.rows[0] : null;
+  if (result.rows.length === 0) return null;
+  const project = result.rows[0];
+  const assessment = await pool.query(`SELECT id FROM assessments WHERE project_id = $1`, [project.id]);
+  project["assessment_id"] = assessment.rows[0].id
+  return project
 };
 
 export const createNewProjectQuery = async (


### PR DESCRIPTION
## Describe your changes

- Added code change to send `assessment_id` when getting projects

CC: @samuel-coutinho 

## Issue number

NA

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for associating projects with assessments
	- Enhanced project data retrieval to include assessment identifiers

- **Bug Fixes**
	- Improved project query handling to return `null` when no project is found

The release notes highlight the introduction of an `assessment_id` to the project schema and updates to project retrieval functions to support this new relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->