### PR TITLE
Reports: Remove tabs and move “Generate report” button to list view

### DIFF
--- a/Clients/src/presentation/pages/Reporting/GenerateReport/ReportStatus/index.tsx
+++ b/Clients/src/presentation/pages/Reporting/GenerateReport/ReportStatus/index.tsx
@@ -1,26 +1,21 @@
-import React from 'react';
-import { Typography } from '@mui/material';
-import {styles} from '../styles';
+import React from "react";
+import { Typography } from "@mui/material";
+import { styles } from "../styles";
 
 interface DisabledProps {
-  isDisabled: boolean
+  isDisabled: boolean;
 }
 
-const ReportStatus: React.FC<DisabledProps> = ({
-  isDisabled
-}) => {
+const ReportStatus: React.FC<DisabledProps> = ({ isDisabled }) => {
   return (
     <>
-      {isDisabled ? 
+      {isDisabled && (
         <Typography sx={styles.baseText}>
           There is no report to download.
-        </Typography> : 
-        <Typography sx={styles.baseText}>
-          Clicking on this link will generate a report in Microsoft Word file you can modify.          
         </Typography>
-      }
+      )}
     </>
-  )
-}
+  );
+};
 
-export default ReportStatus
+export default ReportStatus;

--- a/Clients/src/presentation/pages/Reporting/GenerateReport/styles.ts
+++ b/Clients/src/presentation/pages/Reporting/GenerateReport/styles.ts
@@ -1,10 +1,9 @@
 export const styles = {
   container: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
     gap: 2,
-    padding: "50px"
   },
   buttonStyle: {
     width: { xs: "100%", sm: "180px" },
@@ -16,5 +15,5 @@ export const styles = {
   baseText: {
     color: "#344054",
     fontSize: 13,
-  }
-}
+  },
+};

--- a/Clients/src/presentation/pages/Reporting/index.tsx
+++ b/Clients/src/presentation/pages/Reporting/index.tsx
@@ -1,22 +1,15 @@
-import { Suspense, SyntheticEvent, lazy, useState } from "react";
-import { Stack, Tab, Box } from "@mui/material";
-import { TabContext, TabPanel, TabList } from "@mui/lab";
-import { tabStyle, tabPanelStyle } from "../Vendors/style";
+import { Suspense, lazy, useState } from "react";
+import { Stack, Box } from "@mui/material";
 const GenerateReport = lazy(() => import("./GenerateReport"));
 const ReportLists = lazy(() => import("./Reports"));
 const ReportingHeader = lazy(
-  () => import("../../components/Reporting/ReportOverviewHeader")
+  () => import("../../components/Reporting/ReportOverviewHeader"),
 );
 import { styles } from "./styles";
 import HelperDrawer from "../../components/Drawer/HelperDrawer";
 import reportingHelpContent from "../../../presentation/helpers/reporting-help.html?raw";
 
 const Reporting = () => {
-  const [value, setValue] = useState<string>("generate");
-
-  const handleTabChange = (_: SyntheticEvent, newValue: string) => {
-    setValue(newValue);
-  };
   const [isHelperDrawerOpen, setIsHelperDrawerOpen] = useState(false);
 
   return (
@@ -27,47 +20,24 @@ const Reporting = () => {
         helpContent={reportingHelpContent}
         pageTitle="Reporting Dashboard"
       />
+
       <Suspense fallback={"loading..."}>
         <ReportingHeader
           titlesx={styles.vwHeadingTitle}
           subsx={styles.vwSubHeadingTitle}
         />
       </Suspense>
+
       <Stack>
-        <TabContext value={value}>
-          <Box sx={styles.tabDivider}>
-            <TabList
-              TabIndicatorProps={{ style: { backgroundColor: "#13715B" } }}
-              sx={styles.tabList}
-              onChange={handleTabChange}
-            >
-              <Tab
-                sx={tabStyle}
-                label="Generate a report"
-                value="generate"
-                disableRipple
-              />
-              <Tab
-                sx={tabStyle}
-                label="Reports generated"
-                value="reports"
-                disableRipple
-              />
-            </TabList>
-          </Box>
-          <TabPanel value="generate" sx={tabPanelStyle}>
-            {/* Render generate view */}
-            <Suspense fallback={"loading..."}>
-              <GenerateReport />
-            </Suspense>
-          </TabPanel>
-          <TabPanel value="reports" sx={tabPanelStyle}>
-            {/* Render a report view */}
-            <Suspense fallback={"loading..."}>
-              <ReportLists />
-            </Suspense>
-          </TabPanel>
-        </TabContext>
+        <Box sx={styles.reportButtonContainer}>
+          <Suspense fallback={"loading..."}>
+            <GenerateReport />
+          </Suspense>
+        </Box>
+
+        <Suspense fallback={"loading..."}>
+          <ReportLists />
+        </Suspense>
       </Stack>
     </Stack>
   );

--- a/Clients/src/presentation/pages/Reporting/styles.ts
+++ b/Clients/src/presentation/pages/Reporting/styles.ts
@@ -9,34 +9,10 @@ export const styles = {
     color: "#344054",
     fontSize: 13,
   },
-  tabDivider: {
-    borderBottom: 1,
-    borderColor: "divider",
-  },
-  tabList: {
-    minHeight: "20px",
-    "& .MuiTabs-flexContainer": { columnGap: "34px" },
-  },
   reportButtonContainer: {
     display: "flex",
     justifyContent: "flex-end",
     alignItems: "center",
     mb: 2,
-    "& button": {
-      backgroundColor: "#1976d2",
-      color: "#fff",
-      padding: "0",
-      textTransform: "none",
-      "&:hover": {
-        backgroundColor: "#1565c0",
-      },
-      "&:focus": {
-        outline: "none",
-        boxShadow: "0 0 0 0",
-      },
-      "&:active": {
-        backgroundColor: "#013973",
-      },
-    },
   },
 };

--- a/Clients/src/presentation/pages/Reporting/styles.ts
+++ b/Clients/src/presentation/pages/Reporting/styles.ts
@@ -10,11 +10,33 @@ export const styles = {
     fontSize: 13,
   },
   tabDivider: {
-    borderBottom: 1, 
-    borderColor: "divider"
+    borderBottom: 1,
+    borderColor: "divider",
   },
   tabList: {
     minHeight: "20px",
-    "& .MuiTabs-flexContainer": { columnGap: "34px" }
-  }
-}
+    "& .MuiTabs-flexContainer": { columnGap: "34px" },
+  },
+  reportButtonContainer: {
+    display: "flex",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    mb: 2,
+    "& button": {
+      backgroundColor: "#1976d2",
+      color: "#fff",
+      padding: "0",
+      textTransform: "none",
+      "&:hover": {
+        backgroundColor: "#1565c0",
+      },
+      "&:focus": {
+        outline: "none",
+        boxShadow: "0 0 0 0",
+      },
+      "&:active": {
+        backgroundColor: "#013973",
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Describe your changes

Removed the tabs from the Reports page to consolidate it into a single view. Moved the “Generate your report” button into the Reports list view on the right side, with updated styling for better usability and consistent design. Optimized the button styling and spacing for a cleaner layout.

## Write your issue number after "Fixes "

Fixes #1881

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.


<img width="1884" height="840" alt="Screenshot 2025-08-13 191453" src="https://github.com/user-attachments/assets/1f515791-fccd-47aa-8195-556d28eaa3b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified Reporting page: removed tabs; “Generate a report” and “Reports generated” now appear together.
  - Streamlined status messaging: only displays “There is no report to download.” when applicable.

- Style
  - Added a right-aligned container for the report action button.
  - Reduced padding/spacing in the Generate Report section and minor visual polish across Reporting pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->