### PR TITLE
Fix: Risk Categories Selection

### DIFF
--- a/Clients/src/application/validations/selectValidation.ts
+++ b/Clients/src/application/validations/selectValidation.ts
@@ -21,7 +21,10 @@ function feedback(accepted: boolean, message: string) {
  */
 function selectValidation(title: string, value: number | number[]): {accepted: boolean; message: string} {
     if (Array.isArray(value)) {
-        return feedback(false, `${title} is required.`);
+        if (value.length === 0) {
+            return feedback(false, `${title} is required.`);
+        }
+        return feedback(true, "Success");
     }
     if (value === 0) {
         return feedback(false, `${title} is required.`);

--- a/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
@@ -77,7 +77,7 @@ const RiskSection: FC<RiskSectionProps> = ({
   const isEditingDisabled =
     !allowedRoles.projectRisks.edit.includes(userRoleName);
 
-  const [_, setErrors] = useState<RiskFormErrors>({});
+  const [, setErrors] = useState<RiskFormErrors>({});
   const [alert, setAlert] = useState<alertState | null>(null);
   const { users } = useUsers();
 
@@ -282,6 +282,14 @@ const RiskSection: FC<RiskSectionProps> = ({
                       "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
                         borderColor: "#888",
                         borderWidth: "1px",
+                      },
+                    },
+                    "& .MuiChip-root": {
+                      "& .MuiChip-deleteIcon": {
+                        display:
+                          riskValues.riskCategory.length === 1
+                            ? "none"
+                            : "flex",
                       },
                     },
                   }}


### PR DESCRIPTION
## Describe your changes

This PR implements a hotfix for when one risk category is selected.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- x ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for selection fields to allow non-empty arrays, ensuring users can select multiple options without error messages.
  * Prevented users from removing the last remaining risk category in the risk selection interface by hiding the delete icon when only one category is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->