### PR TITLE
Framework validation in create-new-project popup

### DIFF
--- a/Clients/src/presentation/vw-v2-components/Forms/ProjectForm/constants.ts
+++ b/Clients/src/presentation/vw-v2-components/Forms/ProjectForm/constants.ts
@@ -38,6 +38,7 @@ export interface FormValues {
 export interface FormErrors {
   projectTitle?: string;
   members?: string;
+  frameworks?: string;
   owner?: string;
   startDate?: string;
   riskClassification?: string;

--- a/Clients/src/presentation/vw-v2-components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/vw-v2-components/Forms/ProjectForm/index.tsx
@@ -53,6 +53,7 @@ const ProjectForm = ({ sx, onClose }: ProjectFormProps) => {
   const { allFrameworks } = useFrameworks({ listOfFrameworks: [] });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [memberRequired, setMemberRequired] = useState<boolean>(false);
+  const [frameworkRequired, setFrameworkRequired] = useState<boolean>(false);
   const authState = useSelector(
     (state: { auth: { authToken: string; userExists: boolean } }) => state.auth
   );
@@ -103,11 +104,16 @@ const ProjectForm = ({ sx, onClose }: ProjectFormProps) => {
   const handleOnMultiSelect = useCallback(
     (prop: keyof FormValues) =>
       (_event: React.SyntheticEvent, newValue: any[]) => {
+        console.log(values)
         setValues((prevValues) => ({
           ...prevValues,
           [prop]: newValue,
         }));
-        setMemberRequired(false);
+        if (prop === "members") {
+          setMemberRequired(newValue.length > 0 ? false : true);
+        } else {
+          setFrameworkRequired(newValue.length > 0 ? false : true);
+        }
       },
     []
   );
@@ -169,6 +175,11 @@ const ProjectForm = ({ sx, onClose }: ProjectFormProps) => {
     if (values.members.length === 0) {
       newErrors.members = "At least one team member is required.";
       setMemberRequired(true);
+    }
+
+    if (values.monitored_regulations_and_standards.length === 0) {
+      newErrors.frameworks = "At least one framework is required.";
+      setFrameworkRequired(true);
     }
 
     setErrors(newErrors);
@@ -503,6 +514,7 @@ const ProjectForm = ({ sx, onClose }: ProjectFormProps) => {
                 renderInput={(params) => (
                   <TextField
                     {...params}
+                    error={!!errors.frameworks}
                     placeholder="Select regulations and standards"
                     sx={teamMembersRenderInputStyle}
                   />
@@ -513,12 +525,12 @@ const ProjectForm = ({ sx, onClose }: ProjectFormProps) => {
                 }}
                 slotProps={teamMembersSlotProps}
               />
-              {memberRequired && (
+              {frameworkRequired && (
                 <Typography
                   variant="caption"
                   sx={{ mt: 4, color: "#f04438", fontWeight: 300 }}
                 >
-                  {errors.members}
+                  {errors.frameworks}
                 </Typography>
               )}
             </Stack>

--- a/Clients/src/presentation/vw-v2-components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/vw-v2-components/Forms/ProjectForm/index.tsx
@@ -253,9 +253,9 @@ const ProjectForm = ({ sx, onClose }: ProjectFormProps) => {
         <Stack
           sx={{
             width: "100vw",
-            height: "120vh",
+            height: "100%",
             position: "fixed",
-            top: "-50%",
+            top: "0",
             left: "50%",
             transform: "translateX(-50%)",
             zIndex: 9999,


### PR DESCRIPTION
## Describe your changes

- Validate framework
- Fix: Show loading background as full height after project has created

## Write your issue number after "Fixes "

Enter the corresponding issue number after "Fixes #" 
Fixes #1601 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="1096" alt="Screenshot 2025-06-08 at 9 42 01 PM" src="https://github.com/user-attachments/assets/c85fdf2d-bc5e-4a16-8e76-270b86ee275d" />

![Frame 20](https://github.com/user-attachments/assets/9f38990d-8744-4660-b123-d71180c00f63)

https://github.com/user-attachments/assets/fcad26c3-3911-4422-ab40-472a9f8d2d51
