### PR TITLE
Migrate critical MUI icons to Lucide

### DIFF
--- a/Clients/src/application/commands/registry.ts
+++ b/Clients/src/application/commands/registry.ts
@@ -1,21 +1,21 @@
 import { Command, CommandGroup, CommandContext, CommandRegistry } from './types'
 import allowedRoles from '../constants/permissions'
 import {
-  HomeOutlined,
-  WarningAmberOutlined,
-  BusinessOutlined,
-  AccountTreeOutlined,
-  SchoolOutlined,
-  FolderOutlined,
-  TimelineOutlined,
-  AccountBalanceOutlined,
-  BalanceOutlined,
-  SettingsOutlined,
-  AssignmentOutlined,
-  PolicyOutlined,
-  VerifiedUserOutlined,
-  GroupOutlined
-} from '@mui/icons-material'
+  Home as HomeOutlined,
+  AlertTriangle as WarningAmberOutlined,
+  Building2 as BusinessOutlined,
+  GitBranch as AccountTreeOutlined,
+  GraduationCap as SchoolOutlined,
+  Folder as FolderOutlined,
+  Activity as TimelineOutlined,
+  Landmark as AccountBalanceOutlined,
+  Scale as BalanceOutlined,
+  Settings as SettingsOutlined,
+  ClipboardList as AssignmentOutlined,
+  FileText as PolicyOutlined,
+  ShieldCheck as VerifiedUserOutlined,
+  Users as GroupOutlined
+} from 'lucide-react'
 
 // Define command groups
 export const COMMAND_GROUPS: CommandGroup[] = [

--- a/Clients/src/presentation/components/Dashboard/DashboardErrorBoundary.tsx
+++ b/Clients/src/presentation/components/Dashboard/DashboardErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { Box, Typography, Button, Card, CardContent } from '@mui/material';
-import { Error as ErrorIcon, Refresh as RefreshIcon } from '@mui/icons-material';
+import { AlertCircle as ErrorIcon, RefreshCw as RefreshIcon } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -83,10 +83,10 @@ class DashboardErrorBoundary extends Component<Props, State> {
           >
             <CardContent sx={{ p: 4 }}>
               <ErrorIcon
-                sx={{
-                  fontSize: 64,
-                  color: 'error.main',
-                  mb: 2
+                size={64}
+                style={{
+                  color: '#d32f2f',
+                  marginBottom: 16
                 }}
               />
 
@@ -111,7 +111,7 @@ class DashboardErrorBoundary extends Component<Props, State> {
               <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
                 <Button
                   variant="contained"
-                  startIcon={<RefreshIcon />}
+                  startIcon={<RefreshIcon size={16} />}
                   onClick={this.handleReset}
                 >
                   Try Again

--- a/Clients/src/presentation/components/Dashboard/WidgetErrorBoundary.tsx
+++ b/Clients/src/presentation/components/Dashboard/WidgetErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { Box, Card, CardContent, Typography, Button } from '@mui/material';
-import { Error as ErrorIcon, Refresh as RefreshIcon } from '@mui/icons-material';
+import { AlertCircle as ErrorIcon, RefreshCw as RefreshIcon } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -74,10 +74,10 @@ class WidgetErrorBoundary extends Component<Props, State> {
         >
           <CardContent sx={{ textAlign: 'center', p: 3 }}>
             <ErrorIcon
-              sx={{
-                fontSize: 48,
-                color: 'error.main',
-                mb: 2
+              size={48}
+              style={{
+                color: '#d32f2f',
+                marginBottom: 16
               }}
             />
 
@@ -101,7 +101,7 @@ class WidgetErrorBoundary extends Component<Props, State> {
             <Button
               variant="contained"
               size="small"
-              startIcon={<RefreshIcon />}
+              startIcon={<RefreshIcon size={14} />}
               onClick={this.handleRetry}
               sx={{ fontSize: '0.75rem' }}
             >

--- a/Clients/src/presentation/pages/DashboardOverview/EnhancedDashboard.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/EnhancedDashboard.tsx
@@ -17,14 +17,14 @@ import {
 } from '@mui/material';
 import {
   Edit as EditIcon,
-  Visibility as ViewIcon,
-  DragIndicator as DragIcon,
+  Eye as ViewIcon,
+  GripVertical as DragIcon,
   Settings as SettingsIcon,
-  Refresh as RefreshIcon,
+  RefreshCw as RefreshIcon,
   Download as DownloadIcon,
   Upload as UploadIcon,
-  RestartAlt as ResetIcon,
-} from '@mui/icons-material';
+  RotateCcw as ResetIcon,
+} from 'lucide-react';
 import { Responsive, WidthProvider, Layout, Layouts } from 'react-grid-layout';
 import { DashboardProvider, useDashboardContext } from './contexts/DashboardContext';
 import { MetricsWidget, ProjectsWidget, RisksWidget } from './widgets';
@@ -231,14 +231,14 @@ const DashboardContent: React.FC = () => {
           {/* Refresh Button */}
           <Tooltip title="Refresh all widgets">
             <IconButton onClick={() => actions.refreshAllWidgets()}>
-              <RefreshIcon />
+              <RefreshIcon size={20} />
             </IconButton>
           </Tooltip>
 
           {/* Settings Menu */}
           <Tooltip title="Dashboard settings">
             <IconButton onClick={handleSettingsClick}>
-              <SettingsIcon />
+              <SettingsIcon size={20} />
             </IconButton>
           </Tooltip>
           <Menu
@@ -247,14 +247,14 @@ const DashboardContent: React.FC = () => {
             onClose={handleSettingsClose}
           >
             <MenuItem onClick={() => { actions.resetLayout(); handleSettingsClose(); }}>
-              <ResetIcon sx={{ mr: 1 }} /> Reset Layout
+              <ResetIcon size={16} style={{ marginRight: 8 }} /> Reset Layout
             </MenuItem>
             <MenuItem onClick={() => { actions.exportDashboard(); handleSettingsClose(); }}>
-              <DownloadIcon sx={{ mr: 1 }} /> Export Dashboard
+              <DownloadIcon size={16} style={{ marginRight: 8 }} /> Export Dashboard
             </MenuItem>
             <Divider />
             <MenuItem disabled>
-              <UploadIcon sx={{ mr: 1 }} /> Import Dashboard
+              <UploadIcon size={16} style={{ marginRight: 8 }} /> Import Dashboard
             </MenuItem>
           </Menu>
 
@@ -269,7 +269,7 @@ const DashboardContent: React.FC = () => {
             }
             label={
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {state.editMode ? <EditIcon /> : <ViewIcon />}
+                {state.editMode ? <EditIcon size={18} /> : <ViewIcon size={18} />}
                 <Typography>{state.editMode ? 'Edit Mode' : 'View Mode'}</Typography>
               </Box>
             }
@@ -429,9 +429,9 @@ const DashboardContent: React.FC = () => {
               avatar={
                 state.editMode && (
                   <DragIcon
-                    sx={{
+                    size={20}
+                    style={{
                       color: alpha(theme.palette.text.secondary, 0.6),
-                      fontSize: '1.2rem',
                     }}
                   />
                 )
@@ -441,7 +441,7 @@ const DashboardContent: React.FC = () => {
                 state.editMode && (
                   <Tooltip title="Widget settings">
                     <IconButton size="small" className="no-drag">
-                      <SettingsIcon fontSize="small" />
+                      <SettingsIcon size={16} />
                     </IconButton>
                   </Tooltip>
                 )


### PR DESCRIPTION
## Summary
- Replace 26 MUI icons with Lucide equivalents in command registry and dashboard
- Apply consistent sizing standards across components