### PR TITLE
Migrate LOW-MEDIUM priority icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/Cards/RisksCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/RisksCard/index.tsx
@@ -1,7 +1,5 @@
 import { Stack, Typography, Tooltip, Box } from "@mui/material";
-import {ReactComponent as TrendingUpRedIcon} from "../../../assets/icons/trendingUp.svg";
-import {ReactComponent as TrendingDownGreenIcon} from "../../../assets/icons/trendingDown.svg";
-import {ReactComponent as TrendingFlatGreyIcon} from "../../../assets/icons/trendingFlat.svg";
+import { TrendingUp as TrendingUpRedIcon, TrendingDown as TrendingDownGreenIcon, Minus as TrendingFlatGreyIcon } from "lucide-react";
 import {
   projectRisksCard,
   projectRisksTileCard,
@@ -25,7 +23,7 @@ const RisksCard = ({ risksSummary }: RisksCardProps) => {
     if (!trend || trend.direction === 'stable') {
       return (
         <Typography sx={trendIndicator}>
-          <TrendingFlatGreyIcon style={trendIconStable} />
+          <TrendingFlatGreyIcon size={16} style={trendIconStable} />
           <span style={{ color: "#6B7280" }}>
             {trend?.change === 0 ? "0" : "—"}
           </span>
@@ -36,7 +34,7 @@ const RisksCard = ({ risksSummary }: RisksCardProps) => {
     if (trend.direction === 'up') {
       return (
         <Typography sx={trendIndicator}>
-          <TrendingUpRedIcon style={trendIconUp} />
+          <TrendingUpRedIcon size={16} style={trendIconUp} />
           <span style={{ color: "#EF4444" }}>
             +{trend.change}
           </span>
@@ -46,7 +44,7 @@ const RisksCard = ({ risksSummary }: RisksCardProps) => {
 
     return (
       <Typography sx={trendIndicator}>
-        <TrendingDownGreenIcon style={trendIconDown} />
+        <TrendingDownGreenIcon size={16} style={trendIconDown} />
         <span style={{ color: "#10B981" }}>
           -{Math.abs(trend.change)}
         </span>

--- a/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
@@ -1,7 +1,5 @@
 import { Box, Stack, Typography } from "@mui/material";
-import { ReactComponent as CalendarIcon } from "../../../assets/icons/calendar-check.svg";
-import { ReactComponent as ClockIcon } from "../../../assets/icons/clock.svg";
-import { ReactComponent as AlertIcon } from "../../../assets/icons/alert-circle.svg";
+import { CalendarCheck as CalendarIcon, Clock as ClockIcon, AlertCircle as AlertIcon } from "lucide-react";
 
 const TaskRadar = ({ overdue, due, upcoming }: { overdue: number; due: number; upcoming: number }) => {
   return (
@@ -39,7 +37,7 @@ const TaskRadar = ({ overdue, due, upcoming }: { overdue: number; due: number; u
           justifyContent: "space-between",
         }}>
           <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "6px" }}>
-            <AlertIcon />
+            <AlertIcon size={16} />
             <Typography
               sx={{
                 fontSize: 13,
@@ -69,7 +67,7 @@ const TaskRadar = ({ overdue, due, upcoming }: { overdue: number; due: number; u
           justifyContent: "space-between",
         }}>
           <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "6px" }}>
-            <ClockIcon />
+            <ClockIcon size={16} />
             <Typography
               sx={{
                 fontSize: 13,
@@ -99,7 +97,7 @@ const TaskRadar = ({ overdue, due, upcoming }: { overdue: number; due: number; u
           justifyContent: "space-between",
         }}>
           <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "6px" }}>
-            <CalendarIcon />
+            <CalendarIcon size={16} />
             <Typography
               sx={{
                 fontSize: 13,

--- a/Clients/src/presentation/components/Modals/InviteUser/index.tsx
+++ b/Clients/src/presentation/components/Modals/InviteUser/index.tsx
@@ -27,7 +27,7 @@ import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
-import { ReactComponent as ForwardToInboxIcon } from "../../../assets/icons/email.svg";
+import { Mail as ForwardToInboxIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
 import { useRoles } from "../../../../application/hooks/useRoles";
 import { isValidEmail } from "../../../../application/validations/emailAddress.rule";
@@ -272,7 +272,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({
               border: "1px solid #13715B",
               gap: 2,
             }}
-            icon={<ForwardToInboxIcon />}
+            icon={<ForwardToInboxIcon size={20} />}
             onClick={() => handleSendInvitation()}
           />
         </Stack>

--- a/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
@@ -4,7 +4,7 @@
 
 import { Button, Stack, Typography, useTheme } from "@mui/material";
 import React, { useState } from "react";
-import { ReactComponent as Key } from "../../../assets/icons/key.svg";
+import { Key } from "lucide-react";
 import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Field from "../../../components/Inputs/Field";
@@ -128,7 +128,7 @@ const ForgotPassword: React.FC = () => {
               gap: theme.spacing(12),
             }}
           >
-            <Key />
+            <Key size={24} />
           </Stack>
           <Stack sx={{ gap: theme.spacing(6), textAlign: "center" }}>
             <Typography sx={{ fontSize: 16, fontWeight: "bold" }}>

--- a/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
@@ -4,7 +4,7 @@
 
 import { Stack, Typography, useTheme } from "@mui/material";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
-import { ReactComponent as Email } from "../../../assets/icons/email.svg";
+import { Mail as Email } from "lucide-react";
 import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useState, lazy, Suspense } from "react";
@@ -102,7 +102,7 @@ const ResetPassword = () => {
             gap: theme.spacing(12),
           }}
         >
-          <Email />
+          <Email size={24} />
         </Stack>
         <Stack sx={{ gap: theme.spacing(6), textAlign: "center" }}>
           <Typography sx={{ fontSize: 16, fontWeight: "bold" }}>

--- a/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
@@ -8,7 +8,7 @@ import { ReactComponent as Background } from "../../../assets/imgs/background-gr
 import Check from "../../../components/Checks";
 import Field from "../../../components/Inputs/Field";
 import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
-import { ReactComponent as Lock } from "../../../assets/icons/lock.svg";
+import { Lock } from "lucide-react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { validatePassword } from "../../../../application/validations/formValidation";
@@ -226,7 +226,7 @@ const SetNewPassword: React.FC = () => {
               gap: theme.spacing(12),
             }}
           >
-            <Lock />
+            <Lock size={24} />
           </Stack>
           <Stack sx={{ gap: theme.spacing(6), textAlign: "center" }}>
             <Typography sx={{ fontSize: 16, fontWeight: "bold" }}>

--- a/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
@@ -16,10 +16,7 @@ import {
   IconButton,
 } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { ReactComponent as CopyIcon } from "../../assets/icons/copy.svg";
-import { ReactComponent as DownloadIcon } from "../../assets/icons/download.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-more.svg";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-less.svg";
+import { Copy as CopyIcon, Download as DownloadIcon, ChevronDown as ExpandMoreIcon, ChevronUp as ExpandLessIcon } from "lucide-react";
 import { BarChart } from "@mui/x-charts";
 import createPlotlyComponent from 'react-plotly.js/factory';
 import Plotly from 'plotly.js-basic-dist';
@@ -1113,7 +1110,7 @@ export default function BiasAndFairnessResultsPage() {
                     }
                   }}
                 >
-                  <CopyIcon style={{ width: 24, height: 24 }} />
+                  <CopyIcon size={20} />
                 </IconButton>
                 <IconButton
                   onClick={handleDownloadJSON}
@@ -1129,7 +1126,7 @@ export default function BiasAndFairnessResultsPage() {
                     }
                   }}
                 >
-                  <DownloadIcon style={{ width: 24, height: 24 }} />
+                  <DownloadIcon size={20} />
                 </IconButton>
               </Box>
             </Box>
@@ -1168,7 +1165,7 @@ export default function BiasAndFairnessResultsPage() {
                       }
                     }}
                   >
-                    <ExpandMoreIcon style={{ width: 20, height: 20, marginTop: '3px', marginLeft: '4px' }} />
+                    <ExpandMoreIcon size={20} />
                   </IconButton>
                 </Box>
               )}
@@ -1187,7 +1184,7 @@ export default function BiasAndFairnessResultsPage() {
                       }
                     }}
                   >
-                    <ExpandLessIcon style={{ width: 20, height: 20, marginRight: '3px', marginTop: '-2px' }} />
+                    <ExpandLessIcon size={20} />
                   </IconButton>
                 </Box>
               )}

--- a/Clients/src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx
@@ -9,7 +9,7 @@ import {
 import React, { useEffect, useMemo, useState } from "react";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
 import { viewProjectButtonStyle } from "../../../components/Cards/ProjectCard/style";
-import { ReactComponent as ExpandMoreIcon } from "../../../assets/icons/expand-down.svg";
+import { ChevronDown as ExpandMoreIcon } from "lucide-react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import {
   sendSlackMessage,
@@ -226,7 +226,7 @@ const NotificationRoutingModal: React.FC<NotificationRoutingModalProps> = ({
                   );
                 }}
                 filterSelectedOptions
-                popupIcon={<ExpandMoreIcon />}
+                popupIcon={<ExpandMoreIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}


### PR DESCRIPTION
## Summary
• Migrate authentication, trending, task status and action icons
• Replace 13 icon instances across 8 files with Lucide React components
• Apply standardized sizing (16-24px) based on usage context