### PR TITLE
feat: Migrate additional SVG icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskFilters.tsx
@@ -9,8 +9,7 @@ import {
   Collapse,
   IconButton,
 } from "@mui/material";
-import { ReactComponent as FilterIcon } from "../../assets/icons/filter.svg";
-import { ReactComponent as ClearIcon } from "../../assets/icons/clear.svg";
+import { Filter as FilterIcon, X as ClearIcon } from "lucide-react";
 import { ChevronDown as ExpandMoreIcon, ChevronUp as ExpandLessIcon } from "lucide-react";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
 import Select from "../Inputs/Select";
@@ -304,7 +303,7 @@ const RiskFilters: React.FC<RiskFiltersProps> = ({
         onClick={() => handleExpandedChange(!expanded)}
       >
         <Stack direction="row" alignItems="center" spacing={1}>
-          <FilterIcon style={{ color: "#13715B", height: "20px", width:"20px" }} />
+          <FilterIcon size={20} style={{ color: "#13715B" }} />
           <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "#1A1919" }}>
             Filters
           </Typography>
@@ -331,7 +330,7 @@ const RiskFilters: React.FC<RiskFiltersProps> = ({
           {activeFilterCount > 0 && (
             <Button
               size="small"
-              startIcon={<ClearIcon />}
+              startIcon={<ClearIcon size={16} />}
               onClick={(e) => {
                 e.stopPropagation();
                 clearAllFilters();

--- a/Clients/src/presentation/components/VWQuestion/index.tsx
+++ b/Clients/src/presentation/components/VWQuestion/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Chip, Stack, Tooltip, Typography, Dialog, useTheme } from "@mui/material";
 import { Question } from "../../../domain/types/Question";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 import {
   priorities,
   PriorityLevel,
@@ -260,7 +260,7 @@ const QuestionFrame = ({
                 }}
               >
                 <Box component="span" sx={{ display: "inline-flex", cursor: "pointer" }}>
-          <GreyCircleInfoIcon />
+          <GreyCircleInfoIcon size={16} />
         </Box>
               </Tooltip>
             </Box>

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -13,8 +13,7 @@ import {
   Tooltip,
 } from "@mui/material";
 import Alert from "../../../components/Alert";
-import {ReactComponent as VisibilityIcon} from "../../../assets/icons/visibility-grey.svg"
-import {ReactComponent as VisibilityOffIcon} from "../../../assets/icons/visibility-off-grey.svg"
+import { Eye as VisibilityIcon, EyeOff as VisibilityOffIcon } from "lucide-react";
 import { CirclePlus as AddCircleOutlineIcon, X as CloseGreyIcon } from "lucide-react";
 import Toggle from "../../../components/Inputs/Toggle";
 import { useStyles } from "./styles";
@@ -104,13 +103,13 @@ const ResourceTableRow: React.FC<{
         {resource.visible ? (
           <Tooltip title="Click to make this resource invisible">
             <Box component="span" sx={{ display: "inline-flex" }}>
-              <VisibilityIcon/>
+              <VisibilityIcon size={20} />
             </Box>
           </Tooltip>
         ) : (
           <Tooltip title="Click to make this resource visible">
             <Box component="span" sx={{ display: "inline-flex" }}>
-              <VisibilityOffIcon/>
+              <VisibilityOffIcon size={20} />
             </Box>
           </Tooltip>
         )}

--- a/Clients/src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx
@@ -9,7 +9,7 @@ import {
 import React, { useEffect, useMemo, useState } from "react";
 import CustomizableButton from "../../../components/Button/CustomizableButton";
 import { viewProjectButtonStyle } from "../../../components/Cards/ProjectCard/style";
-import { ReactComponent as ExpandMoreIcon } from "../../../assets/icons/expand-down.svg";
+import { ChevronDown as ExpandMoreIcon } from "lucide-react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import {
   sendSlackMessage,
@@ -226,7 +226,7 @@ const NotificationRoutingModal: React.FC<NotificationRoutingModalProps> = ({
                   );
                 }}
                 filterSelectedOptions
-                popupIcon={<ExpandMoreIcon />}
+                popupIcon={<ExpandMoreIcon size={20} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}


### PR DESCRIPTION
## Summary
This PR migrates additional SVG icons to Lucide React components that were identified from the closed PRs #2347 and #2348.

## Changes Made
- **VWQuestion Component**: Migrated info circle icon to Lucide `Info` component
- **RiskFilters Component**: Replaced filter and clear SVG icons with Lucide `Filter` and `X` components
- **Slack NotificationRoutingModal**: Updated expand/dropdown icon to Lucide `ChevronDown`
- **AITrustCenter Resources**: Migrated visibility toggle icons to Lucide `Eye` and `EyeOff` components
- **Icon Sizing**: Applied consistent sizing (16px for small icons, 20px for standard UI icons)

## Files Updated
- `src/presentation/components/VWQuestion/index.tsx` - Info icon migration
- `src/presentation/components/RiskVisualization/RiskFilters.tsx` - Filter and clear icons
- `src/presentation/pages/SettingsPage/Slack/NotificationRoutingModal.tsx` - Dropdown icon
- `src/presentation/pages/AITrustCenter/Resources/index.tsx` - Visibility toggle icons

## Test plan
- [ ] Verify info tooltips display correctly in question components
- [ ] Test filter functionality with new filter/clear icons
- [ ] Check Slack notification routing dropdown works properly
- [ ] Validate visibility toggle functionality in AI Trust Center resources
- [ ] Confirm consistent icon sizing across all migrated components

This PR continues the comprehensive icon migration work, addressing remaining SVG assets identified from the original PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)