### PR TITLE
Migrate MEDIUM priority MUI and SVG icons to Lucide React

### DIFF
--- a/Clients/src/application/commands/registry.ts
+++ b/Clients/src/application/commands/registry.ts
@@ -1,21 +1,21 @@
 import { Command, CommandGroup, CommandContext, CommandRegistry } from './types'
 import allowedRoles from '../constants/permissions'
 import {
-  HomeOutlined,
-  WarningAmberOutlined,
-  BusinessOutlined,
-  AccountTreeOutlined,
-  SchoolOutlined,
-  FolderOutlined,
-  TimelineOutlined,
-  AccountBalanceOutlined,
-  BalanceOutlined,
-  SettingsOutlined,
-  AssignmentOutlined,
-  PolicyOutlined,
-  VerifiedUserOutlined,
-  GroupOutlined
-} from '@mui/icons-material'
+  Home as HomeOutlined,
+  AlertTriangle as WarningAmberOutlined,
+  Building2 as BusinessOutlined,
+  GitBranch as AccountTreeOutlined,
+  GraduationCap as SchoolOutlined,
+  Folder as FolderOutlined,
+  Activity as TimelineOutlined,
+  Landmark as AccountBalanceOutlined,
+  Scale as BalanceOutlined,
+  Settings as SettingsOutlined,
+  ClipboardList as AssignmentOutlined,
+  FileText as PolicyOutlined,
+  ShieldCheck as VerifiedUserOutlined,
+  Users as GroupOutlined
+} from 'lucide-react'
 
 // Define command groups
 export const COMMAND_GROUPS: CommandGroup[] = [

--- a/Clients/src/presentation/components/Breadcrumbs/index.tsx
+++ b/Clients/src/presentation/components/Breadcrumbs/index.tsx
@@ -9,7 +9,7 @@ import {
 import { useLocation, useNavigate } from "react-router-dom";
 import { getRouteMapping } from "./routeMapping";
 
-import { ReactComponent as ChevronRightGreyIcon } from "../../assets/icons/chevron-right-grey.svg";
+import { ChevronRight as ChevronRightGreyIcon } from "lucide-react";
 import {
   IBreadcrumbItem,
   IBreadcrumbsProps,
@@ -25,7 +25,7 @@ import {
  */
 const Breadcrumbs: React.FC<IBreadcrumbsProps> = ({
   items,
-  separator = <ChevronRightGreyIcon style={{ width: "80%", height: "auto" }} />,
+  separator = <ChevronRightGreyIcon size={16} />,
   maxItems = 8,
   sx,
   autoGenerate = false,

--- a/Clients/src/presentation/components/HelperIcon/index.tsx
+++ b/Clients/src/presentation/components/HelperIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IconButton } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 
 interface HelperIconProps {
   onClick: () => void;
@@ -23,7 +23,7 @@ const HelperIcon: React.FC<HelperIconProps> = ({ onClick, size = "small" }) => {
         },
       }}
     >
-      <GreyCircleInfoIcon />
+      <GreyCircleInfoIcon size={20} />
     </IconButton>
   );
 };

--- a/Clients/src/presentation/components/Inputs/Field/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Field/index.tsx
@@ -33,8 +33,7 @@ import {
 } from "@mui/material";
 import "./index.css";
 import { forwardRef, useState } from "react";
-import {ReactComponent as VisibilityIcon} from "../../../assets/icons/visibility-grey.svg"
-import {ReactComponent as VisibilityOffIcon} from "../../../assets/icons/visibility-off-grey.svg"
+import { Eye as VisibilityIcon, EyeOff as VisibilityOffIcon } from "lucide-react";
 import { ForwardedRef } from "react";
 import { FieldProps as OriginalFieldProps } from "../../../../domain/interfaces/iWidget";
 
@@ -194,7 +193,7 @@ const Field = forwardRef(
                     },
                   }}
                 >
-                  {!isVisible ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                  {!isVisible ? <VisibilityOffIcon size={20} /> : <VisibilityIcon size={20} />}
                 </IconButton>
               </InputAdornment>
             ),

--- a/Clients/src/presentation/components/MetricInfoIcon/index.tsx
+++ b/Clients/src/presentation/components/MetricInfoIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IconButton, Box } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 
 interface MetricInfoIconProps {
   onClick: () => void;
@@ -24,7 +24,7 @@ const MetricInfoIcon = React.forwardRef<HTMLDivElement, MetricInfoIconProps>(({ 
           },
         }}
       >
-        <GreyCircleInfoIcon />
+        <GreyCircleInfoIcon size={20} />
       </IconButton>
     </Box>
   );

--- a/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
@@ -9,8 +9,7 @@ import {
   Collapse,
   IconButton,
 } from "@mui/material";
-import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
-import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
+import { Filter as FilterIcon, XCircle as ClearIcon } from "lucide-react";
 import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
 import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
@@ -305,7 +304,7 @@ const RiskFilters: React.FC<RiskFiltersProps> = ({
         onClick={() => handleExpandedChange(!expanded)}
       >
         <Stack direction="row" alignItems="center" spacing={1}>
-          <FilterIcon style={{ color: "#13715B", height: "20px", width:"20px" }} />
+          <FilterIcon style={{ color: "#13715B" }} size={20} />
           <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "#1A1919" }}>
             Filters
           </Typography>
@@ -332,7 +331,7 @@ const RiskFilters: React.FC<RiskFiltersProps> = ({
           {activeFilterCount > 0 && (
             <Button
               size="small"
-              startIcon={<ClearIcon />}
+              startIcon={<ClearIcon size={16} />}
               onClick={(e) => {
                 e.stopPropagation();
                 clearAllFilters();

--- a/Clients/src/presentation/components/Search/SearchBox/index.tsx
+++ b/Clients/src/presentation/components/Search/SearchBox/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, InputBase, SxProps, Theme } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 
 export interface SearchBoxProps {
   placeholder?: string;
@@ -45,7 +45,7 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 
   return (
     <Box sx={searchBoxStyle}>
-      <SearchIcon style={{ color: "#6b7280", marginRight: "8px" }} />
+      <SearchIcon size={16} style={{ color: "#6b7280", marginRight: "8px" }} />
       <InputBase
         placeholder={placeholder}
         value={value}

--- a/Clients/src/presentation/components/StatusDropdown/index.tsx
+++ b/Clients/src/presentation/components/StatusDropdown/index.tsx
@@ -21,7 +21,7 @@ import {
   useTheme,
   SelectChangeEvent,
 } from "@mui/material";
-import { ReactComponent as WhiteDownArrowIcon  } from "../../assets/icons/chevron-down-white.svg";
+import { ChevronDown as WhiteDownArrowIcon } from "lucide-react";
 import { getStatusColor } from "../../pages/ISO/style";
 
 interface StatusDropdownProps {

--- a/Clients/src/presentation/components/VWQuestion/index.tsx
+++ b/Clients/src/presentation/components/VWQuestion/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Chip, Stack, Tooltip, Typography, Dialog, useTheme } from "@mui/material";
 import { Question } from "../../../domain/types/Question";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 import {
   priorities,
   PriorityLevel,
@@ -260,7 +260,7 @@ const QuestionFrame = ({
                 }}
               >
                 <Box component="span" sx={{ display: "inline-flex", cursor: "pointer" }}>
-          <GreyCircleInfoIcon />
+          <GreyCircleInfoIcon size={16} />
         </Box>
               </Tooltip>
             </Box>

--- a/Clients/src/presentation/components/ViewToggle/index.tsx
+++ b/Clients/src/presentation/components/ViewToggle/index.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { ToggleButton, ToggleButtonGroup, useTheme } from "@mui/material";
 import { SxProps, Theme } from "@mui/material/styles";
-import {ReactComponent as ViewModuleIcon} from "../../assets/icons/viewModule.svg";
-import {ReactComponent as TableRowsIcon} from "../../assets/icons/tableRows.svg";
+import { LayoutGrid as ViewModuleIcon, List as TableRowsIcon } from "lucide-react";
 
 export type ViewMode = "card" | "table";
 
@@ -92,10 +91,10 @@ const ViewToggle: React.FC<ViewToggleProps> = ({
       ]}
     >
       <ToggleButton value="card" aria-label="card view" disableRipple>
-        <ViewModuleIcon/>
+        <ViewModuleIcon size={20} />
       </ToggleButton>
       <ToggleButton value="table" aria-label="table view" disableRipple>
-        <TableRowsIcon />
+        <TableRowsIcon size={20} />
       </ToggleButton>
     </ToggleButtonGroup>
   );

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -13,8 +13,7 @@ import {
   Tooltip,
 } from "@mui/material";
 import Alert from "../../../components/Alert";
-import {ReactComponent as VisibilityIcon} from "../../../assets/icons/visibility-grey.svg"
-import {ReactComponent as VisibilityOffIcon} from "../../../assets/icons/visibility-off-grey.svg"
+import { Eye as VisibilityIcon, EyeOff as VisibilityOffIcon } from "lucide-react";
 import { ReactComponent as AddCircleOutlineIcon } from "../../../assets/icons/plus-circle-white.svg";
 import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
 import Toggle from "../../../components/Inputs/Toggle";
@@ -105,13 +104,13 @@ const ResourceTableRow: React.FC<{
         {resource.visible ? (
           <Tooltip title="Click to make this resource invisible">
             <Box component="span" sx={{ display: "inline-flex" }}>
-              <VisibilityIcon/>
+              <VisibilityIcon size={20} />
             </Box>
           </Tooltip>
         ) : (
           <Tooltip title="Click to make this resource visible">
             <Box component="span" sx={{ display: "inline-flex" }}>
-              <VisibilityOffIcon/>
+              <VisibilityOffIcon size={20} />
             </Box>
           </Tooltip>
         )}

--- a/Clients/src/presentation/pages/AITrustCenter/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/index.tsx
@@ -5,7 +5,7 @@ import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
 import Tab from "@mui/material/Tab";
-import {ReactComponent as VisibilityIcon} from "../../assets/icons/visibility-white.svg"
+import { Eye as VisibilityIcon } from "lucide-react";
 import TrustCenterResources from "./Resources";
 import AITrustCenterSubprocessors from "./Subprocessors";
 import AITrustCenterSettings from "./Settings";
@@ -141,7 +141,7 @@ const AITrustCenter: React.FC = () => {
                   opacity: !tenantHash ? 0.5 : 1,
                   cursor: !tenantHash ? "not-allowed" : "pointer",
                 }}
-                icon={<VisibilityIcon />}
+                icon={<VisibilityIcon size={20} />}
                 onClick={handlePreviewMode}
                 isDisabled={!tenantHash}
               />

--- a/Clients/src/presentation/pages/Assessment/NewAssessment/AssessmentQuestions/AssessmentQuestions.tsx
+++ b/Clients/src/presentation/pages/Assessment/NewAssessment/AssessmentQuestions/AssessmentQuestions.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 import RichTextEditor from "../../../../components/RichTextEditor";
 import { priorities, PriorityLevel } from "../priorities";
 import { Topic } from "../../../../../application/hooks/useAssessmentAnswers";
@@ -104,7 +104,7 @@ const AssessmentQuestions = ({
                           },
                         }}
                       >
-                        <GreyCircleInfoIcon fontSize="inherit" />
+                        <GreyCircleInfoIcon size={16} />
                       </Tooltip>
                     </Box>
                   )}

--- a/Clients/src/presentation/pages/DashboardOverview/EnhancedDashboard.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/EnhancedDashboard.tsx
@@ -17,14 +17,14 @@ import {
 } from '@mui/material';
 import {
   Edit as EditIcon,
-  Visibility as ViewIcon,
-  DragIndicator as DragIcon,
+  Eye as ViewIcon,
+  GripVertical as DragIcon,
   Settings as SettingsIcon,
-  Refresh as RefreshIcon,
+  RefreshCw as RefreshIcon,
   Download as DownloadIcon,
   Upload as UploadIcon,
-  RestartAlt as ResetIcon,
-} from '@mui/icons-material';
+  RotateCcw as ResetIcon,
+} from 'lucide-react';
 import { Responsive, WidthProvider, Layout, Layouts } from 'react-grid-layout';
 import { DashboardProvider, useDashboardContext } from './contexts/DashboardContext';
 import { MetricsWidget, ProjectsWidget, RisksWidget } from './widgets';
@@ -231,14 +231,14 @@ const DashboardContent: React.FC = () => {
           {/* Refresh Button */}
           <Tooltip title="Refresh all widgets">
             <IconButton onClick={() => actions.refreshAllWidgets()}>
-              <RefreshIcon />
+              <RefreshIcon size={20} />
             </IconButton>
           </Tooltip>
 
           {/* Settings Menu */}
           <Tooltip title="Dashboard settings">
             <IconButton onClick={handleSettingsClick}>
-              <SettingsIcon />
+              <SettingsIcon size={20} />
             </IconButton>
           </Tooltip>
           <Menu
@@ -247,14 +247,14 @@ const DashboardContent: React.FC = () => {
             onClose={handleSettingsClose}
           >
             <MenuItem onClick={() => { actions.resetLayout(); handleSettingsClose(); }}>
-              <ResetIcon sx={{ mr: 1 }} /> Reset Layout
+              <ResetIcon size={20} style={{ marginRight: 8 }} /> Reset Layout
             </MenuItem>
             <MenuItem onClick={() => { actions.exportDashboard(); handleSettingsClose(); }}>
-              <DownloadIcon sx={{ mr: 1 }} /> Export Dashboard
+              <DownloadIcon size={20} style={{ marginRight: 8 }} /> Export Dashboard
             </MenuItem>
             <Divider />
             <MenuItem disabled>
-              <UploadIcon sx={{ mr: 1 }} /> Import Dashboard
+              <UploadIcon size={20} style={{ marginRight: 8 }} /> Import Dashboard
             </MenuItem>
           </Menu>
 
@@ -269,7 +269,7 @@ const DashboardContent: React.FC = () => {
             }
             label={
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {state.editMode ? <EditIcon /> : <ViewIcon />}
+                {state.editMode ? <EditIcon size={18} /> : <ViewIcon size={18} />}
                 <Typography>{state.editMode ? 'Edit Mode' : 'View Mode'}</Typography>
               </Box>
             }
@@ -429,9 +429,9 @@ const DashboardContent: React.FC = () => {
               avatar={
                 state.editMode && (
                   <DragIcon
-                    sx={{
+                    size={20}
+                    style={{
                       color: alpha(theme.palette.text.secondary, 0.6),
-                      fontSize: '1.2rem',
                     }}
                   />
                 )
@@ -441,7 +441,7 @@ const DashboardContent: React.FC = () => {
                 state.editMode && (
                   <Tooltip title="Widget settings">
                     <IconButton size="small" className="no-drag">
-                      <SettingsIcon fontSize="small" />
+                      <SettingsIcon size={16} />
                     </IconButton>
                   </Tooltip>
                 )

--- a/Clients/src/presentation/pages/FairnessDashboard/FairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/FairnessResultsPage.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from "@mui/material";
 import {ReactComponent as ArrowBackIcon} from "../../assets/icons/left-arrow-long.svg";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 import { BarChart } from "@mui/x-charts";
 import { fairnessService } from "../../../infrastructure/api/fairnessService";
 import singleTheme from "../../themes/v1SingleTheme";
@@ -137,7 +137,7 @@ export default function FairnessResultsPage() {
                 sx={{ fontSize: 13 }}
               >
                 <IconButton size="small" sx={{ ml: 1 }}>
-                  <GreyCircleInfoIcon fontSize="small" />
+                  <GreyCircleInfoIcon size={16} />
                 </IconButton>
               </Tooltip>
             </Box>
@@ -186,7 +186,7 @@ export default function FairnessResultsPage() {
                 sx={{ fontSize: 13 }}
               >
                 <IconButton size="small" sx={{ ml: 1 }}>
-                  <GreyCircleInfoIcon fontSize="small" />
+                  <GreyCircleInfoIcon size={16} />
                 </IconButton>
               </Tooltip>
             </Box>

--- a/Clients/src/presentation/pages/Framework/index.tsx
+++ b/Clients/src/presentation/pages/Framework/index.tsx
@@ -17,7 +17,7 @@ import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-
 import { ReactComponent as SettingsIcon } from "../../assets/icons/setting-small.svg";
 import { ReactComponent as DeleteIconRed } from "../../assets/icons/trash-filled-red.svg";
 import {ReactComponent as EditIconGrey} from "../../assets/icons/edit.svg";
-import { ReactComponent as WhiteDownArrowIcon } from "../../assets/icons/chevron-down-white.svg";
+import { ChevronDown as WhiteDownArrowIcon } from "lucide-react";
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
 import useMultipleOnScreen from "../../../application/hooks/useMultipleOnScreen";
 import singleTheme from "../../themes/v1SingleTheme";
@@ -643,7 +643,7 @@ const Framework = () => {
             <>
               <Button
                 variant="contained"
-                endIcon={<WhiteDownArrowIcon />}
+                endIcon={<WhiteDownArrowIcon size={16} />}
                 onClick={(event) => {
                   setRotated((prev) => !prev);
                   handleManageProjectClick(event);

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -49,7 +49,7 @@ import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import Tab from "@mui/material/Tab";
 import { IconButton, InputBase } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 import { searchBoxStyle, inputStyle } from "./style";
 import { ModelInventoryStatus } from "../../../domain/enums/modelInventory.enum";
 
@@ -720,7 +720,7 @@ const ModelInventory: React.FC = () => {
                     aria-expanded={isSearchBarVisible}
                     onClick={() => setIsSearchBarVisible((prev) => !prev)}
                   >
-                    <SearchIcon />
+                    <SearchIcon size={20} />
                   </IconButton>
 
                   {isSearchBarVisible && (

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -13,8 +13,7 @@ import {
 } from "@mui/material";
 import { ReactComponent as AddCircleIcon } from "../../assets/icons/add-circle.svg";
 import { SearchBox } from "../../components/Search";
-import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
-import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
+import { Filter as FilterIcon, XCircle as ClearIcon } from "lucide-react";
 import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
 import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
 import TasksTable from "../../components/Table/TasksTable";
@@ -475,7 +474,8 @@ const Tasks: React.FC = () => {
           >
             <Stack direction="row" alignItems="center" spacing={1.5}>
               <FilterIcon
-                style={{ color: "#13715B", width: "20px", height: "20px" }}
+                style={{ color: "#13715B" }}
+                size={20}
               />
               <Typography
                 variant="subtitle2"
@@ -506,7 +506,7 @@ const Tasks: React.FC = () => {
               {activeFilterCount > 0 && (
                 <Button
                   size="small"
-                  startIcon={<ClearIcon />}
+                  startIcon={<ClearIcon size={16} />}
                   onClick={(e: React.MouseEvent) => {
                     e.stopPropagation();
                     clearAllFilters();


### PR DESCRIPTION
## Summary
• Migrate filter, view toggle, info, search and navigation icons
• Replace all MUI command registry and dashboard icons with Lucide equivalents  
• Update 32 icon instances across 18 files with standardized sizing