### PR TITLE
Refactor report type field: replace RadioGroup with Select to optimize space in GenerateReportFrom

### DIFF
--- a/Clients/src/presentation/components/Inputs/Select/index.css
+++ b/Clients/src/presentation/components/Inputs/Select/index.css
@@ -3,5 +3,5 @@
   height: 34px;
   display: flex;
   align-items: center;
-  line-height: 1;
+  line-height: 2;
 }

--- a/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  useEffect
 } from "react";
 import { Stack, Typography, useTheme, SelectChangeEvent } from "@mui/material";
 import CustomizableButton from "../../../../vw-v2-components/Buttons";
@@ -65,6 +66,22 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
   const [values, setValues] = useState<FormValues>({...initialState, project: dashboardValues.projects[0].id});
   const [errors, setErrors] = useState<FormErrors>({});
   const theme = useTheme();
+
+  useEffect(() => {
+    const availableTypes = values.framework === 1 ? EUAI_REPORT_TYPES : ISO_REPORT_TYPES;
+
+    if (!availableTypes.includes(values.report_type)) {
+      setValues((prev) => ({
+        ...prev,
+        report_type: availableTypes[0], // reset to the first valid type
+      }));
+
+      setErrors((prev) => ({
+        ...prev,
+        report_type: undefined, // clear any error
+      }));
+    }
+  }, [values.framework]);
 
   const handleOnTextFieldChange = useCallback(
     (prop: keyof FormValues) =>
@@ -134,7 +151,7 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
                 ) || []
               }
               sx={{
-                width: "350px",
+                width: "100%",
                 backgroundColor: theme.palette.background.main,
               }}
               error={errors.project}
@@ -158,7 +175,7 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
                 })) || []
               }
               sx={{
-                width: "350px",
+                width: "100%",
                 backgroundColor: theme.palette.background.main,
               }}
               error={errors.framework}
@@ -168,10 +185,10 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
         </Stack>
 
         <Stack sx={{ paddingTop: theme.spacing(8) }}>
-          <Typography sx={styles.semiTitleText}>Report Type *</Typography>
           <Suspense fallback={<div>Loading...</div>}>
             <Select
               id="report-type-input"
+              label="Report Type"
               placeholder="Select report type"
               value={values.report_type}
               onChange={handleOnSelectChange("report_type")}
@@ -188,12 +205,12 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
           </Suspense>
         </Stack>
 
-        <Stack sx={{ paddingTop: theme.spacing(4) }}>
+        <Stack sx={{ paddingTop: theme.spacing(8) }}>
           <Suspense fallback={<div>Loading...</div>}>
             <Field
               id="report-name"
               label="What should we call your report?"
-              width="350px"
+              width="100%"
               value={values.report_name}
               onChange={handleOnTextFieldChange("report_name")}
               error={errors.report_name}

--- a/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/index.tsx
@@ -9,9 +9,8 @@ import React, {
 import { Stack, Typography, useTheme, SelectChangeEvent } from "@mui/material";
 import CustomizableButton from "../../../../vw-v2-components/Buttons";
 const Field = lazy(() => import("../../../Inputs/Field"));
-import { styles, fieldStyle } from "./styles";
+import { styles, fieldStyle,selectReportStyle } from "./styles";
 import { EUAI_REPORT_TYPES, ISO_REPORT_TYPES } from "../constants";
-const RadioGroup = lazy(() => import("../../../RadioGroup"));
 const Select = lazy(() => import("../../../../components/Inputs/Select"));
 import { VerifyWiseContext } from "../../../../../application/contexts/VerifyWise.context";
 
@@ -171,17 +170,24 @@ const GenerateReportFrom: React.FC<ReportProps> = ({ onGenerate }) => {
         <Stack sx={{ paddingTop: theme.spacing(8) }}>
           <Typography sx={styles.semiTitleText}>Report Type *</Typography>
           <Suspense fallback={<div>Loading...</div>}>
-            <RadioGroup
-              values={
-                values.framework === 1 ? EUAI_REPORT_TYPES : ISO_REPORT_TYPES
-              }
-              defaultValue="Project risks report"
-              onChange={(event) =>
-                setValues({ ...values, report_type: event.target.value })
-              }
+            <Select
+              id="report-type-input"
+              placeholder="Select report type"
+              value={values.report_type}
+              onChange={handleOnSelectChange("report_type")}
+              items={(values.framework === 1 ? EUAI_REPORT_TYPES : ISO_REPORT_TYPES).map(
+                (type) => ({
+                  _id: type,   // unique key / value
+                  name: type,  // display name
+                })
+              )}
+              sx={selectReportStyle}
+              error={errors.report_type}
+              isRequired
             />
           </Suspense>
         </Stack>
+
         <Stack sx={{ paddingTop: theme.spacing(4) }}>
           <Suspense fallback={<div>Loading...</div>}>
             <Field

--- a/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/styles.ts
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/styles.ts
@@ -35,3 +35,9 @@ export const fieldStyle = (theme: any) => ({
     padding: "0 14px",
   },
 });
+
+export const selectReportStyle = (theme:any) => ({
+  width: "350px",
+  backgroundColor: theme.palette.background.main,
+
+});

--- a/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/styles.ts
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/GenerateReportFrom/styles.ts
@@ -21,11 +21,6 @@ export const styles = {
     color: "#344054",
     fontSize: 13,
   },
-  semiTitleText: {
-    color: "#344054",
-    fontSize: 13,
-    fontWeight: "medium",
-  },
 };
 
 export const fieldStyle = (theme: any) => ({
@@ -37,7 +32,6 @@ export const fieldStyle = (theme: any) => ({
 });
 
 export const selectReportStyle = (theme:any) => ({
-  width: "350px",
+  width: "100%",
   backgroundColor: theme.palette.background.main,
-
 });

--- a/Clients/src/presentation/components/Reporting/GenerateReport/styles.ts
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/styles.ts
@@ -2,7 +2,7 @@ export const styles = {
   formContainer: {
     padding: 12,
     width: { xs: "100%", sm: "400px" },
-    height: '595px'
+    height: '100%'
   },
   contentCenter: {
     display: 'flex',


### PR DESCRIPTION
…eportFrom component, update styles, and remove unused import.

## Describe your changes

- Converted the **Report Type** field from a `RadioGroup` to a `Select` dropdown in the `GenerateReportFrom` component.  
- This reduces vertical space usage and prepares the UI for upcoming features such as PDF report options.  
- Updated styles to adjust dropdown line-height for better alignment with the design system.  
- Removed unused `RadioGroup` import.

## Write your issue number after "Fixes "

Fixes #1986

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.


<img width="467" height="508" alt="Screenshot 2025-08-28 232520" src="https://github.com/user-attachments/assets/f7c98aa2-1370-4150-94e9-5c85b161a4ed" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Report Type now uses a dropdown selector with framework-specific options, required validation, and consistent theming for improved selection and readability.

* Style
  * Increased select input line-height for better spacing and tap targets.
  * Report form container height changed to be fluid (relative to its parent) and selector width standardized for more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->