### PR TITLE
fixed joyride tour in compliance tracker page

### DIFF
--- a/Clients/src/App.tsx
+++ b/Clients/src/App.tsx
@@ -47,6 +47,8 @@ function App() {
   const [componentsVisible, setComponentsVisible] = useState<ComponentVisible>({
     home: false,
     sidebar: false,
+    projectFrameworks: false,
+    compliance: false,
   });
   const changeComponentVisibility = useCallback(
     (component: keyof ComponentVisible, value: boolean) => {

--- a/Clients/src/application/contexts/VerifyWise.context.ts
+++ b/Clients/src/application/contexts/VerifyWise.context.ts
@@ -46,7 +46,7 @@ const VerifyWiseContext = createContext<VerifyWiseContextProps>({
   userId: "",
   projects: [],
   setProjects: () => {},
-  componentsVisible: { home: false, sidebar: false },
+  componentsVisible: { home: false, sidebar: false, projectFrameworks: false, compliance: false },
   changeComponentVisibility: () => {},
 });
 

--- a/Clients/src/application/interfaces/ComponentVisible.ts
+++ b/Clients/src/application/interfaces/ComponentVisible.ts
@@ -1,4 +1,6 @@
 export interface ComponentVisible {
   home: boolean;
   sidebar: boolean;
+  projectFrameworks: boolean;
+  compliance: boolean;
 }

--- a/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/index.tsx
+++ b/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Stack, Typography } from "@mui/material";
 import { pageHeadingStyle } from "../../Assessment/1.0AssessmentTracker/index.style";
 import { getEntityById } from "../../../../application/repository/entity.repository";
@@ -9,6 +9,7 @@ import ControlCategoryTile from "./ControlCategory";
 import PageTour from "../../../components/PageTour";
 import ComplianceSteps from "./ComplianceSteps";
 import useMultipleOnScreen from "../../../../application/hooks/useMultipleOnScreen";
+import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import { ComplianceData } from "../../../../domain/interfaces/iCompliance";
 import { Project } from "../../../../domain/types/Project";
 
@@ -22,17 +23,25 @@ const ComplianceTracker = ({ project }: { project: Project }) => {
     useState<ControlCategoryModel[]>();
   const [error, setError] = useState<unknown>(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const { componentsVisible, changeComponentVisibility } = useContext(
+    VerifyWiseContext);
   const [runComplianceTour, setRunComplianceTour] = useState(false);
 
   const { refs, allVisible } = useMultipleOnScreen<HTMLDivElement>({
-    countToTrigger: 3,
+    countToTrigger: 2,
   });
 
   useEffect(() => {
     if (allVisible) {
-      setRunComplianceTour(true);
+      changeComponentVisibility("compliance", true);
     }
   }, [allVisible]);
+
+    useEffect(() => {
+      if (componentsVisible.compliance && componentsVisible.projectFrameworks) {
+        setRunComplianceTour(true);
+      }
+    }, [componentsVisible]);
 
   // Reset state when project changes
   useEffect(() => {
@@ -121,13 +130,6 @@ const ComplianceTracker = ({ project }: { project: Project }) => {
         }}
         tourKey="compliance-tour"
       />
-      <Stack
-        ref={refs[0]}
-        data-joyride-id="compliance-heading"
-        sx={{ position: "relative" }}
-      >
-        {/* <Typography sx={pageHeadingStyle}>Compliance tracker</Typography> */}
-      </Stack>
       {complianceData && (
         <Stack ref={refs[1]} data-joyride-id="compliance-progress-bar">
           <StatsCard

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useContext } from "react";
 import { Box, Button, Tab, Alert } from "@mui/material";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
@@ -10,6 +10,8 @@ import { Project } from "../../../../domain/types/Project";
 import AssessmentTracker from "../../Assessment/1.0AssessmentTracker";
 import useFrameworks from "../../../../application/hooks/useFrameworks";
 import AddFrameworkModal from "../AddNewFramework";
+import useMultipleOnScreen from "../../../../application/hooks/useMultipleOnScreen";
+import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 
 import {
   containerStyle,
@@ -58,6 +60,21 @@ const ProjectFrameworks = ({ project }: { project: Project }) => {
     "compliance"
   );
   const [isModalOpen, setIsModalOpen] = useState(false);
+  //joyride
+  const { changeComponentVisibility } = useContext(VerifyWiseContext);
+
+  const { refs, allVisible } = useMultipleOnScreen<HTMLElement>({
+    countToTrigger: 1,
+  });
+
+  useEffect(() => {
+    changeComponentVisibility("projectFrameworks", allVisible);
+    changeComponentVisibility(
+      "compliance",
+      tracker === "compliance" && allVisible
+    );
+    console.log("allVisible", allVisible);
+  }, [allVisible, tracker, changeComponentVisibility]);
 
   const associatedFrameworkIds =
     project.framework?.map((f) => f.framework_id) || [];
@@ -201,6 +218,10 @@ const ProjectFrameworks = ({ project }: { project: Project }) => {
                 label={tab.label}
                 value={tab.value}
                 disableRipple
+                data-joyride-id={
+                  tab.value === "compliance" ? "compliance-heading" : undefined
+                } // Add Joyride ID here
+                ref={tab.value === "compliance" ? refs[0] : undefined} // Add ref here
               />
             ))}
           </TabList>
@@ -217,7 +238,7 @@ const ProjectFrameworks = ({ project }: { project: Project }) => {
         ) : (
           <>
             <TabPanel value="compliance" sx={tabPanelStyle}>
-              <ComplianceTracker project={project} />
+                <ComplianceTracker project={project} />
             </TabPanel>
             <TabPanel value="assessment" sx={tabPanelStyle}>
               <AssessmentTracker project={project} />


### PR DESCRIPTION

## Describe your changes

-Used componentsVisible and changeComponentsVisible in VW Context to track the visibility of "Compliance Tracker" tab in the DOM before starting tour. 
-In ProjectFrameworks, the first step is conditionally rendered in Tab component. On mount, projectFrameworks visibility is tied to allVisible and compliance visibility is tied to both tracker being set to "compliance" and allVisible. 
-In ComplianceTracker, on mount the joyride tour starts when both componentsVisible.compliance and componentsVisible.projectFrameworks  are true and available in the DOM.


## Write your issue number after "Fixes "

Fixes #1362 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added visibility tracking for "projectFrameworks" and "compliance" UI components, enabling enhanced control over their display state.
  - Improved integration of guided tours or analytics by detecting when specific components are visible to the user.

- **Bug Fixes**
  - Adjusted logic for starting the compliance tour to ensure it only runs when both relevant components are visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->