### PR TITLE
Fix response for getting vendor by project id

### DIFF
--- a/Servers/controllers/vendor.ctrl.ts
+++ b/Servers/controllers/vendor.ctrl.ts
@@ -47,11 +47,11 @@ export async function getVendorByProjectId(req: Request, res: Response): Promise
 
     const vendor = await getVendorByProjectIdQuery(vendorId);
 
-    if (vendor) {
+    if (vendor !== null) {
       return res.status(200).json(STATUS_CODE[200](vendor));
     }
 
-    return res.status(404).json(STATUS_CODE[404](vendor));
+    return res.status(404).json(STATUS_CODE[404]([]));
   } catch (error) {
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }

--- a/Servers/utils/vendor.utils.ts
+++ b/Servers/utils/vendor.utils.ts
@@ -53,7 +53,12 @@ export const getVendorByIdQuery = async (
 export const getVendorByProjectIdQuery = async (
   project_id: number
 ): Promise<Vendor[] | null> => {
-  const result = await sequelize.query(
+  const projectExists = await sequelize.query(
+    "SELECT 1 AS exists FROM projects WHERE id = :project_id",
+    { replacements: { project_id } }
+  );
+  if (!(projectExists[0].length > 0)) return null;
+  const vendors_projects = await sequelize.query(
     "SELECT vendor_id FROM vendors_projects WHERE project_id = :project_id",
     {
       replacements: { project_id },
@@ -61,9 +66,8 @@ export const getVendorByProjectIdQuery = async (
       model: VendorsProjectsModel
     }
   );
-  if (!result.length) return null;
   const vendors: Vendor[] = []
-  for (let vendors_project of (result || [])) {
+  for (let vendors_project of (vendors_projects || [])) {
     const vendor = await sequelize.query(
       "SELECT * FROM vendors WHERE id = :id ORDER BY created_at DESC, id ASC",
       {


### PR DESCRIPTION
## Describe your changes

- Updated the response to send empty response if the project exists but there are no vendors attached to the project
- Send 404 if the project does not exists
<img width="977" alt="image" src="https://github.com/user-attachments/assets/c711ecaf-fdde-445f-b465-6ca3793d6e75" />
<img width="977" alt="image" src="https://github.com/user-attachments/assets/4eab907b-2a36-4f65-a12d-c28458d68822" />

CC: @srwa-rsp 

## Write your issue number after "Fixes "

Fixes #123 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [ ] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling when fetching vendors by project ID: now returns an empty array and a 404 status if the project does not exist, instead of returning null or undefined.
	- Enhanced accuracy in vendor lookup by ensuring the project exists before attempting to retrieve associated vendors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->