### PR TITLE
Disable org framework

### DIFF
--- a/Clients/src/presentation/vw-v2-components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/vw-v2-components/Forms/ProjectForm/index.tsx
@@ -320,6 +320,7 @@ const ProjectForm = ({ sx, onClose }: ProjectFormProps) => {
               key={option.value}
               value={option.value}
               control={<Radio />}
+              disabled={option.value === FrameworkTypeEnum.OrganizationWide}
               label={
                 <Stack sx={{ gap: 1 }}>
                   <Typography


### PR DESCRIPTION
## Describe your changes

Provide a concise description of the changes made and their intended purpose.

## Write your issue number after "Fixes "

Enter the corresponding issue number after "Fixes #" 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - In the Project form’s framework selection, the “Organization-wide” option is now disabled and cannot be chosen. Other framework options remain selectable, and labels are unchanged. This change only affects the framework type radio group within the Project form. There are no changes to validations, navigation, or submission behavior elsewhere in the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->