### PR TITLE
Move Assessment Tracker to Frameworks Tab

### DIFF
--- a/Clients/src/application/config/routes.tsx
+++ b/Clients/src/application/config/routes.tsx
@@ -16,7 +16,6 @@ import FileManager from "../../presentation/pages/FileManager";
 import Reporting from "../../presentation/pages/Reporting";
 import Playground from "../../presentation/pages";
 import AssessmentTracker from "../../presentation/pages/Assessment/1.0AssessmentTracker";
-import ComplianceTracker from "../../presentation/pages/ComplianceTracker/1.0ComplianceTracker";
 import VWHome from "../../presentation/pages/Home/1.0Home";
 import VWProjectView from "../../presentation/pages/ProjectView/V1.0ProjectView";
 import PageNotFound from "../../presentation/pages/PageNotFound";
@@ -37,7 +36,6 @@ export const createRoutes = (
       path="/test"
       element={<Home onProjectUpdate={triggerSidebarReload} />}
     />
-    <Route path="/compliance-tracker" element={<ComplianceTracker />} />
     <Route path="/assessment" element={<AssessmentTracker />} />
     <Route path="/vendors" element={<Vendors />} />
     <Route path="/setting" element={<Setting />} />

--- a/Clients/src/application/config/routes.tsx
+++ b/Clients/src/application/config/routes.tsx
@@ -15,7 +15,6 @@ import ProjectView from "../../presentation/pages/ProjectView";
 import FileManager from "../../presentation/pages/FileManager";
 import Reporting from "../../presentation/pages/Reporting";
 import Playground from "../../presentation/pages";
-import AssessmentTracker from "../../presentation/pages/Assessment/1.0AssessmentTracker";
 import VWHome from "../../presentation/pages/Home/1.0Home";
 import VWProjectView from "../../presentation/pages/ProjectView/V1.0ProjectView";
 import PageNotFound from "../../presentation/pages/PageNotFound";
@@ -36,7 +35,6 @@ export const createRoutes = (
       path="/test"
       element={<Home onProjectUpdate={triggerSidebarReload} />}
     />
-    <Route path="/assessment" element={<AssessmentTracker />} />
     <Route path="/vendors" element={<Vendors />} />
     <Route path="/setting" element={<Setting />} />
     <Route path="/team" element={<Team />} />

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -27,7 +27,6 @@ import { ReactComponent as DotsVertical } from "../../assets/icons/dots-vertical
 import { ReactComponent as LogoutSvg } from "../../assets/icons/logout.svg";
 import { ReactComponent as ReportingSvg } from "../../assets/icons/reporting.svg";
 
-import { ReactComponent as Assessment } from "../../assets/icons/chart.svg";
 import { ReactComponent as Vendors } from "../../assets/icons/building.svg";
 import { ReactComponent as Settings } from "../../assets/icons/setting.svg";
 import { ReactComponent as FileManager } from "../../assets/icons/file.svg";
@@ -51,11 +50,6 @@ const menu = [
     name: "Dashboard",
     icon: <Dashboard />,
     path: "/",
-  },
-  {
-    name: "Assessment tracker",
-    icon: <Assessment />,
-    path: "/assessment",
   },
   {
     name: "Vendors",

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -53,11 +53,11 @@ const menu = [
     icon: <Dashboard />,
     path: "/",
   },
-  {
-    name: "Compliance tracker",
-    icon: <Compliance />,
-    path: "/compliance-tracker",
-  },
+  // {
+  //   name: "Compliance tracker",
+  //   icon: <Compliance />,
+  //   path: "/compliance-tracker",
+  // },
   {
     name: "Assessment tracker",
     icon: <Assessment />,

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -27,7 +27,6 @@ import { ReactComponent as DotsVertical } from "../../assets/icons/dots-vertical
 import { ReactComponent as LogoutSvg } from "../../assets/icons/logout.svg";
 import { ReactComponent as ReportingSvg } from "../../assets/icons/reporting.svg";
 
-import { ReactComponent as Compliance } from "../../assets/icons/globe.svg";
 import { ReactComponent as Assessment } from "../../assets/icons/chart.svg";
 import { ReactComponent as Vendors } from "../../assets/icons/building.svg";
 import { ReactComponent as Settings } from "../../assets/icons/setting.svg";
@@ -53,11 +52,6 @@ const menu = [
     icon: <Dashboard />,
     path: "/",
   },
-  // {
-  //   name: "Compliance tracker",
-  //   icon: <Compliance />,
-  //   path: "/compliance-tracker",
-  // },
   {
     name: "Assessment tracker",
     icon: <Assessment />,

--- a/Clients/src/presentation/pages/Assessment/1.0AssessmentTracker/index.tsx
+++ b/Clients/src/presentation/pages/Assessment/1.0AssessmentTracker/index.tsx
@@ -19,7 +19,6 @@ import {
 import StatsCard from "../../../components/Cards/StatsCard";
 import VWSkeleton from "../../../vw-v2-components/Skeletons";
 import Questions from "./questions";
-import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import useAssessmentProgress from "../../../../application/hooks/useAssessmentProgress";
 import useAssessmentData from "../../../../application/hooks/useAssessmentData";
 import useAssessmentTopics from "../../../../application/hooks/useAssessmentTopcis";
@@ -27,21 +26,22 @@ import useAssessmentSubtopics from "../../../../application/hooks/useAssessmentS
 import PageTour from "../../../components/PageTour";
 import useMultipleOnScreen from "../../../../application/hooks/useMultipleOnScreen";
 import AssessmentSteps from "./AssessmentSteps";
+import { Project } from "../../../../domain/types/Project";
 
-const AssessmentTracker = () => {
+const AssessmentTracker = ({ project }: { project: Project }) => {
   const theme = useTheme();
   const [refreshKey, setRefreshKey] = useState(false);
-  const { currentProjectId } = useContext(VerifyWiseContext);
+  const currentProjectId = project?.id;
   const [activeTab, setActiveTab] = useState<number>(0);
   const [runAssessmentTour, setRunAssessmentTour] = useState(false);
 
   const { assessmentProgress, loading: loadingAssessmentProgress } =
     useAssessmentProgress({
-      selectedProjectId: currentProjectId || "",
+      selectedProjectId: String(currentProjectId) || "",
       refreshKey,
     });
   const { assessmentData, loading: loadingAssessmentData } = useAssessmentData({
-    selectedProjectId: currentProjectId || "",
+    selectedProjectId: String(currentProjectId) || "",
   });
   const { assessmentTopics, loading: loadingAssessmentTopics } =
     useAssessmentTopics({ assessmentId: assessmentData?.id });
@@ -140,7 +140,6 @@ const AssessmentTracker = () => {
           backgroundColor: theme.palette.background.alt,
         }}
       >
-        <Typography sx={pageHeadingStyle}>Assessment tracker</Typography>
         <Stack
           sx={{ maxWidth: 1400, marginTop: "10px", gap: theme.spacing(10) }}
           data-joyride-id="assessment-progress-bar"

--- a/Clients/src/presentation/pages/Assessment/1.0AssessmentTracker/index.tsx
+++ b/Clients/src/presentation/pages/Assessment/1.0AssessmentTracker/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useState, useEffect } from "react";
+import { useCallback, useState, useEffect } from "react";
 import {
   Box,
   Divider,
@@ -12,7 +12,6 @@ import {
 } from "@mui/material";
 import {
   listItemStyle,
-  pageHeadingStyle,
   subHeadingStyle,
   topicsListStyle,
 } from "./index.style";

--- a/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/index.tsx
+++ b/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/index.tsx
@@ -12,8 +12,8 @@ import ComplianceSteps from "./ComplianceSteps";
 import useMultipleOnScreen from "../../../../application/hooks/useMultipleOnScreen";
 import { ComplianceData } from "../../../../domain/interfaces/iCompliance";
 
-const ComplianceTracker = () => {
-  const { currentProjectId } = useContext(VerifyWiseContext);
+const ComplianceTracker = ({ project }: { project: any }) => {
+  const currentProjectId = project?.id;
   const [complianceData, setComplianceData] = useState<ComplianceData>();
   const [controlCategories, setControlCategories] =
     useState<ControlCategoryModel[]>();
@@ -41,7 +41,7 @@ const ComplianceTracker = () => {
 
   const fetchComplianceData = async () => {
     if (!currentProjectId) return;
-
+    
     try {
       const response = await getEntityById({
         routeUrl: `projects/compliance/progress/${currentProjectId}`,
@@ -123,7 +123,7 @@ const ComplianceTracker = () => {
         data-joyride-id="compliance-heading"
         sx={{ position: "relative" }}
       >
-        <Typography sx={pageHeadingStyle}>Compliance tracker</Typography>
+        {/* <Typography sx={pageHeadingStyle}>Compliance tracker</Typography> */}
       </Stack>
       {complianceData && (
         <Stack ref={refs[1]} data-joyride-id="compliance-progress-bar">

--- a/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/index.tsx
+++ b/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/index.tsx
@@ -10,8 +10,9 @@ import PageTour from "../../../components/PageTour";
 import ComplianceSteps from "./ComplianceSteps";
 import useMultipleOnScreen from "../../../../application/hooks/useMultipleOnScreen";
 import { ComplianceData } from "../../../../domain/interfaces/iCompliance";
+import { Project } from "../../../../domain/types/Project";
 
-const ComplianceTracker = ({ project }: { project: any }) => {
+const ComplianceTracker = ({ project }: { project: Project }) => {
   const currentProjectId = project?.id;
   const [complianceData, setComplianceData] = useState<ComplianceData>();
   const [controlCategories, setControlCategories] =

--- a/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/index.tsx
+++ b/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext } from "react";
+import { useEffect, useState } from "react";
 import { Stack, Typography } from "@mui/material";
 import { pageHeadingStyle } from "../../Assessment/1.0AssessmentTracker/index.style";
 import { getEntityById } from "../../../../application/repository/entity.repository";
@@ -6,7 +6,6 @@ import StatsCard from "../../../components/Cards/StatsCard";
 import VWSkeleton from "../../../vw-v2-components/Skeletons";
 import { ControlCategory as ControlCategoryModel } from "../../../../domain/types/ControlCategory";
 import ControlCategoryTile from "./ControlCategory";
-import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import PageTour from "../../../components/PageTour";
 import ComplianceSteps from "./ComplianceSteps";
 import useMultipleOnScreen from "../../../../application/hooks/useMultipleOnScreen";
@@ -41,7 +40,7 @@ const ComplianceTracker = ({ project }: { project: any }) => {
 
   const fetchComplianceData = async () => {
     if (!currentProjectId) return;
-    
+
     try {
       const response = await getEntityById({
         routeUrl: `projects/compliance/progress/${currentProjectId}`,

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.md
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.md
@@ -1,0 +1,62 @@
+# ProjectFrameworks Component
+
+## Overview
+The ProjectFrameworks component is a React component that provides a framework selection interface with compliance and assessment tracking capabilities. It's designed to help users manage and track different AI frameworks (like EU AI Act and ISO 42001) within a project context.
+
+## Features
+- Framework selection tabs (EU AI Act, ISO 42001)
+- Add new framework functionality
+- Compliance and Assessment tracking tabs
+- Modern, clean UI with consistent styling
+
+## Component Structure
+
+### Main Components
+- Framework Selection Tabs
+- Add Framework Button
+- Tracker Tabs (Compliance/Assessment)
+
+### Props
+This component doesn't accept any props as it manages its own state internally.
+
+### State Management
+- `framework`: Tracks the currently selected framework ('eu-ai-act' | 'iso-42001')
+- `tracker`: Tracks the active tracker tab ('compliance' | 'assessment')
+
+## Styling
+The component uses Material-UI (MUI) for styling and follows a consistent design system:
+- Colors:
+  - Primary: #13715B (Green)
+  - Background: #F5F6F6 (Light Gray)
+  - Border: #BFC9C5
+  - Text: #232B3A
+- Typography: Inter font family
+- Consistent spacing and sizing
+
+## Usage Example
+```tsx
+import ProjectFrameworks from './ProjectFrameworks';
+
+const YourComponent = () => {
+  return (
+    <ProjectFrameworks />
+  );
+};
+```
+
+## Dependencies
+- @mui/material
+- @mui/lab
+- React
+
+## File Structure
+- `index.tsx`: Main component file
+- `styles.ts`: Styling definitions
+- `index.md`: Documentation (this file)
+
+## Future Improvements
+- Add support for more frameworks
+- Implement framework addition functionality
+- Add content for compliance and assessment trackers
+- Add loading states and error handling
+- Implement data persistence

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Button, Tab } from '@mui/material';
+import { Box, Button, Tab, Typography, Stack } from '@mui/material';
 import TabList from '@mui/lab/TabList';
 import TabPanel from '@mui/lab/TabPanel';
 import TabContext from '@mui/lab/TabContext';
@@ -7,6 +7,7 @@ import { tabStyle, tabPanelStyle } from '../V1.0ProjectView/style';
 import VWSkeleton from '../../../vw-v2-components/Skeletons';
 import ComplianceTracker from '../../../pages/ComplianceTracker/1.0ComplianceTracker';
 import { Project } from '../../../../domain/types/Project';
+import AssessmentTracker from '../../Assessment/1.0AssessmentTracker';
 
 import {
   containerStyle,
@@ -17,7 +18,6 @@ import {
   tabListStyle,
 } from './styles';
 
-
 const frameworks = [
   { label: 'EU AI Act', value: 'eu-ai-act' },
   { label: 'ISO 42001', value: 'iso-42001' },
@@ -27,6 +27,29 @@ const trackerTabs = [
   { label: 'Compliance tracker', value: 'compliance' },
   { label: 'Assessment tracker', value: 'assessment' },
 ];
+
+const ComingSoonMessage = () => (
+  <Stack 
+    sx={{ 
+      height: 400, 
+      display: 'flex', 
+      alignItems: 'center', 
+      justifyContent: 'center',
+      backgroundColor: '#F5F6F6',
+      borderRadius: 2,
+      p: 4
+    }}
+  >
+    <Typography variant="h6" sx={{ color: '#13715B', mb: 2 }}>
+      Coming Soon!
+    </Typography>
+    <Typography sx={{ color: '#232B3A', textAlign: 'center' }}>
+      We're currently working on implementing this framework.
+      <br />
+      EU AI Act is currently available for your compliance and assessment needs.
+    </Typography>
+  </Stack>
+);
 
 const ProjectFrameworks = ({ project }: { project: Project }) => {
   const [framework, setFramework] = useState('eu-ai-act');
@@ -77,13 +100,25 @@ const ProjectFrameworks = ({ project }: { project: Project }) => {
         </Box>
         <TabPanel value="compliance" sx={tabPanelStyle}>
           {project ? (
-            <ComplianceTracker project={project} />
+            framework === 'eu-ai-act' ? (
+              <ComplianceTracker project={project} />
+            ) : (
+              <ComingSoonMessage />
+            )
           ) : (
             <VWSkeleton variant="rectangular" width="100%" height={400} />
           )}
         </TabPanel>
         <TabPanel value="assessment" sx={tabPanelStyle}>
-          {/* Assessment tracker content goes here */}
+          {project ? (
+            framework === 'eu-ai-act' ? (
+              <AssessmentTracker project={project} />
+            ) : (
+              <ComingSoonMessage />
+            )
+          ) : (
+            <VWSkeleton variant="rectangular" width="100%" height={400} />
+          )}
         </TabPanel>
       </TabContext>
     </Box>

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -6,6 +6,7 @@ import TabContext from '@mui/lab/TabContext';
 import { tabStyle, tabPanelStyle } from '../V1.0ProjectView/style';
 import VWSkeleton from '../../../vw-v2-components/Skeletons';
 import ComplianceTracker from '../../../pages/ComplianceTracker/1.0ComplianceTracker';
+
 import {
   containerStyle,
   headerContainerStyle,

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -54,7 +54,7 @@ const ComingSoonMessage = () => (
 const ProjectFrameworks = ({ project }: { project: Project }) => {
   const [framework, setFramework] = useState('eu-ai-act');
   const [tracker, setTracker] = useState('compliance');
-  console.log("project in project frameworks", project);
+  
   return (
     <Box sx={containerStyle}>
       {/* Framework Tabs and Add Button */}

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -6,6 +6,7 @@ import TabContext from '@mui/lab/TabContext';
 import { tabStyle, tabPanelStyle } from '../V1.0ProjectView/style';
 import VWSkeleton from '../../../vw-v2-components/Skeletons';
 import ComplianceTracker from '../../../pages/ComplianceTracker/1.0ComplianceTracker';
+import { Project } from '../../../../domain/types/Project';
 
 import {
   containerStyle,
@@ -15,6 +16,7 @@ import {
   addButtonStyle,
   tabListStyle,
 } from './styles';
+
 
 const frameworks = [
   { label: 'EU AI Act', value: 'eu-ai-act' },
@@ -26,7 +28,7 @@ const trackerTabs = [
   { label: 'Assessment tracker', value: 'assessment' },
 ];
 
-const ProjectFrameworks = ({ project }: { project: any }) => {
+const ProjectFrameworks = ({ project }: { project: Project }) => {
   const [framework, setFramework] = useState('eu-ai-act');
   const [tracker, setTracker] = useState('compliance');
   console.log("project in project frameworks", project);

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { Box, Button, Tab, Typography } from '@mui/material';
+import TabList from '@mui/lab/TabList';
+import TabPanel from '@mui/lab/TabPanel';
+import TabContext from '@mui/lab/TabContext';
+import { tabStyle, tabPanelStyle } from '../V1.0ProjectView/style';
+import {
+  containerStyle,
+  headerContainerStyle,
+  frameworkTabsContainerStyle,
+  getFrameworkTabStyle,
+  addButtonStyle,
+  tabListStyle,
+} from './styles';
+
+const frameworks = [
+  { label: 'EU AI Act', value: 'eu-ai-act' },
+  { label: 'ISO 42001', value: 'iso-42001' },
+];
+const trackerTabs = [
+  { label: 'Compliance tracker', value: 'compliance' },
+  { label: 'Assessment tracker', value: 'assessment' },
+];
+
+const ProjectFrameworks = () => {
+  const [framework, setFramework] = useState('eu-ai-act');
+  const [tracker, setTracker] = useState('compliance');
+
+  return (
+    <Box sx={containerStyle}>
+      {/* Framework Tabs and Add Button */}
+      <Box sx={headerContainerStyle}>
+        {/* Framework Tabs as classic tabs, not buttons */}
+        <Box sx={frameworkTabsContainerStyle}>
+          {frameworks.map((fw, idx) => {
+            const isActive = framework === fw.value;
+            return (
+              <Box
+                key={fw.value}
+                onClick={() => setFramework(fw.value)}
+                sx={getFrameworkTabStyle(isActive, idx === frameworks.length - 1)}
+              >
+                {fw.label}
+              </Box>
+            );
+          })}
+        </Box>
+        <Button variant="contained" sx={addButtonStyle}>
+          Add new framework
+        </Button>
+      </Box>
+
+      {/* Tracker Tabs */}
+      <TabContext value={tracker}>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 1 }}>
+          <TabList
+            onChange={(_, v) => setTracker(v)}
+            TabIndicatorProps={{ style: { backgroundColor: '#13715B' } }}
+            sx={tabListStyle}
+          >
+            {trackerTabs.map(tab => (
+              <Tab
+                key={tab.value}
+                sx={tabStyle}
+                label={tab.label}
+                value={tab.value}
+                disableRipple
+              />
+            ))}
+          </TabList>
+        </Box>
+        <TabPanel value="compliance" sx={tabPanelStyle}>
+          {/* Compliance tracker content goes here */}
+        </TabPanel>
+        <TabPanel value="assessment" sx={tabPanelStyle}>
+          {/* Assessment tracker content goes here */}
+        </TabPanel>
+      </TabContext>
+    </Box>
+  );
+};
+
+export default ProjectFrameworks;

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
-import { Box, Button, Tab, Typography } from '@mui/material';
+import { useState } from 'react';
+import { Box, Button, Tab } from '@mui/material';
 import TabList from '@mui/lab/TabList';
 import TabPanel from '@mui/lab/TabPanel';
 import TabContext from '@mui/lab/TabContext';
 import { tabStyle, tabPanelStyle } from '../V1.0ProjectView/style';
+import VWSkeleton from '../../../vw-v2-components/Skeletons';
+import ComplianceTracker from '../../../pages/ComplianceTracker/1.0ComplianceTracker';
 import {
   containerStyle,
   headerContainerStyle,
@@ -17,15 +19,16 @@ const frameworks = [
   { label: 'EU AI Act', value: 'eu-ai-act' },
   { label: 'ISO 42001', value: 'iso-42001' },
 ];
+
 const trackerTabs = [
   { label: 'Compliance tracker', value: 'compliance' },
   { label: 'Assessment tracker', value: 'assessment' },
 ];
 
-const ProjectFrameworks = () => {
+const ProjectFrameworks = ({ project }: { project: any }) => {
   const [framework, setFramework] = useState('eu-ai-act');
   const [tracker, setTracker] = useState('compliance');
-
+  console.log("project in project frameworks", project);
   return (
     <Box sx={containerStyle}>
       {/* Framework Tabs and Add Button */}
@@ -70,7 +73,11 @@ const ProjectFrameworks = () => {
           </TabList>
         </Box>
         <TabPanel value="compliance" sx={tabPanelStyle}>
-          {/* Compliance tracker content goes here */}
+          {project ? (
+            <ComplianceTracker project={project} />
+          ) : (
+            <VWSkeleton variant="rectangular" width="100%" height={400} />
+          )}
         </TabPanel>
         <TabPanel value="assessment" sx={tabPanelStyle}>
           {/* Assessment tracker content goes here */}

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/styles.ts
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/styles.ts
@@ -1,0 +1,61 @@
+import { SxProps, Theme } from '@mui/material';
+
+export const containerStyle: SxProps<Theme> = {
+  width: '100%',
+  mt: 2,
+};
+
+export const headerContainerStyle: SxProps<Theme> = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  mb: 2,
+};
+
+export const frameworkTabsContainerStyle: SxProps<Theme> = {
+  display: 'flex',
+  border: '1px solid #BFC9C5',
+  borderRadius: '4px',
+  overflow: 'hidden',
+  height: 43,
+  bgcolor: '#fff',
+};
+
+export const getFrameworkTabStyle = (isActive: boolean, isLast: boolean): SxProps<Theme> => ({
+  cursor: 'pointer',
+  px: 5,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  bgcolor: isActive ? '#F5F6F6' : '#fff',
+  color: '#232B3A',
+  fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+  fontSize: 13,
+  borderRight: isLast ? 'none' : '1px solid #BFC9C5',
+  fontWeight: 400,
+  transition: 'background 0.2s',
+  userSelect: 'none',
+  width: '142px',
+});
+
+export const addButtonStyle: SxProps<Theme> = {
+  borderRadius: 2,
+  textTransform: 'none',
+  fontWeight: 400,
+  backgroundColor: '#13715B',
+  border: '1px solid #13715B',
+  color: '#fff',
+  fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+  fontSize: 13,
+  '&:hover': {
+    backgroundColor: '#10614d',
+  },
+};
+
+export const tabListStyle: SxProps<Theme> = {
+  minHeight: '20px',
+  '& .MuiTabs-flexContainer': {
+    columnGap: '34px',
+  },
+}; 

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/styles.ts
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/styles.ts
@@ -14,11 +14,11 @@ export const headerContainerStyle: SxProps<Theme> = {
 
 export const frameworkTabsContainerStyle: SxProps<Theme> = {
   display: 'flex',
-  border: '1px solid #BFC9C5',
+  border: (theme) => `1px solid ${theme.palette.divider}`,
   borderRadius: '4px',
   overflow: 'hidden',
   height: 43,
-  bgcolor: '#fff',
+  bgcolor: 'background.paper'
 };
 
 export const getFrameworkTabStyle = (isActive: boolean, isLast: boolean): SxProps<Theme> => ({
@@ -28,12 +28,12 @@ export const getFrameworkTabStyle = (isActive: boolean, isLast: boolean): SxProp
   alignItems: 'center',
   justifyContent: 'center',
   height: '100%',
-  bgcolor: isActive ? '#F5F6F6' : '#fff',
-  color: '#232B3A',
-  fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
-  fontSize: 13,
-  borderRight: isLast ? 'none' : '1px solid #BFC9C5',
-  fontWeight: 400,
+  bgcolor: isActive ? 'action.hover' : 'background.paper',
+  color: 'text.primary',
+  fontFamily: (theme) => theme.typography.fontFamily,
+  fontSize: (theme) => theme.typography.caption.fontSize,
+  borderRight: (theme) => isLast ? 'none' : `1px solid ${theme.palette.divider}`,
+  fontWeight: (theme) => theme.typography.body2.fontWeight,
   transition: 'background 0.2s',
   userSelect: 'none',
   width: '142px',

--- a/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/index.tsx
@@ -15,6 +15,7 @@ import VWSkeleton from "../../../vw-v2-components/Skeletons";
 import VWProjectRisks from "./ProjectRisks";
 import ProjectSettings from "../ProjectSettings";
 import useProjectData from "../../../../application/hooks/useProjectData";
+import ProjectFrameworks from "../ProjectFrameworks";
 
 const VWProjectView = () => {
   const [searchParams] = useSearchParams();
@@ -77,6 +78,12 @@ const VWProjectView = () => {
                 disableRipple
               />
               <Tab
+                label="Frameworks"
+                value="frameworks"
+                sx={tabStyle}
+                disableRipple
+              />
+              <Tab
                 sx={tabStyle}
                 label="Settings"
                 value="settings"
@@ -96,6 +103,14 @@ const VWProjectView = () => {
             {project ? (
               // Render project risks content here
               <VWProjectRisks />
+            ) : (
+              <VWSkeleton variant="rectangular" width="100%" height={400} />
+            )}
+          </TabPanel>
+          <TabPanel value="frameworks" sx={tabPanelStyle}>
+            {project ? (
+              // Render frameworks content here
+              <ProjectFrameworks />
             ) : (
               <VWSkeleton variant="rectangular" width="100%" height={400} />
             )}

--- a/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/index.tsx
@@ -110,7 +110,7 @@ const VWProjectView = () => {
           <TabPanel value="frameworks" sx={tabPanelStyle}>
             {project ? (
               // Render frameworks content here
-              <ProjectFrameworks />
+              <ProjectFrameworks project={project} />
             ) : (
               <VWSkeleton variant="rectangular" width="100%" height={400} />
             )}


### PR DESCRIPTION
## Describe your changes

1. Move Assessment Tracker Page to Frameworks tab
2. Remove Assessment Tracker from Sidebar.

## Write your issue number after "Fixes "

Fixes #1247 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Frameworks" tab in the project view, allowing users to manage and track compliance and assessment for frameworks such as the EU AI Act and ISO 42001.
  - Added a new interface for selecting frameworks and switching between compliance and assessment trackers within projects.

- **Bug Fixes**
  - Removed sidebar menu entries and navigation routes for "Compliance tracker" and "Assessment tracker" to streamline navigation.

- **Documentation**
  - Added comprehensive documentation for the new framework management interface, outlining features, usage, and planned improvements.

- **Style**
  - Implemented new styles for the frameworks management interface to ensure a consistent and visually appealing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->