### PR TITLE
Fix: Project Framework ID from FE to BE

### DIFF
--- a/Clients/src/application/tools/fileDownload.ts
+++ b/Clients/src/application/tools/fileDownload.ts
@@ -6,6 +6,8 @@ interface GenerateReportProps {
   projectOwner: string;
   reportType: string;
   reportName: string;
+  frameworkId: number;
+  projectFrameworkId: number;
 }
 
 export const handleDownload = async (fileId: string, fileName: string) => {

--- a/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
@@ -61,6 +61,14 @@ interface ReportProps {
   onGenerate: (formValues: any) => void;
 }
 
+const safeNumberConversion = (value: string | number): number => {
+  const num = Number(value);
+  if (isNaN(num)) {
+    throw new Error('Invalid number conversion');
+  }
+  return num;
+};
+
 const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
   const { dashboardValues } = useContext(VerifyWiseContext);
   const [values, setValues] = useState<FormValues>({...initialState, project: dashboardValues.projects[0].id});
@@ -99,7 +107,7 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
   );
 
   const handleFrameworkChange = (event: SelectChangeEvent<string | number>) => {
-    const selectedFrameworkId = Number(event.target.value);
+    const selectedFrameworkId = safeNumberConversion(event.target.value);
     const selectedFramework = projectFrameworks.find(
       (fw) => fw.framework_id === selectedFrameworkId
     );

--- a/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
@@ -23,7 +23,7 @@ interface FormValues {
   report_name: string;
   project: number;
   framework: number;
-  project_framework_id: number;
+  projectFrameworkId: number;
 }
 
 interface FormErrors {
@@ -31,7 +31,7 @@ interface FormErrors {
   report_name?: string;
   project?: string;
   framework?: string;
-  project_framework_id?: string;
+  projectFrameworkId?: string;
 }
 
 const initialState: FormValues = {
@@ -39,7 +39,7 @@ const initialState: FormValues = {
   report_name: "",
   project: 1,
   framework: 1,
-  project_framework_id: 1,
+  projectFrameworkId: 1,
 };
 
 /**
@@ -77,7 +77,7 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
       )?.framework || "";
     setProjectFrameworks(pfw);
     if (pfw.length > 0) {
-      setValues({ ...values, framework: pfw[0].framework_id, project_framework_id: pfw[0].project_framework_id });
+      setValues({ ...values, framework: pfw[0].framework_id, projectFrameworkId: pfw[0].project_framework_id });
     }
   }, [values.project]);
 
@@ -107,7 +107,7 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
       setValues({
         ...values,
         framework: selectedFramework.framework_id,
-        project_framework_id: selectedFramework.project_framework_id,
+        projectFrameworkId: selectedFramework.project_framework_id,
       });
       setErrors({ ...errors, framework: "" });
     }
@@ -160,7 +160,7 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
               projectFrameworks?.map((framework) => ({
                 _id: framework.framework_id,
                 name: framework.name,
-                project_framework_id: framework.project_framework_id,
+                projectFrameworkId: framework.project_framework_id,
               })) || []
             }
             sx={{

--- a/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
@@ -23,6 +23,7 @@ interface FormValues {
   report_name: string;
   project: number;
   framework: number;
+  project_framework_id: number;
 }
 
 interface FormErrors {
@@ -30,6 +31,7 @@ interface FormErrors {
   report_name?: string;
   project?: string;
   framework?: string;
+  project_framework_id?: string;
 }
 
 const initialState: FormValues = {
@@ -37,6 +39,7 @@ const initialState: FormValues = {
   report_name: "",
   project: 1,
   framework: 1,
+  project_framework_id: 1,
 };
 
 /**
@@ -74,7 +77,7 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
       )?.framework || "";
     setProjectFrameworks(pfw);
     if (pfw.length > 0) {
-      setValues({ ...values, framework: pfw[0].framework_id });
+      setValues({ ...values, framework: pfw[0].framework_id, project_framework_id: pfw[0].project_framework_id });
     }
   }, [values.project]);
 
@@ -94,6 +97,21 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
     },
     [values, errors]
   );
+
+  const handleFrameworkChange = (event: SelectChangeEvent<string | number>) => {
+    const selectedFrameworkId = Number(event.target.value);
+    const selectedFramework = projectFrameworks.find(
+      (fw) => fw.framework_id === selectedFrameworkId
+    );
+    if (selectedFramework) {
+      setValues({
+        ...values,
+        framework: selectedFramework.framework_id,
+        project_framework_id: selectedFramework.project_framework_id,
+      });
+      setErrors({ ...errors, framework: "" });
+    }
+  };
 
   const handleFormSubmit = () => {
     onGenerate(values);
@@ -137,11 +155,12 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
             label="Framework"
             placeholder="Select framework"
             value={values.framework}
-            onChange={handleOnSelectChange("framework")}
+            onChange={handleFrameworkChange}
             items={
               projectFrameworks?.map((framework) => ({
                 _id: framework.framework_id,
                 name: framework.name,
+                project_framework_id: framework.project_framework_id,
               })) || []
             }
             sx={{

--- a/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
@@ -18,7 +18,7 @@ interface InputProps {
   report_name: string;
   project: number;
   framework: number;
-  project_framework_id: number;
+  projectFrameworkId: number;
 }
 
 const GenerateReportPopup: React.FC<GenerateReportProps> = ({
@@ -82,7 +82,7 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
       reportType: reportTypeLabel,
       reportName: input.report_name,
       frameworkId: input.framework,
-      projectFrameworkId: input.project_framework_id
+      projectFrameworkId: input.projectFrameworkId
     }
     const reportDownloadResponse = await handleAutoDownload(body);
     setResponseStatusCode(reportDownloadResponse);

--- a/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
@@ -18,6 +18,7 @@ interface InputProps {
   report_name: string;
   project: number;
   framework: number;
+  project_framework_id: number;
 }
 
 const GenerateReportPopup: React.FC<GenerateReportProps> = ({
@@ -45,7 +46,7 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
   };
 
   const handleGenerateReport = async (input: InputProps) => {       
-    const currentProject = dashboardValues.projects.find((project: { id: number | null; }) => project.id === input.project);         
+    const currentProject = dashboardValues.projects.find((project: { id: number | null; }) => project.id === input.project);
     
     if (!currentProject) {
       handleToast("error", "Project not found");
@@ -80,7 +81,8 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
       projectOwner: currentProjectOwner,
       reportType: reportTypeLabel,
       reportName: input.report_name,
-      frameworkId: input.framework
+      frameworkId: input.framework,
+      projectFrameworkId: input.project_framework_id
     }
     const reportDownloadResponse = await handleAutoDownload(body);
     setResponseStatusCode(reportDownloadResponse);

--- a/Servers/controllers/reporting.ctrl.ts
+++ b/Servers/controllers/reporting.ctrl.ts
@@ -61,7 +61,8 @@ export async function generateReports(
       projectTitle,
       projectOwner,
       frameworkId: frameworkIdRaw,
-      reportName
+      reportName,
+      projectFrameworkId
     } = req.body;
     const projectId = parseInt(projectIdRaw);
     const frameworkId = parseInt(frameworkIdRaw);
@@ -81,7 +82,8 @@ export async function generateReports(
       projectId,
       frameworkId,
       reportType,
-      reportData
+      reportData,
+      projectFrameworkId
     );
     const markdownDoc = await marked.parse(markdownData); // markdown file
     const generatedDoc = await htmlDocx(markdownDoc); // convert markdown to docx

--- a/Servers/routes/reporting.route.ts
+++ b/Servers/routes/reporting.route.ts
@@ -10,7 +10,7 @@ import authenticateJWT from "../middleware/auth.middleware";
 import { validateId } from "../validations/id.valid";
 
 // POST, PUT, DELETE requests
-router.post("/generate-report", authenticateJWT, validateId("projectId"), validateId("frameworkId"), generateReports);
+router.post("/generate-report", authenticateJWT, validateId("projectId"), validateId("frameworkId"), validateId("projectFrameworkId"), generateReports);
 router.delete("/:id", authenticateJWT, deleteGeneratedReportById);
 
 // GET request

--- a/Servers/services/markdowns/allReportMarkdown.ts
+++ b/Servers/services/markdowns/allReportMarkdown.ts
@@ -16,12 +16,13 @@ import { getProjectRiskReportData } from './projectRiskMarkdown';
 import { getVendorReportData, getVendorRiskReportData } from './vendorAndRisksMarkdown';
 
 export async function getAllReportMarkdown (
+  frameworkId: number,
   projectFrameworkId: number,
   projectId: number,
   data: ReportBodyData
 ) : Promise<string> {
   try {
-    const framework = await getAllFrameworkByIdQuery(projectFrameworkId);
+    const framework = await getAllFrameworkByIdQuery(frameworkId);
 
     if (framework) {
       let projectReportMarkdown = await getProjectRiskReportData(projectId);
@@ -29,8 +30,8 @@ export async function getAllReportMarkdown (
       let vendorRiskReportMarkdown = await getVendorRiskReportData(projectId);
 
       if (framework.name === "EU AI Act") { 
-        const complianceReportMarkdown = await getComplianceReportData(projectFrameworkId);
-        const assessmentReportMarkdown = await getAssessmentTrackerReportData(projectId, projectFrameworkId);
+        const complianceReportMarkdown = await getComplianceReportData(frameworkId);
+        const assessmentReportMarkdown = await getAssessmentTrackerReportData(projectId, frameworkId);
 
       const euAIMD = `
 VerifyWise ${framework.name} report
@@ -67,7 +68,7 @@ ${assessmentReportMarkdown}
 `
         return euAIMD;
       } else {        
-        let clausesAndAnnexesMarkdown = await getClausesAndAnnexesReportData(projectFrameworkId);
+        let clausesAndAnnexesMarkdown = await getClausesAndAnnexesReportData(frameworkId, projectFrameworkId);
         const isoMD = `
 VerifyWise ${framework.name} report
 ========================
@@ -100,7 +101,7 @@ ${clausesAndAnnexesMarkdown}
         return isoMD;
       }
     } else {
-      throw new Error(`Framework with ID ${projectFrameworkId} not found`);
+      throw new Error(`Framework with ID ${frameworkId} not found`);
     }
   } catch (error){
     console.error('Error generating all reports markdown:', error);

--- a/Servers/services/markdowns/annexesMarkdown.ts
+++ b/Servers/services/markdowns/annexesMarkdown.ts
@@ -50,7 +50,7 @@ export async function getClausesAndAnnexesReportData (
   let annexRows: string = ``;
   let clausesReportData: string = ``;
   try {
-    const annexesReportData = await getAnnexesReportQuery(frameworkId) as AllAnnexes[];    
+    const annexesReportData = await getAnnexesReportQuery(projectFrameworkId) as AllAnnexes[];    
     clausesReportData = await getClausesMarkdown(projectFrameworkId);
 
     if (annexesReportData.length > 0) {

--- a/Servers/services/markdowns/annexesMarkdown.ts
+++ b/Servers/services/markdowns/annexesMarkdown.ts
@@ -22,10 +22,11 @@ type AllAnnexes = AnnexStructISOModel & {
 };
 
 export async function getClausesAndAnnexesMarkdown (
+  frameworkId: number,
   projectFrameworkId: number,
   data: ReportBodyData
 ) : Promise<string> {
-  const clausesAndAnnexesReportData = await getClausesAndAnnexesReportData(projectFrameworkId);  
+  const clausesAndAnnexesReportData = await getClausesAndAnnexesReportData(frameworkId, projectFrameworkId);  
   
   const markdown = `
 VerifyWise clauses and annexes report
@@ -43,12 +44,13 @@ ${clausesAndAnnexesReportData}
 }
 
 export async function getClausesAndAnnexesReportData (
+  frameworkId: number,
   projectFrameworkId: number
 ) : Promise<string> {
   let annexRows: string = ``;
   let clausesReportData: string = ``;
   try {
-    const annexesReportData = await getAnnexesReportQuery(projectFrameworkId) as AllAnnexes[];    
+    const annexesReportData = await getAnnexesReportQuery(frameworkId) as AllAnnexes[];    
     clausesReportData = await getClausesMarkdown(projectFrameworkId);
 
     if (annexesReportData.length > 0) {

--- a/Servers/services/markdowns/annexesMarkdown.ts
+++ b/Servers/services/markdowns/annexesMarkdown.ts
@@ -22,11 +22,10 @@ type AllAnnexes = AnnexStructISOModel & {
 };
 
 export async function getClausesAndAnnexesMarkdown (
-  frameworkId: number,
   projectFrameworkId: number,
   data: ReportBodyData
 ) : Promise<string> {
-  const clausesAndAnnexesReportData = await getClausesAndAnnexesReportData(frameworkId, projectFrameworkId);  
+  const clausesAndAnnexesReportData = await getClausesAndAnnexesReportData(projectFrameworkId);  
   
   const markdown = `
 VerifyWise clauses and annexes report
@@ -44,7 +43,6 @@ ${clausesAndAnnexesReportData}
 }
 
 export async function getClausesAndAnnexesReportData (
-  frameworkId: number,
   projectFrameworkId: number
 ) : Promise<string> {
   let annexRows: string = ``;

--- a/Servers/services/reportService.ts
+++ b/Servers/services/reportService.ts
@@ -84,7 +84,8 @@ export async function getReportData(
     projectId: number,
     frameworkId: number,
     reportType: string,
-    reportBody: ReportBodyData
+    reportBody: ReportBodyData,
+    projectFrameworkId: number
   ) : Promise<any> {
   let markdownFormattedData;
   switch(reportType) {
@@ -98,13 +99,13 @@ export async function getReportData(
       markdownFormattedData = await getVendorReportMarkdown(projectId, reportBody)
       break;
     case ReportType.ANNEXES_REPORT:
-      markdownFormattedData = await getClausesAndAnnexesMarkdown(frameworkId, reportBody)
+      markdownFormattedData = await getClausesAndAnnexesMarkdown(frameworkId, projectFrameworkId, reportBody)
       break;
     case ReportType.COMPLIANCE_REPORT:
       markdownFormattedData = await getComplianceMarkdown(frameworkId, reportBody)
       break;
     case ReportType.ALL_REPORT:
-      markdownFormattedData = await getAllReportMarkdown(frameworkId, projectId, reportBody)
+      markdownFormattedData = await getAllReportMarkdown(frameworkId, projectFrameworkId, projectId, reportBody)
       break;
     default:
       throw new Error(`Report type "${reportType}" is not supported`);

--- a/Servers/services/reportService.ts
+++ b/Servers/services/reportService.ts
@@ -99,7 +99,7 @@ export async function getReportData(
       markdownFormattedData = await getVendorReportMarkdown(projectId, reportBody)
       break;
     case ReportType.ANNEXES_REPORT:
-      markdownFormattedData = await getClausesAndAnnexesMarkdown(frameworkId, projectFrameworkId, reportBody)
+      markdownFormattedData = await getClausesAndAnnexesMarkdown(projectFrameworkId, reportBody)
       break;
     case ReportType.COMPLIANCE_REPORT:
       markdownFormattedData = await getComplianceMarkdown(frameworkId, reportBody)


### PR DESCRIPTION
## Describe your changes

This PR address the implementation of `projectFrameworkId `and the seperation of `framework_id` and `project_framework_id`.

## Write your issue number after "Fixes "

Fixes #1530 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] My pull request is focused and addresses a single, specific feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying both framework and project framework when generating reports, allowing for more precise report customization.

- **Bug Fixes**
  - Improved consistency in naming conventions for framework identifiers across the report generation workflow.

- **Refactor**
  - Streamlined how framework and project framework IDs are handled throughout the report generation process for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->