### PR TITLE
Fix: TabIndicator Width Settings & Project Overview

### DIFF
--- a/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/style.ts
+++ b/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/style.ts
@@ -13,10 +13,11 @@ export const projectViewHeaderDesc = {
 export const tabStyle = {
   textTransform: "none",
   fontWeight: 400,
-  alignItems: "flex-start",
+  alignItems: "center",
   justifyContent: "flex-end",
   padding: "16px 0 7px",
   minHeight: "20px",
+  minWidth: "auto",
   "&.Mui-selected": {
     color: "#13715B",
   },

--- a/Clients/src/presentation/pages/SettingsPage/style.ts
+++ b/Clients/src/presentation/pages/SettingsPage/style.ts
@@ -8,9 +8,10 @@ export const tabContainerStyle = {
 export const settingTabStyle = {
   textTransform: "none",
   fontWeight: 400,
-  alignItems: "flex-start",
+  alignItems: "center",
   justifyContent: "flex-end",
   padding: "16px 0 7px",
+  minWidth: "auto",
   minHeight: "20px",
   "&.Mui-selected": {
     color: "#13715B",


### PR DESCRIPTION
## Describe your changes

This PR fixes the tabindicator width for remaining pages.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="653" alt="Screenshot 2025-05-17 at 11 34 49 AM" src="https://github.com/user-attachments/assets/9e0f3c4d-c196-40dc-b08c-d5dc376a01d1" />
<img width="250" alt="Screenshot 2025-05-17 at 11 31 55 AM" src="https://github.com/user-attachments/assets/5f945bdc-abba-40ea-a70a-3232377d733c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved vertical alignment of tab content for a more visually balanced appearance.
  - Updated minimum width settings for tabs to better adapt to content size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->