### PR TITLE
feat: Migrate utility and action icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/Table/FileTable/FileTable.tsx
+++ b/Clients/src/presentation/components/Table/FileTable/FileTable.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useMemo } from "react";
 import FileBasicTable from "../FilesBasicTable/FileBasicTable";
 import { Stack, Box, Typography } from "@mui/material";
-import AscendingIcon from "../../../assets/icons/up-arrow.svg";
-import DescendingIcon from "../../../assets/icons/down-arrow.svg";
+import { ArrowUp as AscendingIcon, ArrowDown as DescendingIcon } from "lucide-react";
 import EmptyTableImage from "../../../assets/imgs/empty-state.svg";
 import { FileData } from "../../../../domain/types/File";
 
@@ -100,16 +99,11 @@ const FileTable: React.FC<FileTableProps> = ({ cols, files }) => {
                   sx={{ cursor: "pointer" }}
                 >
                   {col.name}
-                  <Box
-                    component="img"
-                    src={
-                      sortField === colKey && sortDirection === "asc"
-                        ? AscendingIcon
-                        : DescendingIcon
-                    }
-                    alt="Sort"
-                    sx={{ width: 16, height: 16, ml: 0.5 }}
-                  />
+                  {sortField === colKey && sortDirection === "asc" ? (
+                    <AscendingIcon size={16} style={{ marginLeft: 4 }} />
+                  ) : (
+                    <DescendingIcon size={16} style={{ marginLeft: 4 }} />
+                  )}
                 </Stack>
               ),
             }

--- a/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ResetPassword/index.tsx
@@ -4,7 +4,7 @@
 
 import { Stack, Typography, useTheme } from "@mui/material";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
-import { ReactComponent as Email } from "../../../assets/icons/email.svg";
+import { Mail as Email } from "lucide-react";
 import { ArrowLeft as LeftArrowLong } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useState, lazy, Suspense } from "react";
@@ -102,7 +102,7 @@ const ResetPassword = () => {
             gap: theme.spacing(12),
           }}
         >
-          <Email />
+          <Email size={24} />
         </Stack>
         <Stack sx={{ gap: theme.spacing(6), textAlign: "center" }}>
           <Typography sx={{ fontSize: 16, fontWeight: "bold" }}>

--- a/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
@@ -16,10 +16,7 @@ import {
   IconButton,
 } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { ReactComponent as CopyIcon } from "../../assets/icons/copy.svg";
-import { ReactComponent as DownloadIcon } from "../../assets/icons/download.svg";
-import { ReactComponent as ExpandMoreIcon } from "../../assets/icons/expand-more.svg";
-import { ReactComponent as ExpandLessIcon } from "../../assets/icons/expand-less.svg";
+import { Copy as CopyIcon, Download as DownloadIcon, ChevronDown as ExpandMoreIcon, ChevronUp as ExpandLessIcon } from "lucide-react";
 import { BarChart } from "@mui/x-charts";
 import createPlotlyComponent from 'react-plotly.js/factory';
 import Plotly from 'plotly.js-basic-dist';
@@ -1113,7 +1110,7 @@ export default function BiasAndFairnessResultsPage() {
                     }
                   }}
                 >
-                  <CopyIcon style={{ width: 24, height: 24 }} />
+                  <CopyIcon size={24} />
                 </IconButton>
                 <IconButton
                   onClick={handleDownloadJSON}
@@ -1129,7 +1126,7 @@ export default function BiasAndFairnessResultsPage() {
                     }
                   }}
                 >
-                  <DownloadIcon style={{ width: 24, height: 24 }} />
+                  <DownloadIcon size={24} />
                 </IconButton>
               </Box>
             </Box>
@@ -1168,7 +1165,7 @@ export default function BiasAndFairnessResultsPage() {
                       }
                     }}
                   >
-                    <ExpandMoreIcon style={{ width: 20, height: 20, marginTop: '3px', marginLeft: '4px' }} />
+                    <ExpandMoreIcon size={20} style={{ marginTop: '3px', marginLeft: '4px' }} />
                   </IconButton>
                 </Box>
               )}
@@ -1187,7 +1184,7 @@ export default function BiasAndFairnessResultsPage() {
                       }
                     }}
                   >
-                    <ExpandLessIcon style={{ width: 20, height: 20, marginRight: '3px', marginTop: '-2px' }} />
+                    <ExpandLessIcon size={20} style={{ marginRight: '3px', marginTop: '-2px' }} />
                   </IconButton>
                 </Box>
               )}

--- a/Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx
@@ -7,8 +7,7 @@ import {
   IconButton,
   Button,
 } from "@mui/material";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
-import { ReactComponent as CheckGreenIcon } from "../../../assets/icons/check-green.svg";
+import { X as CloseGreyIcon, Check as CheckGreenIcon } from "lucide-react";
 import { Project } from "../../../../domain/types/Project";
 import { Framework } from "../../../../domain/types/Framework";
 import {
@@ -173,7 +172,7 @@ const AddFrameworkModal: React.FC<AddFrameworkModalProps> = ({
             onClick={onClose}
             sx={modalCloseButtonStyle}
           >
-            <CloseGreyIcon/>
+            <CloseGreyIcon size={16}/>
           </IconButton>
         </Box>
         {/* Description */}
@@ -213,7 +212,7 @@ const AddFrameworkModal: React.FC<AddFrameworkModalProps> = ({
                           color: "#13715B",
                         }}
                       >
-                        <CheckGreenIcon />
+                        <CheckGreenIcon size={16} />
                         Added
                       </Box>
                     )}


### PR DESCRIPTION
## Summary
• Migrate utility and action icons to Lucide React for better consistency
• Replace close, check, copy, download, and sorting icons with Lucide equivalents
• Modernize icon implementation from img src to direct component usage

## Changes
• Replace close-grey.svg and check-green.svg with Lucide X and Check
• Migrate copy/download icons to Lucide Copy/Download 
• Convert expand icons to Lucide ChevronDown/ChevronUp
• Update email icon to Lucide Mail in authentication
• Replace table sorting arrows with Lucide ArrowUp/ArrowDown

## Test plan
- [ ] Verify close buttons work in AddNewFramework modal
- [ ] Check copy/download functionality in BiasAndFairnessResultsPage
- [ ] Test expand/collapse actions work correctly
- [ ] Confirm email icon displays in ResetPassword page
- [ ] Validate table sorting arrows appear and function properly