### PR TITLE
Add button highlight for assessment tracker add/remove button

### DIFF
--- a/Clients/src/presentation/components/VWQuestion/index.tsx
+++ b/Clients/src/presentation/components/VWQuestion/index.tsx
@@ -283,11 +283,6 @@ const VWQuestion = ({ question }: QuestionProps) => {
               border: "1px solid #D0D5DD",
               backgroundColor: "white",
               color: "#344054",
-              "&:hover": {
-                boxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
-                WebkitBoxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
-                MozBoxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
-              },
             }}
             style={currentEl === values.id ? highlight : {}}
             disableRipple

--- a/Clients/src/presentation/components/VWQuestion/index.tsx
+++ b/Clients/src/presentation/components/VWQuestion/index.tsx
@@ -50,6 +50,13 @@ const VWQuestion = ({ question }: QuestionProps) => {
   const { userId, currentProjectId } = useContext(VerifyWiseContext);
   const [values, setValues] = useState<Question>(question);
   const [isFileUploadOpen, setIsFileUploadOpen] = useState(false);
+  const [currentEl, setCurrentEl] = useState<number | undefined>(undefined);
+
+  const highlight = {
+    boxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
+    WebkitBoxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
+    MozBoxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
+  };
 
   const initialEvidenceFiles = question.evidence_files
     ? question.evidence_files.reduce((acc: FileData[], file) => {
@@ -186,6 +193,13 @@ const VWQuestion = ({ question }: QuestionProps) => {
     }
   };
 
+  const handleModalClose = () => {
+    setIsFileUploadOpen(false)
+    setTimeout(() => {
+      setCurrentEl(undefined)
+    }, 1000);
+  }
+
   return (
     <Box key={question.id} mt={10}>
       <Box
@@ -269,9 +283,18 @@ const VWQuestion = ({ question }: QuestionProps) => {
               border: "1px solid #D0D5DD",
               backgroundColor: "white",
               color: "#344054",
+              "&:hover": {
+                boxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
+                WebkitBoxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
+                MozBoxShadow: "1px 0px 6px 2px rgba(202, 202, 202, 0.75)",
+              },
             }}
+            style={currentEl === values.id ? highlight : {}}
             disableRipple
-            onClick={() => setIsFileUploadOpen(true)}
+            onClick={() => {
+              setIsFileUploadOpen(true)
+              setCurrentEl(values.id)
+            }}
           >
             Add/Remove evidence
           </Button>
@@ -296,12 +319,12 @@ const VWQuestion = ({ question }: QuestionProps) => {
       </Stack>
       <Dialog
         open={isFileUploadOpen}
-        onClose={() => setIsFileUploadOpen(false)}
+        onClose={() => handleModalClose()}
       >
         <UppyUploadFile
           uppy={uppy}
           files={evidenceFiles}
-          onClose={() => setIsFileUploadOpen(false)}
+          onClose={() => handleModalClose()}
           onRemoveFile={handleRemoveFile}
         />
       </Dialog>


### PR DESCRIPTION
## Describe your changes

- Show button hover in assessment tracker add/remove button
- Display box-shadow highlight at the current add/remove button after closing the modal

## Issue number

Mention the issue number(s) this PR addresses (e.g., #1038 ).

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

https://github.com/user-attachments/assets/0e9b546c-93c3-4808-924c-f98fdf77f31c





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced evidence actions with dynamic visual feedback that highlights the selected element.
	- Improved file upload modal behavior with a smoother, automated reset process after closing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->