### PR TITLE
Migrate table sorting icons to Lucide

### DIFF
--- a/Clients/src/presentation/components/ProjectsList/ProjectTableView.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectTableView.tsx
@@ -16,7 +16,7 @@ import { Project } from "../../../domain/types/Project";
 import singleTheme from "../../themes/v1SingleTheme";
 import TablePaginationActions from "../../components/TablePagination";
 import placeholderImage from "../../assets/imgs/empty-state.svg";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 
 interface ProjectTableViewProps {
   projects: Project[];

--- a/Clients/src/presentation/components/Table/AITrustCenterTable/index.tsx
+++ b/Clients/src/presentation/components/Table/AITrustCenterTable/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "@mui/material";
 import singleTheme from "../../../themes/v1SingleTheme";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import Placeholder from "../../../assets/imgs/empty-state.svg";
 
 const DEFAULT_ROWS_PER_PAGE = 5;

--- a/Clients/src/presentation/components/Table/AuditRiskTable/AuditRiskTableBody.tsx
+++ b/Clients/src/presentation/components/Table/AuditRiskTable/AuditRiskTableBody.tsx
@@ -11,7 +11,7 @@ import { useCallback, useState } from "react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { ReactComponent as CheckboxOutline } from "../../../assets/icons/checkbox-outline.svg";
 import { ReactComponent as CheckboxFilled } from "../../../assets/icons/checkbox-filled.svg";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import {
   paginationStyle,
   paginationDropdown,

--- a/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
@@ -14,7 +14,7 @@ import {
   import TablePaginationActions from "../../TablePagination";
   import TableHeader from "../TableHead";
   import placeholderImage from "../../../assets/imgs/empty-state.svg";
-  import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+  import { ChevronsUpDown as SelectorVertical } from "lucide-react";
   import {
     emptyData,
     paginationStatus,

--- a/Clients/src/presentation/components/Table/EventsTable/index.tsx
+++ b/Clients/src/presentation/components/Table/EventsTable/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import TablePaginationActions from "../../TablePagination";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import Placeholder from "../../../assets/imgs/empty-state.svg";
 import { formatDateTime } from "../../../tools/isoDateToString";
 import { Event } from "../../../../domain/types/Event";

--- a/Clients/src/presentation/components/Table/FairnessTable/index.tsx
+++ b/Clients/src/presentation/components/Table/FairnessTable/index.tsx
@@ -13,7 +13,7 @@ import {
   import TablePaginationActions from "../../TablePagination";
   import TableHeader from "../TableHead";
   import placeholderImage from "../../../assets/imgs/empty-state.svg";
-  import { ReactComponent as SelectorVertical } from '../../../assets/icons/selector-vertical.svg';
+  import { ChevronsUpDown as SelectorVertical } from 'lucide-react';
   import {
     styles,
     paginationStatus,

--- a/Clients/src/presentation/components/Table/FileTable/FileTable.tsx
+++ b/Clients/src/presentation/components/Table/FileTable/FileTable.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useMemo } from "react";
 import FileBasicTable from "../FilesBasicTable/FileBasicTable";
 import { Stack, Box, Typography } from "@mui/material";
-import AscendingIcon from "../../../assets/icons/up-arrow.svg";
-import DescendingIcon from "../../../assets/icons/down-arrow.svg";
+import { ArrowUp as AscendingIcon, ArrowDown as DescendingIcon } from "lucide-react";
 import EmptyTableImage from "../../../assets/imgs/empty-state.svg";
 import { FileData } from "../../../../domain/types/File";
 
@@ -100,16 +99,11 @@ const FileTable: React.FC<FileTableProps> = ({ cols, files }) => {
                   sx={{ cursor: "pointer" }}
                 >
                   {col.name}
-                  <Box
-                    component="img"
-                    src={
-                      sortField === colKey && sortDirection === "asc"
-                        ? AscendingIcon
-                        : DescendingIcon
-                    }
-                    alt="Sort"
-                    sx={{ width: 16, height: 16, ml: 0.5 }}
-                  />
+                  {sortField === colKey && sortDirection === "asc" ? (
+                    <AscendingIcon size={16} style={{ marginLeft: 4 }} />
+                  ) : (
+                    <DescendingIcon size={16} style={{ marginLeft: 4 }} />
+                  )}
                 </Stack>
               ),
             }

--- a/Clients/src/presentation/components/Table/LinkedRisksTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/LinkedRisksTable/TableBody/index.tsx
@@ -4,7 +4,7 @@ import singleTheme from '../../../../themes/v1SingleTheme';
 import { TableBody, TableCell, TableRow, useTheme, Checkbox as MuiCheckbox, TableFooter, TablePagination, } from '@mui/material';
 import { ReactComponent as CheckboxOutline } from "../../../../assets/icons/checkbox-outline.svg";
 import { ReactComponent as CheckboxFilled } from "../../../../assets/icons/checkbox-filled.svg";
-import { ReactComponent as SelectorVertical } from '../../../../assets/icons/selector-vertical.svg'
+import { ChevronsUpDown as SelectorVertical } from 'lucide-react'
 import RiskChip from '../../../RiskLevel/RiskChip';
 
 import {

--- a/Clients/src/presentation/components/Table/PolicyTable/index.tsx
+++ b/Clients/src/presentation/components/Table/PolicyTable/index.tsx
@@ -15,7 +15,7 @@ import {
 import TablePaginationActions from "../../TablePagination";
 import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import { getPaginationRowCount, setPaginationRowCount } from "../../../../application/utils/paginationStorage";
 
 const DEFAULT_ROWS_PER_PAGE = 10;

--- a/Clients/src/presentation/components/Table/ProjectRiskMitigationTable/ProjectRiskMitigationTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ProjectRiskMitigationTable/ProjectRiskMitigationTableBody.tsx
@@ -10,7 +10,7 @@ import { ProjectRiskMitigation } from "../../../../domain/types/ProjectRisk";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useState } from "react";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import {
   paginationDropdown,
   paginationSelect,

--- a/Clients/src/presentation/components/Table/ReportTable/index.tsx
+++ b/Clients/src/presentation/components/Table/ReportTable/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import singleTheme from '../../../themes/v1SingleTheme';
 import placeholderImage from "../../../assets/imgs/empty-state.svg";
-import { ReactComponent as SelectorVertical } from '../../../assets/icons/selector-vertical.svg'
+import { ChevronsUpDown as SelectorVertical } from 'lucide-react'
 import TablePaginationActions from '../../TablePagination';
 import TableHeader from '../TableHead';
 const ReportTableBody = lazy(() => import("./TableBody"))

--- a/Clients/src/presentation/components/Table/RisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/RisksTable/index.tsx
@@ -18,7 +18,7 @@ import Placeholder from "../../../assets/imgs/empty-state.svg";
 import singleTheme from "../../../themes/v1SingleTheme";
 import IconButton from "../../IconButton";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import RiskChip from "../../RiskLevel/RiskChip";
 import { VendorDetails } from "../../../pages/Vendors";
 import { VendorRisk } from "../../../../domain/types/VendorRisk";

--- a/Clients/src/presentation/components/Table/TasksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/TasksTable/index.tsx
@@ -17,7 +17,7 @@ import Placeholder from "../../../assets/imgs/empty-state.svg";
 import singleTheme from "../../../themes/v1SingleTheme";
 import TablePaginationActions from "../../TablePagination";
 import TableHeader from "../TableHead";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import { ITask } from "../../../../domain/interfaces/i.task";
 import { User } from "../../../../domain/types/User";
 import CustomSelect from "../../CustomSelect";

--- a/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
@@ -13,7 +13,7 @@ import {
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useMemo, useState, useEffect } from "react";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import placeholderImage from "../../../assets/imgs/empty-state.svg";
 import VWProjectRisksTableHead from "./VWProjectRisksTableHead";
 import VWProjectRisksTableBody from "./VWProjectRisksTableBody";

--- a/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
+++ b/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
@@ -19,7 +19,7 @@ import CustomizableButton from "../../Button/CustomizableButton";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { formatDate } from "../../../tools/isoDateToString";
 import TablePaginationActions from "../../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import VendorRisksDialog from "../../VendorRisksDialog";
 import { VendorDetails } from "../../../pages/Vendors";
 import { User } from "../../../../domain/types/User";

--- a/Clients/src/presentation/components/VendorRisksDialog/index.tsx
+++ b/Clients/src/presentation/components/VendorRisksDialog/index.tsx
@@ -33,7 +33,7 @@ import {
 } from "../Table/styles";
 import placeholderImage from '../../assets/imgs/empty-state.svg';
 import TablePaginationActions from "../TablePagination";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 
 interface VendorRisk {
   id: number;

--- a/Clients/src/presentation/pages/ModelInventory/ModelRisksTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelRisksTable.tsx
@@ -17,7 +17,7 @@ import Placeholder from "../../assets/imgs/empty-state.svg";
 import singleTheme from "../../themes/v1SingleTheme";
 import IconButton from "../../components/IconButton";
 import TablePaginationActions from "../../components/TablePagination";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import RiskChip from "../../components/RiskLevel/RiskChip";
 import { IModelRisk } from "../../../domain/interfaces/i.modelRisk";
 import { User } from "../../../domain/types/User";

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -19,7 +19,7 @@ import singleTheme from "../../themes/v1SingleTheme";
 import CustomIconButton from "../../components/IconButton";
 import allowedRoles from "../../../application/constants/permissions";
 import { useAuth } from "../../../application/hooks/useAuth";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import Placeholder from "../../assets/imgs/empty-state.svg";
 import { IModelInventory } from "../../../domain/interfaces/i.modelInventory";
 import { getAllEntities } from "../../../application/repository/entity.repository";

--- a/Clients/src/presentation/pages/SettingsPage/Slack/SlackIntegrations.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Slack/SlackIntegrations.tsx
@@ -1,6 +1,6 @@
 import TablePaginationActions from "@mui/material/TablePagination/TablePaginationActions";
 import { singleTheme } from "../../../themes";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import {
   Box,
   Stack,

--- a/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
@@ -25,7 +25,7 @@ import {
   TableFooter,
 } from "@mui/material";
 import {ReactComponent as GroupsIcon} from "../../../assets/icons/group.svg";
-import { ReactComponent as SelectorVertical } from "../../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import TablePaginationActions from "../../../components/TablePagination";
 import InviteUserModal from "../../../components/Modals/InviteUser";
 import DualButtonModal from "../../../components/Dialogs/DualButtonModal";

--- a/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
@@ -17,7 +17,7 @@ import "../../components/Table/index.css";
 import singleTheme from "../../themes/v1SingleTheme";
 import CustomIconButton from "../../components/IconButton";
 import allowedRoles from "../../../application/constants/permissions";
-import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
+import { ChevronsUpDown as SelectorVertical } from "lucide-react";
 import Placeholder from "../../assets/imgs/empty-state.svg";
 import { useAuth } from "../../../application/hooks/useAuth";
 import { getPaginationRowCount, setPaginationRowCount } from "../../../application/utils/paginationStorage";


### PR DESCRIPTION
## Summary
- Replace 22 table sorting SVG icons with Lucide equivalents across 21 components
- Standardize pagination dropdown selectors and column header sorting