### PR TITLE
Migrate core action and modal icons to Lucide

### DIFF
--- a/Clients/src/presentation/components/IconButton/index.tsx
+++ b/Clients/src/presentation/components/IconButton/index.tsx
@@ -12,7 +12,7 @@ import {
   IconButton as MuiIconButton,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as Setting } from "../../assets/icons/setting.svg";
+import { MoreVertical as Setting } from "lucide-react";
 import { useState } from "react";
 import BasicModal from "../Modals/Basic";
 import ModelRiskConfirmation from "../Modals/ModelRiskConfirmation";
@@ -282,7 +282,7 @@ const IconButton: React.FC<IconButtonProps> = ({
         openMenu(event, id, "someUrl");
       }}
     >
-      <Setting />
+      <Setting size={20} />
     </MuiIconButton>
   );
 

--- a/Clients/src/presentation/components/Modals/CreateTask/index.tsx
+++ b/Clients/src/presentation/components/Modals/CreateTask/index.tsx
@@ -19,10 +19,8 @@ import { lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
-import { ReactComponent as SaveIcon } from "../../../assets/icons/save.svg";
+import { ChevronDown as GreyDownArrowIcon, Save as SaveIcon, X as CloseIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
 import { ITask } from "../../../../domain/interfaces/i.task";
 import dayjs, { Dayjs } from "dayjs";
 import { datePickerStyle } from "../../Forms/ProjectForm/style";
@@ -346,6 +344,7 @@ const CreateTask: FC<CreateTaskProps> = ({
             </Typography>
           </Stack>
           <CloseIcon
+            size={20}
             style={{ color: "#98A2B3", cursor: "pointer" }}
             onClick={handleClose}
           />
@@ -477,7 +476,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                         : "No options"
                     }
                     filterSelectedOptions
-                    popupIcon={<GreyDownArrowIcon />}
+                    popupIcon={<GreyDownArrowIcon size={16} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}
@@ -565,7 +564,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                     }}
                     getOptionLabel={(option: string) => option}
                     filterSelectedOptions
-                    popupIcon={<GreyDownArrowIcon />}
+                    popupIcon={<GreyDownArrowIcon size={16} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}
@@ -692,7 +691,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                 marginTop: 2,
               }}
               onClick={handleSubmit}
-              icon={<SaveIcon />}
+              icon={<SaveIcon size={16} />}
             />
           </Stack>
         </form>

--- a/Clients/src/presentation/components/Modals/NewRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewRisk/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@mui/material";
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
-import { ReactComponent as Close } from "../../../assets/icons/close.svg";
+import { X as Close, Save as SaveIconSVGWhite } from "lucide-react";
 import { Suspense, useEffect, useState, lazy, useCallback } from "react";
 import Alert from "../../Alert";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
@@ -31,7 +31,6 @@ import useUsers from "../../../../application/hooks/useUsers";
 import CustomizableToast from "../../Toast";
 import { logEngine } from "../../../../application/tools/log.engine";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
 import { RiskCalculator } from "../../../tools/riskCalculator";
 import { RiskLikelihood, RiskSeverity } from "../../RiskLevel/riskValues";
 import allowedRoles from "../../../../application/constants/permissions";
@@ -589,7 +588,7 @@ const AddNewRisk: React.FC<AddNewRiskProps> = ({
             >
               {existingRisk ? "Edit risk" : "Add a new vendor risk"}
             </Typography>
-            <Close style={{ cursor: "pointer" }} onClick={setIsOpen} />
+            <Close size={20} style={{ cursor: "pointer" }} onClick={setIsOpen} />
           </Stack>
           {!existingRisk && (
             <Typography
@@ -617,7 +616,7 @@ const AddNewRisk: React.FC<AddNewRiskProps> = ({
                   gap: 2,
                 }}
                 onClick={handleSave}
-                icon={<SaveIconSVGWhite />}
+                icon={<SaveIconSVGWhite size={16} />}
                 isDisabled={isEditingDisabled}
               />
             </Stack>

--- a/Clients/src/presentation/components/Modals/NewVendor/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewVendor/index.tsx
@@ -27,7 +27,7 @@ import {
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import DatePicker from "../../Inputs/Datepicker";
-import { ReactComponent as Close } from "../../../assets/icons/close.svg";
+import { X as Close, Save as SaveIconSVGWhite, ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 import Alert from "../../Alert";
@@ -38,8 +38,6 @@ import useUsers from "../../../../application/hooks/useUsers";
 import CustomizableToast from "../../Toast";
 import { logEngine } from "../../../../application/tools/log.engine";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
 import allowedRoles from "../../../../application/constants/permissions";
 import {
   useCreateVendor,
@@ -556,7 +554,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
                 );
               }}
               filterSelectedOptions
-              popupIcon={<GreyDownArrowIcon />}
+              popupIcon={<GreyDownArrowIcon size={16} />}
               renderInput={(params: AutocompleteRenderInputParams) => (
                 <TextField
                   {...params}
@@ -836,7 +834,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
             >
               {existingVendor ? "Edit vendor" : "Add new vendor"}
             </Typography>
-            <Close style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)} />
+            <Close size={20} style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)} />
           </Stack>
           {!existingVendor && (
             <Typography
@@ -868,7 +866,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
                 gap: 2,
               }}
               onClick={handleSave}
-              icon={<SaveIconSVGWhite />}
+              icon={<SaveIconSVGWhite size={16} />}
               isDisabled={isEditingDisabled}
             />
           </Stack>

--- a/Clients/src/presentation/pages/Vendors/index.tsx
+++ b/Clients/src/presentation/pages/Vendors/index.tsx
@@ -24,7 +24,7 @@ import useMultipleOnScreen from "../../../application/hooks/useMultipleOnScreen"
 import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
-import { ReactComponent as AddCircleOutlineIcon } from "../../assets/icons/plus-circle-white.svg"
+import { PlusCircle as AddCircleOutlineIcon } from "lucide-react";
 import AddNewRisk from "../../components/Modals/NewRisk";
 import CustomizableButton from "../../components/Button/CustomizableButton";
 import CustomizableSkeleton from "../../components/Skeletons";
@@ -524,7 +524,7 @@ const Vendors = () => {
                       border: "1px solid #13715B",
                       gap: 2,
                     }}
-                    icon={<AddCircleOutlineIcon />}
+                    icon={<AddCircleOutlineIcon size={16} />}
                     onClick={() => {
                       openAddNewVendor();
                       setSelectedVendor(null);


### PR DESCRIPTION
## Summary
- Replace 11 critical SVG icons with Lucide equivalents in core CRUD operations
- Update settings, close, save, and dropdown icons across modal components