### PR TITLE
Add migration for `is_demo` false

### DIFF
--- a/Servers/database/migrations/20250325044112-set-is_demo-false.js
+++ b/Servers/database/migrations/20250325044112-set-is_demo-false.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await Promise.all([
+      'roles', 'users', 'projects', 'projects_members', 'vendors', 'vendors_projects',
+      'assessments', 'controlcategories', 'controls', 'subcontrols', 'projectrisks',
+      'vendorrisks', 'projectscopes', 'topics', 'subtopics', 'questions', 'files',
+    ].map(async (table) => {
+      await queryInterface.sequelize.query(
+        `UPDATE ${table} SET is_demo = false WHERE is_demo IS NULL;`
+      );
+      await queryInterface.changeColumn(table, 'is_demo', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
+    }));
+  },
+
+  async down(queryInterface, Sequelize) {
+    await Promise.all([
+      'roles', 'users', 'projects', 'projects_members', 'vendors', 'vendors_projects',
+      'assessments', 'controlcategories', 'controls', 'subcontrols', 'projectrisks',
+      'vendorrisks', 'projectscopes', 'topics', 'subtopics', 'questions', 'files',
+    ].map(async (table) => {
+      await queryInterface.changeColumn(table, 'is_demo', {
+        type: Sequelize.BOOLEAN,
+        allowNull: true,
+      });
+      await queryInterface.sequelize.query(
+        `UPDATE ${table} SET is_demo = NULL WHERE is_demo = false;`
+      );
+    }));
+  }
+};

--- a/Servers/models/assessment.model.ts
+++ b/Servers/models/assessment.model.ts
@@ -34,6 +34,8 @@ export class AssessmentModel extends Model<Assessment> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/control.model.ts
+++ b/Servers/models/control.model.ts
@@ -96,6 +96,8 @@ export class ControlModel extends Model<Control> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/controlCategory.model.ts
+++ b/Servers/models/controlCategory.model.ts
@@ -45,6 +45,8 @@ export class ControlCategoryModel extends Model<ControlCategory> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/file.model.ts
+++ b/Servers/models/file.model.ts
@@ -50,6 +50,8 @@ export class FileModel extends Model<File> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/project.model.ts
+++ b/Servers/models/project.model.ts
@@ -88,6 +88,8 @@ export class ProjectModel extends Model<Project> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/projectRisk.model.ts
+++ b/Servers/models/projectRisk.model.ts
@@ -254,6 +254,8 @@ export class ProjectRiskModel extends Model<ProjectRisk> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/projectScope.model.ts
+++ b/Servers/models/projectScope.model.ts
@@ -80,6 +80,8 @@ export class ProjectScopeModel extends Model<ProjectScope> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/projectsMembers.model.ts
+++ b/Servers/models/projectsMembers.model.ts
@@ -24,4 +24,11 @@ export class ProjectsMembersModel extends Model<ProjectsMembers> {
     primaryKey: true
   })
   project_id!: number;
+
+  @Column({
+    type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  })
+  is_demo?: boolean;
 }

--- a/Servers/models/question.model.ts
+++ b/Servers/models/question.model.ts
@@ -97,6 +97,8 @@ export class QuestionModel extends Model<Question> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/role.model.ts
+++ b/Servers/models/role.model.ts
@@ -30,6 +30,8 @@ export class RoleModel extends Model<Role> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/subcontrol.model.ts
+++ b/Servers/models/subcontrol.model.ts
@@ -119,6 +119,8 @@ export class SubcontrolModel extends Model<Subcontrol> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/subtopic.model.ts
+++ b/Servers/models/subtopic.model.ts
@@ -43,6 +43,8 @@ export class SubtopicModel extends Model<Subtopic> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/topic.model.ts
+++ b/Servers/models/topic.model.ts
@@ -43,6 +43,8 @@ export class TopicModel extends Model<Topic> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/user.model.ts
+++ b/Servers/models/user.model.ts
@@ -75,6 +75,8 @@ export class UserModel extends Model<User> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/vendor.model.ts
+++ b/Servers/models/vendor.model.ts
@@ -102,6 +102,8 @@ export class VendorModel extends Model<Vendor> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/vendorRisk.model.ts
+++ b/Servers/models/vendorRisk.model.ts
@@ -96,6 +96,8 @@ export class VendorRiskModel extends Model<VendorRisk> {
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
   })
   is_demo?: boolean;
 }

--- a/Servers/models/vendorsProjects.model.ts
+++ b/Servers/models/vendorsProjects.model.ts
@@ -24,4 +24,11 @@ export class VendorsProjectsModel extends Model<VendorsProjects> {
     primaryKey: true
   })
   project_id!: number;
+
+  @Column({
+    type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  })
+  is_demo?: boolean;
 }


### PR DESCRIPTION
## Describe your changes

- Added migration script to set `is_demo` to false for all current `null` values

## Issue number

- #1027 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [ ] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Rolled out a backend update to enforce consistent, non-null settings for the demo flag across multiple datasets.
  - Applied a migration that standardizes the demo indicator with a default value, ensuring improved data integrity throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->