### PR TITLE
Migrate final remaining formatting and UI icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/Checks/index.tsx
+++ b/Clients/src/presentation/components/Checks/index.tsx
@@ -12,9 +12,11 @@
 import { Box, Stack, Typography, useTheme } from "@mui/material";
 import "./index.css";
 
-import { ReactComponent as CheckGrey } from "../../assets/icons/check.svg";
+import { Check as CheckIcon } from "lucide-react";
 import { ReactComponent as CheckOutlined } from "../../assets/icons/checkbox-outline.svg";
 import { CheckVariants } from "../../../domain/enums/checkVariants";
+
+const CheckGrey = () => <CheckIcon size={16} />;
 
 const Check = ({
   text,

--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -14,13 +14,31 @@ import {
   BlockquotePlugin,
 } from "@platejs/basic-nodes/react";
 import { serializeHtml } from "platejs";
-import {ReactComponent as LooksThree} from "../../assets/icons/three.svg"
-import {ReactComponent as LooksOne} from "../../assets/icons/one.svg"
-import {ReactComponent as LooksTwo} from "../../assets/icons/two.svg"
-import {ReactComponent as FormatBold} from "../../assets/icons/formatBold.svg"
-import {ReactComponent as FormatQuote} from "../../assets/icons/formatQuote.svg"
-import {ReactComponent as FormatItalic} from "../../assets/icons/formatItalic.svg"
-import {ReactComponent as FormatUnderlined} from "../../assets/icons/formatUnderlined.svg"
+import { Quote, Underline, Bold, Italic } from "lucide-react";
+
+// Custom number components for heading levels (Lucide doesn't have numbered heading icons)
+const LooksOne = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+    <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" fontSize="14" fontWeight="600">1</text>
+  </svg>
+);
+
+const LooksTwo = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+    <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" fontSize="14" fontWeight="600">2</text>
+  </svg>
+);
+
+const LooksThree = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+    <text x="50%" y="50%" dominantBaseline="middle" textAnchor="middle" fontSize="14" fontWeight="600">3</text>
+  </svg>
+);
+
+const FormatQuote = () => <Quote size={20} />;
+const FormatUnderlined = () => <Underline size={20} />;
+const FormatBold = () => <Bold size={20} />;
+const FormatItalic = () => <Italic size={20} />;
 import { IconButton, Tooltip, useTheme, Box } from "@mui/material";
 import { Drawer, Stack, Typography, Divider } from "@mui/material";
 import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.svg";

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from "react";
 import { Box, Tooltip, IconButton, Stack, useTheme } from "@mui/material";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import {ReactComponent as FormatBold} from "../../assets/icons/formatBold.svg";
-import {ReactComponent as FormatItalic} from "../../assets/icons/formatItalic.svg";
-import {ReactComponent as FormatListBulleted} from "../../assets/icons/formatListBulleted.svg";
-import {ReactComponent as FormatListNumbered} from "../../assets/icons/formatListNumbered.svg";
+import { Bold, Italic, List, ListOrdered } from "lucide-react";
 import "./index.css";
+
+const FormatBold = () => <Bold size={20} />;
+const FormatItalic = () => <Italic size={20} />;
+const FormatListBulleted = () => <List size={20} />;
+const FormatListNumbered = () => <ListOrdered size={20} />;
 
 interface RichTextEditorProps {
   onContentChange?: (content: string) => void;

--- a/Clients/src/presentation/pages/SettingsPage/Slack/SlackIntegrations.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Slack/SlackIntegrations.tsx
@@ -15,7 +15,9 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as SliderIcon} from "../../../assets/icons/sliders.svg";
+import { SlidersHorizontal } from "lucide-react";
+
+const SliderIcon = () => <SlidersHorizontal size={20} />;
 import { sendSlackMessage } from "../../../../application/repository/slack.integration.repository";
 import { Suspense, useCallback, useState } from "react";
 import { formatDate } from "../../../tools/isoDateToString";


### PR DESCRIPTION
## Summary
• Complete icon migration with text formatting and settings icons
• Replace 12+ icon instances across 4 files with Lucide React components
• Custom SVG components for numbered heading levels (1, 2, 3)