### PR TITLE
Add risk categories in add-new-risk popup

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
@@ -12,6 +12,7 @@ import {
   Suspense,
   Dispatch,
   SetStateAction,
+  useMemo
 } from "react";
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
@@ -72,6 +73,27 @@ const RiskSection: FC<RiskSectionProps> = ({
     body: string;
   } | null>(null);
   const {users, loading, error } = useUsers();
+
+  const riskCategorylItems = useMemo(
+    () => [
+      { _id: 1, name: "Strategic risk" },
+      { _id: 2, name: "Operational risk" },
+      { _id: 3, name: "Compliance risk" },
+      { _id: 4, name: "Financial risk" },
+      { _id: 5, name: "Cybersecurity risk" },
+      { _id: 6, name: "Reputational risk" },
+      { _id: 7, name: "Legal risk" },
+      { _id: 8, name: "Technological risk" },
+      { _id: 9, name: "Third-party/vendor risk" },
+      { _id: 10, name: "Environmental risk"},
+      { _id: 11, name: "Human resources risk"},
+      { _id: 12, name: "Geopolitical risk"},
+      { _id: 13, name: "Fraud risk"},
+      { _id: 14, name: "Data privacy risk"},
+      { _id: 15, name: "Health and safety risk"}
+    ],
+    []
+  );
 
   const handleOnSelectChange = useCallback(
     (prop: keyof RiskFormValues) =>
@@ -197,11 +219,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                   placeholder="Select category"
                   value={riskValues.riskCategory}
                   onChange={handleOnSelectChange("riskCategory")}
-                  items={[
-                    { _id: 1, name: "Category 1" },
-                    { _id: 2, name: "Category 2" },
-                    { _id: 3, name: "Category 3" },
-                  ]}
+                  items={riskCategorylItems}
                   isRequired
                   error={riskErrors.riskCategory}
                   sx={{


### PR DESCRIPTION
## Describe your changes

- Add risk categories in add-new-risk popup
- 
<img width="379" alt="Screenshot 2025-02-07 at 5 19 09 AM" src="https://github.com/user-attachments/assets/240846f9-f235-44cf-9f9c-102a4b85de46" />

## Issue number

Mention the issue number(s) this PR addresses (#747 ).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The risk input form's category dropdown has been updated to dynamically generate its options. This enhancement optimizes performance and provides a more consistent, streamlined experience when entering risk details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->