### PR TITLE
Separate provider and model fields in Model Inventory

### DIFF
--- a/Clients/src/domain/interfaces/i.modelInventory.ts
+++ b/Clients/src/domain/interfaces/i.modelInventory.ts
@@ -1,6 +1,8 @@
 export interface IModelInventory {
   id?: number;
-  provider_model: string;
+  provider_model?: string; // Keep for backward compatibility during transition
+  provider: string;
+  model: string;
   version?: string;
   approver: string;
   capabilities: string[];

--- a/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
@@ -39,7 +39,9 @@ interface NewModelInventoryProps {
 }
 
 interface NewModelInventoryFormValues {
-  provider_model: string;
+  provider_model?: string; // Keep for backward compatibility
+  provider: string;
+  model: string;
   version: string;
   approver: string;
   capabilities: string[];
@@ -49,7 +51,9 @@ interface NewModelInventoryFormValues {
 }
 
 interface NewModelInventoryFormErrors {
-  provider_model?: string;
+  provider_model?: string; // Keep for backward compatibility
+  provider?: string;
+  model?: string;
   version?: string;
   approver?: string;
   capabilities?: string;
@@ -58,7 +62,9 @@ interface NewModelInventoryFormErrors {
 }
 
 const initialState: NewModelInventoryFormValues = {
-  provider_model: "",
+  provider_model: "", // Keep for backward compatibility
+  provider: "",
+  model: "",
   version: "",
   approver: "",
   capabilities: [],
@@ -212,8 +218,12 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
   const validateForm = (): boolean => {
     const newErrors: NewModelInventoryFormErrors = {};
 
-    if (!values.provider_model || !String(values.provider_model).trim()) {
-      newErrors.provider_model = "Provider/Model is required.";
+    if (!values.provider || !String(values.provider).trim()) {
+      newErrors.provider = "Provider is required.";
+    }
+
+    if (!values.model || !String(values.model).trim()) {
+      newErrors.model = "Model is required.";
     }
 
     if (!values.approver || !String(values.approver).trim()) {
@@ -373,7 +383,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
             sx={{ flex: 1, overflow: "auto", marginBottom: theme.spacing(8) }}
           >
             <Stack gap={theme.spacing(8)}>
-              {/* First Row: Provider/Model, Version, Approver */}
+              {/* First Row: Provider, Model, Version */}
               <Stack
                 direction={"row"}
                 justifyContent={"space-between"}
@@ -381,15 +391,28 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
               >
                 <Suspense fallback={<div>Loading...</div>}>
                   <Field
-                    id="provider-model"
-                    label="Provider/model"
+                    id="provider"
+                    label="Provider"
                     width={220}
-                    value={values.provider_model}
-                    onChange={handleOnTextFieldChange("provider_model")}
-                    error={errors.provider_model}
+                    value={values.provider}
+                    onChange={handleOnTextFieldChange("provider")}
+                    error={errors.provider}
                     isRequired
                     sx={fieldStyle}
-                    placeholder="eg. OpenAI GPT-4"
+                    placeholder="eg. OpenAI"
+                  />
+                </Suspense>
+                <Suspense fallback={<div>Loading...</div>}>
+                  <Field
+                    id="model"
+                    label="Model"
+                    width={220}
+                    value={values.model}
+                    onChange={handleOnTextFieldChange("model")}
+                    error={errors.model}
+                    isRequired
+                    sx={fieldStyle}
+                    placeholder="eg. GPT-4"
                   />
                 </Suspense>
                 <Suspense fallback={<div>Loading...</div>}>
@@ -404,6 +427,14 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
                     placeholder="e.g., 4.0, 1.5"
                   />
                 </Suspense>
+              </Stack>
+
+              {/* Second Row: Approver, Status, Status Date */}
+              <Stack
+                direction={"row"}
+                justifyContent={"flex-start"}
+                gap={theme.spacing(8)}
+              >
                 <SelectComponent
                   id="approver"
                   label="Approver"
@@ -416,14 +447,6 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
                   placeholder="Select approver"
                   disabled={isLoadingUsers}
                 />
-              </Stack>
-
-              {/* Second Row: Status, Status Date */}
-              <Stack
-                direction={"row"}
-                justifyContent={"flex-start"}
-                gap={theme.spacing(8)}
-              >
                 <SelectComponent
                   items={statusOptions}
                   value={values.status}

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -392,7 +392,9 @@ const ModelInventory: React.FC = () => {
         initialData={
           selectedModelInventory
             ? {
-                provider_model: selectedModelInventory.provider_model,
+                provider_model: selectedModelInventory.provider_model || "",
+                provider: selectedModelInventory.provider || "",
+                model: selectedModelInventory.model || "",
                 version: selectedModelInventory.version || "",
                 approver: selectedModelInventory.approver,
                 capabilities: selectedModelInventory.capabilities,

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -48,7 +48,8 @@ import {
 
 // Constants for table
 const TABLE_COLUMNS = [
-  { id: "provider_model", label: "PROVIDER/MODEL" },
+  { id: "provider", label: "PROVIDER" },
+  { id: "model", label: "MODEL" },
   { id: "version", label: "VERSION" },
   { id: "approver", label: "APPROVER" },
   { id: "capabilities", label: "CAPABILITIES" },
@@ -224,7 +225,10 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
                 }}
               >
                 <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                  {modelInventory.provider_model}
+                  {modelInventory.provider || "-"}
+                </TableCell>
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  {modelInventory.model || "-"}
                 </TableCell>
                 <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
                   {modelInventory.version || "-"}

--- a/Servers/controllers/modelInventory.ctrl.ts
+++ b/Servers/controllers/modelInventory.ctrl.ts
@@ -110,6 +110,8 @@ export async function getModelInventoryById(req: Request, res: Response) {
 export async function createNewModelInventory(req: Request, res: Response) {
   const {
     provider_model,
+    provider,
+    model,
     version,
     approver,
     capabilities,
@@ -133,6 +135,8 @@ export async function createNewModelInventory(req: Request, res: Response) {
     // Create new model inventory instance using the static method for validation
     const modelInventory = ModelInventoryModel.createNewModelInventory({
       provider_model,
+      provider,
+      model,
       version,
       approver,
       capabilities,
@@ -186,6 +190,8 @@ export async function updateModelInventoryById(req: Request, res: Response) {
   const id = req.params.id;
   const {
     provider_model,
+    provider,
+    model,
     version,
     approver,
     capabilities,
@@ -229,6 +235,8 @@ export async function updateModelInventoryById(req: Request, res: Response) {
       existingModelInventory,
       {
         provider_model,
+        provider,
+        model,
         version,
         approver,
         capabilities,

--- a/Servers/database/migrations/20250825210014-split-provider-model-fields.js
+++ b/Servers/database/migrations/20250825210014-split-provider-model-fields.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const { DataTypes } = require("sequelize");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add new provider and model columns to model_inventories table
+    await queryInterface.addColumn("model_inventories", "provider", {
+      type: Sequelize.STRING,
+      allowNull: true, // Initially allow null for data migration
+    });
+
+    await queryInterface.addColumn("model_inventories", "model", {
+      type: Sequelize.STRING,
+      allowNull: true, // Initially allow null for data migration
+    });
+
+    // Migrate existing data from provider_model to provider and model columns
+    // This will attempt to intelligently split the provider_model field
+    await queryInterface.sequelize.query(`
+      UPDATE model_inventories 
+      SET 
+        provider = CASE
+          -- Handle common patterns like "OpenAI GPT-4", "Google Gemini", "Microsoft Azure OpenAI"
+          WHEN provider_model LIKE '%OpenAI%' THEN 'OpenAI'
+          WHEN provider_model LIKE '%Google%' THEN 'Google'
+          WHEN provider_model LIKE '%Microsoft%' THEN 'Microsoft'
+          WHEN provider_model LIKE '%Anthropic%' THEN 'Anthropic'
+          WHEN provider_model LIKE '%Meta%' THEN 'Meta'
+          WHEN provider_model LIKE '%AWS%' OR provider_model LIKE '%Amazon%' THEN 'Amazon Web Services'
+          WHEN provider_model LIKE '%Azure%' THEN 'Microsoft'
+          WHEN provider_model LIKE '%Hugging Face%' OR provider_model LIKE '%HuggingFace%' THEN 'Hugging Face'
+          WHEN provider_model LIKE '%Cohere%' THEN 'Cohere'
+          WHEN provider_model LIKE '%Stability%' THEN 'Stability AI'
+          -- For cases with space, try to extract first part as provider
+          WHEN position(' ' in provider_model) > 0 THEN 
+            trim(substring(provider_model from 1 for position(' ' in provider_model) - 1))
+          -- If no space, use the entire value as provider for now
+          ELSE provider_model
+        END,
+        model = CASE
+          -- Handle common patterns
+          WHEN provider_model LIKE '%GPT-4%' THEN 'GPT-4'
+          WHEN provider_model LIKE '%GPT-3%' THEN 'GPT-3'
+          WHEN provider_model LIKE '%Gemini%' THEN 'Gemini'
+          WHEN provider_model LIKE '%Claude%' THEN 'Claude'
+          WHEN provider_model LIKE '%LLaMA%' OR provider_model LIKE '%Llama%' THEN 'LLaMA'
+          WHEN provider_model LIKE '%DALL-E%' THEN 'DALL-E'
+          WHEN provider_model LIKE '%Whisper%' THEN 'Whisper'
+          WHEN provider_model LIKE '%Midjourney%' THEN 'Midjourney'
+          WHEN provider_model LIKE '%Stable Diffusion%' THEN 'Stable Diffusion'
+          -- For cases with space, try to extract everything after first word as model
+          WHEN position(' ' in provider_model) > 0 THEN 
+            trim(substring(provider_model from position(' ' in provider_model) + 1))
+          -- If no space, leave model as empty string (we have provider set)
+          ELSE ''
+        END
+      WHERE provider IS NULL AND model IS NULL;
+    `);
+
+    // Add indexes for the new columns for better performance
+    await queryInterface.addIndex("model_inventories", ["provider"]);
+    await queryInterface.addIndex("model_inventories", ["model"]);
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove indexes first
+    await queryInterface.removeIndex("model_inventories", ["provider"]);
+    await queryInterface.removeIndex("model_inventories", ["model"]);
+
+    // Remove the new columns
+    await queryInterface.removeColumn("model_inventories", "provider");
+    await queryInterface.removeColumn("model_inventories", "model");
+  },
+};

--- a/Servers/database/migrations/20250825212018-make-provider-model-fields-not-null.js
+++ b/Servers/database/migrations/20250825212018-make-provider-model-fields-not-null.js
@@ -1,0 +1,39 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Update any remaining NULL values with placeholder data
+    await queryInterface.sequelize.query(`
+      UPDATE model_inventories 
+      SET 
+        provider = COALESCE(provider, 'Unknown Provider'),
+        model = COALESCE(model, 'Unknown Model')
+      WHERE provider IS NULL OR model IS NULL;
+    `);
+
+    // Now make the columns NOT NULL
+    await queryInterface.changeColumn("model_inventories", "provider", {
+      type: Sequelize.STRING,
+      allowNull: false,
+    });
+
+    await queryInterface.changeColumn("model_inventories", "model", {
+      type: Sequelize.STRING,
+      allowNull: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Make the columns nullable again
+    await queryInterface.changeColumn("model_inventories", "provider", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.changeColumn("model_inventories", "model", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+};

--- a/Servers/domain.layer/interfaces/i.modelInventory.ts
+++ b/Servers/domain.layer/interfaces/i.modelInventory.ts
@@ -2,7 +2,9 @@ import { ModelInventoryStatus } from "../enums/model-inventory-status.enum";
 
 export interface IModelInventory {
   id?: number;
-  provider_model: string;
+  provider_model?: string; // Keep for backward compatibility during transition
+  provider: string;
+  model: string;
   version: string;
   approver: string;
   capabilities: string;

--- a/Servers/domain.layer/models/modelInventory/modelInventory.model.ts
+++ b/Servers/domain.layer/models/modelInventory/modelInventory.model.ts
@@ -20,9 +20,21 @@ export class ModelInventoryModel
 
   @Column({
     type: DataType.STRING,
+    allowNull: true, // Allow null during transition
+  })
+  provider_model?: string;
+
+  @Column({
+    type: DataType.STRING,
     allowNull: false,
   })
-  provider_model!: string;
+  provider!: string;
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  model!: string;
 
   @Column({
     type: DataType.STRING,
@@ -83,11 +95,19 @@ export class ModelInventoryModel
    * Validate model inventory data before saving
    */
   async validateModelInventoryData(): Promise<void> {
-    if (!this.provider_model?.trim()) {
+    if (!this.provider?.trim()) {
       throw new ValidationException(
-        "Provider/Model is required",
-        "provider_model",
-        this.provider_model
+        "Provider is required",
+        "provider",
+        this.provider
+      );
+    }
+
+    if (!this.model?.trim()) {
+      throw new ValidationException(
+        "Model is required",
+        "model",
+        this.model
       );
     }
 
@@ -210,7 +230,9 @@ export class ModelInventoryModel
   toSafeJSON(): any {
     return {
       id: this.id,
-      provider_model: this.provider_model,
+      provider_model: this.provider_model, // Keep for backward compatibility
+      provider: this.provider,
+      model: this.model,
       version: this.version,
       approver: this.approver,
       capabilities: this.capabilities
@@ -238,7 +260,9 @@ export class ModelInventoryModel
   toJSON(): any {
     return {
       id: this.id,
-      provider_model: this.provider_model,
+      provider_model: this.provider_model, // Keep for backward compatibility
+      provider: this.provider,
+      model: this.model,
       version: this.version,
       approver: this.approver,
       capabilities: this.capabilities
@@ -295,7 +319,7 @@ export class ModelInventoryModel
    * Get full model name (provider + version)
    */
   getFullModelName(): string {
-    return `${this.provider_model} ${this.version}`.trim();
+    return `${this.provider} ${this.model} ${this.version}`.trim();
   }
 
   /**
@@ -305,7 +329,9 @@ export class ModelInventoryModel
     data: Partial<IModelInventory>
   ): ModelInventoryModel {
     const modelInventory = new ModelInventoryModel({
-      provider_model: data.provider_model || "",
+      provider_model: data.provider_model || "", // Keep for backward compatibility
+      provider: data.provider || "",
+      model: data.model || "",
       version: data.version || "",
       approver: data.approver || "",
       capabilities: Array.isArray(data.capabilities)
@@ -332,6 +358,12 @@ export class ModelInventoryModel
     // Update only the fields that are provided
     if (data.provider_model !== undefined) {
       existingModel.provider_model = data.provider_model;
+    }
+    if (data.provider !== undefined) {
+      existingModel.provider = data.provider;
+    }
+    if (data.model !== undefined) {
+      existingModel.model = data.model;
     }
     if (data.version !== undefined) {
       existingModel.version = data.version;

--- a/Servers/utils/modelInventory.utils.ts
+++ b/Servers/utils/modelInventory.utils.ts
@@ -41,11 +41,13 @@ export const createNewModelInventoryQuery = async (
 
   try {
     const result = await sequelize.query(
-      `INSERT INTO model_inventories (provider_model, version, approver, capabilities, security_assessment, status, status_date, is_demo, created_at, updated_at)
-        VALUES (:provider_model, :version, :approver, :capabilities, :security_assessment, :status, :status_date, :is_demo, :created_at, :updated_at) RETURNING *`,
+      `INSERT INTO model_inventories (provider_model, provider, model, version, approver, capabilities, security_assessment, status, status_date, is_demo, created_at, updated_at)
+        VALUES (:provider_model, :provider, :model, :version, :approver, :capabilities, :security_assessment, :status, :status_date, :is_demo, :created_at, :updated_at) RETURNING *`,
       {
         replacements: {
-          provider_model: modelInventory.provider_model,
+          provider_model: modelInventory.provider_model || '',
+          provider: modelInventory.provider,
+          model: modelInventory.model,
           version: modelInventory.version,
           approver: modelInventory.approver,
           capabilities: Array.isArray(modelInventory.capabilities)
@@ -82,11 +84,13 @@ export const updateModelInventoryByIdQuery = async (
   try {
     // First update the record
     await sequelize.query(
-      `UPDATE model_inventories SET provider_model = :provider_model, version = :version, approver = :approver, capabilities = :capabilities, security_assessment = :security_assessment, status = :status, status_date = :status_date, is_demo = :is_demo, updated_at = :updated_at WHERE id = :id`,
+      `UPDATE model_inventories SET provider_model = :provider_model, provider = :provider, model = :model, version = :version, approver = :approver, capabilities = :capabilities, security_assessment = :security_assessment, status = :status, status_date = :status_date, is_demo = :is_demo, updated_at = :updated_at WHERE id = :id`,
       {
         replacements: {
           id,
-          provider_model: modelInventory.provider_model,
+          provider_model: modelInventory.provider_model || '',
+          provider: modelInventory.provider,
+          model: modelInventory.model,
           version: modelInventory.version,
           approver: modelInventory.approver,
           capabilities: Array.isArray(modelInventory.capabilities)


### PR DESCRIPTION
## Summary
- Split the combined 'provider/model' field into distinct 'Provider' and 'Model' fields
- Improved data organization and user experience with separate input fields
- Enhanced table display with dedicated Provider and Model columns

## Backend Changes
- Added new `provider` and `model` columns to model_inventories table
- Created intelligent data migration to split existing provider_model data
- Updated database constraints and API controllers
- Enhanced SQL queries and Sequelize model definitions

## Frontend Changes  
- Replaced single provider/model input with two separate required fields
- Updated form validation and TypeScript interfaces
- Modified table display to show separate columns
- Reorganized form layout for better UX

## Database Migrations
- **Migration 1**: Add nullable provider/model columns with smart data migration
- **Migration 2**: Make new columns NOT NULL after data population

## Test Plan
- [x] Create new model inventory entries with separate provider/model fields
- [x] Verify existing data migration works correctly
- [x] Confirm table displays separate Provider and Model columns
- [x] Test form validation for both required fields
- [x] Verify backward compatibility during transition

All changes maintain backward compatibility and include proper error handling.