### PR TITLE
fix: Replace MUI icons with Lucide icons in dashboard

### DIFF
--- a/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
@@ -15,18 +15,18 @@ import {
   useTheme,
 } from "@mui/material";
 import {
-  DragIndicator as DragIcon,
-  Refresh as ResetIcon,
-  LockOutlined as LockIcon,
-  LockOpenOutlined as LockOpenIcon,
-} from "@mui/icons-material";
+  GripVertical,
+  RefreshCw,
+  Lock,
+  LockOpen,
+  ChevronRight,
+} from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Responsive, WidthProvider, Layout, Layouts } from "react-grid-layout";
 import { useDashboard } from "../../../application/hooks/useDashboard";
 import { useDashboardMetrics } from "../../../application/hooks/useDashboardMetrics";
 import { cardStyles } from "../../themes";
 import { useAuth } from "../../../application/hooks/useAuth";
-import { ReactComponent as RightArrow } from "../../assets/icons/right-arrow.svg";
 import StatusDonutChart from "../../components/Charts/StatusDonutChart";
 import { getDefaultStatusDistribution } from "../../utils/statusColors";
 import {
@@ -186,7 +186,7 @@ const MetricCard: React.FC<MetricCardProps> = ({
                 transition: "opacity 0.2s ease",
               }}
             >
-              <RightArrow />
+              <ChevronRight size={20} />
             </Box>
           )}
         </Box>
@@ -1126,18 +1126,16 @@ const IntegratedDashboard: React.FC = () => {
               size="medium"
             >
               {editMode ? (
-                <LockOpenIcon
-                  sx={{
-                    color: "#344054",
-                    "& path": { strokeWidth: "1.5px" },
-                  }}
+                <LockOpen
+                  size={20}
+                  color="#344054"
+                  strokeWidth={1.5}
                 />
               ) : (
-                <LockIcon
-                  sx={{
-                    color: "#344054",
-                    "& path": { strokeWidth: "1.5px" },
-                  }}
+                <Lock
+                  size={20}
+                  color="#344054"
+                  strokeWidth={1.5}
                 />
               )}
             </IconButton>
@@ -1145,7 +1143,7 @@ const IntegratedDashboard: React.FC = () => {
           {editMode && (
             <Tooltip title="Reset Layout">
               <IconButton onClick={resetLayout} size="small">
-                <ResetIcon />
+                <RefreshCw size={20} />
               </IconButton>
             </Tooltip>
           )}
@@ -1376,11 +1374,9 @@ const IntegratedDashboard: React.FC = () => {
                   },
                 }}
                 avatar={
-                  <DragIcon
-                    sx={{
-                      color: alpha(theme.palette.text.secondary, 0.6),
-                      fontSize: "1rem",
-                    }}
+                  <GripVertical
+                    size={16}
+                    color={alpha(theme.palette.text.secondary, 0.6)}
                   />
                 }
                 title={widget.title}

--- a/Clients/src/presentation/pages/DashboardOverview/widgets/MetricsWidget.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/widgets/MetricsWidget.tsx
@@ -10,8 +10,8 @@ import {
 import {
   TrendingUp,
   TrendingDown,
-  TrendingFlat,
-} from '@mui/icons-material';
+  Minus,
+} from 'lucide-react';
 
 interface MetricData {
   label: string;
@@ -43,9 +43,9 @@ export const MetricsWidget: React.FC<MetricsWidgetProps> = ({
   const metrics = data.length > 0 ? data : defaultData;
 
   const getTrendIcon = (change?: number) => {
-    if (!change) return <TrendingFlat fontSize="small" />;
-    if (change > 0) return <TrendingUp fontSize="small" color="success" />;
-    return <TrendingDown fontSize="small" color="error" />;
+    if (!change) return <Minus size={16} />;
+    if (change > 0) return <TrendingUp size={16} color="green" />;
+    return <TrendingDown size={16} color="red" />;
   };
 
   const getTrendColor = (change?: number) => {

--- a/Clients/src/presentation/pages/DashboardOverview/widgets/RisksWidget.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/widgets/RisksWidget.tsx
@@ -9,10 +9,10 @@ import {
   alpha,
 } from '@mui/material';
 import {
-  Warning as WarningIcon,
-  Error as ErrorIcon,
-  Info as InfoIcon,
-} from '@mui/icons-material';
+  AlertTriangle,
+  AlertCircle,
+  Info,
+} from 'lucide-react';
 
 interface RiskData {
   level: 'high' | 'medium' | 'low';
@@ -58,28 +58,28 @@ export const RisksWidget: React.FC<RisksWidgetProps> = ({
         return {
           color: theme.palette.error.main,
           background: alpha(theme.palette.error.main, 0.1),
-          icon: <ErrorIcon />,
+          icon: <AlertCircle size={20} />,
           label: 'High Risk',
         };
       case 'medium':
         return {
           color: theme.palette.warning.main,
           background: alpha(theme.palette.warning.main, 0.1),
-          icon: <WarningIcon />,
+          icon: <AlertTriangle size={20} />,
           label: 'Medium Risk',
         };
       case 'low':
         return {
           color: theme.palette.success.main,
           background: alpha(theme.palette.success.main, 0.1),
-          icon: <InfoIcon />,
+          icon: <Info size={20} />,
           label: 'Low Risk',
         };
       default:
         return {
           color: theme.palette.text.primary,
           background: theme.palette.grey[100],
-          icon: <InfoIcon />,
+          icon: <Info size={20} />,
           label: 'Unknown',
         };
     }


### PR DESCRIPTION
## Summary
- Replace MUI icons with Lucide equivalents in dashboard components
- Update IntegratedDashboard, MetricsWidget, and RisksWidget
- Replace custom SVG RightArrow with Lucide ChevronRight

## Changes
- 11 MUI icons → Lucide icons
- 1 custom SVG → Lucide ChevronRight  
- Improved icon consistency across dashboard

Fixes #2318