### PR TITLE
Add route to download public resources

### DIFF
--- a/Servers/controllers/aiTrustCentre.ctrl.ts
+++ b/Servers/controllers/aiTrustCentre.ctrl.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import { sequelize } from "../database/db";
-import { createAITrustCentreResourceQuery, createAITrustCentreSubprocessorQuery, deleteAITrustCentreResourceQuery, deleteAITrustCentreSubprocessorQuery, deleteCompanyLogoQuery, getAITrustCentreOverviewQuery, getAITrustCentrePublicPageQuery, getAITrustCentreResourcesQuery, getAITrustCentreSubprocessorsQuery, getCompanyLogoQuery, updateAITrustCentreOverviewQuery, updateAITrustCentreResourceQuery, updateAITrustCentreSubprocessorQuery, uploadCompanyLogoQuery } from "../utils/aiTrustCentre.utils";
+import { createAITrustCentreResourceQuery, createAITrustCentreSubprocessorQuery, deleteAITrustCentreResourceQuery, deleteAITrustCentreSubprocessorQuery, deleteCompanyLogoQuery, getAITrustCentreOverviewQuery, getAITrustCentrePublicPageQuery, getAITrustCentrePublicResourceByIdQuery, getAITrustCentreResourcesQuery, getAITrustCentreSubprocessorsQuery, getCompanyLogoQuery, updateAITrustCentreOverviewQuery, updateAITrustCentreResourceQuery, updateAITrustCentreSubprocessorQuery, uploadCompanyLogoQuery } from "../utils/aiTrustCentre.utils";
 import { RequestWithFile, UploadedFile } from "../utils/question.utils";
 import { deleteFileById, uploadFile } from "../utils/fileUpload.utils";
 import { IAITrustCentreOverview } from "../domain.layer/interfaces/i.aiTrustCentreOverview";
@@ -47,6 +47,32 @@ export async function getAITrustCentrePublicPage(
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }
 }
+
+export async function getAITrustCentrePublicResource(
+  req: Request,
+  res: Response
+) {
+  try {
+    const { hash, id } = req.params;
+
+    const resource = await getAITrustCentrePublicResourceByIdQuery(hash, parseInt(id));
+    if (!resource) {
+      return res.status(404).json(STATUS_CODE[404]({
+        message: "Resource not found"
+      }));
+    }
+
+    res.setHeader("Content-Type", resource.type);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${resource.filename}"`
+    );
+    return res.status(200).end(resource.content);
+  } catch (error) {
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+}
+
 
 export async function getAITrustCentreOverview(
   req: Request,

--- a/Servers/routes/aiTrustCentre.route.ts
+++ b/Servers/routes/aiTrustCentre.route.ts
@@ -12,6 +12,7 @@ import {
   deleteCompanyLogo,
   getAITrustCentreOverview,
   getAITrustCentrePublicPage,
+  getAITrustCentrePublicResource,
   getAITrustCentreResources,
   getAITrustCentreSubprocessors,
   getCompanyLogo,
@@ -29,6 +30,7 @@ router.get("/resources", authenticateJWT, getAITrustCentreResources);
 router.get("/subprocessors", authenticateJWT, getAITrustCentreSubprocessors);
 router.get("/:hash", validateVisibility, getAITrustCentrePublicPage);
 router.get("/:hash/logo", validateVisibility, getCompanyLogo);
+router.get("/:hash/resources/:id", validateVisibility, getAITrustCentrePublicResource);
 
 router.post("/resources", authenticateJWT, upload.single("file"), createAITrustResource);
 router.post("/subprocessors", authenticateJWT, createAITrustSubprocessor);


### PR DESCRIPTION
## Describe your changes

- Added route to download public resources for AI Trust Centre
   - `GET aiTrustCentre/<hash>/resources/<resource_id>`

## Write your issue number after "Fixes "

Enter the corresponding issue number after "Fixes #" 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to allow users to download specific public resources from the AI Trust Centre by providing a hash and resource ID.

* **Bug Fixes**
  * Improved error handling when requested resources are not found or are not visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->