### PR TITLE
Fix scroll height in project-risk popup

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/styles.module.css
+++ b/Clients/src/presentation/components/AddNewRiskForm/styles.module.css
@@ -5,7 +5,7 @@
 .popupBody {
   padding: 10px;
   overflow: auto;
-  height: calc(100vh - 309px);
+  max-height: calc(100vh - 309px);
   /* height: 572.08px; */
 }
 .popupBody::-webkit-scrollbar-track {


### PR DESCRIPTION
## Describe your changes

- Remove extra space at the bottom of the project-risk modal
- Change height into max-height for form scroll 

## Issue number

Mention the issue number(s) this PR addresses (#748).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


https://github.com/user-attachments/assets/1ef3f456-33f4-4239-8cd3-d453f41c9563

