### PR TITLE
feat: implement localStorage persistence for pagination settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,7 +34,8 @@
       "mcp__ide__getDiagnostics",
       "Read(/A:\\VerifyWiseRepository\\verifywise\\Clients\\src\\presentation\\components\\AddNewRiskForm\\MitigationSection/**)",
       "Read(/A:\\VerifyWiseRepository\\verifywise\\Clients\\src\\presentation\\components\\AddNewRiskForm\\MitigationSection/**)",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "Bash(VITE_APP_PORT=8001 npm run dev)"
     ],
     "deny": [],
     "ask": []

--- a/Clients/src/application/utils/paginationStorage.ts
+++ b/Clients/src/application/utils/paginationStorage.ts
@@ -1,0 +1,49 @@
+/**
+ * Utility functions for managing pagination row count in localStorage
+ */
+
+const PAGINATION_STORAGE_KEY_PREFIX = 'pagination_rows_';
+
+export const getPaginationRowCount = (tableKey: string, defaultCount: number = 10): number => {
+  try {
+    const stored = localStorage.getItem(`${PAGINATION_STORAGE_KEY_PREFIX}${tableKey}`);
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to retrieve pagination setting from localStorage:', error);
+  }
+  return defaultCount;
+};
+
+export const setPaginationRowCount = (tableKey: string, rowCount: number): void => {
+  try {
+    localStorage.setItem(`${PAGINATION_STORAGE_KEY_PREFIX}${tableKey}`, rowCount.toString());
+  } catch (error) {
+    console.warn('Failed to save pagination setting to localStorage:', error);
+  }
+};
+
+export const clearPaginationRowCount = (tableKey: string): void => {
+  try {
+    localStorage.removeItem(`${PAGINATION_STORAGE_KEY_PREFIX}${tableKey}`);
+  } catch (error) {
+    console.warn('Failed to clear pagination setting from localStorage:', error);
+  }
+};
+
+export const clearAllPaginationSettings = (): void => {
+  try {
+    const keys = Object.keys(localStorage);
+    keys.forEach(key => {
+      if (key.startsWith(PAGINATION_STORAGE_KEY_PREFIX)) {
+        localStorage.removeItem(key);
+      }
+    });
+  } catch (error) {
+    console.warn('Failed to clear all pagination settings from localStorage:', error);
+  }
+};

--- a/Clients/src/presentation/components/Table/EventsTable/index.tsx
+++ b/Clients/src/presentation/components/Table/EventsTable/index.tsx
@@ -19,6 +19,7 @@ import Placeholder from "../../../assets/imgs/empty-state.svg";
 import { formatDateTime } from "../../../tools/isoDateToString";
 import { Event } from "../../../../domain/types/Event";
 import { User } from "../../../../domain/types/User";
+import { getPaginationRowCount, setPaginationRowCount } from "../../../../application/utils/paginationStorage";
 
 const TABLE_COLUMNS = [
   { id: "id", label: "ID" },
@@ -35,7 +36,7 @@ interface EventsTableProps {
   paginated?: boolean;
 }
 
-const DEFAULT_ROWS_PER_PAGE = 5;
+const DEFAULT_ROWS_PER_PAGE = 10;
 
 const EventTypeBadge: React.FC<{ eventType: Event["event_type"] }> = ({
   eventType,
@@ -76,7 +77,9 @@ const EventsTable: React.FC<EventsTableProps> = ({
 }) => {
   const theme = useTheme();
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => 
+    getPaginationRowCount('eventTracker', DEFAULT_ROWS_PER_PAGE)
+  );
 
   // Format users data like other tables do
   const formattedUsers = useMemo(() => {
@@ -92,7 +95,9 @@ const EventsTable: React.FC<EventsTableProps> = ({
 
   const handleChangeRowsPerPage = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setRowsPerPage(parseInt(event.target.value, 10));
+      const newRowsPerPage = parseInt(event.target.value, 10);
+      setRowsPerPage(newRowsPerPage);
+      setPaginationRowCount('eventTracker', newRowsPerPage);
       setPage(0);
     },
     []

--- a/Clients/src/presentation/components/Table/FilesBasicTable/FileBasicTable.tsx
+++ b/Clients/src/presentation/components/Table/FilesBasicTable/FileBasicTable.tsx
@@ -17,8 +17,9 @@ import IconButton from "../../IconButton";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { handleDownload } from "../../../../application/tools/fileDownload";
 import { FileData } from "../../../../domain/types/File";
+import { getPaginationRowCount, setPaginationRowCount } from "../../../../application/utils/paginationStorage";
 
-const DEFAULT_ROWS_PER_PAGE = 5;
+const DEFAULT_ROWS_PER_PAGE = 10;
 
 interface Column {
   id: number;
@@ -47,7 +48,9 @@ const FileBasicTable: React.FC<FileBasicTableProps> = ({
 }) => {
   const theme = useTheme();
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => 
+    getPaginationRowCount('evidences', DEFAULT_ROWS_PER_PAGE)
+  );
 
   useEffect(() => setPage(0), [data]);
 
@@ -57,7 +60,9 @@ const FileBasicTable: React.FC<FileBasicTableProps> = ({
 
   const handleChangeRowsPerPage = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setRowsPerPage(parseInt(event.target.value, 10));
+      const newRowsPerPage = parseInt(event.target.value, 10);
+      setRowsPerPage(newRowsPerPage);
+      setPaginationRowCount('evidences', newRowsPerPage);
       setPage(0);
     },
     [],

--- a/Clients/src/presentation/components/Table/PolicyTable/index.tsx
+++ b/Clients/src/presentation/components/Table/PolicyTable/index.tsx
@@ -16,8 +16,9 @@ import TablePaginationActions from "../../TablePagination";
 import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { getPaginationRowCount, setPaginationRowCount } from "../../../../application/utils/paginationStorage";
 
-const DEFAULT_ROWS_PER_PAGE = 5;
+const DEFAULT_ROWS_PER_PAGE = 10;
 
 interface TableProps {
   data: {
@@ -45,7 +46,9 @@ const CustomizablePolicyTable = ({
 }: TableProps) => {
   const theme = useTheme();
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => 
+    getPaginationRowCount('policyManager', DEFAULT_ROWS_PER_PAGE)
+  );
   const { setInputValues } =
     useContext(VerifyWiseContext);
 
@@ -57,7 +60,9 @@ const CustomizablePolicyTable = ({
   );
   const handleChangeRowsPerPage = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setRowsPerPage(parseInt(event.target.value, 10));
+      const newRowsPerPage = parseInt(event.target.value, 10);
+      setRowsPerPage(newRowsPerPage);
+      setPaginationRowCount('policyManager', newRowsPerPage);
       setPage(0);
     },
     []

--- a/Clients/src/presentation/components/Table/ReportTable/index.tsx
+++ b/Clients/src/presentation/components/Table/ReportTable/index.tsx
@@ -17,6 +17,7 @@ import TablePaginationActions from '../../TablePagination';
 import TableHeader from '../TableHead';
 const ReportTableBody = lazy(() => import("./TableBody"))
 import {styles, tableWrapper, emptyData, pagniationStatus, paginationStyle, paginationDropdown, paginationSelect} from './styles'
+import { getPaginationRowCount, setPaginationRowCount } from '../../../../application/utils/paginationStorage';
 
 interface ReportTableProps {
   columns: any[];
@@ -34,7 +35,9 @@ const ReportTable: React.FC<ReportTableProps> = ({
     setCurrentPagingation
   }) => {
   const theme = useTheme();
-  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const [rowsPerPage, setRowsPerPage] = useState(() => 
+    getPaginationRowCount('reporting', 10)
+  );
 
   const getRange = useMemo(() => {
     const start = page * rowsPerPage + 1;
@@ -48,7 +51,9 @@ const ReportTable: React.FC<ReportTableProps> = ({
 
   const handleChangeRowsPerPage = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setRowsPerPage(parseInt(event.target.value, 10));
+      const newRowsPerPage = parseInt(event.target.value, 10);
+      setRowsPerPage(newRowsPerPage);
+      setPaginationRowCount('reporting', newRowsPerPage);
       setCurrentPagingation(0);
     },
     [setRowsPerPage, setCurrentPagingation]

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../../domain/interfaces/i.modelInventory";
 import { getAllEntities } from "../../../application/repository/entity.repository";
 import { User } from "../../../domain/types/User";
+import { getPaginationRowCount, setPaginationRowCount } from "../../../application/utils/paginationStorage";
 import {
   statusBadgeStyle,
   securityAssessmentBadgeStyle,
@@ -67,7 +68,7 @@ interface ModelInventoryTableProps {
   deletingId?: string | null;
 }
 
-const DEFAULT_ROWS_PER_PAGE = 5;
+const DEFAULT_ROWS_PER_PAGE = 10;
 
 const StatusBadge: React.FC<{ status: ModelInventoryStatus }> = ({
   status,
@@ -120,7 +121,9 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
   const theme = useTheme();
   const { userRoleName } = useAuth();
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => 
+    getPaginationRowCount('modelInventory', DEFAULT_ROWS_PER_PAGE)
+  );
   const [users, setUsers] = useState<User[]>([]);
 
   // Fetch users when component mounts
@@ -157,7 +160,9 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
 
   const handleChangeRowsPerPage = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setRowsPerPage(parseInt(event.target.value, 10));
+      const newRowsPerPage = parseInt(event.target.value, 10);
+      setRowsPerPage(newRowsPerPage);
+      setPaginationRowCount('modelInventory', newRowsPerPage);
       setPage(0);
     },
     []

--- a/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
@@ -20,6 +20,7 @@ import allowedRoles from "../../../application/constants/permissions";
 import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
 import Placeholder from "../../assets/imgs/empty-state.svg";
 import { useAuth } from "../../../application/hooks/useAuth";
+import { getPaginationRowCount, setPaginationRowCount } from "../../../application/utils/paginationStorage";
 
 //const Alert = lazy(() => import("../../../components/Alert"));
 
@@ -53,7 +54,7 @@ interface TrainingTableProps {
   paginated?: boolean;
 }
 
-const DEFAULT_ROWS_PER_PAGE = 5;
+const DEFAULT_ROWS_PER_PAGE = 10;
 
 const StatusBadge: React.FC<{ status: IAITraining["status"] }> = ({
   status,
@@ -94,7 +95,9 @@ const TrainingTable: React.FC<TrainingTableProps> = ({
   const theme = useTheme();
   const { userRoleName } = useAuth();
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  const [rowsPerPage, setRowsPerPage] = useState(() => 
+    getPaginationRowCount('trainingRegistry', DEFAULT_ROWS_PER_PAGE)
+  );
 
   const isDeletingAllowed =
     allowedRoles.training?.delete?.includes(userRoleName);
@@ -105,7 +108,9 @@ const TrainingTable: React.FC<TrainingTableProps> = ({
 
   const handleChangeRowsPerPage = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setRowsPerPage(parseInt(event.target.value, 10));
+      const newRowsPerPage = parseInt(event.target.value, 10);
+      setRowsPerPage(newRowsPerPage);
+      setPaginationRowCount('trainingRegistry', newRowsPerPage);
       setPage(0);
     },
     []


### PR DESCRIPTION
## Summary
- Add pagination row count persistence across all table components using localStorage
- Update default pagination from 5 to 10 rows per page  
- Implement centralized pagination storage utility

## Technical Implementation

### New Utility Module
- **`paginationStorage.ts`** - Centralized localStorage management for pagination settings
- Provides functions: `getPaginationRowCount()`, `setPaginationRowCount()`, `clearPaginationRowCount()`
- Includes error handling with graceful fallback to defaults

### Updated Components
- **Model Inventory** (`modelInventoryTable.tsx`)
- **Policy Manager** (`PolicyTable/index.tsx`)
- **Training Registry** (`trainingTable.tsx`) 
- **Reporting** (`ReportTable/index.tsx`)
- **Event Tracker** (`EventsTable/index.tsx`)
- **Evidences** (`FilesBasicTable/FileBasicTable.tsx`)

### Key Features
- **Persistent State**: User's rows-per-page selection automatically saved to localStorage
- **Individual Settings**: Each table maintains independent pagination preferences
- **Cross-Session**: Settings persist across browser sessions
- **Error Resilient**: Graceful fallback to defaults if localStorage fails
- **Default Enhancement**: All tables now default to 10 rows instead of 5

### Storage Implementation
Uses prefixed localStorage keys for each component:
- `pagination_rows_modelInventory`
- `pagination_rows_policyManager`
- `pagination_rows_trainingRegistry`
- `pagination_rows_reporting`
- `pagination_rows_eventTracker`
- `pagination_rows_evidences`
