### PR TITLE
feat: Migrate medium priority icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
@@ -15,7 +15,7 @@ import {
   Box,
   TextField,
 } from "@mui/material";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import Alert from "../../Alert";
@@ -248,7 +248,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                     </Box>
                   );
                 }}
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}
@@ -354,7 +354,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                     </Box>
                   );
                 }}
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}
@@ -532,7 +532,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                       </Box>
                     );
                   }}
-                  popupIcon={<GreyDownArrowIcon />}
+                  popupIcon={<GreyDownArrowIcon size={20} />}
                   renderInput={(params) => (
                     <TextField
                       {...params}

--- a/Clients/src/presentation/components/CreateProjectForm/index.tsx
+++ b/Clients/src/presentation/components/CreateProjectForm/index.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
   Box,
 } from "@mui/material";
-import { ReactComponent as GreyDownArrowIcon } from "../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { useSelector } from "react-redux";
 import dayjs, { Dayjs } from "dayjs";
 import { checkStringValidation } from "../../../application/validations/stringValidation";
@@ -382,7 +382,7 @@ const CreateProjectForm: FC<CreateProjectFormProps> = ({
                   );
                 }}
                 filterSelectedOptions
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}

--- a/Clients/src/presentation/components/Inputs/Dropdowns/ProjectFilter/ProjectFilterDropdown.tsx
+++ b/Clients/src/presentation/components/Inputs/Dropdowns/ProjectFilter/ProjectFilterDropdown.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { Select, MenuItem, FormControl, useTheme } from "@mui/material";
 import { dropdownStyles, inputStyles } from "./style";
 import { ProjectFilterDropdownProps } from "../../../../../domain/interfaces/iDropdown";
-import { ReactComponent as GreyDownArrowIcon  } from "../../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown } from "lucide-react";
 
+const GreyDownArrowIcon = (props: any) => <ChevronDown size={20} {...props} />;
 
 const ProjectFilterDropdown: React.FC<ProjectFilterDropdownProps> = ({
   projects,

--- a/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
@@ -1,6 +1,6 @@
 import { TableBody, TableRow, TableCell, Box } from "@mui/material";
 import singleTheme from '../../../../themes/v1SingleTheme';
-import trash from '../../../../assets/icons/trash-grey.svg';
+import { Trash2 as TrashIcon } from 'lucide-react';
 import Button from '../../../../components/Button/index';
 import ConfirmableDeleteIconButton from "../../../../components/Modals/ConfirmableDeleteIconButton";
 
@@ -111,7 +111,7 @@ const EvaluationTableBody: React.FC<EvaluationTableBodyProps> = ({
             onConfirm={(id) => onRemoveModel.onConfirm(String(id))}
             title={`Delete this evaluation?`}
             message={`Are you sure you want to delete evaluation ID ${row.id} (Status: ${row.status})? This action is non-recoverable.`}
-            customIcon={<img src={trash} alt="Delete" style={{ width: '20px', height: '20px' }} />}
+            customIcon={<TrashIcon size={20} />}
           />
           </TableCell>
         </TableRow>


### PR DESCRIPTION
## Summary
This PR addresses PR #2344 conflicts by migrating medium priority icons to Lucide React components.

## Changes Made
- **Chevron Dropdowns**: Migrated `chevron-down-grey.svg` to Lucide `ChevronDown` component across form components
- **Trash Icons**: Replaced SVG trash icons with Lucide `Trash2` in table components
- **Icon Sizing**: Applied consistent 20px sizing for medium priority UI elements
- **MUI Integration**: Added wrapper components for `IconComponent` usage in MUI Select dropdowns

## Files Updated
- `AddNewRiskForm/RisksSection/index.tsx` - Chevron dropdown migration
- `CreateProjectForm/index.tsx` - Chevron dropdown migration  
- `Inputs/Dropdowns/ProjectFilter/ProjectFilterDropdown.tsx` - Chevron dropdown with wrapper
- `Table/EvaluationTable/TableBody/index.tsx` - Trash icon migration

## Test plan
- [ ] Verify dropdown arrows display correctly in form components
- [ ] Test project filter dropdown functionality
- [ ] Check table delete icons render properly
- [ ] Confirm consistent 20px icon sizing

This is the initial migration batch. Additional medium priority icon migrations will follow based on the original PR scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)