### PR TITLE
Disabled global ripple effect

### DIFF
--- a/Clients/src/App.css
+++ b/Clients/src/App.css
@@ -39,3 +39,22 @@ div.react-joyride > * {
   padding:0;
   box-sizing: border-box;
 }
+
+/* Global ripple effect disable for all MUI components */
+.MuiTouchRipple-root {
+  display: none !important;
+}
+
+.MuiButtonBase-root .MuiTouchRipple-root,
+.MuiButton-root .MuiTouchRipple-root,
+.MuiIconButton-root .MuiTouchRipple-root,
+.MuiMenuItem-root .MuiTouchRipple-root,
+.MuiListItemButton-root .MuiTouchRipple-root,
+.MuiTab-root .MuiTouchRipple-root,
+.MuiCheckbox-root .MuiTouchRipple-root,
+.MuiRadio-root .MuiTouchRipple-root,
+.MuiSwitch-root .MuiTouchRipple-root,
+.MuiFab-root .MuiTouchRipple-root,
+.MuiChip-root .MuiTouchRipple-root {
+  display: none !important;
+}

--- a/Clients/src/presentation/pages/FairnessDashboard/FairnessDashboard.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/FairnessDashboard.tsx
@@ -323,6 +323,7 @@ export default function FairnessDashboard() {
               ref={buttonRef}
               variant="contained"
               startIcon={<AddCircleOutlineIcon />}
+              disableRipple
               onClick={() => setDialogOpen(true)}
               sx={{
                 backgroundColor: "#13715B",

--- a/Clients/src/presentation/pages/Framework/index.tsx
+++ b/Clients/src/presentation/pages/Framework/index.tsx
@@ -558,6 +558,7 @@ const Framework = () => {
                 variant="contained"
                 endIcon={<KeyboardArrowDownIcon sx={{ fontSize: "18px" }} />}
                 onClick={handleManageProjectClick}
+                disableRipple
                 disabled={
                   !allowedRoles.frameworks.manage.includes(userRoleName) &&
                   !allowedRoles.projects.edit.includes(userRoleName) &&

--- a/Clients/src/presentation/themes/dark.ts
+++ b/Clients/src/presentation/themes/dark.ts
@@ -271,6 +271,31 @@ const dark = createTheme({
         disableRipple: true,
       },
     },
+    MuiTab: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+    MuiToggleButton: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+    MuiSwitch: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+    MuiRadio: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+    MuiChip: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
   },
 });
 

--- a/Clients/src/presentation/themes/dark.ts
+++ b/Clients/src/presentation/themes/dark.ts
@@ -291,11 +291,6 @@ const dark = createTheme({
         disableRipple: true,
       },
     },
-    MuiChip: {
-      defaultProps: {
-        disableRipple: true,
-      },
-    },
   },
 });
 

--- a/Clients/src/presentation/themes/light.ts
+++ b/Clients/src/presentation/themes/light.ts
@@ -269,6 +269,26 @@ const light = createTheme({
         disableRipple: true,
       },
     },
+    MuiTab: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+    MuiToggleButton: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+    MuiSwitch: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+    MuiRadio: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
   },
 });
 

--- a/Clients/src/presentation/themes/v1SingleTheme.ts
+++ b/Clients/src/presentation/themes/v1SingleTheme.ts
@@ -47,6 +47,7 @@ const buttons = {
       textTransform: "Inherit",
       borderRadius: "4px",
       border: `1px solid ${borderColors.primary}`,
+      disableRipple: true, // Apply ripple setting
       "&:hover": {
         boxShadow: shadowEffect.NoShadow,
       },
@@ -83,6 +84,7 @@ const buttons = {
       textTransform: "Inherit",
       borderRadius: "4px",
       border: `1px solid ${borderColors.error}`,
+      disableRipple: true, // Apply ripple setting
       "&:hover": {
         boxShadow: shadowEffect.NoShadow,
         backgroundColor: "#d32f2f",


### PR DESCRIPTION
## Describe your changes

 - Fixed ripple effects not being disabled globally due to emotion/react ThemeProvider incompatibility with MUI theme  configuration
  - Added global CSS rules to disable ripple effects for all MUI components

## Write your issue number after "Fixes "

Fixes #2071 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.




https://github.com/user-attachments/assets/dedfb494-a88b-41ab-9dab-4287335c467c

