### PR TITLE
Fix: Add missing Training API endpoints to Swagger documentation

### DIFF
--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -1769,6 +1769,32 @@ paths:
 
   # Training
   /training:
+    get:
+      summary: Get all training records
+      tags: [Training]
+      security:
+        - JWTAuth: []
+      responses:
+        '200':
+          description: List of training records
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Training'
+        '204':
+          description: No training records found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
     post:
       summary: Create training registry entry
       tags: [Training]
@@ -1779,10 +1805,113 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Training'
+              $ref: '#/components/schemas/TrainingInput'
       responses:
         '201':
           description: Training registry entry created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          description: Missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /training/training-id/{id}:
+    get:
+      summary: Get training record by ID
+      tags: [Training]
+      security:
+        - JWTAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Training record ID
+      responses:
+        '200':
+          description: Training record details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: '#/components/schemas/Training'
+        '404':
+          description: Training record not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /training/{id}:
+    patch:
+      summary: Update training record
+      tags: [Training]
+      security:
+        - JWTAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Training record ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingUpdate'
+      responses:
+        '202':
+          description: Training record updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          description: Missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Training record not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+    delete:
+      summary: Delete training record
+      tags: [Training]
+      security:
+        - JWTAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Training record ID
+      responses:
+        '202':
+          description: Training record deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Training record not found
           content:
             application/json:
               schema:
@@ -3098,13 +3227,82 @@ components:
           type: integer
         training_name:
           type: string
-        description:
+        duration:
           type: string
+          description: Duration of the training (e.g., "2 days", "8 hours")
+        provider:
+          type: string
+          description: Training provider organization
+        department:
+          type: string
+          description: Target department for the training
         status:
           type: string
-        completion_date:
+          enum: ["Planned", "In Progress", "Completed"]
+        people:
+          type: integer
+          description: Number of participants
+        description:
           type: string
-          format: date
+          description: Detailed description of the training
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    TrainingInput:
+      type: object
+      required: [training_name, duration, provider, department, status, numberOfPeople]
+      properties:
+        training_name:
+          type: string
+          minLength: 1
+        duration:
+          type: string
+          minLength: 1
+        provider:
+          type: string
+          minLength: 1
+        department:
+          type: string
+          minLength: 1
+        status:
+          type: string
+          enum: ["Planned", "In Progress", "Completed"]
+        numberOfPeople:
+          type: integer
+          minimum: 1
+          description: Number of participants (mapped to 'people' in database)
+        description:
+          type: string
+
+    TrainingUpdate:
+      type: object
+      required: [training_name, duration, provider, department, status, numberOfPeople]
+      properties:
+        training_name:
+          type: string
+          minLength: 1
+        duration:
+          type: string
+          minLength: 1
+        provider:
+          type: string
+          minLength: 1
+        department:
+          type: string
+          minLength: 1
+        status:
+          type: string
+          enum: ["Planned", "In Progress", "Completed"]
+        numberOfPeople:
+          type: integer
+          minimum: 1
+          description: Number of participants (mapped to 'people' in database)
+        description:
+          type: string
 
     Answer:
       type: object


### PR DESCRIPTION
## Summary
This PR adds complete Swagger documentation for the Training Registry API endpoints that were already implemented in the backend but missing from the API documentation.

## Problem
The Training module had only 1 out of 5 endpoints documented in Swagger (20% coverage), while all endpoints were fully functional in the backend and actively used by the frontend.

## Solution
Added comprehensive documentation for all Training API endpoints to achieve 100% documentation coverage.

## Changes Made

### Added 4 Missing Endpoints:
- `GET /training` - Get all training records
- `GET /training/training-id/{id}` - Get training record by ID  
- `PATCH /training/{id}` - Update training record
- `DELETE /training/{id}` - Delete training record

### Updated Schemas:
- **Training Schema**: Added all required fields (duration, provider, department, people, description)
- **TrainingInput Schema**: Created for POST request validation with required fields
- **TrainingUpdate Schema**: Created for PATCH request validation with required fields
- **Status Enum**: Properly documented values: "Planned", "In Progress", "Completed"

### Technical Details:
- All endpoints include proper HTTP status codes (200, 202, 204, 400, 404)
- JWT authentication requirements specified
- Request/response schemas with field descriptions
- Documented field mapping: `numberOfPeople` (frontend) → `people` (database)

## Verification
- All endpoints verified to exist in `trainingRegistar.route.ts`
- All controller functions verified in `trainingRegistar.ctrl.ts`
- Data model fields verified against `trainingRegistar.model.ts`
- Frontend usage patterns confirmed in Training component

## Impact
Developers using the Swagger documentation will now have complete visibility into all Training API capabilities, improving API discoverability and reducing integration issues.