### PR TITLE
Implementing vw placeholder and loading in project risk view

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
@@ -2,7 +2,6 @@ import {
   FC,
   useState,
   useCallback,
-  useMemo,
   lazy,
   Suspense,
   Dispatch,
@@ -16,7 +15,6 @@ import {
   useTheme,
 } from "@mui/material";
 import dayjs, { Dayjs } from "dayjs";
-import { RISK_LABELS } from "../../RiskLevel/constants";
 import { MitigationFormValues, MitigationFormErrors } from "../interface";
 import styles from "../styles.module.css";
 import useUsers from "../../../../application/hooks/useUsers";
@@ -242,7 +240,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                   date={
                     mitigationValues.deadline
                       ? dayjs(mitigationValues.deadline)
-                      : null
+                      : dayjs(new Date())
                   }
                   handleDateChange={(e) => handleDateChange("deadline", e)}
                   sx={{
@@ -330,7 +328,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
               date={
                 mitigationValues.dateOfAssessment
                   ? dayjs(mitigationValues.dateOfAssessment)
-                  : null
+                  : dayjs(new Date())
               }
               handleDateChange={(e) => handleDateChange("dateOfAssessment", e)}
               sx={{

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -376,13 +376,13 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
     }
     if(mitigationValues.recommendations.length > 0) {
       const recommendations = checkStringValidation(
-        "Mitigation plan",
+        "Recommendation",
         mitigationValues.recommendations,
         1,
         1024
       );
       if (!recommendations.accepted) {
-        newMitigationErrors.recommendations = mitigationPlan.message;
+        newMitigationErrors.recommendations = recommendations.message;
       }
     }    
 

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -42,7 +42,6 @@ import {
 import VWButton from "../../vw-v2-components/Buttons";
 import SaveIcon from "@mui/icons-material/Save";
 import UpdateIcon from "@mui/icons-material/Update";
-import VWToast from "../../vw-v2-components/Toast";
 
 const RiskSection = lazy(() => import("./RisksSection"));
 const MitigationSection = lazy(() => import("./MitigationSection"));
@@ -280,15 +279,19 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
     if (!potentialImpact.accepted) {
       newErrors.potentialImpact = potentialImpact.message;
     }
-    const reviewNotes = checkStringValidation(
-      "Review notes",
-      riskValues.reviewNotes,
-      0,
-      1024
-    );
-    if (!reviewNotes.accepted) {
-      newErrors.reviewNotes = reviewNotes.message;
+
+    if(riskValues.reviewNotes.length > 0){
+      const reviewNotes = checkStringValidation(
+        "Review notes",
+        riskValues.reviewNotes,
+        0,
+        1024
+      );
+      if (!reviewNotes.accepted) {
+        newErrors.reviewNotes = reviewNotes.message;
+      }
     }
+    
     const actionOwner = selectValidation(
       "Action owner",
       riskValues.actionOwner
@@ -371,6 +374,17 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
     if (!approvalStatus.accepted) {
       newMitigationErrors.approvalStatus = approvalStatus.message;
     }
+    if(mitigationValues.recommendations.length > 0) {
+      const recommendations = checkStringValidation(
+        "Mitigation plan",
+        mitigationValues.recommendations,
+        1,
+        1024
+      );
+      if (!recommendations.accepted) {
+        newMitigationErrors.recommendations = mitigationPlan.message;
+      }
+    }    
 
     setMigitateErrors(newMitigationErrors);
     setRiskErrors(newErrors);

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -42,6 +42,7 @@ import {
 import VWButton from "../../vw-v2-components/Buttons";
 import SaveIcon from "@mui/icons-material/Save";
 import UpdateIcon from "@mui/icons-material/Update";
+import VWToast from "../../vw-v2-components/Toast";
 
 const RiskSection = lazy(() => import("./RisksSection"));
 const MitigationSection = lazy(() => import("./MitigationSection"));
@@ -53,6 +54,7 @@ interface AddNewRiskFormProps {
   initialMitigationValues?: MitigationFormValues; // New prop for initial values
   onSuccess: () => void;
   onError?: (message: any) => void;
+  onLoading?: (message: any) => void;
 }
 
 interface ApiResponse {
@@ -110,6 +112,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
   closePopup,
   onSuccess,
   onError = () => {},
+  onLoading = () => {},
   popupStatus,
   initialRiskValues = riskInitialState, // Default to initial state if not provided
   initialMitigationValues = mitigationInitialState,
@@ -398,6 +401,10 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
 
     // check forms validate
     if (isValid) {
+      onLoading(popupStatus !== "new" ? 
+      "Updating the risk. Please wait..." : 
+      "Creating the risk. Please wait...");
+
       const formData = {
         project_id: projectId,
         risk_name: riskValues.riskName,

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -81,13 +81,13 @@ const mitigationInitialState: MitigationFormValues = {
   mitigationPlan: "",
   currentRiskLevel: 0,
   implementationStrategy: "",
-  deadline: "",
+  deadline: new Date().toISOString(),
   doc: "",
   likelihood: 1 as Likelihood,
   riskSeverity: 1 as Severity,
   approver: 0,
   approvalStatus: 0,
-  dateOfAssessment: "",
+  dateOfAssessment: new Date().toISOString(),
   recommendations: "",
 };
 

--- a/Clients/src/presentation/components/AddNewRiskForm/interface.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/interface.tsx
@@ -64,7 +64,7 @@ export interface MitigationFormValues {
   approver: number;
   approvalStatus: number;
   dateOfAssessment: string;
-  recommendations?: string;
+  recommendations: string;
 }
 
 export interface MitigationFormErrors {

--- a/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/ProjectRisks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/ProjectRisks/index.tsx
@@ -16,6 +16,7 @@ import { handleAlert } from "../../../../../application/tools/alertUtils";
 import Alert from "../../../../components/Alert";
 import { deleteEntityById } from "../../../../../application/repository/entity.repository";
 import VWToast from "../../../../vw-v2-components/Toast";
+import VWSkeleton from "../../../../vw-v2-components/Skeletons";
 
 const TITLE_OF_COLUMNS = [
   "RISK NAME",
@@ -29,6 +30,9 @@ const TITLE_OF_COLUMNS = [
   "",
 ];
 
+/**
+ * Set initial loading status for all CRUD process
+*/  
 interface LoadingStatus {
   loading: boolean;
   message: string;
@@ -55,25 +59,24 @@ const VWProjectRisks = ({ project }: { project?: Project }) => {
   } | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
   const [isLoading, setIsLoading] = useState<LoadingStatus>(initialLoadingState);
+  const [showVWSkeleton, setShowVWSkeleton] = useState<boolean>(false);
   
   const fetchProjectRisks = useCallback(async () => {
     try {
       const response = await getEntityById({
         routeUrl: `/projectRisks/by-projid/${projectId}`,
       });
+      setShowVWSkeleton(false);
       setProjectRisks(response.data);
     } catch (error) {
-      console.error("Error fetching project risks:", error);
-      handleAlert({
-        variant: "error",
-        body: "Error fetching project risks",
-        setAlert,
-      });
+      console.error("Error fetching project risks:", error);      
+      handleToast("error", "Unexpected error occurs while fetching project risks.");      
     }
   }, [projectId]);
 
   useEffect(() => {
     if (projectId) {
+      setShowVWSkeleton(true);
       fetchProjectRisks();
     }
   }, [projectId, fetchProjectRisks, refreshKey]); // Add refreshKey to dependencies
@@ -265,15 +268,19 @@ const VWProjectRisks = ({ project }: { project?: Project }) => {
           />
           )
         }
-        <VWProjectRisksTable
-          columns={TITLE_OF_COLUMNS}
-          rows={projectRisks}
-          setPage={setCurrentPagingation}
-          page={currentPage}
-          setSelectedRow={(row: ProjectRisk) => setSelectedRow([row])}
-          setAnchor={setAnchor}
-          deleteRisk={handleDelete}
-        />
+        {showVWSkeleton ? (
+          <VWSkeleton variant="rectangular" width="100%" height={200} />
+        ) : (
+          <VWProjectRisksTable
+            columns={TITLE_OF_COLUMNS}
+            rows={projectRisks}
+            setPage={setCurrentPagingation}
+            page={currentPage}
+            setSelectedRow={(row: ProjectRisk) => setSelectedRow([row])}
+            setAnchor={setAnchor}
+            deleteRisk={handleDelete}
+          />
+        )}
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
## Describe your changes

- Add VWloading component for all CRUD operations
- Show VWSkeleton as a placeholder while fetching project risk
- Set today as default date in project risk's mitigation tab in modal
- Modify validation for optional form fields in project risk modal

## Issue number

Mention the issue number(s) this PR addresses (#985 ).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

VWSkeleton in project risk, tested with slow network

https://github.com/user-attachments/assets/38d4837f-7bae-4a32-a27b-5c747ece2252

VWToast for displaying loading in all CRUD 

https://github.com/user-attachments/assets/a84372dd-369b-4e7b-b04b-9abb760fee80




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced real-time loading indicators and improved notifications, providing clear feedback during risk creation, updates, deletions, and data fetching.
- **Refactor**
	- Updated risk forms to default date fields to the current date for better consistency.
	- Enhanced input validation for review notes and recommendations to ensure reliable data entry.
	- Added loading state management for improved user experience during data fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->