### PR TITLE
feat: Migrate remaining MUI and SVG icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
@@ -10,7 +10,7 @@ import {
   FormControlLabel,
   Radio,
 } from "@mui/material";
-import { ClearIcon } from "@mui/x-date-pickers/icons";
+import { X as ClearIcon } from "lucide-react";
 import {
   Suspense,
   useCallback,
@@ -455,7 +455,8 @@ const ProjectForm = ({
           </Typography>
         </Stack>
         <ClearIcon
-          sx={{ color: "#98A2B3", cursor: "pointer" }}
+          size={20}
+          style={{ color: "#98A2B3", cursor: "pointer" }}
           onClick={onClose}
         />
       </Stack>
@@ -585,7 +586,8 @@ const ProjectForm = ({
           </Typography>
         </Stack>
         <ClearIcon
-          sx={{ color: "#98A2B3", cursor: "pointer" }}
+          size={20}
+          style={{ color: "#98A2B3", cursor: "pointer" }}
           onClick={onClose}
         />
       </Stack>

--- a/Clients/src/presentation/components/LinkedRisks/index.tsx
+++ b/Clients/src/presentation/components/LinkedRisks/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Stack, Typography } from "@mui/material";
-import { ClearIcon } from "@mui/x-date-pickers/icons";
+import { X as ClearIcon } from "lucide-react";
 import React, { useState, useEffect } from "react";
 import Field from "../Inputs/Field";
 import useProjectRisks from "../../../application/hooks/useProjectRisks";
@@ -84,7 +84,7 @@ const LinkedRisksPopup: React.FC<LinkedRisksModalProps> = ({
           <Typography sx={styles.textTitle}>
             Link a risk from risk database
           </Typography>
-          <ClearIcon sx={styles.clearIconStyle} onClick={onClose} />
+          <ClearIcon size={20} style={styles.clearIconStyle} onClick={onClose} />
         </Stack>
         <Stack component="form" sx={styles.searchInputWrapper}>
           <Typography sx={{ fontSize: 13, color: "#344054", mr: 8 }}>

--- a/Clients/src/presentation/components/Modals/Banner/index.tsx
+++ b/Clients/src/presentation/components/Modals/Banner/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Paper, Typography } from "@mui/material";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { IBannerProps } from "../../../../domain/interfaces/iWidget";
 import {
   bannerBoxStyle,
@@ -19,7 +19,7 @@ const index = ({ onClose, bannerText, bannerWidth }: IBannerProps) => {
       >
         <Typography sx={bannerTextStyle}>
           {bannerText}
-          <CloseGreyIcon onClick={onClose} style={closeIconStyle} />
+          <CloseGreyIcon size={16} onClick={onClose} style={closeIconStyle} />
         </Typography>
       </Paper>
     </Box>

--- a/Clients/src/presentation/components/Popup/index.tsx
+++ b/Clients/src/presentation/components/Popup/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Typography, useTheme, Stack } from "@mui/material";
-import { ClearIcon } from "@mui/x-date-pickers/icons";
+import { X as ClearIcon } from "lucide-react";
 import React from "react";
 import { FC } from "react";
 import { Unstable_Popup as BasePopup } from "@mui/base/Unstable_Popup";
@@ -130,7 +130,7 @@ const Popup: FC<PopupProps> = ({
             </Typography>
           )}
           <Button onClick={handleOpenOrClose} sx={styles.closePopupButton}>
-            <ClearIcon />
+            <ClearIcon size={20} />
           </Button>
           {popupContent}
         </Stack>

--- a/Clients/src/presentation/components/ProjectRiskMitigation/ProjectRiskMitigation.tsx
+++ b/Clients/src/presentation/components/ProjectRiskMitigation/ProjectRiskMitigation.tsx
@@ -1,5 +1,5 @@
 import { Stack, Typography } from "@mui/material"
-import { ClearIcon } from "@mui/x-date-pickers/icons"
+import { X as ClearIcon } from "lucide-react"
 import { ProjectRiskMitigationTable } from "../Table/ProjectRiskMitigationTable/ProjectRiskMitigationTable";
 import { ProjectRiskMitigation as ProjectRiskMitigationType } from "../../../domain/types/ProjectRisk";
 
@@ -42,10 +42,12 @@ export const ProjectRiskMitigation: React.FC<ProjectRiskMitigationProps> = ({
           color: "#344054", 
           fontWeight: "bold",
         }}>Linked controls components</Typography>
-        <ClearIcon sx={{
-          color: "#98A2B3", 
-          cursor: "pointer"
-        }}
+        <ClearIcon
+          size={20}
+          style={{
+            color: "#98A2B3",
+            cursor: "pointer"
+          }}
           onClick={onClose}
         />
       </Stack>

--- a/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
@@ -1,7 +1,7 @@
 // New component file: ProjectList.tsx
 import { useState, useMemo } from "react";
 import { Box, Typography, InputBase, IconButton } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 import ProjectCard from "../Cards/ProjectCard";
 import ProjectTableView from "./ProjectTableView";
 import NoProject from "../NoProject/NoProject";
@@ -102,7 +102,7 @@ const ProjectList = ({ projects }: ProjectListProps) => {
             aria-expanded={isSearchBarVisible}
             onClick={() => setIsSearchBarVisible((prev) => !prev)}
           >
-            <SearchIcon />
+            <SearchIcon size={16} />
           </IconButton>
 
           {isSearchBarVisible && (

--- a/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, lazy, Suspense, useRef } from "react";
 import { IconButton, Box, Stack } from "@mui/material";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { styles } from "./styles";
 const GenerateReportFrom = lazy(() => import("./GenerateReportFrom"));
 const DownloadReportForm = lazy(() => import("./DownloadReportFrom"));
@@ -150,7 +150,7 @@ const GenerateReportPopup: React.FC<GenerateReportProps> = ({
 
 
 
-          <CloseGreyIcon />
+          <CloseGreyIcon size={16} />
         </IconButton>
         {isReportRequest ? (
           <Suspense fallback={<div>Loading...</div>}>

--- a/Clients/src/presentation/components/VendorRisksDialog/index.tsx
+++ b/Clients/src/presentation/components/VendorRisksDialog/index.tsx
@@ -17,7 +17,7 @@ import {
 } from "@mui/material";
 import { useState, useEffect } from "react";
 import React from "react";
-import { ClearIcon } from "@mui/x-date-pickers/icons";
+import { X as ClearIcon } from "lucide-react";
 import { getSeverityColorByText, getRiskChipStyle } from "../RiskLevel/constants";
 import { getVendorRisksByVendorId } from "../../../application/repository/vendorRisk.repository";
 import AddNewRisk from "../Modals/NewRisk";
@@ -162,10 +162,12 @@ const VendorRisksDialog: React.FC<VendorRisksDialogProps> = ({
             }}>
               Vendor Risks {vendorName ? `- ${vendorName}` : ""} ({vendorRisks.length})
             </Typography>
-            <ClearIcon sx={{
-              color: "#98A2B3",
-              cursor: "pointer"
-            }}
+            <ClearIcon
+              size={20}
+              style={{
+                color: "#98A2B3",
+                cursor: "pointer"
+              }}
               onClick={onClose}
             />
           </Stack>


### PR DESCRIPTION
## Summary
• Complete migration of all remaining MUI icons to Lucide React
• Replace critical SVG icons with Lucide equivalents for better consistency
• Remove dependency on @mui/x-date-pickers/icons for cleaner bundle

## Changes
• Migrated all ClearIcon usages from MUI to Lucide X icon (5 files)
• Replaced close-grey.svg with Lucide X in modal components
• Updated search.svg to Lucide Search icon
• Added consistent size props to all migrated icons

## Test plan
- [ ] Verify all modal close buttons work correctly
- [ ] Check search functionality still works
- [ ] Confirm icon sizes are consistent across components
- [ ] Test that all migrated components render without errors