### PR TITLE
feat: Complete remaining icon migrations to Lucide React

### DIFF
--- a/Clients/src/application/commands/registry.ts
+++ b/Clients/src/application/commands/registry.ts
@@ -1,21 +1,21 @@
 import { Command, CommandGroup, CommandContext, CommandRegistry } from './types'
 import allowedRoles from '../constants/permissions'
 import {
-  HomeOutlined,
-  WarningAmberOutlined,
-  BusinessOutlined,
-  AccountTreeOutlined,
-  SchoolOutlined,
-  FolderOutlined,
-  TimelineOutlined,
-  AccountBalanceOutlined,
-  BalanceOutlined,
-  SettingsOutlined,
-  AssignmentOutlined,
-  PolicyOutlined,
-  VerifiedUserOutlined,
-  GroupOutlined
-} from '@mui/icons-material'
+  Home as HomeOutlined,
+  AlertTriangle as WarningAmberOutlined,
+  Building as BusinessOutlined,
+  GitBranch as AccountTreeOutlined,
+  GraduationCap as SchoolOutlined,
+  Folder as FolderOutlined,
+  Activity as TimelineOutlined,
+  Landmark as AccountBalanceOutlined,
+  Scale as BalanceOutlined,
+  Settings as SettingsOutlined,
+  ClipboardList as AssignmentOutlined,
+  FileText as PolicyOutlined,
+  ShieldCheck as VerifiedUserOutlined,
+  Users as GroupOutlined
+} from 'lucide-react'
 
 // Define command groups
 export const COMMAND_GROUPS: CommandGroup[] = [

--- a/Clients/src/presentation/components/Alert/index.tsx
+++ b/Clients/src/presentation/components/Alert/index.tsx
@@ -17,12 +17,7 @@ import { closeIconStyles, iconButtonStyles } from "./style";
 import { CloseIconProps } from "../../../domain/interfaces/iWidget";
 import AlertBody from "./AlertBody";
 
-import { ReactComponent as BlueInfoIcon } from "../../assets/icons/info-circle-blue.svg";
-import { ReactComponent as GreenSuccessIcon } from "../../assets/icons/success-circle-green.svg";
-import { ReactComponent as OrangeWarningIcon } from "../../assets/icons/warning-orange.svg";
-import { ReactComponent as RedErrorIcon } from "../../assets/icons/error-circle-red.svg";
-
-import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.svg";
+import { Info as BlueInfoIcon, CheckCircle as GreenSuccessIcon, AlertTriangle as OrangeWarningIcon, XCircle as RedErrorIcon, X as CloseGreyIcon } from "lucide-react";
 
 /**
  * Mapping of alert variants to their respective icons.
@@ -31,10 +26,10 @@ import { ReactComponent as CloseGreyIcon } from "../../assets/icons/close-grey.s
  * @type {object}
  */
 const icons: { [s: string]: JSX.Element } = {
-  success: <GreenSuccessIcon />, // #079455
-  info: <BlueInfoIcon />, // #0288d1
-  error: <RedErrorIcon />, // #f04438
-  warning: <OrangeWarningIcon />, // #DC6803
+  success: <GreenSuccessIcon size={20} />, // #079455
+  info: <BlueInfoIcon size={20} />, // #0288d1
+  error: <RedErrorIcon size={20} />, // #f04438
+  warning: <OrangeWarningIcon size={20} />, // #DC6803
 };
 
 /**
@@ -46,7 +41,7 @@ const icons: { [s: string]: JSX.Element } = {
 const CloseButton: React.FC<CloseIconProps> = ({
   text,
 }: CloseIconProps): JSX.Element => (
-  <CloseGreyIcon style={closeIconStyles(text)} />
+  <CloseGreyIcon size={16} style={closeIconStyles(text)} />
 );
 
 /**

--- a/Clients/src/presentation/components/HelperIcon/index.tsx
+++ b/Clients/src/presentation/components/HelperIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IconButton } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 
 interface HelperIconProps {
   onClick: () => void;
@@ -23,7 +23,7 @@ const HelperIcon: React.FC<HelperIconProps> = ({ onClick, size = "small" }) => {
         },
       }}
     >
-      <GreyCircleInfoIcon />
+      <GreyCircleInfoIcon size={16} />
     </IconButton>
   );
 };

--- a/Clients/src/presentation/components/MetricInfoIcon/index.tsx
+++ b/Clients/src/presentation/components/MetricInfoIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IconButton, Box } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 
 interface MetricInfoIconProps {
   onClick: () => void;
@@ -24,7 +24,7 @@ const MetricInfoIcon = React.forwardRef<HTMLDivElement, MetricInfoIconProps>(({ 
           },
         }}
       >
-        <GreyCircleInfoIcon />
+        <GreyCircleInfoIcon size={16} />
       </IconButton>
     </Box>
   );


### PR DESCRIPTION
## Summary
This PR completes the remaining icon migrations to Lucide React that were originally planned in PRs #2359 and #2360 (which were closed due to conflicts).

## Changes Made
- **Command Registry**: Migrated MUI dashboard icons (`@mui/icons-material`) to Lucide equivalents with proper aliasing
- **Alert System**: Replaced SVG status icons with Lucide `Info`, `CheckCircle`, `AlertTriangle`, `XCircle`, and `X` components
- **Helper Components**: Updated `HelperIcon` and `MetricInfoIcon` to use Lucide `Info` component
- **Icon Sizing**: Applied consistent sizing (16px for info/close icons, 20px for status icons)
- **Dependencies**: Removed final dependencies on MUI icons and custom SVG assets for these components

## Files Updated
- `src/application/commands/registry.ts` - Command palette dashboard icons
- `src/presentation/components/Alert/index.tsx` - Alert status and close icons
- `src/presentation/components/HelperIcon/index.tsx` - Helper info icon
- `src/presentation/components/MetricInfoIcon/index.tsx` - Metric info icon

## Test plan
- [ ] Verify command palette icons display correctly
- [ ] Test alert notifications show proper status icons with correct colors
- [ ] Check helper/info icons render properly in forms and components
- [ ] Confirm consistent sizing across all migrated icons
- [ ] Validate that no MUI icon dependencies remain

This PR resolves the remaining work from the original PRs #2342, #2343, and #2344 icon migration chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)