### PR TITLE
Changed-the-wording-inside-project-framework

### DIFF
--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -527,7 +527,7 @@ const VWISO42001AnnexDrawerDialog = ({
               sx={{
                 mt: 2,
                 borderRadius: 2,
-                width: 155,
+                minWidth: 155,      // minimum width
                 height: 25,
                 fontSize: 11,
                 border: "1px solid #D0D5DD",
@@ -540,7 +540,7 @@ const VWISO42001AnnexDrawerDialog = ({
               onClick={() => setIsFileUploadOpen(true)}
               disabled={isEditingDisabled}
             >
-              Add/Remove evidence
+             Add, remove or download evidence 
             </Button>
             <Stack direction="row" spacing={10}>
               <Typography

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -489,7 +489,7 @@ const VWISO42001ClauseDrawerDialog = ({
               sx={{
                 mt: 2,
                 borderRadius: 2,
-                width: 155,
+                minWidth: 155,      // minimum width
                 height: 25,
                 fontSize: 11,
                 border: "1px solid #D0D5DD",
@@ -502,7 +502,7 @@ const VWISO42001ClauseDrawerDialog = ({
               onClick={() => setIsFileUploadOpen(true)}
               disabled={isEditingDisabled}
             >
-              Add/Remove evidence
+              Add, remove or download evidence
             </Button>
             <Stack direction="row" spacing={10}>
               <Typography

--- a/Clients/src/presentation/components/Modals/ComplianceFeedback/ComplianceFeedback.tsx
+++ b/Clients/src/presentation/components/Modals/ComplianceFeedback/ComplianceFeedback.tsx
@@ -149,7 +149,7 @@ const AuditorFeedback: React.FC<AuditorFeedbackProps> = ({
           sx={{
             mt: 2,
             borderRadius: 2,
-            width: 155,
+            minWidth: 155,      // minimum width
             height: 25,
             fontSize: 11,
             border: "1px solid #D0D5DD",
@@ -162,7 +162,7 @@ const AuditorFeedback: React.FC<AuditorFeedbackProps> = ({
           onClick={() => setIsFileUploadOpen(true)}
           disabled={readOnly}
         >
-          Add/Remove evidence
+         Add, remove or download evidence
         </Button>
         <Stack direction="row" spacing={10}>
           <Typography

--- a/Clients/src/presentation/components/VWQuestion/index.tsx
+++ b/Clients/src/presentation/components/VWQuestion/index.tsx
@@ -322,16 +322,17 @@ const QuestionFrame = ({
           <Button
             variant="contained"
             sx={{
-              width: 155,
+              minWidth: 155,      // minimum width
               border: "1px solid #D0D5DD",
               backgroundColor: "white",
               color: "#344054",
+              flexShrink: 0,        //  prevent shrinking in flex layouts
             }}
             disableRipple
             onClick={() => setIsFileUploadOpen(true)}
             disabled={isEditingDisabled}
           >
-            Add/Remove evidence
+            Add, remove or download evidence
           </Button>
           <Typography
             sx={{

--- a/Clients/src/presentation/pages/Assessment/NewAssessment/AssessmentQuestions/AssessmentQuestions.tsx
+++ b/Clients/src/presentation/pages/Assessment/NewAssessment/AssessmentQuestions/AssessmentQuestions.tsx
@@ -150,7 +150,7 @@ const AssessmentQuestions = ({
                   sx={{
                     mt: 2,
                     borderRadius: 2,
-                    width: 155,
+                    minWidth: 155,      // ✅ minimum width
                     height: 25,
                     fontSize: 11,
                     border: "1px solid #D0D5DD",
@@ -162,7 +162,7 @@ const AssessmentQuestions = ({
                   }
                   onClick={handleOpenFileUploadModal}
                 >
-                  Add/Remove evidence
+                  Add, remove or download evidence
                 </Button>
                 <Typography
                   sx={{ fontSize: 11, color: "#344054", fontWeight: "300" }}


### PR DESCRIPTION
 **Describe your changes**

Change the wording of "Add/remove evidence" to "Add, remove or download evidence"

Fixes #1979 

**Please ensure all items are checked off before requesting a review:**

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

@MuhammadKhalilzadeh Please find the attached document with screenshots for reference and changes

https://docs.google.com/document/d/1N1YVdusYcOAbpa_b_K5QDvDkiO7SU6ciPxE_JxY0QIQ/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the evidence button label across relevant dialogs and pages to “Add, remove or download evidence” for clearer action description.
  - Switched button sizing from fixed width to minimum width to improve responsiveness and accommodate longer text.
  - Prevented button shrinkage in flexible layouts to maintain readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->