### PR TITLE
-Fix pagination on Setting's Team page

### DIFF
--- a/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
@@ -2,7 +2,6 @@ import React, {
   useState,
   useCallback,
   useMemo,
-  useContext,
   lazy,
   Suspense,
 } from "react";
@@ -28,7 +27,6 @@ import {
 import GroupsIcon from "@mui/icons-material/Groups";
 import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
 import TablePaginationActions from "../../../components/TablePagination";
-import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import InviteUserModal from "../../../components/Modals/InviteUser";
 import DualButtonModal from "../../../components/Dialogs/DualButtonModal";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
@@ -80,7 +78,6 @@ const TeamManagement: React.FC = (): JSX.Element => {
   const [filter, setFilter] = useState(0);
 
   const [page, setPage] = useState(0); // Current page
-  const { dashboardValues } = useContext(VerifyWiseContext);
   const { userId } = useAuth();
   const { users, refreshUsers } = useUsers();
 
@@ -499,11 +496,7 @@ const TeamManagement: React.FC = (): JSX.Element => {
                   <TableFooter>
                     <TableRow>
                       <TablePagination
-                        count={
-                          dashboardValues.vendors
-                            ? dashboardValues.vendors.length
-                            : 0
-                        }
+                        count={filteredMembers.length}
                         page={page}
                         onPageChange={handleChangePage}
                         rowsPerPage={rowsPerPage}


### PR DESCRIPTION
# Pull Request Template

## Describe your changes

Fixed pagination on Settings > Team page. The pagination was incorrectly using `dashboardValues.vendors.length` instead of `filteredMembers.length`, causing incorrect pagination count for team members. Changed the count parameter in TablePagination component to use the correct filtered team members data.

## Write your issue number after "Fixes "

Fixes #2027

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
