### PR TITLE
vendor-risk-sections-should-accept-256-chars

### DIFF
--- a/Clients/src/presentation/components/Modals/NewRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewRisk/index.tsx
@@ -210,7 +210,7 @@ const AddNewRisk: React.FC<AddNewRiskProps> = ({
       "Risk description",
       values.risk_description,
       1,
-      64
+      256 // updated from 64
     );
     if (!risk_description.accepted) {
       newErrors.risk_description = risk_description.message;
@@ -219,7 +219,7 @@ const AddNewRisk: React.FC<AddNewRiskProps> = ({
       "Impact description",
       values.impact_description,
       1,
-      64
+      256 // updated from 64
     );
     if (!impact_description.accepted) {
       newErrors.impact_description = impact_description.message;
@@ -228,7 +228,7 @@ const AddNewRisk: React.FC<AddNewRiskProps> = ({
       "Action plan",
       values.action_plan,
       1,
-      64
+      256 // updated from 64
     );
     if (!action_plan.accepted) {
       newErrors.action_plan = action_plan.message;


### PR DESCRIPTION
## Describe your changes

Vendor risk sections should accept 256 chars
 
"Fixes #1987 "

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.


![Screenshot 2025-08-28 at 1 30 19 PM](https://github.com/user-attachments/assets/7eb7d5e1-aebb-4bf7-bd22-11cf830e0d67)

![Screenshot 2025-08-28 at 1 29 02 PM](https://github.com/user-attachments/assets/56e9bc64-d6a7-4b80-a0d0-eefb4753647d)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded text limits in the New Risk modal to allow more detailed entries.
  * Risk Description, Impact Description, and Action Plan fields now support up to 256 characters (previously 64).
  * No changes to how the form submits or handles errors; existing workflows remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->