### PR TITLE
Status dropdown for clauses and annexes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(npx tsc:*)",
       "Bash(npm run lint:*)",
       "Bash(npx eslint:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(find:*)"
     ],
     "deny": [],
     "ask": []

--- a/Clients/src/presentation/components/StatusDropdown/index.tsx
+++ b/Clients/src/presentation/components/StatusDropdown/index.tsx
@@ -115,10 +115,16 @@ const StatusDropdown: React.FC<StatusDropdownProps> = ({
   const padding = size === 'small' ? "4px 8px" : "5px 10px";
   const minWidth = size === 'small' ? '100px' : '120px';
 
+  const handleClick = (event: React.MouseEvent) => {
+    // Prevent event bubbling to parent elements (e.g., drawer opening)
+    event.stopPropagation();
+  };
+
   return (
     <MuiSelect
       value={normalizedStatus}
       onChange={handleStatusChange}
+      onClick={handleClick}
       disabled={isDisabled || isUpdating}
       displayEmpty
       renderValue={renderValue}


### PR DESCRIPTION
## Dropdown status for frameworks' clauses and annexes status

Now, user can change status using dropdowns as well

Addressing to close #1965 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="1918" height="916" alt="image" src="https://github.com/user-attachments/assets/9872e917-537e-4d19-b2c1-4944d843dc8f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevented Status dropdown clicks from triggering parent component actions (e.g., drawers), improving interaction reliability.

- Chores
  - Updated internal tooling configuration to expand allowed commands and fix JSON formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->