### PR TITLE
feat: Continue SVG icon migration to Lucide React

### DIFF
--- a/Clients/src/presentation/components/Cards/RisksCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/RisksCard/index.tsx
@@ -1,7 +1,5 @@
 import { Stack, Typography, Tooltip, Box } from "@mui/material";
-import {ReactComponent as TrendingUpRedIcon} from "../../../assets/icons/trendingUp.svg";
-import {ReactComponent as TrendingDownGreenIcon} from "../../../assets/icons/trendingDown.svg";
-import {ReactComponent as TrendingFlatGreyIcon} from "../../../assets/icons/trendingFlat.svg";
+import { TrendingUp as TrendingUpRedIcon, TrendingDown as TrendingDownGreenIcon, Minus as TrendingFlatGreyIcon } from "lucide-react";
 import {
   projectRisksCard,
   projectRisksTileCard,
@@ -25,7 +23,7 @@ const RisksCard = ({ risksSummary }: RisksCardProps) => {
     if (!trend || trend.direction === 'stable') {
       return (
         <Typography sx={trendIndicator}>
-          <TrendingFlatGreyIcon style={trendIconStable} />
+          <TrendingFlatGreyIcon size={16} style={trendIconStable} />
           <span style={{ color: "#6B7280" }}>
             {trend?.change === 0 ? "0" : "—"}
           </span>
@@ -36,7 +34,7 @@ const RisksCard = ({ risksSummary }: RisksCardProps) => {
     if (trend.direction === 'up') {
       return (
         <Typography sx={trendIndicator}>
-          <TrendingUpRedIcon style={trendIconUp} />
+          <TrendingUpRedIcon size={16} style={trendIconUp} />
           <span style={{ color: "#EF4444" }}>
             +{trend.change}
           </span>
@@ -46,7 +44,7 @@ const RisksCard = ({ risksSummary }: RisksCardProps) => {
 
     return (
       <Typography sx={trendIndicator}>
-        <TrendingDownGreenIcon style={trendIconDown} />
+        <TrendingDownGreenIcon size={16} style={trendIconDown} />
         <span style={{ color: "#10B981" }}>
           -{Math.abs(trend.change)}
         </span>

--- a/Clients/src/presentation/components/CommandPalette/index.tsx
+++ b/Clients/src/presentation/components/CommandPalette/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react'
 import { Command } from 'cmdk'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { Box, Typography, IconButton } from '@mui/material'
-import { ReactComponent as CloseIcon } from '../../assets/icons/close-grey.svg'
+import { X as CloseIcon } from 'lucide-react'
 import { useAuth } from '../../../application/hooks/useAuth'
 import commandRegistry from '../../../application/commands/registry'
 import CommandActionHandler, { CommandActionHandlers } from '../../../application/commands/actionHandler'
@@ -192,7 +192,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChange }) =
                         height: 24
                       }}
                     >
-                      <CloseIcon/>
+                      <CloseIcon size={16}/>
                     </IconButton>
                   </Box>
 

--- a/Clients/src/presentation/components/Inputs/FileUpload/index.tsx
+++ b/Clients/src/presentation/components/Inputs/FileUpload/index.tsx
@@ -1,8 +1,7 @@
 import { Stack, useTheme, IconButton, Typography, Link } from "@mui/material";
 import Uppy from "@uppy/core";
 import { useState } from "react";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
-import { ReactComponent as DeleteIconGrey } from "../../../assets/icons/trash-grey.svg";
+import { X as CloseGreyIcon, Trash2 as DeleteIconGrey } from "lucide-react";
 import DeleteFileModal from "./DeleteFileModal";
 import getStyles from "./getStyles";
 import { FileData } from "../../../../domain/types/File";
@@ -40,7 +39,7 @@ const FileListItem: React.FC<{
       </Typography>
     </Link>
     <IconButton onClick={() => onDeleteClick(file.id, file.fileName)}>
-      <DeleteIconGrey />
+      <DeleteIconGrey size={16} />
     </IconButton>
   </Stack>
 );
@@ -81,7 +80,7 @@ const UppyUploadFile: React.FC<UppyUploadFileProps> = ({
     <Stack className="uppy-holder" sx={styles.container}>
       <Stack sx={styles.header}>
         <IconButton onClick={onClose}>
-          <CloseGreyIcon />
+          <CloseGreyIcon size={16} />
         </IconButton>
       </Stack>
 

--- a/Clients/src/presentation/components/Policies/PolicyForm.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyForm.tsx
@@ -12,7 +12,7 @@ import DatePicker from "../Inputs/Datepicker";
 import dayjs, { Dayjs } from "dayjs";
 import { User } from "../../../domain/types/User";
 import useUsers from "../../../application/hooks/useUsers";
-import { ReactComponent as GreyDownArrowIcon } from "../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { useCallback } from "react";
 import { FormErrors } from "./PolicyDetailsModal";
 
@@ -136,7 +136,7 @@ const PolicyForm: React.FC<Props> = ({ formData, setFormData, tags, errors }) =>
               );
             }}
             filterSelectedOptions
-            popupIcon={<GreyDownArrowIcon />}
+            popupIcon={<GreyDownArrowIcon size={16} />}
             renderInput={(params) => (
               <TextField
                 {...params}
@@ -219,7 +219,7 @@ const PolicyForm: React.FC<Props> = ({ formData, setFormData, tags, errors }) =>
               );
             }}
             filterSelectedOptions
-            popupIcon={<GreyDownArrowIcon />}
+            popupIcon={<GreyDownArrowIcon size={16} />}
             renderInput={(params) => (
               <TextField
                 {...params}

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -49,7 +49,7 @@ import TabContext from "@mui/lab/TabContext";
 import TabList from "@mui/lab/TabList";
 import Tab from "@mui/material/Tab";
 import { IconButton, InputBase } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 import { searchBoxStyle, inputStyle } from "./style";
 import { ModelInventoryStatus } from "../../../domain/enums/modelInventory.enum";
 
@@ -720,7 +720,7 @@ const ModelInventory: React.FC = () => {
                     aria-expanded={isSearchBarVisible}
                     onClick={() => setIsSearchBarVisible((prev) => !prev)}
                   >
-                    <SearchIcon />
+                    <SearchIcon size={16} />
                   </IconButton>
 
                   {isSearchBarVisible && (


### PR DESCRIPTION
## Summary
• Continue migrating SVG icons to Lucide React for better consistency
• Replace close, search, chevron, and trending icons with Lucide equivalents
• Reduce bundle size by removing additional SVG dependencies

## Changes
• Replace close-grey.svg with Lucide X icon in FileUpload and CommandPalette  
• Migrate trash-grey.svg to Lucide Trash2 in file deletion actions
• Update search.svg to Lucide Search in ModelInventory page
• Convert chevron-down-grey.svg to Lucide ChevronDown in PolicyForm
• Replace trending icons with Lucide TrendingUp, TrendingDown, and Minus

## Test plan
- [ ] Verify file upload close buttons work correctly
- [ ] Check search functionality in model inventory
- [ ] Test dropdown chevron icons display properly  
- [ ] Confirm trending indicators show correct icons and colors
- [ ] Verify all migrated icons have consistent sizing