### PR TITLE
feat: Migrate remaining common icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskMITForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskMITForm/index.tsx
@@ -13,7 +13,7 @@ import {
   Radio,
   TextField,
 } from "@mui/material";
-import { ReactComponent as GreyCloseIconSVG } from "../../assets/icons/close-grey.svg";
+import { X as GreyCloseIconSVG } from "lucide-react";
 import placeholderImage from "../../assets/imgs/empty-state.svg";
 import riskData from "../../assets/MITAIRISKDB.json";
 import CustomizableButton from "../Button/CustomizableButton";
@@ -263,7 +263,7 @@ const AddNewRiskMITModal = ({
           >
             Add a new risk from risk database
           </Typography>
-          <GreyCloseIconSVG onClick={handleClose} cursor={"pointer"} />
+          <GreyCloseIconSVG size={16} onClick={handleClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Stack
           direction="row"

--- a/Clients/src/presentation/components/Modals/FileUpload/index.tsx
+++ b/Clients/src/presentation/components/Modals/FileUpload/index.tsx
@@ -4,7 +4,7 @@ import {
   StyledDialogContent,
 } from "../../FileUpload/FileUpload.styles";
 import { FileUploadProps } from "../../FileUpload/types";
-import { ReactComponent as CloseGreyIcon } from "../../../assets/icons/close-grey.svg";
+import { X as CloseGreyIcon } from "lucide-react";
 import { IconButton } from "@mui/material";
 import FileUploadComponent from "../../FileUpload";
 
@@ -31,7 +31,7 @@ const FileUploadModal: React.FC<FileUploadModalProps> = ({ uploadProps }) => {
           }}
           disableRipple
         >
-          <CloseGreyIcon />
+          <CloseGreyIcon size={16} />
         </IconButton>
 
         <FileUploadComponent

--- a/Clients/src/presentation/components/Table/LinkedRisksTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/LinkedRisksTable/TableBody/index.tsx
@@ -3,7 +3,7 @@ import { ProjectRisk } from '../../../../../domain/types/ProjectRisk'
 import singleTheme from '../../../../themes/v1SingleTheme';
 import { TableBody, TableCell, TableRow, useTheme, Checkbox as MuiCheckbox, TableFooter, TablePagination, } from '@mui/material';
 import { Square as CheckboxOutline } from "lucide-react";
-import { ReactComponent as CheckboxFilled } from "../../../../assets/icons/checkbox-filled.svg";
+import { CheckSquare as CheckboxFilled } from "lucide-react";
 import { ChevronsUpDown } from "lucide-react";
 
 const SelectorVertical = (props: any) => <ChevronsUpDown size={16} {...props} />;
@@ -85,7 +85,7 @@ const LinkedRisksTableBody: React.FC<TableProps> = ({
                     checked={checkedRows.includes(row.id)}
                     onChange={(e) => handleRowClick(row, e)}
                     onClick={(e) => e.stopPropagation()}  
-                    checkedIcon={<CheckboxFilled />}
+                    checkedIcon={<CheckboxFilled size={16} />}
                     icon={<CheckboxOutline size={16} />}
                     sx={{
                       borderRadius: "4px",

--- a/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ForgotPassword/index.tsx
@@ -4,7 +4,7 @@
 
 import { Button, Stack, Typography, useTheme } from "@mui/material";
 import React, { useState } from "react";
-import { ReactComponent as Key } from "../../../assets/icons/key.svg";
+import { Key } from "lucide-react";
 import { ArrowLeft as LeftArrowLong } from "lucide-react";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
 import Field from "../../../components/Inputs/Field";
@@ -128,7 +128,7 @@ const ForgotPassword: React.FC = () => {
               gap: theme.spacing(12),
             }}
           >
-            <Key />
+            <Key size={24} />
           </Stack>
           <Stack sx={{ gap: theme.spacing(6), textAlign: "center" }}>
             <Typography sx={{ fontSize: 16, fontWeight: "bold" }}>

--- a/Clients/src/presentation/pages/PolicyDashboard/PoliciesDashboard.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PoliciesDashboard.tsx
@@ -9,7 +9,7 @@ import {
   InputBase,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as SearchIcon } from "../../assets/icons/search.svg";
+import { Search as SearchIcon } from "lucide-react";
 import CustomizableButton from "../../components/Button/CustomizableButton";
 import { CirclePlus as AddCircleOutlineIcon } from "lucide-react";
 import HelperDrawer from "../../components/HelperDrawer";
@@ -197,7 +197,7 @@ const PolicyDashboard: React.FC = () => {
                 aria-expanded={isSearchBarVisible}
                 onClick={() => setIsSearchBarVisible((prev) => !prev)}
               >
-                <SearchIcon />
+                <SearchIcon size={16} />
               </IconButton>
 
               {isSearchBarVisible && (


### PR DESCRIPTION
## Summary
• Migrate final set of commonly used SVG icons to Lucide React
• Replace close, checkbox, search, and authentication icons
• Complete migration of most frequently used icon types

## Changes
• Replace close-grey.svg with Lucide X in file upload modals
• Convert checkbox-filled.svg to Lucide CheckSquare for table selections
• Update search.svg to Lucide Search in policy dashboard
• Migrate key.svg to Lucide Key in forgot password page

## Test plan
- [ ] Verify file upload modal close buttons work
- [ ] Check table row selection checkboxes function correctly
- [ ] Test search functionality in policy dashboard
- [ ] Confirm key icon displays in forgot password page