### PR TITLE
Clear timeout for reporting popup

### DIFF
--- a/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, lazy, Suspense, useContext } from 'react'
+import React, { useState, lazy, Suspense, useContext, useRef } from 'react'
 import { IconButton, Box, Stack } from '@mui/material';
 import CloseIcon from "@mui/icons-material/Close";
 import {styles} from './styles';
@@ -31,6 +31,7 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
     title?: string;
     body: string;
   } | null>(null);
+  const clearTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleToast = (type: any, message: string) => {
     handleAlert({
@@ -38,7 +39,7 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
       body: message,
       setAlert,
     });
-    setTimeout(() => {
+    clearTimerRef.current = setTimeout(() => {
       setAlert(null);
       onClose();
     }, 3000);
@@ -101,6 +102,14 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
     }
   }
 
+  const handleOnCloseModal = () => {
+    if (clearTimerRef.current) {
+      clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = null;
+    }
+    onClose();
+  }
+
   return (
     <Stack>
       {alert && (
@@ -124,7 +133,7 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
         }}
         component="form"
       >
-        <IconButton onClick={onClose} sx={styles.iconButton}>
+        <IconButton onClick={handleOnCloseModal} sx={styles.iconButton}>
           <CloseIcon sx={styles.closeButton} />
         </IconButton>
         {isReportRequest ? 


### PR DESCRIPTION
## Describe your changes

- Clear `setTimeout` for reporting popup in the scenario of a user closing the popup by clicking the close button right after success or fail toast without waiting for its timer to close itself.
- By using `clearTimeout`, it prevents the potential bug of unexpected disappearance of the popup for the scenario where a user might close the popup without waiting for the timeout and click to open the popup to generate the report instantly. 

## Write your issue number after "Fixes "

Enter the corresponding issue number after "Fixes #1538 " 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.


https://github.com/user-attachments/assets/54cd0476-6beb-46fe-a56e-021d647d7780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alert dismissal behavior to prevent issues when closing the modal manually, ensuring no state updates occur after the modal is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->