### PR TITLE
Migrate expand/collapse and navigation icons to Lucide

### DIFF
--- a/Clients/src/presentation/components/Dashboard/DashboardErrorBoundary.tsx
+++ b/Clients/src/presentation/components/Dashboard/DashboardErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { Box, Typography, Button, Card, CardContent } from '@mui/material';
-import { Error as ErrorIcon, Refresh as RefreshIcon } from '@mui/icons-material';
+import { AlertCircle, RefreshCw } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -82,11 +82,11 @@ class DashboardErrorBoundary extends Component<Props, State> {
             }}
           >
             <CardContent sx={{ p: 4 }}>
-              <ErrorIcon
-                sx={{
-                  fontSize: 64,
-                  color: 'error.main',
-                  mb: 2
+              <AlertCircle
+                size={64}
+                style={{
+                  color: '#d32f2f',
+                  marginBottom: 16
                 }}
               />
 
@@ -111,7 +111,7 @@ class DashboardErrorBoundary extends Component<Props, State> {
               <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
                 <Button
                   variant="contained"
-                  startIcon={<RefreshIcon />}
+                  startIcon={<RefreshCw size={20} />}
                   onClick={this.handleReset}
                 >
                   Try Again

--- a/Clients/src/presentation/components/Dashboard/WidgetErrorBoundary.tsx
+++ b/Clients/src/presentation/components/Dashboard/WidgetErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { Box, Card, CardContent, Typography, Button } from '@mui/material';
-import { Error as ErrorIcon, Refresh as RefreshIcon } from '@mui/icons-material';
+import { AlertCircle, RefreshCw } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -73,11 +73,11 @@ class WidgetErrorBoundary extends Component<Props, State> {
           }}
         >
           <CardContent sx={{ textAlign: 'center', p: 3 }}>
-            <ErrorIcon
-              sx={{
-                fontSize: 48,
-                color: 'error.main',
-                mb: 2
+            <AlertCircle
+              size={48}
+              style={{
+                color: '#d32f2f',
+                marginBottom: 16
               }}
             />
 
@@ -101,7 +101,7 @@ class WidgetErrorBoundary extends Component<Props, State> {
             <Button
               variant="contained"
               size="small"
-              startIcon={<RefreshIcon />}
+              startIcon={<RefreshCw size={16} />}
               onClick={this.handleRetry}
               sx={{ fontSize: '0.75rem' }}
             >

--- a/Clients/src/presentation/components/RiskVisualization/RiskCategories.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskCategories.tsx
@@ -8,8 +8,7 @@ import {
   Grid,
   Collapse,
 } from "@mui/material";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
+import { ChevronUp, ChevronDown } from "lucide-react";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
 import { getAllUsers } from "../../../application/repository/user.repository";
 import ButtonToggle from "../ButtonToggle";
@@ -222,7 +221,7 @@ const RiskCategories: React.FC<RiskCategoriesProps> = ({
                       </Typography>
                     </Box>
                     
-                    {isExpanded ? <ExpandLessIcon style={{ color: '#6B7280' }} /> : <ExpandMoreIcon style={{ color: '#6B7280' }} />}
+                    {isExpanded ? <ChevronUp size={16} style={{ color: '#6B7280' }} /> : <ChevronDown size={16} style={{ color: '#6B7280' }} />}
                   </Box>
 
                   <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>

--- a/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
@@ -11,8 +11,7 @@ import {
 } from "@mui/material";
 import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
 import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
 import Select from "../Inputs/Select";
 import { getAllUsers } from "../../../application/repository/user.repository";
@@ -350,7 +349,7 @@ const RiskFilters: React.FC<RiskFiltersProps> = ({
             </Button>
           )}
           <IconButton size="small">
-            {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
           </IconButton>
         </Stack>
       </Box>

--- a/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
@@ -5,7 +5,7 @@
 import { Button, Stack, Typography, useTheme } from "@mui/material";
 import React, { useState } from "react";
 import { ReactComponent as Key } from "../../../assets/icons/key.svg";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Field from "../../../components/Inputs/Field";
 import singleTheme from "../../../themes/v1SingleTheme";
@@ -177,7 +177,7 @@ const ForgotPassword: React.FC = () => {
                 navigate("/login");
               }}
             >
-              <LeftArrowLong />
+              <ArrowLeft size={20} />
               <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
                 Back to log in
               </Typography>

--- a/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
@@ -5,7 +5,7 @@
 import { Stack, Typography, useTheme } from "@mui/material";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import { ReactComponent as Email } from "../../../assets/icons/email.svg";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useState, lazy, Suspense } from "react";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
@@ -146,7 +146,7 @@ const ResetPassword = () => {
               navigate("/login");
             }}
           >
-            <LeftArrowLong />
+            <ArrowLeft size={20} />
             <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
               Back to log in
             </Typography>

--- a/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Check from "../../../components/Checks";
 import Field from "../../../components/Inputs/Field";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { ReactComponent as Lock } from "../../../assets/icons/lock.svg";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -299,7 +299,7 @@ const SetNewPassword: React.FC = () => {
               }}
               onClick={() => navigate("/login")}
             >
-              <LeftArrowLong />
+              <ArrowLeft size={20} />
               <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
                 Back to log in
               </Typography>

--- a/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/ControlCategory.tsx
+++ b/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/ControlCategory.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import { ControlCategory as ControlCategoryModel } from "../../../../domain/types/ControlCategory";
 import { useState } from "react";
-import { ReactComponent as RightArrowBlack } from "../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import ControlsTable from "./ControlsTable";
 
 const Table_Columns = [
@@ -66,7 +66,8 @@ const ControlCategoryTile: React.FC<ControlCategoryProps> = ({
         <AccordionSummary
           className="control-category-accordion-summary"
           expandIcon={
-            <RightArrowBlack
+            <ArrowRight
+              size={20}
               style={{
                 transform:
                   expanded === controlCategory.id

--- a/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
@@ -18,8 +18,7 @@ import {
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { ReactComponent as CopyIcon } from "../../assets/icons/copy.svg";
 import { ReactComponent as DownloadIcon } from "../../assets/icons/download.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-more.svg";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-less.svg";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { BarChart } from "@mui/x-charts";
 import createPlotlyComponent from 'react-plotly.js/factory';
 import Plotly from 'plotly.js-basic-dist';
@@ -1168,7 +1167,7 @@ export default function BiasAndFairnessResultsPage() {
                       }
                     }}
                   >
-                    <ExpandMoreIcon style={{ width: 20, height: 20, marginTop: '3px', marginLeft: '4px' }} />
+                    <ChevronDown size={20} style={{ marginTop: '3px', marginLeft: '4px' }} />
                   </IconButton>
                 </Box>
               )}
@@ -1187,7 +1186,7 @@ export default function BiasAndFairnessResultsPage() {
                       }
                     }}
                   >
-                    <ExpandLessIcon style={{ width: 20, height: 20, marginRight: '3px', marginTop: '-2px' }} />
+                    <ChevronUp size={20} style={{ marginRight: '3px', marginTop: '-2px' }} />
                   </IconButton>
                 </Box>
               )}

--- a/Clients/src/presentation/pages/FairnessDashboard/FairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/FairnessResultsPage.tsx
@@ -8,7 +8,7 @@ import {
   CircularProgress,
   Tooltip,
 } from "@mui/material";
-import {ReactComponent as ArrowBackIcon} from "../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
 import { BarChart } from "@mui/x-charts";
 import { fairnessService } from "../../../infrastructure/api/fairnessService";
@@ -96,7 +96,7 @@ export default function FairnessResultsPage() {
           onClick={() => navigate("/fairness-dashboard")}
           sx={{ mr: 2 }}
         >
-          <ArrowBackIcon />
+          <ArrowLeft size={20} />
         </IconButton>
         <Typography
           sx={{

--- a/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
@@ -10,7 +10,7 @@ import { GetAnnexesByProjectFrameworkId } from "../../../../../application/repos
 import { useCallback, useEffect, useState } from "react";
 import StatsCard from "../../../../components/Cards/StatsCard";
 import { styles } from "../Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import VWISO27001AnnexDrawerDialog from "../../../../components/Drawer/ISO27001AnnexDrawerDialog";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import { AlertProps } from "../../../../../domain/interfaces/iAlert";
@@ -237,7 +237,8 @@ const ISO27001Annex = ({
                   sx={styles.accordion}
                 >
                   <AccordionSummary sx={styles.accordionSummary}>
-                    <RightArrowBlack
+                    <ArrowRight
+                      size={20}
                       style={styles.expandIcon(expanded === annex.id) as React.CSSProperties}
                     />
                     <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
@@ -10,7 +10,7 @@ import { Iso27001GetClauseStructByFrameworkID } from "../../../../../application
 import { ClauseStructISO } from "../../../../../domain/types/ClauseStructISO";
 import { useCallback, useEffect, useState } from "react";
 import { styles } from "./style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import { ISO27001GetSubClauseByClauseId } from "../../../../../application/repository/subClause_iso.repository";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import Alert from "../../../../components/Alert";
@@ -308,7 +308,8 @@ const ISO27001Clause = ({
               onChange={handleAccordionChange(clause.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                 />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/ISO42001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO42001/Annex/index.tsx
@@ -10,7 +10,7 @@ import { GetAnnexesByProjectFrameworkId } from "../../../../../application/repos
 import { useEffect, useState } from "react";
 import StatsCard from "../../../../components/Cards/StatsCard";
 import { styles } from "../../ISO27001/Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import VWISO42001AnnexDrawerDialog from "../../../../components/Drawer/AnnexDrawerDialog";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import { AlertProps } from "../../../../../domain/interfaces/iAlert";
@@ -262,7 +262,8 @@ const ISO42001Annex = ({
               onChange={handleAccordionChange(annex.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === annex.id) as React.CSSProperties}
                    />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/ISO42001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO42001/Clause/index.tsx
@@ -10,7 +10,7 @@ import { GetClausesByProjectFrameworkId } from "../../../../../application/repos
 import { ClauseStructISO } from "../../../../../domain/types/ClauseStructISO";
 import { useCallback, useEffect, useState } from "react";
 import { styles } from "../../ISO27001/Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import { GetSubClausesById } from "../../../../../application/repository/subClause_iso.repository";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import Alert from "../../../../components/Alert";
@@ -301,7 +301,8 @@ const ISO42001Clause = ({
               onChange={handleAccordionChange(clause.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                 />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/ISO/Annex/index.tsx
+++ b/Clients/src/presentation/pages/ISO/Annex/index.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useCallback, useEffect, useState } from "react";
-import { ReactComponent as RightArrowBlack } from "../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import VWISO42001AnnexDrawerDialog from "../../../components/Drawer/AnnexDrawerDialog";
 import { Project } from "../../../../domain/types/Project";
 import { GetAnnexesByProjectFrameworkId } from "../../../../application/repository/annex_struct_iso.repository";
@@ -201,7 +201,8 @@ const ISO42001Annex = ({
                   sx={styles.accordion}
                 >
                   <AccordionSummary sx={styles.accordionSummary}>
-                    <RightArrowBlack
+                    <ArrowRight
+                      size={20}
                       style={styles.expandIcon(expanded === annex.id) as React.CSSProperties}
                     />
                     {annex.title}

--- a/Clients/src/presentation/pages/ISO/Clause/index.tsx
+++ b/Clients/src/presentation/pages/ISO/Clause/index.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
   CircularProgress,
 } from "@mui/material";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 import VWISO42001ClauseDrawerDialog from "../../../components/Drawer/ClauseDrawerDialog";
 import { Project } from "../../../../domain/types/Project";
@@ -269,7 +269,8 @@ const ISO42001Clauses = ({
               onChange={handleAccordionChange(clause.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                 />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/PageNotFound/index.tsx
+++ b/Clients/src/presentation/pages/PageNotFound/index.tsx
@@ -1,5 +1,5 @@
 import { ReactComponent as Background } from "../../assets/imgs/background-grid.svg";
-import { ReactComponent as LeftArrowLong } from "../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { Typography, Stack, useTheme } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
@@ -46,7 +46,7 @@ function PageNotFound() {
             navigate("/");
           }}
         >
-          <LeftArrowLong />
+          <ArrowLeft size={20} />
           <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
             Back to home
           </Typography>

--- a/Clients/src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx
@@ -9,7 +9,7 @@ import {
 import React, { useEffect, useMemo, useState } from "react";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
 import { viewProjectButtonStyle } from "../../../components/Cards/ProjectCard/style";
-import { ReactComponent as ExpandMoreIcon } from "../../../assets/icons/expand-down.svg";
+import { ChevronDown } from "lucide-react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import {
   sendSlackMessage,
@@ -226,7 +226,7 @@ const NotificationRoutingModal: React.FC<NotificationRoutingModalProps> = ({
                   );
                 }}
                 filterSelectedOptions
-                popupIcon={<ExpandMoreIcon />}
+                popupIcon={<ChevronDown size={16} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -15,8 +15,7 @@ import { ReactComponent as AddCircleIcon } from "../../assets/icons/add-circle.s
 import { SearchBox } from "../../components/Search";
 import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
 import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import TasksTable from "../../components/Table/TasksTable";
 import CustomizableButton from "../../components/Button/CustomizableButton";
 import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
@@ -524,7 +523,7 @@ const Tasks: React.FC = () => {
                 </Button>
               )}
               <IconButton size="small">
-                {filtersExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                {filtersExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
               </IconButton>
             </Stack>
           </Box>
@@ -634,7 +633,7 @@ const Tasks: React.FC = () => {
                     }}
                     getOptionLabel={(option: string) => option}
                     filterSelectedOptions
-                    popupIcon={<ExpandMoreIcon />}
+                    popupIcon={<ChevronDown size={16} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}


### PR DESCRIPTION
## Summary
- Replace expand-down/up icons with ChevronDown/Up for accordions
- Convert left-arrow-long to ArrowLeft for authentication navigation
- Update right-arrow-black to ArrowRight for framework navigation
- Migrate MUI Error/Refresh icons to AlertCircle/RefreshCw
- Apply consistent sizing (16px forms, 20px buttons, 48px/64px errors)

## Test plan
- [ ] Verify expand/collapse buttons work in risk filters and task filters
- [ ] Test back navigation in authentication flows
- [ ] Check framework accordion expand behavior
- [ ] Confirm error boundaries display correctly with new icons
- [ ] Ensure consistent icon sizing across components