### PR TITLE
#1022 Allow users to edit a risk by clicking on a row

### DIFF
--- a/Clients/src/presentation/components/Table/RisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/RisksTable/index.tsx
@@ -125,6 +125,7 @@ const RiskTable: React.FC<RiskTableProps> = ({
               <TableRow
                 key={index}
                 sx={singleTheme.tableStyles.primary.body.row}
+                onClick={() => onEdit(row.id)}
               >
                 <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
                   {

--- a/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
+++ b/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
@@ -120,6 +120,7 @@ const TableWithPlaceholder: React.FC<TableWithPlaceholderProps> = ({
               <TableRow
                 key={index}
                 sx={singleTheme.tableStyles.primary.body.row}
+                onClick={() => onEdit(row.id)}
               >
                 <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
                   {row.vendor_name}


### PR DESCRIPTION
## Describe your changes

Allow users to edit a risk by clicking on a row

## Issue number

#1022 #1020



## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

https://github.com/user-attachments/assets/b3674610-338f-45bb-83d1-c181e90655d7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled clickable rows in tables, allowing users to initiate edit actions directly from both the risks table and the table with placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->