### PR TITLE
#1431: fix the wiggle in vendor risks

### DIFF
--- a/Clients/src/presentation/components/Table/RisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/RisksTable/index.tsx
@@ -143,7 +143,7 @@ const RiskTable: React.FC<RiskTableProps> = ({
                   {
                     formattedVendors?.find(
                       (vendor: any) => vendor._id === row.vendor_id
-                    )?.name
+                    )?.name || row.vendor_name
                   }
                 </TableCell>
                 <TableCell sx={cellStyle}>{row.impact}</TableCell>

--- a/Clients/src/presentation/pages/Vendors/index.tsx
+++ b/Clients/src/presentation/pages/Vendors/index.tsx
@@ -170,18 +170,14 @@ const Vendors = () => {
   }, [selectedProjectId]);
 
   useEffect(() => {
-    fetchVendors();
-    return () => {
-      controller?.abort();
-    };
-  }, [selectedProjectId]);
-
-  useEffect(() => {
-    refetchVendorRisks();
-    return () => {
-      controller?.abort();
-    };
-  }, [selectedProjectId]);
+    if (value === "1") {
+      fetchVendors();
+      return () => {
+        controller?.abort();
+      };
+    }
+    // No fetch on Risks tab
+  }, [selectedProjectId, value]);
 
   useEffect(() => {
     if (allVisible) {


### PR DESCRIPTION
## Describe your changes

Updated the vendor risk dropdown filters to avoid triggering a re-render. Filtering is now handled entirely on the frontend. 

## Write your issue number after "Fixes "

Fixes #1431 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.


https://github.com/user-attachments/assets/c69e7ed1-4b60-4302-aaa1-0fedbfc99f91



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved display of vendor names in the risks table by ensuring a fallback is shown if vendor information is missing.

- **Refactor**
	- Optimized data fetching on the Vendors page to only load vendor data when the Vendors tab is active, reducing unnecessary network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->