### PR TITLE
Ks 015 sep 16 esc button modal close 2058

### DIFF
--- a/Clients/src/presentation/components/Dialogs/DualButtonModal/index.tsx
+++ b/Clients/src/presentation/components/Dialogs/DualButtonModal/index.tsx
@@ -1,6 +1,7 @@
 import CustomizableButton from "../../Button/CustomizableButton";
 import "./index.css";
 import { Stack, SxProps, Theme, Typography } from "@mui/material";
+import {useModalKeyHandling} from "../../../../application/hooks/useModalKeyHandling";
 
 interface DualButtonModalProps {
   title: string;
@@ -19,6 +20,7 @@ interface DualButtonModalProps {
   proceedButtonVariant: "contained" | "outlined" | "text";
   TitleFontSize?: number;
   confirmBtnSx?: SxProps<Theme> | undefined;
+  isOpen?: boolean;
 }
 
 const DualButtonModal: React.FC<DualButtonModalProps> = ({
@@ -32,7 +34,13 @@ const DualButtonModal: React.FC<DualButtonModalProps> = ({
   proceedButtonVariant,
   TitleFontSize,
   confirmBtnSx,
+  isOpen = true,
 }) => {
+  useModalKeyHandling({
+    isOpen,
+    onClose: onCancel,
+  });
+
   return (
     <>
       <Stack

--- a/Clients/src/presentation/components/Dialogs/DualButtonModal/index.tsx
+++ b/Clients/src/presentation/components/Dialogs/DualButtonModal/index.tsx
@@ -41,6 +41,8 @@ const DualButtonModal: React.FC<DualButtonModalProps> = ({
     onClose: onCancel,
   });
 
+  if (!isOpen) return null;
+
   return (
     <>
       <Stack

--- a/Clients/src/presentation/components/Drawer/HelperDrawer/index.tsx
+++ b/Clients/src/presentation/components/Drawer/HelperDrawer/index.tsx
@@ -40,7 +40,11 @@ const HelperDrawer: React.FC<HelperDrawerProps> = ({
     <Drawer
       anchor="right"
       open={isOpen}
-      onClose={onClose}
+      onClose={(_event, reason) => {
+        if (reason !== 'backdropClick') {
+          onClose();
+        }
+      }}
       variant="temporary"
       sx={{
         width: 600,


### PR DESCRIPTION
## Describe your changes

- successfully added ESC key functionality to the DualButtonModal component. Now Delete Modal will close on ESC button
- Updated `onClose` logic to ignore `backdropClick` events, ensuring the drawer remains open unless explicitly closed by the user.

## Write your issue number after "Fixes "

Fixes #2058  

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
