### PR TITLE
feat: Migrate remaining MUI and SVG icons to Lucide React

### DIFF
--- a/Clients/src/application/commands/registry.ts
+++ b/Clients/src/application/commands/registry.ts
@@ -1,21 +1,21 @@
 import { Command, CommandGroup, CommandContext, CommandRegistry } from './types'
 import allowedRoles from '../constants/permissions'
 import {
-  HomeOutlined,
-  WarningAmberOutlined,
-  BusinessOutlined,
-  AccountTreeOutlined,
-  SchoolOutlined,
-  FolderOutlined,
-  TimelineOutlined,
-  AccountBalanceOutlined,
-  BalanceOutlined,
-  SettingsOutlined,
-  AssignmentOutlined,
-  PolicyOutlined,
-  VerifiedUserOutlined,
-  GroupOutlined
-} from '@mui/icons-material'
+  Home as HomeOutlined,
+  AlertTriangle as WarningAmberOutlined,
+  Building as BusinessOutlined,
+  GitBranch as AccountTreeOutlined,
+  GraduationCap as SchoolOutlined,
+  Folder as FolderOutlined,
+  Activity as TimelineOutlined,
+  Landmark as AccountBalanceOutlined,
+  Scale as BalanceOutlined,
+  Settings as SettingsOutlined,
+  ClipboardList as AssignmentOutlined,
+  FileText as PolicyOutlined,
+  ShieldCheck as VerifiedUserOutlined,
+  Users as GroupOutlined
+} from 'lucide-react'
 
 // Define command groups
 export const COMMAND_GROUPS: CommandGroup[] = [

--- a/Clients/src/presentation/components/Alert/index.tsx
+++ b/Clients/src/presentation/components/Alert/index.tsx
@@ -17,12 +17,7 @@ import { closeIconStyles, iconButtonStyles } from "./style";
 import { CloseIconProps } from "../../../domain/interfaces/iWidget";
 import AlertBody from "./AlertBody";
 
-import { ReactComponent as BlueInfoIcon } from "../../assets/icons/info-circle-blue.svg";
-import { ReactComponent as GreenSuccessIcon } from "../../assets/icons/success-circle-green.svg";
-import { ReactComponent as OrangeWarningIcon } from "../../assets/icons/warning-orange.svg";
-import { ReactComponent as RedErrorIcon } from "../../assets/icons/error-circle-red.svg";
-
-import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.svg";
+import { Info as BlueInfoIcon, CheckCircle as GreenSuccessIcon, AlertTriangle as OrangeWarningIcon, XCircle as RedErrorIcon, X as CloseGreyIcon } from "lucide-react";
 
 /**
  * Mapping of alert variants to their respective icons.
@@ -31,10 +26,10 @@ import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.s
  * @type {object}
  */
 const icons: { [s: string]: JSX.Element } = {
-  success: <GreenSuccessIcon />, // #079455
-  info: <BlueInfoIcon />, // #0288d1
-  error: <RedErrorIcon />, // #f04438
-  warning: <OrangeWarningIcon />, // #DC6803
+  success: <GreenSuccessIcon size={20} />, // #079455
+  info: <BlueInfoIcon size={20} />, // #0288d1
+  error: <RedErrorIcon size={20} />, // #f04438
+  warning: <OrangeWarningIcon size={20} />, // #DC6803
 };
 
 /**
@@ -46,7 +41,7 @@ const icons: { [s: string]: JSX.Element } = {
 const CloseButton: React.FC<CloseIconProps> = ({
   text,
 }: CloseIconProps): JSX.Element => (
-  <CloseGreyIcon style={closeIconStyles(text)} />
+  <CloseGreyIcon size={16} style={closeIconStyles(text)} />
 );
 
 /**

--- a/Clients/src/presentation/components/HelperIcon/index.tsx
+++ b/Clients/src/presentation/components/HelperIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IconButton } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 
 interface HelperIconProps {
   onClick: () => void;
@@ -23,7 +23,7 @@ const HelperIcon: React.FC<HelperIconProps> = ({ onClick, size = "small" }) => {
         },
       }}
     >
-      <GreyCircleInfoIcon />
+      <GreyCircleInfoIcon size={16} />
     </IconButton>
   );
 };

--- a/Clients/src/presentation/components/MetricInfoIcon/index.tsx
+++ b/Clients/src/presentation/components/MetricInfoIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IconButton, Box } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 
 interface MetricInfoIconProps {
   onClick: () => void;
@@ -24,7 +24,7 @@ const MetricInfoIcon = React.forwardRef<HTMLDivElement, MetricInfoIconProps>(({ 
           },
         }}
       >
-        <GreyCircleInfoIcon />
+        <GreyCircleInfoIcon size={16} />
       </IconButton>
     </Box>
   );

--- a/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
@@ -5,7 +5,7 @@
 import { Button, Stack, Typography, useTheme } from "@mui/material";
 import React, { useState } from "react";
 import { ReactComponent as Key } from "../../../assets/icons/key.svg";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Field from "../../../components/Inputs/Field";
 import singleTheme from "../../../themes/v1SingleTheme";
@@ -177,7 +177,7 @@ const ForgotPassword: React.FC = () => {
                 navigate("/login");
               }}
             >
-              <LeftArrowLong />
+              <ArrowLeft size={16} />
               <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
                 Back to log in
               </Typography>

--- a/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
@@ -5,7 +5,7 @@
 import { Stack, Typography, useTheme } from "@mui/material";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import { ReactComponent as Email } from "../../../assets/icons/email.svg";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useState, lazy, Suspense } from "react";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
@@ -146,7 +146,7 @@ const ResetPassword = () => {
               navigate("/login");
             }}
           >
-            <LeftArrowLong />
+            <ArrowLeft size={16} />
             <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
               Back to log in
             </Typography>

--- a/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Check from "../../../components/Checks";
 import Field from "../../../components/Inputs/Field";
-import { ReactComponent as LeftArrowLong } from "../../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft } from "lucide-react";
 import { ReactComponent as Lock } from "../../../assets/icons/lock.svg";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -299,7 +299,7 @@ const SetNewPassword: React.FC = () => {
               }}
               onClick={() => navigate("/login")}
             >
-              <LeftArrowLong />
+              <ArrowLeft size={16} />
               <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
                 Back to log in
               </Typography>

--- a/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
@@ -10,7 +10,7 @@ import { GetAnnexesByProjectFrameworkId } from "../../../../../application/repos
 import { useCallback, useEffect, useState } from "react";
 import StatsCard from "../../../../components/Cards/StatsCard";
 import { styles } from "../Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import VWISO27001AnnexDrawerDialog from "../../../../components/Drawer/ISO27001AnnexDrawerDialog";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import { AlertProps } from "../../../../../domain/interfaces/iAlert";
@@ -237,7 +237,8 @@ const ISO27001Annex = ({
                   sx={styles.accordion}
                 >
                   <AccordionSummary sx={styles.accordionSummary}>
-                    <RightArrowBlack
+                    <ArrowRight
+                      size={20}
                       style={styles.expandIcon(expanded === annex.id) as React.CSSProperties}
                     />
                     <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
@@ -10,7 +10,7 @@ import { Iso27001GetClauseStructByFrameworkID } from "../../../../../application
 import { ClauseStructISO } from "../../../../../domain/types/ClauseStructISO";
 import { useCallback, useEffect, useState } from "react";
 import { styles } from "./style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import { ISO27001GetSubClauseByClauseId } from "../../../../../application/repository/subClause_iso.repository";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import Alert from "../../../../components/Alert";
@@ -308,7 +308,8 @@ const ISO27001Clause = ({
               onChange={handleAccordionChange(clause.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                 />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>

--- a/Clients/src/presentation/pages/Framework/ISO42001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO42001/Annex/index.tsx
@@ -10,7 +10,7 @@ import { GetAnnexesByProjectFrameworkId } from "../../../../../application/repos
 import { useEffect, useState } from "react";
 import StatsCard from "../../../../components/Cards/StatsCard";
 import { styles } from "../../ISO27001/Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import VWISO42001AnnexDrawerDialog from "../../../../components/Drawer/AnnexDrawerDialog";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import { AlertProps } from "../../../../../domain/interfaces/iAlert";
@@ -262,9 +262,10 @@ const ISO42001Annex = ({
               onChange={handleAccordionChange(annex.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === annex.id) as React.CSSProperties}
-                   />
+                />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>
                   {annex.arrangement} {annex.title}
                 </Typography>

--- a/Clients/src/presentation/pages/Framework/ISO42001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO42001/Clause/index.tsx
@@ -10,7 +10,7 @@ import { GetClausesByProjectFrameworkId } from "../../../../../application/repos
 import { ClauseStructISO } from "../../../../../domain/types/ClauseStructISO";
 import { useCallback, useEffect, useState } from "react";
 import { styles } from "../../ISO27001/Clause/style";
-import { ReactComponent as RightArrowBlack } from "../../../../assets/icons/right-arrow-black.svg";
+import { ArrowRight } from "lucide-react";
 import { GetSubClausesById } from "../../../../../application/repository/subClause_iso.repository";
 import { handleAlert } from "../../../../../application/tools/alertUtils";
 import Alert from "../../../../components/Alert";
@@ -301,7 +301,8 @@ const ISO42001Clause = ({
               onChange={handleAccordionChange(clause.id ?? 0)}
             >
               <AccordionSummary sx={styles.accordionSummary}>
-                <RightArrowBlack
+                <ArrowRight
+                  size={20}
                   style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                 />
                 <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>


### PR DESCRIPTION
## Summary
- Migrate command registry MUI dashboard icons to Lucide equivalents
- Replace Alert component SVG status icons with Lucide variants  
- Update HelperIcon and MetricInfoIcon components to use Lucide Info
- Migrate framework right arrow icons (ISO27001/ISO42001) to Lucide ArrowRight
- Replace authentication left arrow icons with Lucide ArrowLeft
- Standardize icon sizing: 16px for forms, 20px for buttons/modals

## Changes Made
- **Command Registry**: Migrated MUI icons (`@mui/icons-material`) to Lucide equivalents with aliased names
- **Alert System**: Replaced SVG status icons with Lucide `Info`, `CheckCircle`, `AlertTriangle`, `XCircle`, and `X` icons
- **Helper Components**: Updated `HelperIcon` and `MetricInfoIcon` to use Lucide `Info` icon
- **Framework Pages**: Migrated right arrow expand icons in ISO27001/42001 Clause and Annex components
- **Authentication**: Replaced left arrow navigation icons with Lucide `ArrowLeft`

## Test plan
- [ ] Verify command palette icons display correctly
- [ ] Test alert notifications show proper status icons
- [ ] Check helper/info icons render in forms and components
- [ ] Validate framework accordion expand/collapse arrows work
- [ ] Test authentication page navigation arrows

🤖 Generated with [Claude Code](https://claude.com/claude-code)