### PR TITLE
Limit word for long text in risk table value

### DIFF
--- a/Clients/src/presentation/components/Table/index.tsx
+++ b/Clients/src/presentation/components/Table/index.tsx
@@ -197,8 +197,8 @@ const BasicTable = ({
                 >
                   {label === "Project risk" ? (
                     <>
-                      <TableCell>{row.risk_name}</TableCell>
-                      <TableCell>{row.impact}</TableCell>
+                      <TableCell>{(row.risk_name.length > 30) ? row.risk_name.slice(0, 30) + `...` : row.risk_name}</TableCell>
+                      <TableCell>{(row.impact.length > 30) ? row.impact.slice(0, 30) + `...` : row.impact}</TableCell>
                       <TableCell>{row.risk_owner}</TableCell>
                       <TableCell>{row.severity}</TableCell>
                       <TableCell>{row.likelihood}</TableCell>
@@ -209,7 +209,7 @@ const BasicTable = ({
                   ) : (
                     <>
                       <TableCell>{row.vendor_name}</TableCell>
-                      <TableCell>{row.risk_name}</TableCell>
+                      <TableCell>{(row.risk_name.length > 30) ? row.risk_name.slice(0,30) + `...` : row.risk_name}</TableCell>
                       <TableCell>{row.owner}</TableCell>
                       <TableCell>{row.risk_level}</TableCell>
                       <TableCell>


### PR DESCRIPTION
## Describe your changes

- Limit word for long description and text in project-risk and vendor-risk tables

![Frame 6 (1)](https://github.com/user-attachments/assets/1164bc9f-6be1-4ed0-a844-9a9ca8141668)

## Issue number

Mention the issue number(s) this PR addresses (#732).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved table display by truncating lengthy "Project risk" details to a maximum of 30 characters with an ellipsis, ensuring a cleaner and more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->