### PR TITLE
Change the size for attaching risks model in EU

### DIFF
--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -725,6 +725,13 @@ const NewControlPane = ({
       <Dialog 
         open={isLinkedRisksModalOpen} 
         onClose={() => setIsLinkedRisksModalOpen(false)}
+        PaperProps={{
+          sx: {
+            width: '1500px',
+            maxWidth: '1500px',
+            minHeight: '520px'
+          },
+        }}
       >
         <Suspense fallback={"loading..."}>
           <LinkedRisksPopup
@@ -738,6 +745,13 @@ const NewControlPane = ({
       <Dialog 
         open={auditedStatusModalOpen} 
         onClose={() => setAuditedStatusModalOpen(false)}
+        PaperProps={{
+          sx: {
+            width: '800px',
+            maxWidth: '800px',
+            minHeight: '300px'
+          },
+        }}
       >
         <Suspense fallback={"loading..."}>
           <AuditRiskPopup

--- a/Clients/src/presentation/components/VWQuestion/index.tsx
+++ b/Clients/src/presentation/components/VWQuestion/index.tsx
@@ -430,6 +430,13 @@ const QuestionFrame = ({
       <Dialog 
         open={isLinkedRisksModalOpen} 
         onClose={() => setIsLinkedRisksModalOpen(false)}
+        PaperProps={{
+          sx: {
+            width: '1500px',
+            maxWidth: '1500px',
+            minHeight: '520px'
+          },
+        }}
       >
         <Suspense fallback={"loading..."}>
           <LinkedRisksPopup
@@ -443,6 +450,13 @@ const QuestionFrame = ({
       <Dialog 
         open={auditedStatusModalOpen} 
         onClose={() => setAuditedStatusModalOpen(false)}
+        PaperProps={{
+          sx: {
+            width: '800px',
+            maxWidth: '800px',
+            minHeight: '300px'
+          },
+        }}
       >
         <Suspense fallback={"loading..."}>
           <AuditRiskPopup


### PR DESCRIPTION
## Describe your changes

- Made the attach risk modal wider in EU
<img width="1421" height="533" alt="image" src="https://github.com/user-attachments/assets/88f6abae-e80f-47af-b116-f94829564f06" />
<img width="807" height="412" alt="image" src="https://github.com/user-attachments/assets/c363a8a5-5418-4ede-b146-8dc4675ed2c4" />

## Write your issue number after "Fixes "

Enter the corresponding issue number after "Fixes #" 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the size and layout of modal dialogs for linked risks and audited status to provide a more consistent and improved user experience. The dialogs now have fixed widths and minimum heights for better visibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->