### PR TITLE
feat: Migrate navigation and view icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/Breadcrumbs/index.tsx
+++ b/Clients/src/presentation/components/Breadcrumbs/index.tsx
@@ -9,7 +9,7 @@ import {
 import { useLocation, useNavigate } from "react-router-dom";
 import { getRouteMapping } from "./routeMapping";
 
-import { ReactComponent as ChevronRightGreyIcon } from "../../assets/icons/chevron-right-grey.svg";
+import { ChevronRight as ChevronRightGreyIcon } from "lucide-react";
 import {
   IBreadcrumbItem,
   IBreadcrumbsProps,
@@ -25,7 +25,7 @@ import {
  */
 const Breadcrumbs: React.FC<IBreadcrumbsProps> = ({
   items,
-  separator = <ChevronRightGreyIcon style={{ width: "80%", height: "auto" }} />,
+  separator = <ChevronRightGreyIcon size={16} style={{ width: "80%", height: "auto" }} />,
   maxItems = 8,
   sx,
   autoGenerate = false,

--- a/Clients/src/presentation/components/RiskVisualization/RiskCategories.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskCategories.tsx
@@ -8,8 +8,7 @@ import {
   Grid,
   Collapse,
 } from "@mui/material";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-up.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-down.svg";
+import { ChevronUp as ExpandLessIcon, ChevronDown as ExpandMoreIcon } from "lucide-react";
 import { ProjectRisk } from "../../../domain/types/ProjectRisk";
 import { getAllUsers } from "../../../application/repository/user.repository";
 import ButtonToggle from "../ButtonToggle";
@@ -222,7 +221,7 @@ const RiskCategories: React.FC<RiskCategoriesProps> = ({
                       </Typography>
                     </Box>
                     
-                    {isExpanded ? <ExpandLessIcon style={{ color: '#6B7280' }} /> : <ExpandMoreIcon style={{ color: '#6B7280' }} />}
+                    {isExpanded ? <ExpandLessIcon size={16} style={{ color: '#6B7280' }} /> : <ExpandMoreIcon size={16} style={{ color: '#6B7280' }} />}
                   </Box>
 
                   <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>

--- a/Clients/src/presentation/components/TablePagination/index.tsx
+++ b/Clients/src/presentation/components/TablePagination/index.tsx
@@ -14,10 +14,7 @@
 import { Box, Button } from "@mui/material";
 import "../Table/index.css";
 
-import { ReactComponent as LeftArrowDouble } from "../../assets/icons/left-arrow-double.svg";
-import { ReactComponent as LeftArrow } from "../../assets/icons/left-arrow.svg";
-import { ReactComponent as RightArrow } from "../../assets/icons/right-arrow.svg";
-import { ReactComponent as RightArrowDouble } from "../../assets/icons/right-arrow-double.svg";
+import { ChevronsLeft as LeftArrowDouble, ChevronLeft as LeftArrow, ChevronRight as RightArrow, ChevronsRight as RightArrowDouble } from "lucide-react";
 
 interface TablePaginationActionsProps {
   count: number;
@@ -67,7 +64,7 @@ const TablePaginationActions: React.FC<TablePaginationActionsProps> = ({
         disabled={page === 0}
         aria-label="first page"
       >
-        <LeftArrowDouble />
+        <LeftArrowDouble size={16} />
       </Button>
       <Button
         variant="text"
@@ -75,7 +72,7 @@ const TablePaginationActions: React.FC<TablePaginationActionsProps> = ({
         disabled={page === 0}
         aria-label="previous page"
       >
-        <LeftArrow />
+        <LeftArrow size={16} />
       </Button>
       <Button
         variant="text"
@@ -83,7 +80,7 @@ const TablePaginationActions: React.FC<TablePaginationActionsProps> = ({
         disabled={page >= Math.ceil(count / rowsPerPage) - 1}
         aria-label="next page"
       >
-        <RightArrow />
+        <RightArrow size={16} />
       </Button>
       <Button
         variant="text"
@@ -91,7 +88,7 @@ const TablePaginationActions: React.FC<TablePaginationActionsProps> = ({
         disabled={page >= Math.ceil(count / rowsPerPage) - 1}
         aria-label="last page"
       >
-        <RightArrowDouble />
+        <RightArrowDouble size={16} />
       </Button>
     </Box>
   );

--- a/Clients/src/presentation/components/ViewToggle/index.tsx
+++ b/Clients/src/presentation/components/ViewToggle/index.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { ToggleButton, ToggleButtonGroup, useTheme } from "@mui/material";
 import { SxProps, Theme } from "@mui/material/styles";
-import {ReactComponent as ViewModuleIcon} from "../../assets/icons/viewModule.svg";
-import {ReactComponent as TableRowsIcon} from "../../assets/icons/tableRows.svg";
+import { LayoutGrid as ViewModuleIcon, List as TableRowsIcon } from "lucide-react";
 
 export type ViewMode = "card" | "table";
 
@@ -92,10 +91,10 @@ const ViewToggle: React.FC<ViewToggleProps> = ({
       ]}
     >
       <ToggleButton value="card" aria-label="card view" disableRipple>
-        <ViewModuleIcon/>
+        <ViewModuleIcon size={16}/>
       </ToggleButton>
       <ToggleButton value="table" aria-label="table view" disableRipple>
-        <TableRowsIcon />
+        <TableRowsIcon size={16} />
       </ToggleButton>
     </ToggleButtonGroup>
   );

--- a/Clients/src/presentation/pages/TrainingRegistar/index.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/index.tsx
@@ -27,7 +27,7 @@ import HelperDrawer from "../../components/HelperDrawer";
 import HelperIcon from "../../components/HelperIcon";
 import { useAuth } from "../../../application/hooks/useAuth";
 import PageHeader from "../../components/Layout/PageHeader";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 import Select from "../../components/Inputs/Select";
 import { searchBoxStyle, inputStyle } from "./style";
 
@@ -334,7 +334,7 @@ const Training: React.FC = () => {
                   aria-expanded={isSearchBarVisible}
                   onClick={() => setIsSearchBarVisible((prev) => !prev)}
                 >
-                  <SearchIcon />
+                  <SearchIcon size={16} />
                 </IconButton>
 
                 {isSearchBarVisible && (


### PR DESCRIPTION
## Summary
• Migrate arrow navigation and view toggle icons to Lucide React
• Replace pagination, breadcrumb, and expand/collapse icons with Lucide equivalents
• Improve consistency across navigation components

## Changes
• Replace pagination arrows with Lucide ChevronsLeft/Right and ChevronLeft/Right
• Convert breadcrumb chevron to Lucide ChevronRight
• Update expand/collapse icons to Lucide ChevronUp/ChevronDown
• Replace search icon in TrainingRegistar with Lucide Search
• Migrate view toggle icons to Lucide LayoutGrid and List

## Test plan
- [ ] Verify table pagination arrows work correctly
- [ ] Check breadcrumb navigation displays proper separators
- [ ] Test expand/collapse functionality in risk categories
- [ ] Confirm search icon displays in training registar
- [ ] Validate view toggle switches between card and table views