### PR TITLE
Fix: All Reports Shown in Generated Reports Tab

### DIFF
--- a/Servers/utils/reporting.utils.ts
+++ b/Servers/utils/reporting.utils.ts
@@ -56,6 +56,7 @@ export const getGeneratedReportsQuery = async () => {
     "Project risks report",
     "Compliance tracker report",
     "Assessment tracker report",
+    "Reference controls group",
     "Vendors and risks report",
     "All reports",
   ];
@@ -75,11 +76,10 @@ export const getGeneratedReportsQuery = async () => {
     WHERE report.source IN (:sources)
     ORDER BY uploaded_time DESC, report.id ASC
   `;
-  const reports = await sequelize.query(query, {
+  return await sequelize.query(query, {
     replacements: { sources: validSources },
     type: QueryTypes.SELECT,
   });
-  return reports;
 };
 
 export const deleteReportByIdQuery = async (


### PR DESCRIPTION
## Describe your changes

This PR fixes the issue of all reports not being shown in the `reports generated` tab.

Fixes #1546  

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="1371" alt="Screenshot 2025-06-04 at 6 53 50 PM" src="https://github.com/user-attachments/assets/f50c5a7a-6d57-448a-9586-3d21a9820de8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added "Reference controls group" as a valid report source in report generation.

- **Refactor**
  - Simplified the logic for returning report data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->