### PR TITLE
Migrate close and save icons to Lucide React (resolves #2342)

### DIFF
--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -9,7 +9,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { FileData } from "../../../../domain/types/File";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Checkbox from "../../Inputs/Checkbox";
 import Field from "../../Inputs/Field";
 import { inputStyles } from "../ClauseDrawerDialog";
@@ -398,7 +398,7 @@ const VWISO42001AnnexDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -10,7 +10,7 @@ import {
   Dialog,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import { FileData } from "../../../../domain/types/File";
 import Select from "../../Inputs/Select";
@@ -410,7 +410,7 @@ const VWISO42001ClauseDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {clause?.clause_no + "." + (index + 1)} {displayData?.title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -9,7 +9,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { FileData } from "../../../../domain/types/File";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import { inputStyles } from "../ClauseDrawerDialog";
 import DatePicker from "../../Inputs/Datepicker";
@@ -410,7 +410,7 @@ const VWISO27001AnnexDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack sx={{ padding: "15px 20px", gap: "15px" }}>

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -10,7 +10,7 @@ import {
   Dialog,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import { FileData } from "../../../../domain/types/File";
 import Select from "../../Inputs/Select";
@@ -408,7 +408,7 @@ const VWISO27001ClauseDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {clause?.arrangement + "." + (index + 1)} {displayData?.title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import DropDowns from "../../Inputs/Dropdowns";
 import { useState, Suspense, useEffect } from "react";
 import AuditorFeedback from "../ComplianceFeedback/ComplianceFeedback";
@@ -465,7 +465,7 @@ const NewControlPane = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
           <Typography component="span" fontSize={13}>

--- a/Clients/src/presentation/components/Modals/Controlpane/index.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/index.tsx
@@ -9,7 +9,7 @@ import {
   Tabs,
   Tab,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 
 import React, { useState } from "react";
 import DropDowns from "../../Inputs/Dropdowns";
@@ -131,7 +131,7 @@ const CustomModal: React.FC<CustomModalProps> = ({
             {title}
           </Typography>
 
-          <CloseIcon onClick={handleClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={handleClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Typography fontSize={13}>{content}</Typography>
         <DropDowns />

--- a/Clients/src/presentation/components/Modals/CreateTask/index.tsx
+++ b/Clients/src/presentation/components/Modals/CreateTask/index.tsx
@@ -20,9 +20,9 @@ const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
 import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
-import { ReactComponent as SaveIcon } from "../../../assets/icons/save.svg";
+import { Save as SaveIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import { ITask } from "../../../../domain/interfaces/i.task";
 import dayjs, { Dayjs } from "dayjs";
 import { datePickerStyle } from "../../Forms/ProjectForm/style";
@@ -346,6 +346,7 @@ const CreateTask: FC<CreateTaskProps> = ({
             </Typography>
           </Stack>
           <CloseIcon
+            size={20}
             style={{ color: "#98A2B3", cursor: "pointer" }}
             onClick={handleClose}
           />
@@ -692,7 +693,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                 marginTop: 2,
               }}
               onClick={handleSubmit}
-              icon={<SaveIcon />}
+              icon={<SaveIcon size={16} />}
             />
           </Stack>
         </form>

--- a/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
@@ -23,7 +23,7 @@ const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
 import { Save as SaveIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import { ModelInventoryStatus } from "../../../../domain/enums/modelInventory.enum";
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import { User } from "../../../../domain/types/User";
@@ -464,7 +464,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
 

--- a/Clients/src/presentation/components/Modals/NewModelRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelRisk/index.tsx
@@ -19,7 +19,7 @@ const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
 import { Save as SaveIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import {
   ModelRiskCategory,
   ModelRiskLevel,
@@ -382,7 +382,7 @@ const NewModelRisk: FC<NewModelRiskProps> = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
 

--- a/Clients/src/presentation/components/Modals/NewRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewRisk/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@mui/material";
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
-import { ReactComponent as Close } from "../../../assets/icons/close.svg";
+import { X as Close } from "lucide-react";
 import { Suspense, useEffect, useState, lazy, useCallback } from "react";
 import Alert from "../../Alert";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
@@ -589,7 +589,7 @@ const AddNewRisk: React.FC<AddNewRiskProps> = ({
             >
               {existingRisk ? "Edit risk" : "Add a new vendor risk"}
             </Typography>
-            <Close style={{ cursor: "pointer" }} onClick={setIsOpen} />
+            <Close size={20} style={{ cursor: "pointer" }} onClick={setIsOpen} />
           </Stack>
           {!existingRisk && (
             <Typography

--- a/Clients/src/presentation/components/Modals/NewTraining/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewTraining/index.tsx
@@ -14,7 +14,7 @@ const Field = lazy(() => import("../../Inputs/Field"));
 import Select from "../../Inputs/Select";
 import { Save as SaveIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import { useModalKeyHandling } from "../../../../application/hooks/useModalKeyHandling";
 
 interface NewTrainingProps {
@@ -262,7 +262,7 @@ const NewTraining: FC<NewTrainingProps> = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
           <Typography 

--- a/Clients/src/presentation/components/Modals/NewVendor/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewVendor/index.tsx
@@ -27,7 +27,7 @@ import {
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import DatePicker from "../../Inputs/Datepicker";
-import { ReactComponent as Close } from "../../../assets/icons/close.svg";
+import { X as Close } from "lucide-react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import dayjs, { Dayjs } from "dayjs";
 import Alert from "../../Alert";
@@ -836,7 +836,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
             >
               {existingVendor ? "Edit vendor" : "Add new vendor"}
             </Typography>
-            <Close style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)} />
+            <Close size={20} style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)} />
           </Stack>
           {!existingVendor && (
             <Typography


### PR DESCRIPTION
## Summary
- Migrates close.svg icon imports to Lucide X component across all modal and drawer components
- Migrates remaining save.svg icon imports to Lucide Save component 
- Applies consistent sizing: `size={20}` for close icons, `size={16}` for save icons
- Updates 12 components including modals, drawers, and control panes

## Files Changed
- **Modals**: NewModelInventory, NewRisk, NewVendor, NewTraining, NewModelRisk, CreateTask, Controlpane components
- **Drawers**: ISO27001ClauseDrawerDialog, ISO27001AnnexDrawerDialog, ClauseDrawerDialog, AnnexDrawerDialog

## Test plan
- [ ] Verify all modal close buttons display and function correctly
- [ ] Verify all save buttons display with proper Lucide icons
- [ ] Test modal interactions across different framework components
- [ ] Confirm consistent icon sizing and styling

This PR resolves the conflicts in #2342 by creating a clean implementation on top of the current develop branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)