### PR TITLE
Set report type onChange in reporting form

### DIFF
--- a/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
@@ -97,7 +97,8 @@ const GenerateReportFrom: React.FC<ReportProps> = ({
         <Suspense fallback={<div>Loading...</div>}>
           <RadioGroup 
             values={REPORT_TYPES} 
-            defaultValue='Project risks report' />
+            defaultValue='Project risks report'
+            onChange={(event) => setValues({ ...values, report_type: event.target.value })} />
         </Suspense>
       </Stack>
       <Stack sx={{paddingTop: theme.spacing(4)}}>


### PR DESCRIPTION
## Describe your changes

- Set report type onChange in reporting form. Previously, the report type has set as "Project risk report" as a default type. 

## Write your issue number after "Fixes "

Fixes #1344 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [ ] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved report type selection by updating the displayed report type dynamically when users change their selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->