### PR TITLE
Fix project layout for project lists in dashboard

### DIFF
--- a/Clients/src/presentation/pages/Home/index.tsx
+++ b/Clients/src/presentation/pages/Home/index.tsx
@@ -403,14 +403,16 @@ const Home: FC<HomeProps> = ({ onProjectUpdate }) => {
               {projects.length <= 3 ? (
                 <>
                   {projects.map((item: ProjectCardProps) => (
-                    <ProjectCard
-                      key={item.id}
-                      {...item}
-                      id={item.id}
-                      assessments={assessments}
-                      controls={controls}
-                      last_updated={item.last_updated}
-                    />
+                    <Box key={item.id} sx={{ width: projects.length === 1 ? '50%' : '100%' }}>
+                      <ProjectCard
+                        key={item.id}
+                        {...item}
+                        id={item.id}
+                        assessments={assessments}
+                        controls={controls}
+                        last_updated={item.last_updated}
+                      />
+                    </Box>
                   ))}
                 </>
               ) : (


### PR DESCRIPTION
## Describe your changes

- Re-adding the condition for project layout: When there is only one project, display the width of the box into 1:2 ratio

<img width="1468" alt="Screenshot 2025-02-15 at 11 32 25 PM" src="https://github.com/user-attachments/assets/7a972ede-3f2a-42e7-b47d-2d6bd7a672a3" />

## Issue number

Mention the issue number(s) this PR addresses (#482 ).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Home page project display with an adaptive layout. When fewer projects are shown, the interface automatically adjusts to offer a more balanced and spacious presentation, while the grid view remains consistent for larger project collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->