### PR TITLE
Create ReadyToSubscribe box

### DIFF
--- a/Clients/env.vars.ts
+++ b/Clients/env.vars.ts
@@ -1,4 +1,4 @@
 export const ENV_VARs = {
   URL: import.meta.env.VITE_APP_API_BASE_URL || 'http://localhost:3000',
-  IS_DEMO_APP: import.meta.env.VITE_IS_DEMO_APP === 'true' ,
+  IS_DEMO_APP: import.meta.env.VITE_IS_DEMO_APP === 'true',
 };

--- a/Clients/env.vars.ts
+++ b/Clients/env.vars.ts
@@ -1,3 +1,4 @@
 export const ENV_VARs = {
   URL: import.meta.env.VITE_APP_API_BASE_URL || 'http://localhost:3000',
+  IS_DEMO_APP: import.meta.env.VITE_IS_DEMO_APP === 'true' ,
 };

--- a/Clients/src/presentation/components/DemoBanner/DemoAppBanner.tsx
+++ b/Clients/src/presentation/components/DemoBanner/DemoAppBanner.tsx
@@ -1,0 +1,27 @@
+import { Box, Typography } from "@mui/material";
+import { ENV_VARs } from "../../../../env.vars";
+import styles from "./styles";
+
+interface DemoAppBannerProps {
+    sx?: React.CSSProperties;
+}
+
+const DemoAppBanner = ({ sx }: DemoAppBannerProps) => {
+
+    const isDemoApp = ENV_VARs.IS_DEMO_APP;
+    if (!isDemoApp) {
+        return null;
+    }
+
+    return (
+        <Box
+            sx={{ ...styles.container, ...sx }}
+        >
+            <Typography sx={styles.text} >
+                You're viewing a public demo of the VerifyWise AI governance platform. Feel free to explore using demo data, but please don't enter any personal or company information.
+            </Typography>
+        </Box>
+    );
+}
+
+export default DemoAppBanner;

--- a/Clients/src/presentation/components/DemoBanner/DemoAppBanner.tsx
+++ b/Clients/src/presentation/components/DemoBanner/DemoAppBanner.tsx
@@ -1,26 +1,16 @@
-import { Box, Typography } from "@mui/material";
 import { ENV_VARs } from "../../../../env.vars";
-import styles from "./styles";
+import { Container, Text } from './styles';
 
-interface DemoAppBannerProps {
-    sx?: React.CSSProperties;
-}
+const DemoAppBanner = () => {
 
-const DemoAppBanner = ({ sx }: DemoAppBannerProps) => {
-
-    const isDemoApp = ENV_VARs.IS_DEMO_APP;
-    if (!isDemoApp) {
+    if (!ENV_VARs.IS_DEMO_APP) {
         return null;
     }
 
     return (
-        <Box
-            sx={{ ...styles.container, ...sx }}
-        >
-            <Typography sx={styles.text} >
-                You're viewing a public demo of the VerifyWise AI governance platform. Feel free to explore using demo data, but please don't enter any personal or company information.
-            </Typography>
-        </Box>
+        <Container>
+            <Text>You're viewing a public demo of the VerifyWise AI governance platform. Feel free to explore using demo data, but please don't enter any personal or company information.</Text>
+        </Container>
     );
 }
 

--- a/Clients/src/presentation/components/DemoBanner/styles.ts
+++ b/Clients/src/presentation/components/DemoBanner/styles.ts
@@ -1,0 +1,22 @@
+const styles = {
+    container: {
+        width: '100%',  
+        backgroundColor: '#CBF5E5',
+        borderRadius: '4px',
+        textAlign: 'center',
+        alignContent: 'center',
+        padding: '6px 12px',
+        position: 'relative',
+        top: '-15px',
+    },
+    text: {
+        fontFamily: 'Inter, sans-serif',
+        fontWeight: 500,
+        fontSize: '13px',
+        lineHeight: '20px',
+        letterSpacing: '-0.6%',
+        color: '#176448'
+    },
+};
+
+export default styles;

--- a/Clients/src/presentation/components/DemoBanner/styles.ts
+++ b/Clients/src/presentation/components/DemoBanner/styles.ts
@@ -1,22 +1,28 @@
-const styles = {
-    container: {
-        width: '100%',  
-        backgroundColor: '#CBF5E5',
-        borderRadius: '4px',
-        textAlign: 'center',
-        alignContent: 'center',
-        padding: '6px 12px',
-        position: 'relative',
-        top: '-15px',
-    },
-    text: {
-        fontFamily: 'Inter, sans-serif',
-        fontWeight: 500,
-        fontSize: '13px',
-        lineHeight: '20px',
-        letterSpacing: '-0.6%',
-        color: '#176448'
-    },
-};
+import { styled, Theme } from '@mui/material/styles';
+import { Box, Typography } from '@mui/material';
 
-export default styles;
+interface ContainerProps {
+  theme?: Theme; // Theme is automatically injected
+}
+
+export const Container = styled(Box)<ContainerProps>(() => ({
+  width: '100%',
+  backgroundColor: '#CBF5E5',
+  borderRadius: '4px',
+  textAlign: 'center',
+  alignContent: 'center',
+  padding: '6px 12px',
+  position: 'relative',
+  top: '-15px',
+  role: 'alert',
+  ariaLive: 'polite',
+}));
+
+export const Text = styled(Typography)(() => ({
+  fontFamily: 'Inter, sans-serif',
+  fontWeight: 500,
+  fontSize: '13px',
+  lineHeight: '20px',
+  letterSpacing: '-0.6%',
+  color: '#176448',
+}));

--- a/Clients/src/presentation/components/ReadyToSubscribeBox/ReadyToSubscribeBox.tsx
+++ b/Clients/src/presentation/components/ReadyToSubscribeBox/ReadyToSubscribeBox.tsx
@@ -1,0 +1,38 @@
+import { Box, Button, Stack, Typography, useTheme } from "@mui/material";
+import { ENV_VARs } from "../../../../env.vars";
+import getStyles from "./styles";
+
+// URL constants
+const PRICING_URL = 'https://verifywise.ai/pricing/';
+
+const ReadyToSubscribeBox = () => {
+    const theme = useTheme();
+    const styles = getStyles(theme);
+
+  // Early return if not in demo app mode
+  if (!ENV_VARs.IS_DEMO_APP) {
+    return null;
+  }
+
+  const handleClick = () => {
+    window.open(PRICING_URL, '_blank');
+  };
+
+  return (
+    <Box sx={styles.container}>
+      <Stack spacing={3} sx={styles.stack}>
+        <Typography variant="h5" sx={styles.title}>
+          Ready to subscribe?
+        </Typography>
+        <Typography variant="subtitle1" sx={styles.description}>
+          Unlock the full potential of VerifyWise AI governance with our premium features.
+        </Typography>
+        <Button sx={styles.button} onClick={handleClick}>
+          View plans
+        </Button>
+      </Stack>
+    </Box>
+  );
+};
+
+export default ReadyToSubscribeBox;

--- a/Clients/src/presentation/components/ReadyToSubscribeBox/styles.ts
+++ b/Clients/src/presentation/components/ReadyToSubscribeBox/styles.ts
@@ -1,0 +1,36 @@
+import { Theme } from "@mui/material";
+
+// Define styles as constants to improve readability and reusability
+const getStyles = (theme: Theme) => ({
+    container: {
+        width: '90%',
+        backgroundColor: '#28A745',
+        borderRadius: '4px'
+    },
+    stack: {
+        padding: '15px'
+    },
+    title: {
+        fontWeight: 600,
+        fontSize: '16px',
+        lineHeight: '24px',
+        letterSpacing: '0%',
+        color: '#FFFFFF',
+    },
+    description: {
+        fontWeight: 400,
+        fontSize: '13px',
+        lineHeight: '20px',
+        letterSpacing: '0%',
+        color: '#FFFFFF',
+    },
+    button: {
+        border: '1px solid #A1A1A1',
+        backgroundColor: theme.palette.background.main,
+        color: '#344054',
+        padding: '4px',
+        borderRadius: '4px'
+    }
+});
+
+export default getStyles;

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -530,7 +530,13 @@ const Sidebar = ({ projects }: { projects: any }) => {
         ))}
       </List>
       {!collapsed &&
-        <Box sx={{ height: '100%', alignContent: 'flex-end', justifyItems: 'center' }}>
+        <Box sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          justifyContent: 'flex-end',
+          alignItems: 'center'
+        }}>
           <ReadyToSubscribeBox />
         </Box>
       }

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -341,7 +341,7 @@ const Sidebar = ({ projects }: { projects: any }) => {
                 }
                 className={
                   location.pathname === item.path ||
-                  customMenuHandler() === item.path
+                    customMenuHandler() === item.path
                     ? "selected-path"
                     : "unselected"
                 }
@@ -353,7 +353,7 @@ const Sidebar = ({ projects }: { projects: any }) => {
                   px: theme.spacing(4),
                   backgroundColor:
                     location.pathname === item.path ||
-                    customMenuHandler() === item.path
+                      customMenuHandler() === item.path
                       ? "#F9F9F9"
                       : "transparent",
 
@@ -505,10 +505,10 @@ const Sidebar = ({ projects }: { projects: any }) => {
               onClick={() =>
                 item.path === "support"
                   ? window.open(
-                      "https://github.com/bluewave-labs/bluewave-uptime/issues",
-                      "_blank",
-                      "noreferrer"
-                    )
+                    "https://github.com/bluewave-labs/bluewave-uptime/issues",
+                    "_blank",
+                    "noreferrer"
+                  )
                   : navigate(`${item.path}`)
               }
               sx={{
@@ -529,9 +529,11 @@ const Sidebar = ({ projects }: { projects: any }) => {
           </Tooltip>
         ))}
       </List>
-      <Box sx={{height: '100%', alignContent: 'flex-end', justifyItems: 'center'}}>
-        <ReadyToSubscribeBox />
-      </Box>
+      {!collapsed &&
+        <Box sx={{ height: '100%', alignContent: 'flex-end', justifyItems: 'center' }}>
+          <ReadyToSubscribeBox />
+        </Box>
+      }
       <Divider sx={{ mt: "auto" }} />
       <Stack
         direction="row"

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -44,6 +44,7 @@ import { Link as MuiLink } from "@mui/material";
 import { User } from "../../../application/hooks/useUsers";
 import { ROLES } from "../../../application/constants/roles";
 import useLogout from "../../../application/hooks/useLogout";
+import ReadyToSubscribeBox from "../ReadyToSubscribeBox/ReadyToSubscribeBox";
 
 const menu = [
   {
@@ -528,6 +529,9 @@ const Sidebar = ({ projects }: { projects: any }) => {
           </Tooltip>
         ))}
       </List>
+      <Box sx={{height: '100%', alignContent: 'flex-end', justifyItems: 'center'}}>
+        <ReadyToSubscribeBox />
+      </Box>
       <Divider sx={{ mt: "auto" }} />
       <Stack
         direction="row"

--- a/Clients/src/presentation/containers/Dashboard/index.tsx
+++ b/Clients/src/presentation/containers/Dashboard/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../application/repository/entity.repository";
 import PageTour from "../../components/PageTour";
 import CustomStep from "../../components/PageTour/CustomStep";
+import DemoAppBanner from "../../components/DemoBanner/DemoAppBanner";
 
 interface DashboardProps {
   reloadTrigger: boolean;
@@ -120,17 +121,20 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
       sx={{ backgroundColor: "#FCFCFD" }}
     >
       <Sidebar projects={mappedProjects} />
+      <Stack spacing={3}>      
+        <DemoAppBanner />                      
 
-      {/* Joyride */}
-      {runHomeTour && (
-        <PageTour
+        {/* Joyride */}
+        {runHomeTour && (
+          <PageTour
           steps={homeSteps}
           run={runHomeTour}
           onFinish={() => setRunHomeTour(false)}
           tourKey="home-tour"
-        />
-      )}
-      <Outlet />
+          />
+        )}
+        <Outlet />
+      </Stack>
     </Stack>
   );
 };

--- a/Clients/src/vite-env.d.ts
+++ b/Clients/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+  readonly VITE_IS_DEMO_APP: string; 
+}


### PR DESCRIPTION
## Describe your changes

Create ReadyToSubscribeBox component and add it to Sidebar.

OBS. To see the banner, you need to add `VITE_IS_DEMO_APP=true` to `/Clients/.env`.

This branch was based on `sam-22-apr-add-demo-app-banner` and will be rebased after the last be merged.

## Write your issue number after "Fixes "

Fixes #1224  

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

![image](https://github.com/user-attachments/assets/23a3d7cd-a01f-4b61-86ff-a44cfff95a0a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a banner in the dashboard indicating when the app is in demo mode, advising users not to enter personal or company information.
  - Added a subscription prompt box in the sidebar for demo mode users with a button linking to the pricing page.

- **Style**
  - Added styled components and styles for the demo banner and subscription prompt to ensure clear and consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->