### PR TITLE
Migrate HIGH priority pagination, save and checkbox icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -10,9 +10,11 @@ import React, {
 import { useSearchParams } from "react-router-dom";
 import { Box, Stack, Tab, Typography, useTheme } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { ReactComponent as SaveIconSVGWhite } from "../../assets/icons/save-white.svg";
-import { ReactComponent as UpdateIconSVGWhite } from "../../assets/icons/update-white.svg";
+import { Save, RefreshCw } from "lucide-react";
 import dayjs from "dayjs";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
+const UpdateIconSVGWhite = () => <RefreshCw size={20} />;
 
 import { Likelihood, Severity } from "../RiskLevel/constants";
 import { RiskLikelihood, RiskSeverity } from "../RiskLevel/riskValues";

--- a/Clients/src/presentation/components/Cards/DashboardHeaderCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/DashboardHeaderCard/index.tsx
@@ -1,7 +1,9 @@
 import { Stack, Typography, Box } from "@mui/material";
 import { useNavigate } from "react-router-dom";
-import { ReactComponent as RightArrow } from "../../../assets/icons/right-arrow.svg";
+import { ChevronRight } from "lucide-react";
 import { useState } from "react";
+
+const RightArrow = () => <ChevronRight size={16} />;
 
 const HeaderCard = ({ title, count }: { title: string; count: number }) => {
   const navigate = useNavigate();

--- a/Clients/src/presentation/components/Checks/index.tsx
+++ b/Clients/src/presentation/components/Checks/index.tsx
@@ -11,10 +11,11 @@
 
 import { Box, Stack, Typography, useTheme } from "@mui/material";
 import "./index.css";
-
-import { ReactComponent as CheckGrey } from "../../assets/icons/check.svg";
-import { ReactComponent as CheckOutlined } from "../../assets/icons/checkbox-outline.svg";
+import { Check as CheckIcon, Square } from "lucide-react";
 import { CheckVariants } from "../../../domain/enums/checkVariants";
+
+const CheckGrey = () => <CheckIcon size={16} />;
+const CheckOutlined = () => <Square size={16} />;
 
 const Check = ({
   text,

--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -19,8 +19,10 @@ import { useState, useEffect, lazy, Suspense } from "react";
 import { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { User } from "../../../../domain/types/User";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import {
   GetAnnexCategoriesById,
   UpdateAnnexCategoryById,

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -18,8 +18,10 @@ import DatePicker from "../../Inputs/Datepicker";
 import { Dayjs } from "dayjs";
 import { useState, useEffect, Suspense } from "react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { useAuth } from "../../../../application/hooks/useAuth";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import useUsers from "../../../../application/hooks/useUsers";
 import { User } from "../../../../domain/types/User";
 import UppyUploadFile from "../../Inputs/FileUpload";

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -18,8 +18,10 @@ import { useState, useEffect, lazy, Suspense } from "react";
 import { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { User } from "../../../../domain/types/User";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import UppyUploadFile from "../../Inputs/FileUpload";
 import { STATUSES } from "../../../../domain/types/Status";
 import Alert from "../../Alert";

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -18,8 +18,10 @@ import DatePicker from "../../Inputs/Datepicker";
 import { Dayjs } from "dayjs";
 import { useState, useEffect, Suspense } from "react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { useAuth } from "../../../../application/hooks/useAuth";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import useUsers from "../../../../application/hooks/useUsers";
 import { User } from "../../../../domain/types/User";
 import UppyUploadFile from "../../Inputs/FileUpload";

--- a/Clients/src/presentation/components/Inputs/Checkbox/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Checkbox/index.tsx
@@ -19,11 +19,12 @@ import {
   useTheme,
 } from "@mui/material";
 import "./index.css";
-
-import { ReactComponent as CheckboxOutline } from "../../../assets/icons/checkbox-outline.svg";
-import { ReactComponent as CheckboxFilled } from "../../../assets/icons/checkbox-filled.svg";
+import { Square, CheckSquare } from "lucide-react";
 import { FC } from "react";
 import { CheckboxProps } from "../../../../domain/interfaces/iWidget";
+
+const CheckboxOutline = () => <Square size={20} />;
+const CheckboxFilled = () => <CheckSquare size={20} />;
 
 const Checkbox: FC<CheckboxProps> = ({
   id,

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -19,8 +19,10 @@ import { Control } from "../../../../domain/types/Control";
 import { FileData } from "../../../../domain/types/File";
 import Alert from "../../Alert";
 import CustomizableToast from "../../Toast";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 
 import {
   AlertBox,

--- a/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
@@ -21,8 +21,10 @@ import { lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
 import { ModelInventoryStatus } from "../../../../domain/enums/modelInventory.enum";
 import { getAllEntities } from "../../../../application/repository/entity.repository";

--- a/Clients/src/presentation/components/Modals/NewModelRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelRisk/index.tsx
@@ -17,8 +17,10 @@ import { lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
 import {
   ModelRiskCategory,

--- a/Clients/src/presentation/components/Modals/NewRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewRisk/index.tsx
@@ -31,8 +31,10 @@ import useUsers from "../../../../application/hooks/useUsers";
 import CustomizableToast from "../../Toast";
 import { logEngine } from "../../../../application/tools/log.engine";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { RiskCalculator } from "../../../tools/riskCalculator";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import { RiskLikelihood, RiskSeverity } from "../../RiskLevel/riskValues";
 import allowedRoles from "../../../../application/constants/permissions";
 import { SelectChangeEvent } from "@mui/material";

--- a/Clients/src/presentation/components/Modals/NewTraining/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewTraining/index.tsx
@@ -12,8 +12,10 @@ import {
 import { Suspense, lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 import Select from "../../Inputs/Select";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
 import { useModalKeyHandling } from "../../../../application/hooks/useModalKeyHandling";
 

--- a/Clients/src/presentation/components/Modals/NewVendor/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewVendor/index.tsx
@@ -38,8 +38,10 @@ import useUsers from "../../../../application/hooks/useUsers";
 import CustomizableToast from "../../Toast";
 import { logEngine } from "../../../../application/tools/log.engine";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import allowedRoles from "../../../../application/constants/permissions";
 import {
   useCreateVendor,

--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from "react";
 import PolicyForm, { FormData } from "./PolicyForm";
 import { Policy } from "../../../domain/types/Policy";
-import { ReactComponent as SaveIconSVGWhite } from "../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { Plate, PlateContent, usePlateEditor } from "platejs/react";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 
 import {
   BoldPlugin,

--- a/Clients/src/presentation/components/Table/AuditRiskTable/AuditRiskTableBody.tsx
+++ b/Clients/src/presentation/components/Table/AuditRiskTable/AuditRiskTableBody.tsx
@@ -9,9 +9,11 @@ import {
 } from "@mui/material";
 import { useCallback, useState } from "react";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { ReactComponent as CheckboxOutline } from "../../../assets/icons/checkbox-outline.svg";
-import { ReactComponent as CheckboxFilled } from "../../../assets/icons/checkbox-filled.svg";
+import { Square, CheckSquare } from "lucide-react";
 import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+
+const CheckboxOutline = () => <Square size={20} />;
+const CheckboxFilled = () => <CheckSquare size={20} />;
 import {
   paginationStyle,
   paginationDropdown,

--- a/Clients/src/presentation/components/Table/FileTable/FileTable.tsx
+++ b/Clients/src/presentation/components/Table/FileTable/FileTable.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useMemo } from "react";
 import FileBasicTable from "../FilesBasicTable/FileBasicTable";
 import { Stack, Box, Typography } from "@mui/material";
-import AscendingIcon from "../../../assets/icons/up-arrow.svg";
-import DescendingIcon from "../../../assets/icons/down-arrow.svg";
+import { ArrowUp, ArrowDown } from "lucide-react";
 import EmptyTableImage from "../../../assets/imgs/empty-state.svg";
 import { FileData } from "../../../../domain/types/File";
 
@@ -100,16 +99,13 @@ const FileTable: React.FC<FileTableProps> = ({ cols, files }) => {
                   sx={{ cursor: "pointer" }}
                 >
                   {col.name}
-                  <Box
-                    component="img"
-                    src={
-                      sortField === colKey && sortDirection === "asc"
-                        ? AscendingIcon
-                        : DescendingIcon
-                    }
-                    alt="Sort"
-                    sx={{ width: 16, height: 16, ml: 0.5 }}
-                  />
+                  <Box sx={{ display: 'flex', alignItems: 'center', ml: 0.5 }}>
+                    {sortField === colKey && sortDirection === "asc" ? (
+                      <ArrowUp size={16} />
+                    ) : (
+                      <ArrowDown size={16} />
+                    )}
+                  </Box>
                 </Stack>
               ),
             }

--- a/Clients/src/presentation/components/Table/LinkedRisksTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/LinkedRisksTable/TableBody/index.tsx
@@ -2,9 +2,11 @@ import React, { useCallback, useState } from 'react'
 import { ProjectRisk } from '../../../../../domain/types/ProjectRisk'
 import singleTheme from '../../../../themes/v1SingleTheme';
 import { TableBody, TableCell, TableRow, useTheme, Checkbox as MuiCheckbox, TableFooter, TablePagination, } from '@mui/material';
-import { ReactComponent as CheckboxOutline } from "../../../../assets/icons/checkbox-outline.svg";
-import { ReactComponent as CheckboxFilled } from "../../../../assets/icons/checkbox-filled.svg";
-import { ReactComponent as SelectorVertical } from '../../../../assets/icons/selector-vertical.svg'
+import { Square, CheckSquare } from "lucide-react";
+import { ReactComponent as SelectorVertical } from '../../../../assets/icons/selector-vertical.svg';
+
+const CheckboxOutline = () => <Square size={20} />;
+const CheckboxFilled = () => <CheckSquare size={20} />;
 import RiskChip from '../../../RiskLevel/RiskChip';
 
 import {

--- a/Clients/src/presentation/components/TablePagination/index.tsx
+++ b/Clients/src/presentation/components/TablePagination/index.tsx
@@ -13,11 +13,12 @@
 
 import { Box, Button } from "@mui/material";
 import "../Table/index.css";
+import { ChevronsLeft, ChevronLeft, ChevronRight, ChevronsRight } from "lucide-react";
 
-import { ReactComponent as LeftArrowDouble } from "../../assets/icons/left-arrow-double.svg";
-import { ReactComponent as LeftArrow } from "../../assets/icons/left-arrow.svg";
-import { ReactComponent as RightArrow } from "../../assets/icons/right-arrow.svg";
-import { ReactComponent as RightArrowDouble } from "../../assets/icons/right-arrow-double.svg";
+const LeftArrowDouble = () => <ChevronsLeft size={20} />;
+const LeftArrow = () => <ChevronLeft size={20} />;
+const RightArrow = () => <ChevronRight size={20} />;
+const RightArrowDouble = () => <ChevronsRight size={20} />;
 
 interface TablePaginationActionsProps {
   count: number;

--- a/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
@@ -19,8 +19,10 @@ import {
   useAITrustCentreOverviewMutation,
 } from "../../../../application/hooks/useAITrustCentreOverviewQuery";
 import { handleAlert } from "../../../../application/tools/alertUtils";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import Field from "../../../components/Inputs/Field";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 
 import {
   SectionPaper,

--- a/Clients/src/presentation/pages/AITrustCenter/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Settings/index.tsx
@@ -13,8 +13,10 @@ import { useStyles } from "./styles";
 import Toggle from "../../../components/Inputs/Toggle";
 import Field from "../../../components/Inputs/Field";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import DualButtonModal from "../../../components/Dialogs/DualButtonModal";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import {
   useAITrustCentreOverviewQuery,
   useAITrustCentreOverviewMutation,

--- a/Clients/src/presentation/pages/Authentication/ResetPasswordContinue/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ResetPasswordContinue/index.tsx
@@ -4,8 +4,10 @@
 
 import { Button, Stack, Typography, useTheme } from "@mui/material";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
-import { ReactComponent as Success } from "../../../assets/icons/check-outlined.svg";
+import { Check } from "lucide-react";
 import singleTheme from "../../../themes/v1SingleTheme";
+
+const Success = () => <Check size={24} />;
 import { useNavigate } from "react-router-dom";
 
 const ResetPasswordContinue = () => {

--- a/Clients/src/presentation/pages/Framework/index.tsx
+++ b/Clients/src/presentation/pages/Framework/index.tsx
@@ -14,10 +14,12 @@ import HelperDrawer from "../../components/HelperDrawer";
 import HelperIcon from "../../components/HelperIcon";
 import { useContext, useEffect, useState, useMemo } from "react";
 import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg";
-import { ReactComponent as SettingsIcon } from "../../assets/icons/setting-small.svg";
-import { ReactComponent as DeleteIconRed } from "../../assets/icons/trash-filled-red.svg";
-import {ReactComponent as EditIconGrey} from "../../assets/icons/edit.svg";
+import { Settings, Trash2, Edit } from "lucide-react";
 import { ReactComponent as WhiteDownArrowIcon } from "../../assets/icons/chevron-down-white.svg";
+
+const SettingsIcon = () => <Settings size={16} />;
+const DeleteIconRed = () => <Trash2 size={16} color="#D92D20" />;
+const EditIconGrey = () => <Edit size={16} />;
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
 import useMultipleOnScreen from "../../../application/hooks/useMultipleOnScreen";
 import singleTheme from "../../themes/v1SingleTheme";
@@ -705,13 +707,7 @@ const Framework = () => {
                   }
                 >
                   <ListItemIcon sx={{ minWidth: 32 }}>
-                    <SettingsIcon
-                      fontSize="small"
-                      style={{
-                        color: "text.secondary",
-                        fontSize: "16px",
-                      }}
-                    />
+                    <SettingsIcon />
                   </ListItemIcon>
                   <ListItemText
                     primary="Manage Frameworks"
@@ -727,12 +723,7 @@ const Framework = () => {
                   disabled={!allowedRoles.projects.edit.includes(userRoleName)}
                 >
                   <ListItemIcon sx={{ minWidth: 32 }}>
-                    <EditIconGrey
-                      style={{
-                        color: "text.secondary",
-                        fontSize: "16px",
-                      }}
-                    />
+                    <EditIconGrey />
                   </ListItemIcon>
                   <ListItemText
                     primary="Edit Project"
@@ -751,13 +742,7 @@ const Framework = () => {
                   }
                 >
                   <ListItemIcon sx={{ minWidth: 32 }}>
-                    <DeleteIconRed
-                      fontSize="small"
-                      style={{
-                        color: "error.main",
-                        fontSize: "16px",
-                      }}
-                    />
+                    <DeleteIconRed />
                   </ListItemIcon>
                   <ListItemText
                     primary="Delete Project"

--- a/Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx
@@ -8,8 +8,10 @@ import {
   Button,
 } from "@mui/material";
 import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
-import { ReactComponent as CheckGreenIcon } from "../../../assets/icons/check-green.svg";
+import { CheckCircle } from "lucide-react";
 import { Project } from "../../../../domain/types/Project";
+
+const CheckGreenIcon = () => <CheckCircle size={20} color="#12B76A" />;
 import { Framework } from "../../../../domain/types/Framework";
 import {
   modalContainerStyle,

--- a/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
@@ -34,8 +34,10 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import useProjectData from "../../../../application/hooks/useProjectData";
 import useUsers from "../../../../application/hooks/useUsers";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { ReactComponent as DeleteIconWhite } from "../../../assets/icons/trash-filled-white.svg";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import CustomizableToast from "../../../components/Toast";
 import CustomizableSkeleton from "../../../components/Skeletons";
 import useFrameworks from "../../../../application/hooks/useFrameworks";

--- a/Clients/src/presentation/pages/SettingsPage/Organization/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Organization/index.tsx
@@ -9,8 +9,10 @@ import {
 } from "@mui/material";
 import Field from "../../../components/Inputs/Field";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { useState, useCallback, ChangeEvent, useEffect, useRef } from "react";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import {
   CreateMyOrganization,

--- a/Clients/src/presentation/pages/SettingsPage/Password/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Password/index.tsx
@@ -13,8 +13,10 @@ import Alert from "../../../components/Alert";
 import { store } from "../../../../application/redux/store";
 import { extractUserToken } from "../../../../application/tools/extractToken";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import CustomizableSkeleton from "../../../components/Skeletons";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import CustomizableToast from "../../../components/Toast"; // Import CustomizableToast
 import { updatePassword } from "../../../../application/repository/user.repository";
 

--- a/Clients/src/presentation/pages/SettingsPage/Profile/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Profile/index.tsx
@@ -17,8 +17,10 @@ import Alert from "../../../components/Alert";
 import { store } from "../../../../application/redux/store";
 import { extractUserToken } from "../../../../application/tools/extractToken";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { Save } from "lucide-react";
 import { ReactComponent as DeleteIconWhite } from "../../../assets/icons/trash-filled-white.svg";
+
+const SaveIconSVGWhite = () => <Save size={20} />;
 import CustomizableSkeleton from "../../../components/Skeletons";
 import CustomizableToast from "../../../components/Toast";
 import useLogout from "../../../../application/hooks/useLogout";


### PR DESCRIPTION
## Summary
• Migrate pagination controls, save/update buttons and checkbox states
• Replace 16+ icon types across 28 files with Lucide React components
• Maintain color preservation and backward compatibility with wrapper components