### PR TITLE
added_surname_to_teams_table

### DIFF
--- a/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
@@ -371,7 +371,7 @@ const TeamManagement: React.FC = (): JSX.Element => {
                             <TableCell
                               sx={singleTheme.tableStyles.primary.body.cell}
                             >
-                              {member.name} {member.surname}
+                              {`${member.name}${member.surname ? ` ${member.surname}` : ''}`}
                             </TableCell>
                             <TableCell
                               sx={{

--- a/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
@@ -371,7 +371,7 @@ const TeamManagement: React.FC = (): JSX.Element => {
                             <TableCell
                               sx={singleTheme.tableStyles.primary.body.cell}
                             >
-                              {member.name}
+                              {member.name} {member.surname}
                             </TableCell>
                             <TableCell
                               sx={{

--- a/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
@@ -371,7 +371,7 @@ const TeamManagement: React.FC = (): JSX.Element => {
                             <TableCell
                               sx={singleTheme.tableStyles.primary.body.cell}
                             >
-                              {`${member.name}${member.surname ? ` ${member.surname}` : ''}`}
+                              {[member.name, member.surname].filter(Boolean).join(' ')}
                             </TableCell>
                             <TableCell
                               sx={{


### PR DESCRIPTION
## Describe your changes

Updated the Teams table to display the full name of each team member by combining the `name` and `surname` fields. Previously, only the `name` field was shown.

## Write your issue number after "Fixes "

Fixes #1803 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

I've attached screenshots below for your reference.

**Before**
<img width="1912" height="900" alt="image" src="https://github.com/user-attachments/assets/ffe8781b-50ef-4e8e-9b21-324f18019e59" />


**After**
<img width="1903" height="867" alt="ref" src="https://github.com/user-attachments/assets/c82de842-3cb1-4a6e-9b40-bbc0a62d0e1c" />

Let me know your thoughts on it.

Thanks,
Ritik


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Team member names in the team management table now display both first name and surname together for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->