### PR TITLE
fix Project Risks pagination per page styling

### DIFF
--- a/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
@@ -68,7 +68,7 @@ const VWProjectRisksTable = ({
       setRowsPerPage(parseInt(event.target.value, 10));
       setPage(0);
     },
-    []
+    [],
   );
 
   return (
@@ -146,13 +146,13 @@ const VWProjectRisksTable = ({
                     labelDisplayedRows={({ page, count }) =>
                       `Page ${page + 1} of ${Math.max(
                         0,
-                        Math.ceil(count / rowsPerPage)
+                        Math.ceil(count / rowsPerPage),
                       )}`
                     }
                     sx={{
                       mt: theme.spacing(6),
                       color: theme.palette.text.secondary,
-                      "& .MuiTablePagination-select": {
+                      "& .MuiSelect-select": {
                         width: theme.spacing(10),
                         borderRadius: theme.shape.borderRadius,
                         border: `1px solid ${theme.palette.border.light}`,


### PR DESCRIPTION
Fix Project Risks pagination per page styling
Issue:
<img width="1431" height="275" alt="Screenshot 2025-09-11 at 9 58 22 AM" src="https://github.com/user-attachments/assets/40e2a6ac-c57b-4261-b5c9-63aaf4ada0aa" />


After Fix:
<img width="1431" height="275" alt="Screenshot 2025-09-11 at 9 56 04 AM" src="https://github.com/user-attachments/assets/2111e0bf-64fe-4fc3-950b-ff7939666373" />

Fixes #2090

## Please ensure all items are checked off before requesting a review:

- [X] I deployed the code locally.
- [X] I have performed a self-review of my code.
- [X] I have included the issue # in the PR.
- [X] I have labelled the PR correctly.
- [X] The issue I am working on is assigned to me.
- [X] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [X] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [X] My pull request is focused and addresses a single, specific feature.
- [X] If there are UI changes, I have attached a screenshot or video to this PR.
