### PR TITLE
  Prevents accidental modal/drawer closure on backdrop clicks while adding consistent ESC key support across framework pages.

### DIFF
--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -44,7 +44,7 @@ export const inputStyles = {
 
 interface VWISO42001ClauseDrawerDialogProps {
   open: boolean;
-  onClose: () => void;
+  onClose: (event?: any, reason?: string) => void;
   subClause: any;
   clause: any;
   evidenceFiles?: FileData[];

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -42,7 +42,7 @@ export const inputStyles = {
 
 interface VWISO27001ClauseDrawerDialogProps {
   open: boolean;
-  onClose: () => void;
+  onClose: (event?: any, reason?: string) => void;
   subClause: any;
   clause: any;
   evidenceFiles?: FileData[];

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -41,6 +41,7 @@ import { handleAlert } from "../../../../application/tools/alertUtils";
 import { TABLE_COLUMNS, WARNING_MESSAGES } from "./constants";
 import { AITrustCentreOverviewData } from "../../../../application/hooks/useAITrustCentreOverview";
 import { useTheme } from "@mui/material/styles";
+import { useModalKeyHandling } from "../../../../application/hooks/useModalKeyHandling";
 
 interface Resource {
   id: number;
@@ -264,6 +265,17 @@ const TrustCenterResources: React.FC = () => {
     });
     setEditResourceError(null);
   };
+
+  // Add modal key handling for ESC key support
+  useModalKeyHandling({
+    isOpen: addModalOpen,
+    onClose: handleCloseAddModal,
+  });
+
+  useModalKeyHandling({
+    isOpen: editModalOpen,
+    onClose: handleCloseEditModal,
+  });
 
   // File handling
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -568,7 +580,12 @@ const TrustCenterResources: React.FC = () => {
         {/* Add Resource Modal */}
         <Dialog
           open={addModalOpen}
-          onClose={handleCloseAddModal}
+          onClose={async (_event, reason) => {
+            if (reason === "backdropClick") {
+              return; // block closing on backdrop click
+            }
+            handleCloseAddModal();
+          }}
           maxWidth="sm"
           fullWidth
           PaperProps={{
@@ -653,7 +670,12 @@ const TrustCenterResources: React.FC = () => {
         {/* Edit Resource Modal */}
         <Dialog
           open={editModalOpen}
-          onClose={handleCloseEditModal}
+          onClose={(_event, reason) => {
+            if (reason === "backdropClick") {
+              return; // block closing on backdrop click
+            }
+            handleCloseEditModal();
+          }}
           maxWidth="sm"
           fullWidth
           PaperProps={{

--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../../../application/hooks/useAITrustCentreSubprocessorsQuery";
 import { handleAlert } from "../../../../application/tools/alertUtils";
 import { AITrustCentreOverviewData } from "../../../../application/hooks/useAITrustCentreOverviewQuery";
+import { useModalKeyHandling } from "../../../../application/hooks/useModalKeyHandling";
 
 import { TABLE_COLUMNS, WARNING_MESSAGES } from "./constants";
 
@@ -265,6 +266,17 @@ const AITrustCenterSubprocessors: React.FC = () => {
     setNewSubprocessor((prev) => ({ ...prev, [field]: value }));
   };
 
+  // Add modal key handling for ESC key support
+  useModalKeyHandling({
+    isOpen: addModalOpen,
+    onClose: handleCloseAddModal,
+  });
+
+  useModalKeyHandling({
+    isOpen: editModalOpen,
+    onClose: handleCloseEditModal,
+  });
+
   // Subprocessor operations
   const handleAddSubprocessor = async () => {
     if (
@@ -489,7 +501,15 @@ const AITrustCenterSubprocessors: React.FC = () => {
         </Box>
 
         {/* Edit Subprocessor Modal */}
-        <Modal open={editModalOpen} onClose={handleCloseEditModal}>
+        <Modal
+          open={editModalOpen}
+          onClose={(_event, reason) => {
+            if (reason === "backdropClick") {
+              return; // block closing on backdrop click
+            }
+            handleCloseEditModal();
+          }}
+        >
           <Box sx={styles.modal}>
             <Box sx={styles.modalHeader}>
               <Typography sx={styles.modalTitle}>Edit subprocessor</Typography>
@@ -547,7 +567,15 @@ const AITrustCenterSubprocessors: React.FC = () => {
         </Modal>
 
         {/* Add Subprocessor Modal */}
-        <Modal open={addModalOpen} onClose={handleCloseAddModal}>
+        <Modal
+          open={addModalOpen}
+          onClose={(_event, reason) => {
+            if (reason === "backdropClick") {
+              return; // block closing on backdrop click
+            }
+            handleCloseAddModal();
+          }}
+        >
           <Box sx={styles.modal}>
             <Box sx={styles.modalHeader}>
               <Typography sx={styles.modalTitle}>

--- a/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
@@ -303,7 +303,12 @@ const ISO27001Annex = ({
             <VWISO27001AnnexDrawerDialog
               title={annexTitle}
               open={drawerOpen}
-              onClose={handleDrawerClose}
+              onClose={(_event?: any, reason?: string) => {
+                if (reason === "backdropClick") {
+                  return; // block closing on backdrop click
+                }
+                handleDrawerClose();
+              }}
               control={selectedControl}
               annex={selectedAnnex}
               projectFrameworkId={Number(projectFrameworkId)}

--- a/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
@@ -24,6 +24,7 @@ import { updateISO27001ClauseStatus } from "../../../../components/StatusDropdow
 import { useAuth } from "../../../../../application/hooks/useAuth";
 import allowedRoles from "../../../../../application/constants/permissions";
 import { Project } from "../../../../../domain/types/Project";
+import { useModalKeyHandling } from "../../../../../application/hooks/useModalKeyHandling";
 
 const ISO27001Clause = ({
   project,
@@ -144,6 +145,12 @@ const ISO27001Clause = ({
       setSearchParams(searchParams);
     }
   };
+
+  // Add modal key handling for ESC key support
+  useModalKeyHandling({
+    isOpen: drawerOpen,
+    onClose: handleDrawerClose,
+  });
 
   const handleSaveSuccess = async (
     success: boolean,
@@ -326,7 +333,12 @@ const ISO27001Clause = ({
       {drawerOpen && (
         <VWISO27001ClauseDrawerDialog
           open={drawerOpen}
-          onClose={handleDrawerClose}
+          onClose={(_event?: any, reason?: string) => {
+            if (reason === "backdropClick") {
+              return; // block closing on backdrop click
+            }
+            handleDrawerClose();
+          }}
           project_id={Number(project.id)}
           subClause={selectedSubClause}
           clause={selectedClause}

--- a/Clients/src/presentation/pages/Framework/ISO42001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO42001/Annex/index.tsx
@@ -263,7 +263,12 @@ const ISO42001Annex = ({
         <VWISO42001AnnexDrawerDialog
           title={selectedControl?.title || ""}
           open={drawerOpen}
-          onClose={handleDrawerClose}
+          onClose={(_event?: any, reason?: string) => {
+            if (reason === "backdropClick") {
+              return; // block closing on backdrop click
+            }
+            handleDrawerClose();
+          }}
           annex={selectedAnnex}
           control={selectedControl}
           projectFrameworkId={Number(projectFrameworkId)}

--- a/Clients/src/presentation/pages/Framework/ISO42001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO42001/Clause/index.tsx
@@ -326,7 +326,12 @@ const ISO42001Clause = ({
       {drawerOpen && (
         <VWISO42001ClauseDrawerDialog
           open={drawerOpen}
-          onClose={handleDrawerClose}
+          onClose={(_event?: any, reason?: string) => {
+            if (reason === "backdropClick") {
+              return; // block closing on backdrop click
+            }
+            handleDrawerClose();
+          }}
           subClause={selectedSubClause}
           clause={selectedClause}
           projectFrameworkId={Number(projectFrameworkId)}

--- a/Clients/src/presentation/pages/Framework/index.tsx
+++ b/Clients/src/presentation/pages/Framework/index.tsx
@@ -742,9 +742,13 @@ const Framework = () => {
       {isProjectFormModalOpen && (
         <Modal
           open={isProjectFormModalOpen}
-          onClose={async () => {
+          onClose={async (_event, reason) => {
+            // Prevent closing on backdrop click
+            if (reason === "backdropClick") {
+              return;
+            }
             setIsProjectFormModalOpen(false);
-            // Refresh project data after creating a new project
+            // Refresh project data after editing the project
             await refreshProjectData();
           }}
           sx={{
@@ -781,7 +785,11 @@ const Framework = () => {
       {isEditProjectModalOpen && organizationalProject && (
         <Modal
           open={isEditProjectModalOpen}
-          onClose={async () => {
+          onClose={async (_event, reason) => {
+            // Prevent closing on backdrop click
+            if (reason === "backdropClick") {
+              return;
+            }
             setIsEditProjectModalOpen(false);
             // Refresh project data after editing the project
             await refreshProjectData();

--- a/Clients/src/presentation/pages/ISO/Clause/index.tsx
+++ b/Clients/src/presentation/pages/ISO/Clause/index.tsx
@@ -283,7 +283,12 @@ const ISO42001Clauses = ({
       {drawerOpen && (
         <VWISO42001ClauseDrawerDialog
           open={drawerOpen}
-          onClose={handleDrawerClose}
+          onClose={(_event?: any, reason?: string) => {
+            if (reason === "backdropClick") {
+              return; // block closing on backdrop click
+            }
+            handleDrawerClose();
+          }}
           subClause={selectedSubClause}
           clause={selectedClause}
           projectFrameworkId={projectFrameworkId}


### PR DESCRIPTION
## Describe your changes
  - Added backdrop click prevention to ISO27001/Clause, AITrustCenter Resources/Subprocessors
  - Added ESC key handling via useModalKeyHandling hook
  - Updated drawer interfaces to support (event?, reason?) pattern for backdrop detection
  - Maintains close button functionality and backward compatibility

## Write your issue number after "Fixes "

Fixes #2058 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
