### PR TITLE
Migrate MEDIUM priority icons to Lucide React

### DIFF
--- a/Clients/src/application/commands/registry.ts
+++ b/Clients/src/application/commands/registry.ts
@@ -1,21 +1,21 @@
 import { Command, CommandGroup, CommandContext, CommandRegistry } from './types'
 import allowedRoles from '../constants/permissions'
 import {
-  HomeOutlined,
-  WarningAmberOutlined,
-  BusinessOutlined,
-  AccountTreeOutlined,
-  SchoolOutlined,
-  FolderOutlined,
-  TimelineOutlined,
-  AccountBalanceOutlined,
-  BalanceOutlined,
-  SettingsOutlined,
-  AssignmentOutlined,
-  PolicyOutlined,
-  VerifiedUserOutlined,
-  GroupOutlined
-} from '@mui/icons-material'
+  Home as HomeOutlined,
+  AlertTriangle as WarningAmberOutlined,
+  Building as BusinessOutlined,
+  GitBranch as AccountTreeOutlined,
+  GraduationCap as SchoolOutlined,
+  Folder as FolderOutlined,
+  Activity as TimelineOutlined,
+  Landmark as AccountBalanceOutlined,
+  Scale as BalanceOutlined,
+  Settings as SettingsOutlined,
+  ClipboardList as AssignmentOutlined,
+  FileText as PolicyOutlined,
+  ShieldCheck as VerifiedUserOutlined,
+  Users as GroupOutlined
+} from 'lucide-react'
 
 // Define command groups
 export const COMMAND_GROUPS: CommandGroup[] = [

--- a/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
@@ -15,7 +15,7 @@ import {
   Box,
   TextField,
 } from "@mui/material";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import Alert from "../../Alert";
@@ -248,7 +248,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                     </Box>
                   );
                 }}
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}
@@ -354,7 +354,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                     </Box>
                   );
                 }}
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}
@@ -532,7 +532,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                       </Box>
                     );
                   }}
-                  popupIcon={<GreyDownArrowIcon />}
+                  popupIcon={<GreyDownArrowIcon size={20} />}
                   renderInput={(params) => (
                     <TextField
                       {...params}

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -10,7 +10,7 @@ import React, {
 import { useSearchParams } from "react-router-dom";
 import { Box, Stack, Tab, Typography, useTheme } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { ReactComponent as SaveIconSVGWhite } from "../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { ReactComponent as UpdateIconSVGWhite } from "../../assets/icons/update-white.svg";
 import dayjs from "dayjs";
 
@@ -813,7 +813,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
             }}
             icon={
               popupStatus === "new" ? (
-                <SaveIconSVGWhite />
+                <SaveIconSVGWhite size={20} />
               ) : (
                 <UpdateIconSVGWhite />
               )

--- a/Clients/src/presentation/components/AddNewRiskMITForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskMITForm/index.tsx
@@ -13,7 +13,7 @@ import {
   Radio,
   TextField,
 } from "@mui/material";
-import { ReactComponent as GreyCloseIconSVG } from "../../assets/icons/close-grey.svg";
+import { X as GreyCloseIconSVG } from "lucide-react";
 import placeholderImage from "../../assets/imgs/empty-state.svg";
 import riskData from "../../assets/MITAIRISKDB.json";
 import CustomizableButton from "../Button/CustomizableButton";
@@ -263,7 +263,7 @@ const AddNewRiskMITModal = ({
           >
             Add a new risk from risk database
           </Typography>
-          <GreyCloseIconSVG onClick={handleClose} cursor={"pointer"} />
+          <GreyCloseIconSVG onClick={handleClose} cursor={"pointer"} size={20} />
         </Stack>
         <Stack
           direction="row"

--- a/Clients/src/presentation/components/Alert/AlertBody.tsx
+++ b/Clients/src/presentation/components/Alert/AlertBody.tsx
@@ -1,7 +1,7 @@
 // AlertBody.tsx
 import React, { useState } from "react";
 import { Box, IconButton, Typography } from "@mui/material";
-import {ReactComponent as ContentCopyIcon} from "../../assets/icons/contentCopy.svg";
+import { Copy as ContentCopyIcon } from "lucide-react";
 
 interface AlertBodyProps {
   body: string;
@@ -61,7 +61,8 @@ const AlertBody: React.FC<AlertBodyProps> = ({ body, textColor }) => {
                   </Typography>
                 ) : (
                   <ContentCopyIcon
-                     style={{ width: "13px", height:"13px" , color: textColor }}
+                     size={13}
+                     style={{ color: textColor }}
                   />
                 )}
               </Box>

--- a/Clients/src/presentation/components/Alert/index.tsx
+++ b/Clients/src/presentation/components/Alert/index.tsx
@@ -17,12 +17,7 @@ import { closeIconStyles, iconButtonStyles } from "./style";
 import { CloseIconProps } from "../../../domain/interfaces/iWidget";
 import AlertBody from "./AlertBody";
 
-import { ReactComponent as BlueInfoIcon } from "../../assets/icons/info-circle-blue.svg";
-import { ReactComponent as GreenSuccessIcon } from "../../assets/icons/success-circle-green.svg";
-import { ReactComponent as OrangeWarningIcon } from "../../assets/icons/warning-orange.svg";
-import { ReactComponent as RedErrorIcon } from "../../assets/icons/error-circle-red.svg";
-
-import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.svg";
+import { Info as BlueInfoIcon, CheckCircle as GreenSuccessIcon, AlertTriangle as OrangeWarningIcon, XCircle as RedErrorIcon, X as CloseGreyIcon } from "lucide-react";
 
 /**
  * Mapping of alert variants to their respective icons.
@@ -31,10 +26,10 @@ import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.s
  * @type {object}
  */
 const icons: { [s: string]: JSX.Element } = {
-  success: <GreenSuccessIcon />, // #079455
-  info: <BlueInfoIcon />, // #0288d1
-  error: <RedErrorIcon />, // #f04438
-  warning: <OrangeWarningIcon />, // #DC6803
+  success: <GreenSuccessIcon size={20} />, // #079455
+  info: <BlueInfoIcon size={20} />, // #0288d1
+  error: <RedErrorIcon size={20} />, // #f04438
+  warning: <OrangeWarningIcon size={20} />, // #DC6803
 };
 
 /**
@@ -46,7 +41,7 @@ const icons: { [s: string]: JSX.Element } = {
 const CloseButton: React.FC<CloseIconProps> = ({
   text,
 }: CloseIconProps): JSX.Element => (
-  <CloseGreyIcon style={closeIconStyles(text)} />
+  <CloseGreyIcon size={16} style={closeIconStyles(text)} />
 );
 
 /**

--- a/Clients/src/presentation/components/CommandPalette/index.tsx
+++ b/Clients/src/presentation/components/CommandPalette/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react'
 import { Command } from 'cmdk'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { Box, Typography, IconButton } from '@mui/material'
-import { ReactComponent as CloseIcon } from '../../assets/icons/close-grey.svg'
+import { X as CloseIcon } from 'lucide-react'
 import { useAuth } from '../../../application/hooks/useAuth'
 import commandRegistry from '../../../application/commands/registry'
 import CommandActionHandler, { CommandActionHandlers } from '../../../application/commands/actionHandler'
@@ -192,7 +192,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChange }) =
                         height: 24
                       }}
                     >
-                      <CloseIcon/>
+                      <CloseIcon size={20} />
                     </IconButton>
                   </Box>
 

--- a/Clients/src/presentation/components/CreateProjectForm/index.tsx
+++ b/Clients/src/presentation/components/CreateProjectForm/index.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
   Box,
 } from "@mui/material";
-import { ReactComponent as GreyDownArrowIcon } from "../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { useSelector } from "react-redux";
 import dayjs, { Dayjs } from "dayjs";
 import { checkStringValidation } from "../../../application/validations/stringValidation";
@@ -382,7 +382,7 @@ const CreateProjectForm: FC<CreateProjectFormProps> = ({
                   );
                 }}
                 filterSelectedOptions
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}

--- a/Clients/src/presentation/components/Dashboard/DashboardErrorBoundary.tsx
+++ b/Clients/src/presentation/components/Dashboard/DashboardErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { Box, Typography, Button, Card, CardContent } from '@mui/material';
-import { Error as ErrorIcon, Refresh as RefreshIcon } from '@mui/icons-material';
+import { AlertCircle, RefreshCw } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -82,11 +82,11 @@ class DashboardErrorBoundary extends Component<Props, State> {
             }}
           >
             <CardContent sx={{ p: 4 }}>
-              <ErrorIcon
-                sx={{
-                  fontSize: 64,
-                  color: 'error.main',
-                  mb: 2
+              <AlertCircle
+                size={64}
+                style={{
+                  color: '#d32f2f',
+                  marginBottom: 16
                 }}
               />
 
@@ -111,7 +111,7 @@ class DashboardErrorBoundary extends Component<Props, State> {
               <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
                 <Button
                   variant="contained"
-                  startIcon={<RefreshIcon />}
+                  startIcon={<RefreshCw size={20} />}
                   onClick={this.handleReset}
                 >
                   Try Again

--- a/Clients/src/presentation/components/Dashboard/WidgetErrorBoundary.tsx
+++ b/Clients/src/presentation/components/Dashboard/WidgetErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { Box, Card, CardContent, Typography, Button } from '@mui/material';
-import { Error as ErrorIcon, Refresh as RefreshIcon } from '@mui/icons-material';
+import { AlertCircle, RefreshCw } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -73,11 +73,11 @@ class WidgetErrorBoundary extends Component<Props, State> {
           }}
         >
           <CardContent sx={{ textAlign: 'center', p: 3 }}>
-            <ErrorIcon
-              sx={{
-                fontSize: 48,
-                color: 'error.main',
-                mb: 2
+            <AlertCircle
+              size={48}
+              style={{
+                color: '#d32f2f',
+                marginBottom: 16
               }}
             />
 
@@ -101,7 +101,7 @@ class WidgetErrorBoundary extends Component<Props, State> {
             <Button
               variant="contained"
               size="small"
-              startIcon={<RefreshIcon />}
+              startIcon={<RefreshCw size={16} />}
               onClick={this.handleRetry}
               sx={{ fontSize: '0.75rem' }}
             >

--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -9,7 +9,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { FileData } from "../../../../domain/types/File";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Checkbox from "../../Inputs/Checkbox";
 import Field from "../../Inputs/Field";
 import { inputStyles } from "../ClauseDrawerDialog";
@@ -19,7 +19,7 @@ import { useState, useEffect, lazy, Suspense } from "react";
 import { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { User } from "../../../../domain/types/User";
 import {
   GetAnnexCategoriesById,
@@ -398,7 +398,7 @@ const VWISO42001AnnexDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack
@@ -850,7 +850,7 @@ const VWISO42001AnnexDrawerDialog = ({
               gap: 2,
             }}
             onClick={handleSave}
-            icon={<SaveIconSVGWhite />}
+            icon={<SaveIconSVGWhite size={20} />}
           />
         </Stack>
       </Stack>

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -10,7 +10,7 @@ import {
   Dialog,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import { FileData } from "../../../../domain/types/File";
 import Select from "../../Inputs/Select";
@@ -18,7 +18,7 @@ import DatePicker from "../../Inputs/Datepicker";
 import { Dayjs } from "dayjs";
 import { useState, useEffect, Suspense } from "react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { useAuth } from "../../../../application/hooks/useAuth";
 import useUsers from "../../../../application/hooks/useUsers";
 import { User } from "../../../../domain/types/User";
@@ -410,7 +410,7 @@ const VWISO42001ClauseDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {clause?.clause_no + "." + (index + 1)} {displayData?.title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack
@@ -824,7 +824,7 @@ const VWISO42001ClauseDrawerDialog = ({
               gap: 2,
             }}
             onClick={handleSave}
-            icon={<SaveIconSVGWhite />}
+            icon={<SaveIconSVGWhite size={20} />}
           />
         </Stack>
       </Stack>

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -9,7 +9,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { FileData } from "../../../../domain/types/File";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import { inputStyles } from "../ClauseDrawerDialog";
 import DatePicker from "../../Inputs/Datepicker";
@@ -18,7 +18,7 @@ import { useState, useEffect, lazy, Suspense } from "react";
 import { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { User } from "../../../../domain/types/User";
 import UppyUploadFile from "../../Inputs/FileUpload";
 import { STATUSES } from "../../../../domain/types/Status";
@@ -410,7 +410,7 @@ const VWISO27001AnnexDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack sx={{ padding: "15px 20px", gap: "15px" }}>
@@ -787,7 +787,7 @@ const VWISO27001AnnexDrawerDialog = ({
               gap: 2,
             }}
             onClick={handleSave}
-            icon={<SaveIconSVGWhite />}
+            icon={<SaveIconSVGWhite size={20} />}
           />
         </Stack>
       </Stack>

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -10,7 +10,7 @@ import {
   Dialog,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import { FileData } from "../../../../domain/types/File";
 import Select from "../../Inputs/Select";
@@ -18,7 +18,7 @@ import DatePicker from "../../Inputs/Datepicker";
 import { Dayjs } from "dayjs";
 import { useState, useEffect, Suspense } from "react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { useAuth } from "../../../../application/hooks/useAuth";
 import useUsers from "../../../../application/hooks/useUsers";
 import { User } from "../../../../domain/types/User";
@@ -408,7 +408,7 @@ const VWISO27001ClauseDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {clause?.arrangement + "." + (index + 1)} {displayData?.title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack
@@ -821,7 +821,7 @@ const VWISO27001ClauseDrawerDialog = ({
               gap: 2,
             }}
             onClick={handleSave}
-            icon={<SaveIconSVGWhite />}
+            icon={<SaveIconSVGWhite size={20} />}
           />
         </Stack>
       </Stack>

--- a/Clients/src/presentation/components/FileUpload/index.tsx
+++ b/Clients/src/presentation/components/FileUpload/index.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import "./drop-file-input.css";
-import UploadSmallIcon from "../../assets/icons/folder-upload.svg";
+import { FolderUp as UploadSmallIcon } from "lucide-react";
 import { FileProps, FileUploadProps } from "./types";
 import {
   DragDropArea,
   fileListStyleFrame,
   fileListText,
   filesListItem,
-  Icon,
 } from "./FileUpload.styles";
 import {
   List,
@@ -18,7 +17,7 @@ import {
   IconButton,
   Button,
 } from "@mui/material";
-import {ReactComponent as DeleteIconGrey} from "../../../assets/icons/trash-grey.svg"
+import { Trash2 as DeleteIconGrey } from "lucide-react"
 
 const FileUploadComponent = ({
   onClose,
@@ -136,7 +135,7 @@ const FileUploadComponent = ({
             onDrop={onDrop}
           >
             <div className="drop-file-input__label">
-              <Icon src={UploadSmallIcon} alt="Upload Icon" sx={{ mb: 2 }} />
+              <UploadSmallIcon size={48} style={{ marginBottom: 16, color: '#6b7280' }} />
               <Typography variant="body2">
                 <span style={{ color: "#3b82f6" }}>Click to upload</span> or
                 drag and drop
@@ -160,7 +159,7 @@ const FileUploadComponent = ({
                       size="small"
                       sx={{ padding: "4px" }}
                     >
-                      <DeleteIconGrey fontSize="small" />
+                      <DeleteIconGrey size={16} />
                     </IconButton>
                   </ListItem>
                 ))}

--- a/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
@@ -20,7 +20,7 @@ import {
   useEffect,
 } from "react";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as AddCircleOutlineIcon } from "../../../assets/icons/plus-circle-white.svg";
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import Field from "../../../components/Inputs/Field";
 import {
   createProjectButtonStyle,

--- a/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
@@ -41,7 +41,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import selectValidation from "../../../../application/validations/selectValidation";
 import CustomizableToast from "../../Toast";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { extractUserToken } from "../../../../application/tools/extractToken";
 import { useSelector } from "react-redux";
 import Checkbox from "../../../components/Inputs/Checkbox";
@@ -740,7 +740,7 @@ const ProjectForm = ({
                   );
                 }}
                 filterSelectedOptions
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}
@@ -836,7 +836,7 @@ const ProjectForm = ({
                       option.name.includes("coming soon")
                     }
                     filterSelectedOptions
-                    popupIcon={<GreyDownArrowIcon />}
+                    popupIcon={<GreyDownArrowIcon size={20} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}
@@ -948,7 +948,7 @@ const ProjectForm = ({
                   option.name.includes("coming soon")
                 }
                 filterSelectedOptions
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}

--- a/Clients/src/presentation/components/HelperDrawer/index.tsx
+++ b/Clients/src/presentation/components/HelperDrawer/index.tsx
@@ -6,7 +6,7 @@ import {
   Stack,
   IconButton,
 } from '@mui/material';
-import {ReactComponent as CloseIcon} from "../../assets/icons/close-grey.svg"
+import { X as CloseIcon } from "lucide-react";
 
 // Simple markdown parser for **bold** and *italic*
 const parseMarkdown = (text: string) => {
@@ -148,7 +148,7 @@ const HelperDrawer: React.FC<HelperDrawerProps> = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </IconButton>
           </Stack>
         </Box>

--- a/Clients/src/presentation/components/HelperIcon/index.tsx
+++ b/Clients/src/presentation/components/HelperIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IconButton } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 
 interface HelperIconProps {
   onClick: () => void;
@@ -23,7 +23,7 @@ const HelperIcon: React.FC<HelperIconProps> = ({ onClick, size = "small" }) => {
         },
       }}
     >
-      <GreyCircleInfoIcon />
+      <GreyCircleInfoIcon size={16} />
     </IconButton>
   );
 };

--- a/Clients/src/presentation/components/Inputs/Dropdowns/ProjectFilter/ProjectFilterDropdown.tsx
+++ b/Clients/src/presentation/components/Inputs/Dropdowns/ProjectFilter/ProjectFilterDropdown.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Select, MenuItem, FormControl, useTheme } from "@mui/material";
 import { dropdownStyles, inputStyles } from "./style";
 import { ProjectFilterDropdownProps } from "../../../../../domain/interfaces/iDropdown";
-import { ReactComponent as GreyDownArrowIcon  } from "../../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 
 
 const ProjectFilterDropdown: React.FC<ProjectFilterDropdownProps> = ({
@@ -22,7 +22,7 @@ const ProjectFilterDropdown: React.FC<ProjectFilterDropdownProps> = ({
           value={selectedProject || ""}
           onChange={(e) => onChange(e.target.value)}
           displayEmpty
-          IconComponent={GreyDownArrowIcon}
+          IconComponent={() => <GreyDownArrowIcon size={20} />}
           sx={{
             ...inputStyles,
             ...dropdownStyles,

--- a/Clients/src/presentation/components/Inputs/FileUpload/index.tsx
+++ b/Clients/src/presentation/components/Inputs/FileUpload/index.tsx
@@ -1,8 +1,8 @@
 import { Stack, useTheme, IconButton, Typography, Link } from "@mui/material";
 import Uppy from "@uppy/core";
 import { useState } from "react";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
-import { ReactComponent as DeleteIconGrey } from "../../../assets/icons/trash-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
+import { Trash2 as DeleteIconGrey } from "lucide-react";
 import DeleteFileModal from "./DeleteFileModal";
 import getStyles from "./getStyles";
 import { FileData } from "../../../../domain/types/File";
@@ -40,7 +40,7 @@ const FileListItem: React.FC<{
       </Typography>
     </Link>
     <IconButton onClick={() => onDeleteClick(file.id, file.fileName)}>
-      <DeleteIconGrey />
+      <DeleteIconGrey size={20} />
     </IconButton>
   </Stack>
 );
@@ -81,7 +81,7 @@ const UppyUploadFile: React.FC<UppyUploadFileProps> = ({
     <Stack className="uppy-holder" sx={styles.container}>
       <Stack sx={styles.header}>
         <IconButton onClick={onClose}>
-          <CloseGreyIcon />
+          <CloseGreyIcon size={20} />
         </IconButton>
       </Stack>
 

--- a/Clients/src/presentation/components/Inputs/Select/Multi/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Select/Multi/index.tsx
@@ -13,7 +13,7 @@ import {
   Box,
 } from "@mui/material";
 import "./index.css";
-import { ReactComponent as GreyDownArrowIcon  } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 
 
 interface CustomizableMultiSelectProps {
@@ -127,7 +127,7 @@ const CustomizableMultiSelect = ({
         multiple
         displayEmpty
         renderValue={renderValue}
-        IconComponent={GreyDownArrowIcon}
+        IconComponent={() => <GreyDownArrowIcon size={20} />}
         error={!!error}
         MenuProps={{
           disableScrollLock: true,

--- a/Clients/src/presentation/components/Inputs/Select/ReviewerSelect/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Select/ReviewerSelect/index.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as GreyDownArrowIcon  } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import "./index.css"; // Include your existing styles
 import useUsers from "../../../../../application/hooks/useUsers";
 
@@ -87,7 +87,7 @@ const ReviewerMultiSelect: React.FC<ReviewerMultiSelectProps> = ({
         value={selected}
         onChange={handleChange}
         renderValue={renderSelected}
-        IconComponent={GreyDownArrowIcon}
+        IconComponent={() => <GreyDownArrowIcon size={20} />}
         error={!!error}
         size="small"
         displayEmpty

--- a/Clients/src/presentation/components/Inputs/Select/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Select/index.tsx
@@ -24,7 +24,7 @@ import {
   useTheme,
 } from "@mui/material";
 import "./index.css";
-import { ReactComponent as GreyDownArrowIcon  } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { SelectProps } from "../../../../domain/interfaces/iWidget";
 
 const Select: React.FC<SelectProps> = ({
@@ -131,7 +131,7 @@ const Select: React.FC<SelectProps> = ({
         displayEmpty
         inputProps={{ id: id }}
         renderValue={renderValue}
-        IconComponent={GreyDownArrowIcon}
+        IconComponent={() => <GreyDownArrowIcon size={20} />}
         disabled={disabled}
         MenuProps={{
           disableScrollLock: true,

--- a/Clients/src/presentation/components/MetricInfoIcon/index.tsx
+++ b/Clients/src/presentation/components/MetricInfoIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IconButton, Box } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 
 interface MetricInfoIconProps {
   onClick: () => void;
@@ -24,7 +24,7 @@ const MetricInfoIcon = React.forwardRef<HTMLDivElement, MetricInfoIconProps>(({ 
           },
         }}
       >
-        <GreyCircleInfoIcon />
+        <GreyCircleInfoIcon size={16} />
       </IconButton>
     </Box>
   );

--- a/Clients/src/presentation/components/Modals/Banner/index.tsx
+++ b/Clients/src/presentation/components/Modals/Banner/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Paper, Typography } from "@mui/material";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { IBannerProps } from "../../../../domain/interfaces/iWidget";
 import {
   bannerBoxStyle,
@@ -19,7 +19,7 @@ const index = ({ onClose, bannerText, bannerWidth }: IBannerProps) => {
       >
         <Typography sx={bannerTextStyle}>
           {bannerText}
-          <CloseGreyIcon onClick={onClose} style={closeIconStyle} />
+          <CloseGreyIcon onClick={onClose} style={closeIconStyle} size={20} />
         </Typography>
       </Paper>
     </Box>

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import DropDowns from "../../Inputs/Dropdowns";
 import { useState, Suspense, useEffect } from "react";
 import AuditorFeedback from "../ComplianceFeedback/ComplianceFeedback";
@@ -19,7 +19,7 @@ import { Control } from "../../../../domain/types/Control";
 import { FileData } from "../../../../domain/types/File";
 import Alert from "../../Alert";
 import CustomizableToast from "../../Toast";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
 
 import {
@@ -465,7 +465,7 @@ const NewControlPane = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
           <Typography component="span" fontSize={13}>
@@ -754,7 +754,7 @@ const NewControlPane = ({
                 gap: 2,
               }}
               onClick={confirmSave}
-              icon={<SaveIconSVGWhite />}
+              icon={<SaveIconSVGWhite size={20} />}
             />
           </Stack>
         </Stack>

--- a/Clients/src/presentation/components/Modals/Controlpane/index.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/index.tsx
@@ -9,7 +9,7 @@ import {
   Tabs,
   Tab,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 
 import React, { useState } from "react";
 import DropDowns from "../../Inputs/Dropdowns";
@@ -131,7 +131,7 @@ const CustomModal: React.FC<CustomModalProps> = ({
             {title}
           </Typography>
 
-          <CloseIcon onClick={handleClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={handleClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Typography fontSize={13}>{content}</Typography>
         <DropDowns />

--- a/Clients/src/presentation/components/Modals/CreateTask/index.tsx
+++ b/Clients/src/presentation/components/Modals/CreateTask/index.tsx
@@ -20,9 +20,9 @@ const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
 import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
-import { ReactComponent as SaveIcon } from "../../../assets/icons/save.svg";
+import { Save as SaveIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import { ITask } from "../../../../domain/interfaces/i.task";
 import dayjs, { Dayjs } from "dayjs";
 import { datePickerStyle } from "../../Forms/ProjectForm/style";
@@ -346,6 +346,7 @@ const CreateTask: FC<CreateTaskProps> = ({
             </Typography>
           </Stack>
           <CloseIcon
+            size={20}
             style={{ color: "#98A2B3", cursor: "pointer" }}
             onClick={handleClose}
           />
@@ -692,7 +693,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                 marginTop: 2,
               }}
               onClick={handleSubmit}
-              icon={<SaveIcon />}
+              icon={<SaveIcon size={20} />}
             />
           </Stack>
         </form>

--- a/Clients/src/presentation/components/Modals/CreateTask/index.tsx
+++ b/Clients/src/presentation/components/Modals/CreateTask/index.tsx
@@ -19,7 +19,7 @@ import { lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { Save as SaveIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
 import { X as CloseIcon } from "lucide-react";
@@ -478,7 +478,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                         : "No options"
                     }
                     filterSelectedOptions
-                    popupIcon={<GreyDownArrowIcon />}
+                    popupIcon={<GreyDownArrowIcon size={20} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}
@@ -566,7 +566,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                     }}
                     getOptionLabel={(option: string) => option}
                     filterSelectedOptions
-                    popupIcon={<GreyDownArrowIcon />}
+                    popupIcon={<GreyDownArrowIcon size={20} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}

--- a/Clients/src/presentation/components/Modals/FileUpload/index.tsx
+++ b/Clients/src/presentation/components/Modals/FileUpload/index.tsx
@@ -4,7 +4,7 @@ import {
   StyledDialogContent,
 } from "../../FileUpload/FileUpload.styles";
 import { FileUploadProps } from "../../FileUpload/types";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { IconButton } from "@mui/material";
 import FileUploadComponent from "../../FileUpload";
 
@@ -31,7 +31,7 @@ const FileUploadModal: React.FC<FileUploadModalProps> = ({ uploadProps }) => {
           }}
           disableRipple
         >
-          <CloseGreyIcon />
+          <CloseGreyIcon size={20} />
         </IconButton>
 
         <FileUploadComponent

--- a/Clients/src/presentation/components/Modals/InviteUser/index.tsx
+++ b/Clients/src/presentation/components/Modals/InviteUser/index.tsx
@@ -27,7 +27,7 @@ import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
-import { ReactComponent as ForwardToInboxIcon } from "../../../assets/icons/email.svg";
+import { Mail as ForwardToInboxIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
 import { useRoles } from "../../../../application/hooks/useRoles";
 import { isValidEmail } from "../../../../application/validations/emailAddress.rule";
@@ -272,7 +272,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({
               border: "1px solid #13715B",
               gap: 2,
             }}
-            icon={<ForwardToInboxIcon />}
+            icon={<ForwardToInboxIcon size={20} />}
             onClick={() => handleSendInvitation()}
           />
         </Stack>

--- a/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
@@ -21,9 +21,9 @@ import { lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import { ModelInventoryStatus } from "../../../../domain/enums/modelInventory.enum";
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import { User } from "../../../../domain/types/User";
@@ -464,7 +464,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
 
@@ -887,7 +887,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
                 gap: 2,
               }}
               onClick={handleSubmit}
-              icon={<SaveIconSVGWhite />}
+              icon={<SaveIconSVGWhite size={20} />}
             />
           </Stack>
         </form>

--- a/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
@@ -28,7 +28,7 @@ import { ModelInventoryStatus } from "../../../../domain/enums/modelInventory.en
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import { User } from "../../../../domain/types/User";
 import dayjs, { Dayjs } from "dayjs";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { useModalKeyHandling } from "../../../../application/hooks/useModalKeyHandling";
 import modelInventoryOptions from "../../../utils/model-inventory.json";
 import { getAllProjects } from "../../../../application/repository/project.repository";
@@ -548,7 +548,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
                           </Typography>
                         </Box>
                       )}
-                      popupIcon={<GreyDownArrowIcon />}
+                      popupIcon={<GreyDownArrowIcon size={20} />}
                       renderInput={(params) => (
                         <TextField
                           {...params}
@@ -699,7 +699,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
                     </Box>
                   )}
                   filterSelectedOptions
-                  popupIcon={<GreyDownArrowIcon />}
+                  popupIcon={<GreyDownArrowIcon size={20} />}
                   renderInput={(params) => (
                     <TextField
                       {...params}
@@ -761,7 +761,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
                     </Box>
                   )}
                   filterSelectedOptions
-                  popupIcon={<GreyDownArrowIcon />}
+                  popupIcon={<GreyDownArrowIcon size={20} />}
                   renderInput={(params) => (
                     <TextField
                       {...params}

--- a/Clients/src/presentation/components/Modals/NewModelRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelRisk/index.tsx
@@ -17,9 +17,9 @@ import { lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import {
   ModelRiskCategory,
   ModelRiskLevel,
@@ -382,7 +382,7 @@ const NewModelRisk: FC<NewModelRiskProps> = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
 
@@ -590,7 +590,7 @@ const NewModelRisk: FC<NewModelRiskProps> = ({
                 gap: 2,
               }}
               onClick={handleSubmit}
-              icon={<SaveIconSVGWhite/>}
+              icon={<SaveIconSVGWhite size={20} />}
             />
           </Stack>
         </form>

--- a/Clients/src/presentation/components/Modals/NewRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewRisk/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@mui/material";
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
-import { ReactComponent as Close } from "../../../assets/icons/close.svg";
+import { X as Close } from "lucide-react";
 import { Suspense, useEffect, useState, lazy, useCallback } from "react";
 import Alert from "../../Alert";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
@@ -31,7 +31,7 @@ import useUsers from "../../../../application/hooks/useUsers";
 import CustomizableToast from "../../Toast";
 import { logEngine } from "../../../../application/tools/log.engine";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { RiskCalculator } from "../../../tools/riskCalculator";
 import { RiskLikelihood, RiskSeverity } from "../../RiskLevel/riskValues";
 import allowedRoles from "../../../../application/constants/permissions";
@@ -589,7 +589,7 @@ const AddNewRisk: React.FC<AddNewRiskProps> = ({
             >
               {existingRisk ? "Edit risk" : "Add a new vendor risk"}
             </Typography>
-            <Close style={{ cursor: "pointer" }} onClick={setIsOpen} />
+            <Close size={20} style={{ cursor: "pointer" }} onClick={setIsOpen} />
           </Stack>
           {!existingRisk && (
             <Typography
@@ -617,7 +617,7 @@ const AddNewRisk: React.FC<AddNewRiskProps> = ({
                   gap: 2,
                 }}
                 onClick={handleSave}
-                icon={<SaveIconSVGWhite />}
+                icon={<SaveIconSVGWhite size={20} />}
                 isDisabled={isEditingDisabled}
               />
             </Stack>

--- a/Clients/src/presentation/components/Modals/NewTraining/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewTraining/index.tsx
@@ -12,9 +12,9 @@ import {
 import { Suspense, lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 import Select from "../../Inputs/Select";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import { useModalKeyHandling } from "../../../../application/hooks/useModalKeyHandling";
 
 interface NewTrainingProps {
@@ -262,7 +262,7 @@ const NewTraining: FC<NewTrainingProps> = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
           <Typography 
@@ -403,7 +403,7 @@ const NewTraining: FC<NewTrainingProps> = ({
                 mt: "16px",
               }}
               onClick={handleSubmit}
-              icon={<SaveIconSVGWhite />}
+              icon={<SaveIconSVGWhite size={20} />}
             />
           </Stack>
         </Stack>

--- a/Clients/src/presentation/components/Modals/NewVendor/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewVendor/index.tsx
@@ -27,7 +27,7 @@ import {
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import DatePicker from "../../Inputs/Datepicker";
-import { ReactComponent as Close } from "../../../assets/icons/close.svg";
+import { X as Close } from "lucide-react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 import Alert from "../../Alert";
@@ -38,7 +38,7 @@ import useUsers from "../../../../application/hooks/useUsers";
 import CustomizableToast from "../../Toast";
 import { logEngine } from "../../../../application/tools/log.engine";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
 import allowedRoles from "../../../../application/constants/permissions";
 import {
@@ -836,7 +836,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
             >
               {existingVendor ? "Edit vendor" : "Add new vendor"}
             </Typography>
-            <Close style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)} />
+            <Close size={20} style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)} />
           </Stack>
           {!existingVendor && (
             <Typography
@@ -868,7 +868,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
                 gap: 2,
               }}
               onClick={handleSave}
-              icon={<SaveIconSVGWhite />}
+              icon={<SaveIconSVGWhite size={20} />}
               isDisabled={isEditingDisabled}
             />
           </Stack>

--- a/Clients/src/presentation/components/Modals/NewVendor/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewVendor/index.tsx
@@ -39,7 +39,7 @@ import CustomizableToast from "../../Toast";
 import { logEngine } from "../../../../application/tools/log.engine";
 import CustomizableButton from "../../Button/CustomizableButton";
 import { Save as SaveIconSVGWhite } from "lucide-react";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import allowedRoles from "../../../../application/constants/permissions";
 import {
   useCreateVendor,
@@ -556,7 +556,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
                 );
               }}
               filterSelectedOptions
-              popupIcon={<GreyDownArrowIcon />}
+              popupIcon={<GreyDownArrowIcon size={20} />}
               renderInput={(params: AutocompleteRenderInputParams) => (
                 <TextField
                   {...params}

--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -17,10 +17,7 @@ import { serializeHtml } from "platejs";
 import {ReactComponent as LooksThree} from "../../assets/icons/three.svg"
 import {ReactComponent as LooksOne} from "../../assets/icons/one.svg"
 import {ReactComponent as LooksTwo} from "../../assets/icons/two.svg"
-import {ReactComponent as FormatBold} from "../../assets/icons/formatBold.svg"
-import {ReactComponent as FormatQuote} from "../../assets/icons/formatQuote.svg"
-import {ReactComponent as FormatItalic} from "../../assets/icons/formatItalic.svg"
-import {ReactComponent as FormatUnderlined} from "../../assets/icons/formatUnderlined.svg"
+import { Bold as FormatBold, Quote as FormatQuote, Italic as FormatItalic, Underline as FormatUnderlined } from "lucide-react";
 import { IconButton, Tooltip, useTheme, Box } from "@mui/material";
 import { Drawer, Stack, Typography, Divider } from "@mui/material";
 import { X as CloseGreyIcon } from "lucide-react";
@@ -352,7 +349,7 @@ const PolicyDetailModal: React.FC<Props> = ({
                   {
                     key: "bold",
                     title: "Bold",
-                    icon: <FormatBold />,
+                    icon: <FormatBold size={20} />,
                     action: () => {
                       editor.tf.bold.toggle();
                       setToolbarState((prev) => ({
@@ -364,7 +361,7 @@ const PolicyDetailModal: React.FC<Props> = ({
                   {
                     key: "italic",
                     title: "Italic",
-                    icon: <FormatItalic />,
+                    icon: <FormatItalic size={20} />,
                     action: () => {
                       editor.tf.italic.toggle();
                       setToolbarState((prev) => ({
@@ -376,7 +373,7 @@ const PolicyDetailModal: React.FC<Props> = ({
                   {
                     key: "underline",
                     title: "Underline",
-                    icon: <FormatUnderlined />,
+                    icon: <FormatUnderlined size={20} />,
                     action: () => {
                       editor.tf.underline.toggle();
                       setToolbarState((prev) => ({
@@ -415,7 +412,7 @@ const PolicyDetailModal: React.FC<Props> = ({
                   {
                     key: "blockquote",
                     title: "Blockquote",
-                    icon: <FormatQuote />,
+                    icon: <FormatQuote size={20} />,
                     action: () => {
                       editor.tf.blockquote.toggle();
                       setToolbarState((prev) => ({

--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import PolicyForm, { FormData } from "./PolicyForm";
 import { Policy } from "../../../domain/types/Policy";
-import { ReactComponent as SaveIconSVGWhite } from "../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { Plate, PlateContent, usePlateEditor } from "platejs/react";
 
 import {
@@ -23,7 +23,7 @@ import {ReactComponent as FormatItalic} from "../../assets/icons/formatItalic.sv
 import {ReactComponent as FormatUnderlined} from "../../assets/icons/formatUnderlined.svg"
 import { IconButton, Tooltip, useTheme, Box } from "@mui/material";
 import { Drawer, Stack, Typography, Divider } from "@mui/material";
-import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import CustomizableButton from "../Button/CustomizableButton";
 import {
   createPolicy,
@@ -308,7 +308,7 @@ const PolicyDetailModal: React.FC<Props> = ({
               {isNew ? "Create new policy" : formData.title}
             </Typography>
           </Stack>
-          <CloseGreyIcon
+          <CloseGreyIcon size={20}
             style={{ color: "#98A2B3", cursor: "pointer" }}
             onClick={onClose}
           />
@@ -532,7 +532,7 @@ const PolicyDetailModal: React.FC<Props> = ({
               },
             }}
             onClick={save}
-            icon={<SaveIconSVGWhite />}
+            icon={<SaveIconSVGWhite size={20} />}
           />
         </Box>
       </Drawer>

--- a/Clients/src/presentation/components/Policies/PolicyForm.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyForm.tsx
@@ -12,7 +12,7 @@ import DatePicker from "../Inputs/Datepicker";
 import dayjs, { Dayjs } from "dayjs";
 import { User } from "../../../domain/types/User";
 import useUsers from "../../../application/hooks/useUsers";
-import { ReactComponent as GreyDownArrowIcon } from "../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { useCallback } from "react";
 import { FormErrors } from "./PolicyDetailsModal";
 
@@ -136,7 +136,7 @@ const PolicyForm: React.FC<Props> = ({ formData, setFormData, tags, errors }) =>
               );
             }}
             filterSelectedOptions
-            popupIcon={<GreyDownArrowIcon />}
+            popupIcon={<GreyDownArrowIcon size={20} />}
             renderInput={(params) => (
               <TextField
                 {...params}
@@ -219,7 +219,7 @@ const PolicyForm: React.FC<Props> = ({ formData, setFormData, tags, errors }) =>
               );
             }}
             filterSelectedOptions
-            popupIcon={<GreyDownArrowIcon />}
+            popupIcon={<GreyDownArrowIcon size={20} />}
             renderInput={(params) => (
               <TextField
                 {...params}

--- a/Clients/src/presentation/components/ProjectsList/ProjectTableView.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectTableView.tsx
@@ -16,7 +16,7 @@ import { Project } from "../../../domain/types/Project";
 import singleTheme from "../../themes/v1SingleTheme";
 import TablePaginationActions from "../../components/TablePagination";
 import placeholderImage from "../../assets/imgs/empty-state.svg";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 
 interface ProjectTableViewProps {
   projects: Project[];
@@ -256,7 +256,7 @@ const ProjectTableView: React.FC<ProjectTableViewProps> = ({ projects }) => {
                     sx: { mt: theme.spacing(-2) },
                   },
                   inputProps: { id: "pagination-dropdown" },
-                  IconComponent: SelectorVertical,
+                  IconComponent: () => <SelectorVertical size={16} />,
                   sx: {
                     ml: theme.spacing(4),
                     mr: theme.spacing(12),

--- a/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
@@ -1,7 +1,7 @@
 // New component file: ProjectList.tsx
 import { useState, useMemo } from "react";
 import { Box, Typography, InputBase, IconButton } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 import ProjectCard from "../Cards/ProjectCard";
 import ProjectTableView from "./ProjectTableView";
 import NoProject from "../NoProject/NoProject";
@@ -102,7 +102,7 @@ const ProjectList = ({ projects }: ProjectListProps) => {
             aria-expanded={isSearchBarVisible}
             onClick={() => setIsSearchBarVisible((prev) => !prev)}
           >
-            <SearchIcon />
+            <SearchIcon size={20} />
           </IconButton>
 
           {isSearchBarVisible && (

--- a/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, lazy, Suspense, useRef } from "react";
 import { IconButton, Box, Stack } from "@mui/material";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { styles } from "./styles";
 const GenerateReportFrom = lazy(() => import("./GenerateReportFrom"));
 const DownloadReportForm = lazy(() => import("./DownloadReportFrom"));
@@ -150,7 +150,7 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
 
 
 
-          <CloseGreyIcon />
+          <CloseGreyIcon size={20} />
         </IconButton>
         {isReportRequest ? (
           <Suspense fallback={<div>Loading...</div>}>

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -2,10 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Box, Tooltip, IconButton, Stack, useTheme } from "@mui/material";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import {ReactComponent as FormatBold} from "../../assets/icons/formatBold.svg";
-import {ReactComponent as FormatItalic} from "../../assets/icons/formatItalic.svg";
-import {ReactComponent as FormatListBulleted} from "../../assets/icons/formatListBulleted.svg";
-import {ReactComponent as FormatListNumbered} from "../../assets/icons/formatListNumbered.svg";
+import { Bold as FormatBold, Italic as FormatItalic, List as FormatListBulleted, ListOrdered as FormatListNumbered } from "lucide-react";
 import "./index.css";
 
 interface RichTextEditorProps {
@@ -81,10 +78,10 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
         }}
       >
         {[
-          { title: "Bold", icon: <FormatBold />, action: "bold" },
-          { title: "Italic", icon: <FormatItalic />, action: "italic" },
-          { title: "Bullets", icon: <FormatListBulleted />, action: "bullets" },
-          { title: "Numbers", icon: <FormatListNumbered />, action: "numbers" },
+          { title: "Bold", icon: <FormatBold size={20} />, action: "bold" },
+          { title: "Italic", icon: <FormatItalic size={20} />, action: "italic" },
+          { title: "Bullets", icon: <FormatListBulleted size={20} />, action: "bullets" },
+          { title: "Numbers", icon: <FormatListNumbered size={20} />, action: "numbers" },
         ].map(({ title, icon, action }) => (
           <Tooltip
             key={action}

--- a/Clients/src/presentation/components/RiskVisualization/RiskCategories.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskCategories.tsx
@@ -8,8 +8,7 @@ import {
   Grid,
   Collapse,
 } from "@mui/material";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
+import { ChevronUp, ChevronDown } from "lucide-react";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
 import { getAllUsers } from "../../../application/repository/user.repository";
 import ButtonToggle from "../ButtonToggle";
@@ -222,7 +221,7 @@ const RiskCategories: React.FC<RiskCategoriesProps> = ({
                       </Typography>
                     </Box>
                     
-                    {isExpanded ? <ExpandLessIcon style={{ color: '#6B7280' }} /> : <ExpandMoreIcon style={{ color: '#6B7280' }} />}
+                    {isExpanded ? <ChevronUp size={16} style={{ color: '#6B7280' }} /> : <ChevronDown size={16} style={{ color: '#6B7280' }} />}
                   </Box>
 
                   <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>

--- a/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
@@ -11,8 +11,7 @@ import {
 } from "@mui/material";
 import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
 import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
 import Select from "../Inputs/Select";
 import { getAllUsers } from "../../../application/repository/user.repository";
@@ -350,7 +349,7 @@ const RiskFilters: React.FC<RiskFiltersProps> = ({
             </Button>
           )}
           <IconButton size="small">
-            {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            {expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
           </IconButton>
         </Stack>
       </Box>

--- a/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
@@ -9,9 +9,7 @@ import {
   Collapse,
   IconButton,
 } from "@mui/material";
-import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
-import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { Filter as FilterIcon, X as ClearIcon, ChevronDown, ChevronUp } from "lucide-react";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
 import Select from "../Inputs/Select";
 import { getAllUsers } from "../../../application/repository/user.repository";
@@ -304,7 +302,7 @@ const RiskFilters: React.FC<RiskFiltersProps> = ({
         onClick={() => handleExpandedChange(!expanded)}
       >
         <Stack direction="row" alignItems="center" spacing={1}>
-          <FilterIcon style={{ color: "#13715B", height: "20px", width:"20px" }} />
+          <FilterIcon size={20} style={{ color: "#13715B" }} />
           <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "#1A1919" }}>
             Filters
           </Typography>
@@ -331,7 +329,7 @@ const RiskFilters: React.FC<RiskFiltersProps> = ({
           {activeFilterCount > 0 && (
             <Button
               size="small"
-              startIcon={<ClearIcon />}
+              startIcon={<ClearIcon size={16} />}
               onClick={(e) => {
                 e.stopPropagation();
                 clearAllFilters();

--- a/Clients/src/presentation/components/Search/SearchBox/index.tsx
+++ b/Clients/src/presentation/components/Search/SearchBox/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, InputBase, SxProps, Theme } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 
 export interface SearchBoxProps {
   placeholder?: string;
@@ -45,7 +45,7 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 
   return (
     <Box sx={searchBoxStyle}>
-      <SearchIcon style={{ color: "#6b7280", marginRight: "8px" }} />
+      <SearchIcon size={20} style={{ color: "#6b7280", marginRight: "8px" }} />
       <InputBase
         placeholder={placeholder}
         value={value}

--- a/Clients/src/presentation/components/Table/AITrustCenterTable/index.tsx
+++ b/Clients/src/presentation/components/Table/AITrustCenterTable/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "@mui/material";
 import singleTheme from "../../../themes/v1SingleTheme";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import Placeholder from "../../../assets/imgs/empty-state.svg";
 
 const DEFAULT_ROWS_PER_PAGE = 5;
@@ -255,7 +255,7 @@ const AITrustCenterTable = <T extends { id: number }>({
                       sx: { mt: theme.spacing(-2) },
                     },
                     inputProps: { id: "pagination-dropdown" },
-                    IconComponent: SelectorVertical,
+                    IconComponent: () => <SelectorVertical size={16} />,
                     sx: {
                       ml: theme.spacing(4),
                       mr: theme.spacing(12),

--- a/Clients/src/presentation/components/Table/AuditRiskTable/AuditRiskTableBody.tsx
+++ b/Clients/src/presentation/components/Table/AuditRiskTable/AuditRiskTableBody.tsx
@@ -11,7 +11,7 @@ import { useCallback, useState } from "react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { ReactComponent as CheckboxOutline } from "../../../assets/icons/checkbox-outline.svg";
 import { ReactComponent as CheckboxFilled } from "../../../assets/icons/checkbox-filled.svg";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import {
   paginationStyle,
   paginationDropdown,
@@ -194,7 +194,7 @@ export const AuditRiskTableBody: React.FC<AuditRiskTableBodyProps> = ({
                   sx: { mt: theme.spacing(-2) },
                 },
                 inputProps: { id: "pagination-dropdown" },
-                IconComponent: SelectorVertical,
+                IconComponent: () => <SelectorVertical size={16} />,
                 sx: paginationSelect,
               },
             }}

--- a/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
@@ -1,6 +1,6 @@
 import { TableBody, TableRow, TableCell, Box } from "@mui/material";
 import singleTheme from '../../../../themes/v1SingleTheme';
-import trash from '../../../../assets/icons/trash-grey.svg';
+import { Trash2 as TrashIcon } from "lucide-react";
 import Button from '../../../../components/Button/index';
 import ConfirmableDeleteIconButton from "../../../../components/Modals/ConfirmableDeleteIconButton";
 
@@ -111,7 +111,7 @@ const EvaluationTableBody: React.FC<EvaluationTableBodyProps> = ({
             onConfirm={(id) => onRemoveModel.onConfirm(String(id))}
             title={`Delete this evaluation?`}
             message={`Are you sure you want to delete evaluation ID ${row.id} (Status: ${row.status})? This action is non-recoverable.`}
-            customIcon={<img src={trash} alt="Delete" style={{ width: '20px', height: '20px' }} />}
+            customIcon={<TrashIcon size={20} />}
           />
           </TableCell>
         </TableRow>

--- a/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
@@ -14,7 +14,7 @@ import {
   import TablePaginationActions from "../../TablePagination";
   import TableHeader from "../TableHead";
   import placeholderImage from "../../../assets/imgs/empty-state.svg";
-  import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+  import { ChevronsUpDown as SelectorVertical } from "lucide-react";
   import {
     emptyData,
     paginationStatus,
@@ -129,7 +129,7 @@ import {
                                     sx: { mt: theme.spacing(-2) },
                                   },
                                   inputProps: { id: "pagination-dropdown" },
-                                  IconComponent: SelectorVertical,
+                                  IconComponent: () => <SelectorVertical size={16} />,
                                   sx: paginationSelect(theme),
                                 },
                               }}

--- a/Clients/src/presentation/components/Table/EventsTable/index.tsx
+++ b/Clients/src/presentation/components/Table/EventsTable/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import TablePaginationActions from "../../TablePagination";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import Placeholder from "../../../assets/imgs/empty-state.svg";
 import { formatDateTime } from "../../../tools/isoDateToString";
 import { Event } from "../../../../domain/types/Event";
@@ -308,7 +308,7 @@ const EventsTable: React.FC<EventsTableProps> = ({
                       sx: { mt: theme.spacing(-2) },
                     },
                     inputProps: { id: "pagination-dropdown" },
-                    IconComponent: SelectorVertical,
+                    IconComponent: () => <SelectorVertical size={16} />,
                     sx: {
                       ml: theme.spacing(4),
                       mr: theme.spacing(12),

--- a/Clients/src/presentation/components/Table/FairnessTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/FairnessTable/TableBody/index.tsx
@@ -1,6 +1,6 @@
 import { TableBody, TableRow, TableCell, Box } from "@mui/material";
 import singleTheme from '../../../../themes/v1SingleTheme';
-import {ReactComponent as DeleteIconGrey} from "../../../../assets/icons/trash-grey.svg"
+import { Trash2 as DeleteIconGrey } from "lucide-react"
 import Button from '../../../../components/Button/index';
 import ConfirmableDeleteIconButton from "../../../../components/Modals/ConfirmableDeleteIconButton";
 

--- a/Clients/src/presentation/components/Table/FairnessTable/index.tsx
+++ b/Clients/src/presentation/components/Table/FairnessTable/index.tsx
@@ -13,7 +13,7 @@ import {
   import TablePaginationActions from "../../TablePagination";
   import TableHeader from "../TableHead";
   import placeholderImage from "../../../assets/imgs/empty-state.svg";
-  import { ReactComponent as SelectorVertical } from '../../../assets/icons/selector-vertical.svg';
+  import { ChevronsUpDown as SelectorVertical } from "lucide-react";
   import {
     styles,
     paginationStatus,
@@ -117,7 +117,7 @@ import {
                                     sx: { mt: 0 },
                                 },
                                 inputProps: { id: "pagination-dropdown" },
-                                IconComponent: SelectorVertical,
+                                IconComponent: () => <SelectorVertical size={16} />,
                                 sx: paginationSelect,
                                 },
                             }}

--- a/Clients/src/presentation/components/Table/LinkedRisksTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/LinkedRisksTable/TableBody/index.tsx
@@ -4,7 +4,7 @@ import singleTheme from '../../../../themes/v1SingleTheme';
 import { TableBody, TableCell, TableRow, useTheme, Checkbox as MuiCheckbox, TableFooter, TablePagination, } from '@mui/material';
 import { ReactComponent as CheckboxOutline } from "../../../../assets/icons/checkbox-outline.svg";
 import { ReactComponent as CheckboxFilled } from "../../../../assets/icons/checkbox-filled.svg";
-import { ReactComponent as SelectorVertical } from '../../../../assets/icons/selector-vertical.svg'
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import RiskChip from '../../../RiskLevel/RiskChip';
 
 import {
@@ -148,7 +148,7 @@ const LinkedRisksTableBody: React.FC<TableProps> = ({
                   sx: { mt: theme.spacing(-2) },
                 },
                 inputProps: { id: "pagination-dropdown" },
-                IconComponent: SelectorVertical,
+                IconComponent: () => <SelectorVertical size={16} />,
                 sx: paginationSelect,
               },
             }}

--- a/Clients/src/presentation/components/Table/PolicyTable/index.tsx
+++ b/Clients/src/presentation/components/Table/PolicyTable/index.tsx
@@ -15,7 +15,7 @@ import {
 import TablePaginationActions from "../../TablePagination";
 import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import { getPaginationRowCount, setPaginationRowCount } from "../../../../application/utils/paginationStorage";
 
 const DEFAULT_ROWS_PER_PAGE = 10;
@@ -205,7 +205,7 @@ const CustomizablePolicyTable = ({
                           sx: { mt: theme.spacing(-2) },
                         },
                         inputProps: { id: "pagination-dropdown" },
-                        IconComponent: SelectorVertical,
+                        IconComponent: () => <SelectorVertical size={16} />,
                         sx: {
                           ml: theme.spacing(4),
                           mr: theme.spacing(12),

--- a/Clients/src/presentation/components/Table/ProjectRiskMitigationTable/ProjectRiskMitigationTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ProjectRiskMitigationTable/ProjectRiskMitigationTableBody.tsx
@@ -10,7 +10,7 @@ import { ProjectRiskMitigation } from "../../../../domain/types/ProjectRisk";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useState } from "react";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import {
   paginationDropdown,
   paginationSelect,
@@ -189,7 +189,7 @@ export const ProjectRiskMitigationTableBody: React.FC<
                   sx: { mt: theme.spacing(-2) },
                 },
                 inputProps: { id: "pagination-dropdown" },
-                IconComponent: SelectorVertical,
+                IconComponent: () => <SelectorVertical size={16} />,
                 sx: paginationSelect,
               },
             }}

--- a/Clients/src/presentation/components/Table/ReportTable/index.tsx
+++ b/Clients/src/presentation/components/Table/ReportTable/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import singleTheme from '../../../themes/v1SingleTheme';
 import placeholderImage from "../../../assets/imgs/empty-state.svg";
-import { ReactComponent as SelectorVertical } from '../../../assets/icons/selector-vertical.svg'
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import TablePaginationActions from '../../TablePagination';
 import TableHeader from '../TableHead';
 const ReportTableBody = lazy(() => import("./TableBody"))
@@ -113,7 +113,7 @@ const ReportTable: React.FC<ReportTableProps> = ({
                             sx: { mt: theme.spacing(-2) },
                           },
                           inputProps: { id: "pagination-dropdown" },
-                          IconComponent: SelectorVertical,
+                          IconComponent: () => <SelectorVertical size={16} />,
                           sx: paginationSelect,
                         },
                       }}

--- a/Clients/src/presentation/components/Table/RisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/RisksTable/index.tsx
@@ -18,7 +18,7 @@ import Placeholder from "../../../assets/imgs/empty-state.svg";
 import singleTheme from "../../../themes/v1SingleTheme";
 import IconButton from "../../IconButton";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import RiskChip from "../../RiskLevel/RiskChip";
 import { VendorDetails } from "../../../pages/Vendors";
 import { VendorRisk } from "../../../../domain/types/VendorRisk";
@@ -389,7 +389,7 @@ const RiskTable: React.FC<RiskTableProps> = ({
                         sx: { mt: theme.spacing(-2) },
                       },
                       inputProps: { id: "pagination-dropdown" },
-                      IconComponent: SelectorVertical,
+                      IconComponent: () => <SelectorVertical size={16} />,
                       sx: {
                         ml: theme.spacing(4),
                         mr: theme.spacing(12),

--- a/Clients/src/presentation/components/Table/TasksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/TasksTable/index.tsx
@@ -17,7 +17,7 @@ import Placeholder from "../../../assets/imgs/empty-state.svg";
 import singleTheme from "../../../themes/v1SingleTheme";
 import TablePaginationActions from "../../TablePagination";
 import TableHeader from "../TableHead";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import { ITask } from "../../../../domain/interfaces/i.task";
 import { User } from "../../../../domain/types/User";
 import CustomSelect from "../../CustomSelect";
@@ -395,7 +395,7 @@ const TasksTable: React.FC<TasksTableProps> = ({
                         sx: { mt: theme.spacing(-2) },
                       },
                       inputProps: { id: "pagination-dropdown" },
-                      IconComponent: SelectorVertical,
+                      IconComponent: () => <SelectorVertical size={16} />,
                       sx: {
                         ml: theme.spacing(4),
                         mr: theme.spacing(12),

--- a/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
@@ -13,7 +13,7 @@ import {
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useMemo, useState, useEffect } from "react";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import placeholderImage from "../../../assets/imgs/empty-state.svg";
 import VWProjectRisksTableHead from "./VWProjectRisksTableHead";
 import VWProjectRisksTableBody from "./VWProjectRisksTableBody";
@@ -182,7 +182,7 @@ const VWProjectRisksTable = ({
                           sx: { mt: theme.spacing(-2) },
                         },
                         inputProps: { id: "pagination-dropdown" },
-                        IconComponent: SelectorVertical,
+                        IconComponent: () => <SelectorVertical size={16} />,
                         sx: {
                           ml: theme.spacing(4),
                           mr: theme.spacing(12),

--- a/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
+++ b/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
@@ -19,7 +19,7 @@ import CustomizableButton from "../../Button/CustomizableButton";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { formatDate } from "../../../tools/isoDateToString";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import VendorRisksDialog from "../../VendorRisksDialog";
 import { VendorDetails } from "../../../pages/Vendors";
 import { User } from "../../../../domain/types/User";
@@ -299,7 +299,7 @@ const TableWithPlaceholder: React.FC<TableWithPlaceholderProps> = ({
                         sx: { mt: theme.spacing(-2) },
                       },
                       inputProps: { id: "pagination-dropdown" },
-                      IconComponent: SelectorVertical,
+                      IconComponent: () => <SelectorVertical size={16} />,
                       sx: {
                         ml: theme.spacing(4),
                         mr: theme.spacing(12),

--- a/Clients/src/presentation/components/VWQuestion/index.tsx
+++ b/Clients/src/presentation/components/VWQuestion/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Chip, Stack, Tooltip, Typography, Dialog, useTheme } from "@mui/material";
 import { Question } from "../../../domain/types/Question";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 import {
   priorities,
   PriorityLevel,
@@ -260,7 +260,7 @@ const QuestionFrame = ({
                 }}
               >
                 <Box component="span" sx={{ display: "inline-flex", cursor: "pointer" }}>
-          <GreyCircleInfoIcon />
+          <GreyCircleInfoIcon size={16} />
         </Box>
               </Tooltip>
             </Box>

--- a/Clients/src/presentation/components/VendorRisksDialog/index.tsx
+++ b/Clients/src/presentation/components/VendorRisksDialog/index.tsx
@@ -33,7 +33,7 @@ import {
 } from "../Table/styles";
 import placeholderImage from '../../assets/imgs/empty-state.svg';
 import TablePaginationActions from "../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 
 interface VendorRisk {
   id: number;
@@ -312,7 +312,7 @@ const VendorRisksDialog: React.FC<VendorRisksDialogProps> = ({
                                 sx: { mt: theme.spacing(-2) },
                               },
                               inputProps: { id: "pagination-dropdown" },
-                              IconComponent: SelectorVertical,
+                              IconComponent: () => <SelectorVertical size={16} />,
                               sx: paginationSelect(theme),
                             },
                           }}

--- a/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
@@ -19,7 +19,7 @@ import {
   useAITrustCentreOverviewMutation,
 } from "../../../../application/hooks/useAITrustCentreOverviewQuery";
 import { handleAlert } from "../../../../application/tools/alertUtils";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import Field from "../../../components/Inputs/Field";
 
 import {
@@ -791,7 +791,7 @@ const AITrustCenterOverview: React.FC = () => {
             backgroundColor: hasUnsavedChanges ? "#13715B" : "#ccc",
             border: `1px solid ${hasUnsavedChanges ? "#13715B" : "#ccc"}`,
           }}
-          icon={<SaveIconSVGWhite />} // you might need a dark icon when active
+          icon={<SaveIconSVGWhite size={20} />} // you might need a dark icon when active
           variant="contained"
           onClick={handleSave}
           isDisabled={!hasUnsavedChanges}

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -16,7 +16,7 @@ import Alert from "../../../components/Alert";
 import {ReactComponent as VisibilityIcon} from "../../../assets/icons/visibility-grey.svg"
 import {ReactComponent as VisibilityOffIcon} from "../../../assets/icons/visibility-off-grey.svg"
 import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import Toggle from "../../../components/Inputs/Toggle";
 import { useStyles } from "./styles";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
@@ -631,7 +631,7 @@ const TrustCenterResources: React.FC = () => {
           <DialogTitle sx={styles.modalTitle}>
             Add a new resource
             <IconButton onClick={handleCloseAddModal} sx={styles.closeButton}>
-              <CloseGreyIcon />
+              <CloseGreyIcon size={20} />
             </IconButton>
           </DialogTitle>
 
@@ -721,7 +721,7 @@ const TrustCenterResources: React.FC = () => {
           <DialogTitle sx={styles.modalTitle}>
             Edit resource
             <IconButton onClick={handleCloseEditModal} sx={styles.closeButton}>
-              <CloseGreyIcon />
+              <CloseGreyIcon size={20} />
             </IconButton>
           </DialogTitle>
 

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -15,7 +15,7 @@ import {
 import Alert from "../../../components/Alert";
 import {ReactComponent as VisibilityIcon} from "../../../assets/icons/visibility-grey.svg"
 import {ReactComponent as VisibilityOffIcon} from "../../../assets/icons/visibility-off-grey.svg"
-import { ReactComponent as AddCircleOutlineIcon } from "../../../assets/icons/plus-circle-white.svg";
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
 import Toggle from "../../../components/Inputs/Toggle";
 import { useStyles } from "./styles";

--- a/Clients/src/presentation/pages/AITrustCenter/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Settings/index.tsx
@@ -13,7 +13,7 @@ import { useStyles } from "./styles";
 import Toggle from "../../../components/Inputs/Toggle";
 import Field from "../../../components/Inputs/Field";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import DualButtonModal from "../../../components/Dialogs/DualButtonModal";
 import {
   useAITrustCentreOverviewQuery,
@@ -712,7 +712,7 @@ const AITrustCenterSettings: React.FC = () => {
             backgroundColor: hasUnsavedChanges ? "#13715B" : "#ccc",
             border: `1px solid ${hasUnsavedChanges ? "#13715B" : "#ccc"}`,
           }}
-          icon={<SaveIconSVGWhite />}
+          icon={<SaveIconSVGWhite size={20} />}
           variant="contained"
           onClick={handleSave}
           isDisabled={!hasUnsavedChanges}

--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -15,7 +15,7 @@ import { useStyles } from "./styles";
 import Field from "../../../components/Inputs/Field";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
 import { Modal, IconButton } from "@mui/material";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import { useTheme } from "@mui/material/styles";
 import AITrustCenterTable from "../../../components/Table/AITrustCenterTable";
@@ -522,7 +522,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
             <Box sx={styles.modalHeader}>
               <Typography sx={styles.modalTitle}>Edit subprocessor</Typography>
               <IconButton onClick={handleCloseEditModal} sx={{ p: 0 }}>
-                <CloseGreyIcon />
+                <CloseGreyIcon size={20} />
               </IconButton>
             </Box>
             <Stack spacing={3}>
@@ -590,7 +590,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
                 Add new subprocessor
               </Typography>
               <IconButton onClick={handleCloseAddModal} sx={{ p: 0 }}>
-                <CloseGreyIcon />
+                <CloseGreyIcon size={20} />
               </IconButton>
             </Box>
             <Stack spacing={3}>

--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -16,7 +16,7 @@ import Field from "../../../components/Inputs/Field";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
 import { Modal, IconButton } from "@mui/material";
 import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
-import { ReactComponent as AddCircleOutlineIcon } from "../../../assets/icons/plus-circle-white.svg";
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import { useTheme } from "@mui/material/styles";
 import AITrustCenterTable from "../../../components/Table/AITrustCenterTable";
 import Alert from "../../../components/Alert";

--- a/Clients/src/presentation/pages/AITrustCentrePublic/Overview/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCentrePublic/Overview/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Paper, Typography, Stack, Button } from "@mui/material";
 import CustomTextField from "../Components/CustomTextField/CustomTextField";
-import {ReactComponent as CheckCircleOutlineIcon} from '../../../assets/icons/check-circle-green.svg';
+import { CheckCircle as CheckCircleOutlineIcon } from "lucide-react";
 import { downloadResource } from "../../../../application/tools/downloadResource";
 
 const Overview = ({

--- a/Clients/src/presentation/pages/AITrustCentrePublic/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCentrePublic/Resources/index.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   Box
 } from '@mui/material';
-import {ReactComponent as CheckCircleOutlineIcon} from '../../../assets/icons/check-circle-green.svg';
+import { CheckCircle as CheckCircleOutlineIcon } from "lucide-react";
 import { downloadResource } from '../../../../application/tools/downloadResource';
 import { aiTrustCenterTableCell } from '../style';
 

--- a/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
@@ -5,7 +5,7 @@
 import { Button, Stack, Typography, useTheme } from "@mui/material";
 import React, { useState } from "react";
 import { ReactComponent as Key } from "../../../assets/icons/key.svg";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Field from "../../../components/Inputs/Field";
 import singleTheme from "../../../themes/v1SingleTheme";
@@ -177,7 +177,7 @@ const ForgotPassword: React.FC = () => {
                 navigate("/login");
               }}
             >
-              <LeftArrowLong />
+              <ArrowLeft size={20} />
               <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
                 Back to log in
               </Typography>

--- a/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
@@ -5,7 +5,7 @@
 import { Stack, Typography, useTheme } from "@mui/material";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import { ReactComponent as Email } from "../../../assets/icons/email.svg";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useState, lazy, Suspense } from "react";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
@@ -146,7 +146,7 @@ const ResetPassword = () => {
               navigate("/login");
             }}
           >
-            <LeftArrowLong />
+            <ArrowLeft size={20} />
             <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
               Back to log in
             </Typography>

--- a/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
@@ -4,8 +4,7 @@
 
 import { Stack, Typography, useTheme } from "@mui/material";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
-import { ReactComponent as Email } from "../../../assets/icons/email.svg";
-import { ArrowLeft } from "lucide-react";
+import { Mail as Email, ArrowLeft } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useState, lazy, Suspense } from "react";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
@@ -102,7 +101,7 @@ const ResetPassword = () => {
             gap: theme.spacing(12),
           }}
         >
-          <Email />
+          <Email size={24} />
         </Stack>
         <Stack sx={{ gap: theme.spacing(6), textAlign: "center" }}>
           <Typography sx={{ fontSize: 16, fontWeight: "bold" }}>

--- a/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Check from "../../../components/Checks";
 import Field from "../../../components/Inputs/Field";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { ReactComponent as Lock } from "../../../assets/icons/lock.svg";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -299,7 +299,7 @@ const SetNewPassword: React.FC = () => {
               }}
               onClick={() => navigate("/login")}
             >
-              <LeftArrowLong />
+              <ArrowLeft size={20} />
               <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
                 Back to log in
               </Typography>

--- a/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/ControlCategory.tsx
+++ b/Clients/src/presentation/pages/ComplianceTracker/1.0ComplianceTracker/ControlCategory.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import { ControlCategory as ControlCategoryModel } from "../../../../domain/types/ControlCategory";
 import { useState } from "react";
-import { ReactComponent as RightArrowBlack } from "../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import ControlsTable from "./ControlsTable";
 
 const Table_Columns = [
@@ -66,7 +66,8 @@ const ControlCategoryTile: React.FC<ControlCategoryProps> = ({
         <AccordionSummary
           className="control-category-accordion-summary"
           expandIcon={
-            <RightArrowBlack
+            <ArrowRight
+              size={20}
               style={{
                 transform:
                   expanded === controlCategory.id

--- a/Clients/src/presentation/pages/DashboardOverview/EnhancedDashboard.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/EnhancedDashboard.tsx
@@ -17,14 +17,14 @@ import {
 } from '@mui/material';
 import {
   Edit as EditIcon,
-  Visibility as ViewIcon,
-  DragIndicator as DragIcon,
+  Eye as ViewIcon,
+  GripVertical as DragIcon,
   Settings as SettingsIcon,
-  Refresh as RefreshIcon,
+  RefreshCw as RefreshIcon,
   Download as DownloadIcon,
   Upload as UploadIcon,
-  RestartAlt as ResetIcon,
-} from '@mui/icons-material';
+  RotateCcw as ResetIcon,
+} from 'lucide-react';
 import { Responsive, WidthProvider, Layout, Layouts } from 'react-grid-layout';
 import { DashboardProvider, useDashboardContext } from './contexts/DashboardContext';
 import { MetricsWidget, ProjectsWidget, RisksWidget } from './widgets';
@@ -231,14 +231,14 @@ const DashboardContent: React.FC = () => {
           {/* Refresh Button */}
           <Tooltip title="Refresh all widgets">
             <IconButton onClick={() => actions.refreshAllWidgets()}>
-              <RefreshIcon />
+              <RefreshIcon size={20} />
             </IconButton>
           </Tooltip>
 
           {/* Settings Menu */}
           <Tooltip title="Dashboard settings">
             <IconButton onClick={handleSettingsClick}>
-              <SettingsIcon />
+              <SettingsIcon size={20} />
             </IconButton>
           </Tooltip>
           <Menu
@@ -247,14 +247,14 @@ const DashboardContent: React.FC = () => {
             onClose={handleSettingsClose}
           >
             <MenuItem onClick={() => { actions.resetLayout(); handleSettingsClose(); }}>
-              <ResetIcon sx={{ mr: 1 }} /> Reset Layout
+              <ResetIcon size={16} style={{ marginRight: 8 }} /> Reset Layout
             </MenuItem>
             <MenuItem onClick={() => { actions.exportDashboard(); handleSettingsClose(); }}>
-              <DownloadIcon sx={{ mr: 1 }} /> Export Dashboard
+              <DownloadIcon size={16} style={{ marginRight: 8 }} /> Export Dashboard
             </MenuItem>
             <Divider />
             <MenuItem disabled>
-              <UploadIcon sx={{ mr: 1 }} /> Import Dashboard
+              <UploadIcon size={16} style={{ marginRight: 8 }} /> Import Dashboard
             </MenuItem>
           </Menu>
 
@@ -269,7 +269,7 @@ const DashboardContent: React.FC = () => {
             }
             label={
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {state.editMode ? <EditIcon /> : <ViewIcon />}
+                {state.editMode ? <EditIcon size={16} /> : <ViewIcon size={16} />}
                 <Typography>{state.editMode ? 'Edit Mode' : 'View Mode'}</Typography>
               </Box>
             }
@@ -429,9 +429,9 @@ const DashboardContent: React.FC = () => {
               avatar={
                 state.editMode && (
                   <DragIcon
-                    sx={{
+                    size={20}
+                    style={{
                       color: alpha(theme.palette.text.secondary, 0.6),
-                      fontSize: '1.2rem',
                     }}
                   />
                 )
@@ -441,7 +441,7 @@ const DashboardContent: React.FC = () => {
                 state.editMode && (
                   <Tooltip title="Widget settings">
                     <IconButton size="small" className="no-drag">
-                      <SettingsIcon fontSize="small" />
+                      <SettingsIcon size={16} />
                     </IconButton>
                   </Tooltip>
                 )

--- a/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessModule.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessModule.tsx
@@ -16,7 +16,7 @@ import {
   CircularProgress,
 } from "@mui/material";
 import { PlusCircle as AddCircleOutlineIcon } from "lucide-react"
-import {ReactComponent as CloseIcon} from "../../assets/icons/close-grey.svg"
+import { X as CloseIcon } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import Alert from "../../components/Alert";
 import { Suspense } from "react";
@@ -449,7 +449,7 @@ export default function BiasAndFairnessModule() {
               setDialogOpen(false);
               resetForm();
             }}>
-              <CloseIcon />
+              <CloseIcon size={20} />
             </IconButton>
           </Box>
         </DialogTitle>

--- a/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessModule.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessModule.tsx
@@ -15,7 +15,7 @@ import {
   MenuItem,
   CircularProgress,
 } from "@mui/material";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg"
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react"
 import {ReactComponent as CloseIcon} from "../../assets/icons/close-grey.svg"
 import { useNavigate } from "react-router-dom";
 import Alert from "../../components/Alert";

--- a/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
@@ -18,8 +18,7 @@ import {
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { ReactComponent as CopyIcon } from "../../assets/icons/copy.svg";
 import { ReactComponent as DownloadIcon } from "../../assets/icons/download.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-more.svg";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-less.svg";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { BarChart } from "@mui/x-charts";
 import createPlotlyComponent from 'react-plotly.js/factory';
 import Plotly from 'plotly.js-basic-dist';
@@ -1168,7 +1167,7 @@ export default function BiasAndFairnessResultsPage() {
                       }
                     }}
                   >
-                    <ExpandMoreIcon style={{ width: 20, height: 20, marginTop: '3px', marginLeft: '4px' }} />
+                    <ChevronDown size={20} style={{ marginTop: '3px', marginLeft: '4px' }} />
                   </IconButton>
                 </Box>
               )}
@@ -1187,7 +1186,7 @@ export default function BiasAndFairnessResultsPage() {
                       }
                     }}
                   >
-                    <ExpandLessIcon style={{ width: 20, height: 20, marginRight: '3px', marginTop: '-2px' }} />
+                    <ChevronUp size={20} style={{ marginRight: '3px', marginTop: '-2px' }} />
                   </IconButton>
                 </Box>
               )}

--- a/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
@@ -16,9 +16,7 @@ import {
   IconButton,
 } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { ReactComponent as CopyIcon } from "../../assets/icons/copy.svg";
-import { ReactComponent as DownloadIcon } from "../../assets/icons/download.svg";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { Copy as CopyIcon, Download as DownloadIcon, ChevronDown, ChevronUp } from "lucide-react";
 import { BarChart } from "@mui/x-charts";
 import createPlotlyComponent from 'react-plotly.js/factory';
 import Plotly from 'plotly.js-basic-dist';
@@ -1112,7 +1110,7 @@ export default function BiasAndFairnessResultsPage() {
                     }
                   }}
                 >
-                  <CopyIcon style={{ width: 24, height: 24 }} />
+                  <CopyIcon size={24} />
                 </IconButton>
                 <IconButton
                   onClick={handleDownloadJSON}
@@ -1128,7 +1126,7 @@ export default function BiasAndFairnessResultsPage() {
                     }
                   }}
                 >
-                  <DownloadIcon style={{ width: 24, height: 24 }} />
+                  <DownloadIcon size={24} />
                 </IconButton>
               </Box>
             </Box>

--- a/Clients/src/presentation/pages/FairnessDashboard/FairnessDashboard.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/FairnessDashboard.tsx
@@ -19,7 +19,7 @@ import {
   IconButton,
 } from "@mui/material";
 import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg"
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react"
 import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.svg";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import Tab from "@mui/material/Tab";

--- a/Clients/src/presentation/pages/FairnessDashboard/FairnessDashboard.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/FairnessDashboard.tsx
@@ -20,7 +20,7 @@ import {
 } from "@mui/material";
 import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
 import { PlusCircle as AddCircleOutlineIcon } from "lucide-react"
-import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import Tab from "@mui/material/Tab";
 import { styles } from "./styles";
@@ -457,7 +457,7 @@ export default function FairnessDashboard() {
                   </Typography>
                 </Box>
                 <IconButton onClick={resetForm}>
-                  <CloseGreyIcon />
+                  <CloseGreyIcon size={20} />
                 </IconButton>
               </Box>
             </DialogTitle>
@@ -548,7 +548,7 @@ export default function FairnessDashboard() {
                               if (ref.current) ref.current.value = "";
                             }}
                           >
-                            {<CloseGreyIcon fontSize="small" />}
+                            {<CloseGreyIcon size={16} />}
                           </IconButton>
                         </Box>
                       )}

--- a/Clients/src/presentation/pages/FairnessDashboard/FairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/FairnessResultsPage.tsx
@@ -8,7 +8,7 @@ import {
   CircularProgress,
   Tooltip,
 } from "@mui/material";
-import {ReactComponent as ArrowBackIcon} from "../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
 import { BarChart } from "@mui/x-charts";
 import { fairnessService } from "../../../infrastructure/api/fairnessService";
@@ -96,7 +96,7 @@ export default function FairnessResultsPage() {
           onClick={() => navigate("/fairness-dashboard")}
           sx={{ mr: 2 }}
         >
-          <ArrowBackIcon />
+          <ArrowLeft size={20} />
         </IconButton>
         <Typography
           sx={{

--- a/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
@@ -10,7 +10,7 @@ import { GetAnnexesByProjectFrameworkId } from "../../../../../application/repos
 import { useCallback, useEffect, useState } from "react";
 import StatsCard from "../../../../components/Cards/StatsCard";
 import { styles } from "../Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import VWISO27001AnnexDrawerDialog from "../../../../components/Drawer/ISO27001AnnexDrawerDialog";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import { AlertProps } from "../../../../../domain/interfaces/iAlert";
@@ -237,7 +237,8 @@ const ISO27001Annex = ({
                   sx={styles.accordion}
                 >
                   <AccordionSummary sx={styles.accordionSummary}>
-                    <RightArrowBlack
+                    <ArrowRight
+                      size={20}
                       style={styles.expandIcon(expanded === annex.id) as React.CSSProperties}
                     />
                     <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
@@ -10,7 +10,7 @@ import { Iso27001GetClauseStructByFrameworkID } from "../../../../../application
 import { ClauseStructISO } from "../../../../../domain/types/ClauseStructISO";
 import { useCallback, useEffect, useState } from "react";
 import { styles } from "./style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import { ISO27001GetSubClauseByClauseId } from "../../../../../application/repository/subClause_iso.repository";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import Alert from "../../../../components/Alert";
@@ -308,7 +308,8 @@ const ISO27001Clause = ({
               onChange={handleAccordionChange(clause.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                 />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/ISO42001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO42001/Annex/index.tsx
@@ -10,7 +10,7 @@ import { GetAnnexesByProjectFrameworkId } from "../../../../../application/repos
 import { useEffect, useState } from "react";
 import StatsCard from "../../../../components/Cards/StatsCard";
 import { styles } from "../../ISO27001/Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import VWISO42001AnnexDrawerDialog from "../../../../components/Drawer/AnnexDrawerDialog";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import { AlertProps } from "../../../../../domain/interfaces/iAlert";
@@ -262,7 +262,8 @@ const ISO42001Annex = ({
               onChange={handleAccordionChange(annex.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === annex.id) as React.CSSProperties}
                    />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/ISO42001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO42001/Clause/index.tsx
@@ -10,7 +10,7 @@ import { GetClausesByProjectFrameworkId } from "../../../../../application/repos
 import { ClauseStructISO } from "../../../../../domain/types/ClauseStructISO";
 import { useCallback, useEffect, useState } from "react";
 import { styles } from "../../ISO27001/Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import { GetSubClausesById } from "../../../../../application/repository/subClause_iso.repository";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import Alert from "../../../../components/Alert";
@@ -301,7 +301,8 @@ const ISO42001Clause = ({
               onChange={handleAccordionChange(clause.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                 />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/index.tsx
+++ b/Clients/src/presentation/pages/Framework/index.tsx
@@ -13,7 +13,7 @@ import {
 import HelperDrawer from "../../components/HelperDrawer";
 import HelperIcon from "../../components/HelperIcon";
 import { useContext, useEffect, useState, useMemo } from "react";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg";
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import { ReactComponent as SettingsIcon } from "../../assets/icons/setting-small.svg";
 import { ReactComponent as DeleteIconRed } from "../../assets/icons/trash-filled-red.svg";
 import {ReactComponent as EditIconGrey} from "../../assets/icons/edit.svg";

--- a/Clients/src/presentation/pages/Home/1.0Home/index.tsx
+++ b/Clients/src/presentation/pages/Home/1.0Home/index.tsx
@@ -7,7 +7,7 @@ import {
   vwhomeHeading,
 } from "./style";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as AddCircleOutlineIcon } from "../../../assets/icons/plus-circle-white.svg"
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react"
 import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import CustomizableToast from "../../../components/Toast";
 import Alert from "../../../components/Alert";
@@ -221,7 +221,7 @@ const Home = () => {
                   border: "1px solid #13715B",
                   gap: 2,
                 }}
-                icon={<AddCircleOutlineIcon />}
+                icon={<AddCircleOutlineIcon size={20} />}
                 onClick={() => setIsProjectFormModalOpen(true)}
                 isDisabled={
                   !allowedRoles.projects.create.includes(userRoleName)

--- a/Clients/src/presentation/pages/ISO/Annex/index.tsx
+++ b/Clients/src/presentation/pages/ISO/Annex/index.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useCallback, useEffect, useState } from "react";
-import { ReactComponent as RightArrowBlack } from "../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import VWISO42001AnnexDrawerDialog from "../../../components/Drawer/AnnexDrawerDialog";
 import { Project } from "../../../../domain/types/Project";
 import { GetAnnexesByProjectFrameworkId } from "../../../../application/repository/annex_struct_iso.repository";
@@ -201,7 +201,8 @@ const ISO42001Annex = ({
                   sx={styles.accordion}
                 >
                   <AccordionSummary sx={styles.accordionSummary}>
-                    <RightArrowBlack
+                    <ArrowRight
+                      size={20}
                       style={styles.expandIcon(expanded === annex.id) as React.CSSProperties}
                     />
                     {annex.title}

--- a/Clients/src/presentation/pages/ISO/Clause/index.tsx
+++ b/Clients/src/presentation/pages/ISO/Clause/index.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
   CircularProgress,
 } from "@mui/material";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 import VWISO42001ClauseDrawerDialog from "../../../components/Drawer/ClauseDrawerDialog";
 import { Project } from "../../../../domain/types/Project";
@@ -269,7 +269,8 @@ const ISO42001Clauses = ({
               onChange={handleAccordionChange(clause.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                 />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/ModelInventory/ModelRisksTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelRisksTable.tsx
@@ -17,7 +17,7 @@ import Placeholder from "../../assets/imgs/empty-state.svg";
 import singleTheme from "../../themes/v1SingleTheme";
 import IconButton from "../../components/IconButton";
 import TablePaginationActions from "../../components/TablePagination";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import RiskChip from "../../components/RiskLevel/RiskChip";
 import { IModelRisk } from "../../../domain/interfaces/i.modelRisk";
 import { User } from "../../../domain/types/User";
@@ -323,7 +323,7 @@ const ModelRisksTable: React.FC<ModelRisksTableProps> = ({
                         sx: { mt: theme.spacing(-2) },
                       },
                       inputProps: { id: "pagination-dropdown" },
-                      IconComponent: SelectorVertical,
+                      IconComponent: () => <SelectorVertical size={16} />,
                       sx: {
                         ml: theme.spacing(4),
                         mr: theme.spacing(12),

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -49,7 +49,7 @@ import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import Tab from "@mui/material/Tab";
 import { IconButton, InputBase } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 import { searchBoxStyle, inputStyle } from "./style";
 import { ModelInventoryStatus } from "../../../domain/enums/modelInventory.enum";
 
@@ -720,7 +720,7 @@ const ModelInventory: React.FC = () => {
                     aria-expanded={isSearchBarVisible}
                     onClick={() => setIsSearchBarVisible((prev) => !prev)}
                   >
-                    <SearchIcon />
+                    <SearchIcon size={20} />
                   </IconButton>
 
                   {isSearchBarVisible && (

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, Suspense, useMemo } from "react";
 import { Box, Stack, Fade } from "@mui/material";
 import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg";
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import { useSearchParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { setModelInventoryStatusFilter } from "../../../application/redux/ui/uiSlice";
@@ -741,7 +741,7 @@ const ModelInventory: React.FC = () => {
                 variant="contained"
                 sx={addNewModelButtonStyle}
                 text="Add new model"
-                icon={<AddCircleOutlineIcon />}
+                icon={<AddCircleOutlineIcon size={20} />}
                 onClick={handleNewModelInventoryClick}
                 isDisabled={isCreatingDisabled}
               />
@@ -813,7 +813,7 @@ const ModelInventory: React.FC = () => {
                 variant="contained"
                 sx={addNewModelButtonStyle}
                 text="Add model risk"
-                icon={<AddCircleOutlineIcon />}
+                icon={<AddCircleOutlineIcon size={20} />}
                 onClick={handleNewModelRiskClick}
                 isDisabled={isCreatingDisabled}
               />

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -19,7 +19,7 @@ import singleTheme from "../../themes/v1SingleTheme";
 import CustomIconButton from "../../components/IconButton";
 import allowedRoles from "../../../application/constants/permissions";
 import { useAuth } from "../../../application/hooks/useAuth";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import Placeholder from "../../assets/imgs/empty-state.svg";
 import { IModelInventory } from "../../../domain/interfaces/i.modelInventory";
 import { getAllEntities } from "../../../application/repository/entity.repository";
@@ -449,7 +449,7 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
                   select: {
                     MenuProps: paginationMenuProps(theme),
                     inputProps: { id: "pagination-dropdown" },
-                    IconComponent: SelectorVertical,
+                    IconComponent: () => <SelectorVertical size={16} />,
                     sx: paginationSelectStyle(theme),
                   },
                 }}

--- a/Clients/src/presentation/pages/PageNotFound/index.tsx
+++ b/Clients/src/presentation/pages/PageNotFound/index.tsx
@@ -1,5 +1,5 @@
 import { ReactComponent as Background } from "../../assets/imgs/background-grid.svg";
-import { ReactComponent as LeftArrowLong } from "../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { Typography, Stack, useTheme } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
@@ -46,7 +46,7 @@ function PageNotFound() {
             navigate("/");
           }}
         >
-          <LeftArrowLong />
+          <ArrowLeft size={20} />
           <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
             Back to home
           </Typography>

--- a/Clients/src/presentation/pages/PolicyDashboard/PoliciesDashboard.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PoliciesDashboard.tsx
@@ -9,9 +9,8 @@ import {
   InputBase,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon, PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import CustomizableButton from "../../components/Button/CustomizableButton";
-import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import HelperDrawer from "../../components/HelperDrawer";
 import HelperIcon from "../../components/HelperIcon";
 import {
@@ -197,7 +196,7 @@ const PolicyDashboard: React.FC = () => {
                 aria-expanded={isSearchBarVisible}
                 onClick={() => setIsSearchBarVisible((prev) => !prev)}
               >
-                <SearchIcon />
+                <SearchIcon size={20} />
               </IconButton>
 
               {isSearchBarVisible && (

--- a/Clients/src/presentation/pages/PolicyDashboard/PoliciesDashboard.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PoliciesDashboard.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mui/material";
 import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
 import CustomizableButton from "../../components/Button/CustomizableButton";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg";
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import HelperDrawer from "../../components/HelperDrawer";
 import HelperIcon from "../../components/HelperIcon";
 import {
@@ -223,7 +223,7 @@ const PolicyDashboard: React.FC = () => {
               gap: 3,
               height: "fit-content",
             }}
-            icon={<AddCircleOutlineIcon />}
+            icon={<AddCircleOutlineIcon size={20} />}
             onClick={handleAddNewPolicy}
           />
         </Stack>

--- a/Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   Button,
 } from "@mui/material";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { ReactComponent as CheckGreenIcon } from "../../../assets/icons/check-green.svg";
 import { Project } from "../../../../domain/types/Project";
 import { Framework } from "../../../../domain/types/Framework";
@@ -173,7 +173,7 @@ const AddFrameworkModal: React.FC<AddFrameworkModalProps> = ({
             onClick={onClose}
             sx={modalCloseButtonStyle}
           >
-            <CloseGreyIcon/>
+            <CloseGreyIcon size={20} />
           </IconButton>
         </Box>
         {/* Description */}

--- a/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
@@ -8,7 +8,7 @@ import {
   TextField,
   Box,
 } from "@mui/material";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import React, {
   useState,
   useCallback,
@@ -939,7 +939,7 @@ const ProjectSettings = React.memo(
                     option.name.includes("coming soon")
                   }
                   filterSelectedOptions
-                  popupIcon={<GreyDownArrowIcon />}
+                  popupIcon={<GreyDownArrowIcon size={20} />}
                   renderInput={(params) => (
                     <TextField
                       {...params}
@@ -1094,7 +1094,7 @@ const ProjectSettings = React.memo(
                   : "No options"
               }
               onChange={handleOnMultiSelect("members")}
-              popupIcon={<GreyDownArrowIcon />}
+              popupIcon={<GreyDownArrowIcon size={20} />}
               renderInput={(params) => (
                 <TextField
                   {...params}

--- a/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
@@ -34,7 +34,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import useProjectData from "../../../../application/hooks/useProjectData";
 import useUsers from "../../../../application/hooks/useUsers";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { ReactComponent as DeleteIconWhite } from "../../../assets/icons/trash-filled-white.svg";
 import CustomizableToast from "../../../components/Toast";
 import CustomizableSkeleton from "../../../components/Skeletons";
@@ -1222,7 +1222,7 @@ const ProjectSettings = React.memo(
                     : "1px solid #13715B",
                   gap: 2,
                 }}
-                icon={<SaveIconSVGWhite />}
+                icon={<SaveIconSVGWhite size={20} />}
                 variant="contained"
                 onClick={(event: any) => {
                   handleSubmit(event);

--- a/Clients/src/presentation/pages/RiskManagement/index.tsx
+++ b/Clients/src/presentation/pages/RiskManagement/index.tsx
@@ -3,7 +3,7 @@ import { Box, Stack } from "@mui/material";
 import RisksCard from "../../components/Cards/RisksCard";
 import RiskFilters from "../../components/RiskVisualization/RiskFilters";
 import CustomizableButton from "../../components/Button/CustomizableButton";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg"
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react"
 import VWProjectRisksTable from "../../components/Table/VWProjectRisksTable";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
 import AddNewRiskForm from "../../components/AddNewRiskForm";
@@ -389,7 +389,7 @@ const RiskManagement = () => {
                 gap: 2,
               }}
               onClick={handleAIModalOpen}
-              icon={<AddCircleOutlineIcon />}
+              icon={<AddCircleOutlineIcon size={20} />}
               isDisabled={
                 !allowedRoles.projectRisks.create.includes(userRoleName)
               }
@@ -403,7 +403,7 @@ const RiskManagement = () => {
                 gap: 2,
               }}
               onClick={handleOpenOrClose}
-              icon={<AddCircleOutlineIcon />}
+              icon={<AddCircleOutlineIcon size={20} />}
               isDisabled={
                 !allowedRoles.projectRisks.create.includes(userRoleName)
               }

--- a/Clients/src/presentation/pages/SettingsPage/Organization/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Organization/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import Field from "../../../components/Inputs/Field";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { useState, useCallback, ChangeEvent, useEffect, useRef } from "react";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import {
@@ -428,7 +428,7 @@ const Organization = () => {
                 isLoading ? (
                   <CircularProgress size={20} />
                 ) : (
-                  <SaveIconSVGWhite />
+                  <SaveIconSVGWhite size={20} />
                 )
               }
               onClick={organizationExists ? handleUpdate : handleCreate}

--- a/Clients/src/presentation/pages/SettingsPage/Password/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Password/index.tsx
@@ -13,7 +13,7 @@ import Alert from "../../../components/Alert";
 import { store } from "../../../../application/redux/store";
 import { extractUserToken } from "../../../../application/tools/extractToken";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import CustomizableSkeleton from "../../../components/Skeletons";
 import CustomizableToast from "../../../components/Toast"; // Import CustomizableToast
 import { updatePassword } from "../../../../application/repository/user.repository";
@@ -285,7 +285,7 @@ const PasswordForm: React.FC = () => {
                     : "1px solid #13715B",
                   gap: 2,
                 }}
-                icon={<SaveIconSVGWhite />}
+                icon={<SaveIconSVGWhite size={20} />}
                 onClick={() => setIsConfirmationModalOpen(true)}
                 isDisabled={isSaveDisabled}
               />

--- a/Clients/src/presentation/pages/SettingsPage/Profile/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Profile/index.tsx
@@ -17,7 +17,7 @@ import Alert from "../../../components/Alert";
 import { store } from "../../../../application/redux/store";
 import { extractUserToken } from "../../../../application/tools/extractToken";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save as SaveIconSVGWhite } from "lucide-react";
 import { ReactComponent as DeleteIconWhite } from "../../../assets/icons/trash-filled-white.svg";
 import CustomizableSkeleton from "../../../components/Skeletons";
 import CustomizableToast from "../../../components/Toast";
@@ -486,7 +486,7 @@ const ProfileForm: React.FC = () => {
                 : "1px solid #13715B",
               gap: 2,
             }}
-            icon={<SaveIconSVGWhite />}
+            icon={<SaveIconSVGWhite size={20} />}
             onClick={handleSave}
             isDisabled={isSaveDisabled}
           />

--- a/Clients/src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx
@@ -9,7 +9,7 @@ import {
 import React, { useEffect, useMemo, useState } from "react";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
 import { viewProjectButtonStyle } from "../../../components/Cards/ProjectCard/style";
-import { ReactComponent as ExpandMoreIcon } from "../../../assets/icons/expand-down.svg";
+import { ChevronDown } from "lucide-react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import {
   sendSlackMessage,
@@ -226,7 +226,7 @@ const NotificationRoutingModal: React.FC<NotificationRoutingModalProps> = ({
                   );
                 }}
                 filterSelectedOptions
-                popupIcon={<ExpandMoreIcon />}
+                popupIcon={<ChevronDown size={16} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}

--- a/Clients/src/presentation/pages/SettingsPage/Slack/SlackIntegrations.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Slack/SlackIntegrations.tsx
@@ -1,6 +1,6 @@
 import TablePaginationActions from "@mui/material/TablePagination/TablePaginationActions";
 import { singleTheme } from "../../../themes";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import {
   Box,
   Stack,
@@ -298,7 +298,7 @@ const SlackIntegrations = ({
                       sx: { mt: theme.spacing(-2) },
                     },
                     inputProps: { id: "pagination-dropdown" },
-                    IconComponent: SelectorVertical,
+                    IconComponent: () => <SelectorVertical size={16} />,
                     sx: {
                       ml: theme.spacing(4),
                       mr: theme.spacing(12),

--- a/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
@@ -24,12 +24,12 @@ import {
   TablePagination,
   TableFooter,
 } from "@mui/material";
-import {ReactComponent as GroupsIcon} from "../../../assets/icons/group.svg";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { Users as GroupsIcon } from "lucide-react";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import TablePaginationActions from "../../../components/TablePagination";
 import InviteUserModal from "../../../components/Modals/InviteUser";
 import DualButtonModal from "../../../components/Dialogs/DualButtonModal";
-import {ReactComponent as DeleteIconGrey} from "../../../assets/icons/trash-grey.svg"
+import { Trash2 as DeleteIconGrey } from "lucide-react"
 import { handleAlert } from "../../../../application/tools/alertUtils";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
 import singleTheme from "../../../themes/v1SingleTheme";
@@ -357,7 +357,7 @@ const TeamManagement: React.FC = (): JSX.Element => {
                   border: "1px solid #13715B",
                   gap: 2,
                 }}
-                icon={<GroupsIcon />}
+                icon={<GroupsIcon size={20} />}
                 onClick={() => inviteTeamMember()}
               />
             </Box>
@@ -475,7 +475,7 @@ const TeamManagement: React.FC = (): JSX.Element => {
                                 disableRipple
                                 disabled={member.id === userId}
                               >
-                                <DeleteIconGrey />
+                                <DeleteIconGrey size={20} />
                               </IconButton>
                             </TableCell>
                           </TableRow>
@@ -534,7 +534,7 @@ const TeamManagement: React.FC = (): JSX.Element => {
                               sx: { mt: theme.spacing(-2) },
                             },
                             inputProps: { id: "pagination-dropdown" },
-                            IconComponent: SelectorVertical,
+                            IconComponent: () => <SelectorVertical size={16} />,
                             sx: {
                               ml: theme.spacing(4),
                               mr: theme.spacing(12),

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -11,7 +11,7 @@ import {
   TextField,
   Autocomplete,
 } from "@mui/material";
-import { ReactComponent as AddCircleIcon } from "../../assets/icons/add-circle.svg";
+import { PlusCircle as AddCircleIcon } from "lucide-react";
 import { SearchBox } from "../../components/Search";
 import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
 import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
@@ -406,7 +406,7 @@ const Tasks: React.FC = () => {
               border: "1px solid #13715B",
               gap: 2,
             }}
-            icon={<AddCircleIcon />}
+            icon={<AddCircleIcon size={20} />}
             onClick={handleCreateTask}
             isDisabled={isCreatingDisabled}
           />

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -11,11 +11,8 @@ import {
   TextField,
   Autocomplete,
 } from "@mui/material";
-import { PlusCircle as AddCircleIcon } from "lucide-react";
+import { PlusCircle as AddCircleIcon, Filter as FilterIcon, X as ClearIcon, ChevronDown, ChevronUp } from "lucide-react";
 import { SearchBox } from "../../components/Search";
-import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
-import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
-import { ChevronDown, ChevronUp } from "lucide-react";
 import TasksTable from "../../components/Table/TasksTable";
 import CustomizableButton from "../../components/Button/CustomizableButton";
 import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
@@ -474,7 +471,8 @@ const Tasks: React.FC = () => {
           >
             <Stack direction="row" alignItems="center" spacing={1.5}>
               <FilterIcon
-                style={{ color: "#13715B", width: "20px", height: "20px" }}
+                size={20}
+                style={{ color: "#13715B" }}
               />
               <Typography
                 variant="subtitle2"
@@ -505,7 +503,7 @@ const Tasks: React.FC = () => {
               {activeFilterCount > 0 && (
                 <Button
                   size="small"
-                  startIcon={<ClearIcon />}
+                  startIcon={<ClearIcon size={16} />}
                   onClick={(e: React.MouseEvent) => {
                     e.stopPropagation();
                     clearAllFilters();

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -15,8 +15,7 @@ import { ReactComponent as AddCircleIcon } from "../../assets/icons/add-circle.s
 import { SearchBox } from "../../components/Search";
 import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
 import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import TasksTable from "../../components/Table/TasksTable";
 import CustomizableButton from "../../components/Button/CustomizableButton";
 import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
@@ -524,7 +523,7 @@ const Tasks: React.FC = () => {
                 </Button>
               )}
               <IconButton size="small">
-                {filtersExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                {filtersExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
               </IconButton>
             </Stack>
           </Box>
@@ -634,7 +633,7 @@ const Tasks: React.FC = () => {
                     }}
                     getOptionLabel={(option: string) => option}
                     filterSelectedOptions
-                    popupIcon={<ExpandMoreIcon />}
+                    popupIcon={<ChevronDown size={16} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}

--- a/Clients/src/presentation/pages/TrainingRegistar/index.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/index.tsx
@@ -27,7 +27,7 @@ import HelperDrawer from "../../components/HelperDrawer";
 import HelperIcon from "../../components/HelperIcon";
 import { useAuth } from "../../../application/hooks/useAuth";
 import PageHeader from "../../components/Layout/PageHeader";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 import Select from "../../components/Inputs/Select";
 import { searchBoxStyle, inputStyle } from "./style";
 
@@ -334,7 +334,7 @@ const Training: React.FC = () => {
                   aria-expanded={isSearchBarVisible}
                   onClick={() => setIsSearchBarVisible((prev) => !prev)}
                 >
-                  <SearchIcon />
+                  <SearchIcon size={20} />
                 </IconButton>
 
                 {isSearchBarVisible && (

--- a/Clients/src/presentation/pages/TrainingRegistar/index.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/index.tsx
@@ -9,7 +9,7 @@ import {
   InputBase,
 } from "@mui/material";
 import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg";
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import CustomizableButton from "../../components/Button/CustomizableButton";
 import { logEngine } from "../../../application/tools/log.engine"; // Assuming this path is correct
 import {
@@ -359,7 +359,7 @@ const Training: React.FC = () => {
                         gap: 2,
                       }}
                       text="New training"
-                      icon={<AddCircleOutlineIcon />}
+                      icon={<AddCircleOutlineIcon size={20} />}
                       onClick={handleNewTrainingClick}
                       isDisabled={isCreatingDisabled}
                     />

--- a/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
@@ -17,7 +17,7 @@ import "../../components/Table/index.css";
 import singleTheme from "../../themes/v1SingleTheme";
 import CustomIconButton from "../../components/IconButton";
 import allowedRoles from "../../../application/constants/permissions";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import Placeholder from "../../assets/imgs/empty-state.svg";
 import { useAuth } from "../../../application/hooks/useAuth";
 import { getPaginationRowCount, setPaginationRowCount } from "../../../application/utils/paginationStorage";
@@ -357,7 +357,7 @@ const TrainingTable: React.FC<TrainingTableProps> = ({
                       sx: { mt: theme.spacing(-2) },
                     },
                     inputProps: { id: "pagination-dropdown" },
-                    IconComponent: SelectorVertical,
+                    IconComponent: () => <SelectorVertical size={16} />,
                     sx: {
                       ml: theme.spacing(4),
                       mr: theme.spacing(12),

--- a/Clients/src/presentation/pages/Vendors/index.tsx
+++ b/Clients/src/presentation/pages/Vendors/index.tsx
@@ -24,7 +24,7 @@ import useMultipleOnScreen from "../../../application/hooks/useMultipleOnScreen"
 import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg"
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react"
 import AddNewRisk from "../../components/Modals/NewRisk";
 import CustomizableButton from "../../components/Button/CustomizableButton";
 import CustomizableSkeleton from "../../components/Skeletons";
@@ -524,7 +524,7 @@ const Vendors = () => {
                       border: "1px solid #13715B",
                       gap: 2,
                     }}
-                    icon={<AddCircleOutlineIcon />}
+                    icon={<AddCircleOutlineIcon size={20} />}
                     onClick={() => {
                       openAddNewVendor();
                       setSelectedVendor(null);

--- a/Clients/src/presentation/structures/ComplianceTracker/01-ai-literacy.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/01-ai-literacy.subcontrol.ts
@@ -1,4 +1,4 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
+import { CheckCircle as Checked } from "lucide-react";
 
 export const AIliteracy = {
   id: 1,

--- a/Clients/src/presentation/structures/ComplianceTracker/02-transparency-provision.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/02-transparency-provision.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const TransparencyProvision = {
   id: 2,

--- a/Clients/src/presentation/structures/ComplianceTracker/03-human-oversight .subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/03-human-oversight .subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const HumanOversight = {
   id: 3,

--- a/Clients/src/presentation/structures/ComplianceTracker/04-corrective-actions.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/04-corrective-actions.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const CorrectiveActionsDutyOfInfo = {
   id: 4,

--- a/Clients/src/presentation/structures/ComplianceTracker/05-responsibilities.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/05-responsibilities.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const ResponsibilitiesAlongAI = {
   id: 5,

--- a/Clients/src/presentation/structures/ComplianceTracker/06-obligations-of-deployers.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/06-obligations-of-deployers.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const ObligationsOfDeployersAIsystems = {
   id: 6,

--- a/Clients/src/presentation/structures/ComplianceTracker/07-fundamental-rights.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/07-fundamental-rights.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const FundamentalRightsImpactAssessments = {
   id: 7,

--- a/Clients/src/presentation/structures/ComplianceTracker/08-transparency-obligations-for-providers.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/08-transparency-obligations-for-providers.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const TransparencyObligationsForProviders = {
   id: 7,

--- a/Clients/src/presentation/structures/ComplianceTracker/09-registration.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/09-registration.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const Registration = {
   id: 9,

--- a/Clients/src/presentation/structures/ComplianceTracker/10-eu-database-for-high-risk.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/10-eu-database-for-high-risk.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const EUdatabaseForHighRiskAI = {
   id: 10,

--- a/Clients/src/presentation/structures/ComplianceTracker/11-post-market-monitor-by-providers.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/11-post-market-monitor-by-providers.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const PostMarketMonitoringByProviders = {
   id: 11,

--- a/Clients/src/presentation/structures/ComplianceTracker/12-report-serious-incidents.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/12-report-serious-incidents.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const ReportingSeriousIncidents = {
   id: 12,

--- a/Clients/src/presentation/structures/ComplianceTracker/13-general-purpose-ai.subcontrol.ts
+++ b/Clients/src/presentation/structures/ComplianceTracker/13-general-purpose-ai.subcontrol.ts
@@ -1,5 +1,5 @@
-import Checked from "../../assets/icons/check-circle-green.svg";
-import Exclamation from "../../assets/icons/alert-circle-orange.svg";
+import { CheckCircle as Checked } from "lucide-react";
+import { AlertCircle as Exclamation } from "lucide-react";
 
 export const GeneralPurposeAImodels = {
   id: 13,


### PR DESCRIPTION
## Summary
• Migrate chevron dropdowns, table pagination, close buttons, trash icons, format icons, and status icons
• Replace 10+ icon types across 75 files with consistent Lucide React components
• Apply standardized sizing (13-48px) based on context

## Test plan
- [x] Build compiles successfully 
- [x] Icon functionality preserved across components
- [x] Visual consistency maintained