### PR TITLE
Show no risk data status in project risk table

### DIFF
--- a/Clients/src/presentation/vw-v2-components/Table/index.tsx
+++ b/Clients/src/presentation/vw-v2-components/Table/index.tsx
@@ -18,6 +18,7 @@ import { ProjectRisk } from "../../../domain/ProjectRisk";
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
 import { RISK_LABELS } from "../../components/RiskLevel/constants";
 import IconButton from "../../components/IconButton";
+import placeholderImage from "../../assets/imgs/empty-state.svg"
 
 const riskLevelChecker = (score: string) => {
   const parsedScore = parseInt(score, 10);
@@ -193,6 +194,7 @@ const VWProjectRisksTable = ({
           }}
         >
           <VWProjectRisksTableHead columns={columns} />
+          {rows.length !== 0 ? 
           <VWProjectRisksTableBody
             rows={rows}
             page={page}
@@ -200,7 +202,24 @@ const VWProjectRisksTable = ({
             setSelectedRow={setSelectedRow}
             setAnchorEl={setAnchorEl}
             onDeleteRisk={deleteRisk}
-          />
+          /> : <>
+            <TableBody>
+              <TableRow>
+                <TableCell 
+                  colSpan={8} 
+                  align="center"
+                  style={{
+                    padding: theme.spacing(15, 5),
+                    paddingBottom: theme.spacing(20)
+                  }}>
+                  <img src={placeholderImage} alt="Placeholder" />
+                  <Typography sx={{ fontSize: "13px", color: "#475467" }}>
+                    There is currently no data in this table.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </>} 
         </Table>
       </TableContainer>
       <Stack


### PR DESCRIPTION
## Describe your changes

- Display no risk data status in project risk table as the same UI layout displayed in vendor and vendor-risk page

## Issue number

Mention the issue number(s) this PR addresses (e.g., #885).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1333" alt="Screenshot 2025-03-12 at 6 59 04 PM" src="https://github.com/user-attachments/assets/5dba06c6-5d5f-4753-87ab-9381dd94d91c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the table component’s empty state by displaying a clear placeholder image and an informative message when no data is available. This update improves the visual feedback and user experience when viewing tables without records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->