### PR TITLE
Migrate remaining SVG icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -10,8 +10,7 @@ import React, {
 import { useSearchParams } from "react-router-dom";
 import { Box, Stack, Tab, Typography, useTheme } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { Save as SaveIcon } from "lucide-react";
-import { ReactComponent as UpdateIconSVGWhite } from "../../assets/icons/update-white.svg";
+import { Save as SaveIcon, RotateCcw as UpdateIconSVGWhite } from "lucide-react";
 import dayjs from "dayjs";
 
 import { Likelihood, Severity } from "../RiskLevel/constants";
@@ -815,7 +814,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
               popupStatus === "new" ? (
                 <SaveIcon size={16} />
               ) : (
-                <UpdateIconSVGWhite />
+                <UpdateIconSVGWhite size={16} />
               )
             }
             variant="contained"

--- a/Clients/src/presentation/components/Alert/AlertBody.tsx
+++ b/Clients/src/presentation/components/Alert/AlertBody.tsx
@@ -1,7 +1,7 @@
 // AlertBody.tsx
 import React, { useState } from "react";
 import { Box, IconButton, Typography } from "@mui/material";
-import {ReactComponent as ContentCopyIcon} from "../../assets/icons/contentCopy.svg";
+import { Copy as ContentCopyIcon } from "lucide-react";
 
 interface AlertBodyProps {
   body: string;
@@ -61,7 +61,8 @@ const AlertBody: React.FC<AlertBodyProps> = ({ body, textColor }) => {
                   </Typography>
                 ) : (
                   <ContentCopyIcon
-                     style={{ width: "13px", height:"13px" , color: textColor }}
+                     size={13}
+                     style={{ color: textColor }}
                   />
                 )}
               </Box>

--- a/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
@@ -1,7 +1,5 @@
 import { Box, Stack, Typography } from "@mui/material";
-import { ReactComponent as CalendarIcon } from "../../../assets/icons/calendar-check.svg";
-import { ReactComponent as ClockIcon } from "../../../assets/icons/clock.svg";
-import { ReactComponent as AlertIcon } from "../../../assets/icons/alert-circle.svg";
+import { CalendarCheck as CalendarIcon, Clock as ClockIcon, AlertCircle as AlertIcon } from "lucide-react";
 
 const TaskRadar = ({ overdue, due, upcoming }: { overdue: number; due: number; upcoming: number }) => {
   return (
@@ -39,7 +37,7 @@ const TaskRadar = ({ overdue, due, upcoming }: { overdue: number; due: number; u
           justifyContent: "space-between",
         }}>
           <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "6px" }}>
-            <AlertIcon />
+            <AlertIcon size={16} />
             <Typography
               sx={{
                 fontSize: 13,
@@ -69,7 +67,7 @@ const TaskRadar = ({ overdue, due, upcoming }: { overdue: number; due: number; u
           justifyContent: "space-between",
         }}>
           <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "6px" }}>
-            <ClockIcon />
+            <ClockIcon size={16} />
             <Typography
               sx={{
                 fontSize: 13,
@@ -99,7 +97,7 @@ const TaskRadar = ({ overdue, due, upcoming }: { overdue: number; due: number; u
           justifyContent: "space-between",
         }}>
           <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "6px" }}>
-            <CalendarIcon />
+            <CalendarIcon size={16} />
             <Typography
               sx={{
                 fontSize: 13,

--- a/Clients/src/presentation/components/FileUpload/index.tsx
+++ b/Clients/src/presentation/components/FileUpload/index.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import "./drop-file-input.css";
-import UploadSmallIcon from "../../assets/icons/folder-upload.svg";
 import { FileProps, FileUploadProps } from "./types";
 import {
   DragDropArea,
   fileListStyleFrame,
   fileListText,
   filesListItem,
-  Icon,
 } from "./FileUpload.styles";
 import {
   List,
@@ -18,7 +16,7 @@ import {
   IconButton,
   Button,
 } from "@mui/material";
-import {ReactComponent as DeleteIconGrey} from "../../../assets/icons/trash-grey.svg"
+import { Upload as UploadIcon, Trash2 as DeleteIconGrey } from "lucide-react";
 
 const FileUploadComponent = ({
   onClose,
@@ -136,7 +134,7 @@ const FileUploadComponent = ({
             onDrop={onDrop}
           >
             <div className="drop-file-input__label">
-              <Icon src={UploadSmallIcon} alt="Upload Icon" sx={{ mb: 2 }} />
+              <UploadIcon size={24} style={{ marginBottom: 16, color: "#6B7280" }} />
               <Typography variant="body2">
                 <span style={{ color: "#3b82f6" }}>Click to upload</span> or
                 drag and drop
@@ -160,7 +158,7 @@ const FileUploadComponent = ({
                       size="small"
                       sx={{ padding: "4px" }}
                     >
-                      <DeleteIconGrey fontSize="small" />
+                      <DeleteIconGrey size={16} />
                     </IconButton>
                   </ListItem>
                 ))}

--- a/Clients/src/presentation/pages/AITrustCentrePublic/Overview/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCentrePublic/Overview/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Paper, Typography, Stack, Button } from "@mui/material";
 import CustomTextField from "../Components/CustomTextField/CustomTextField";
-import {ReactComponent as CheckCircleOutlineIcon} from '../../../assets/icons/check-circle-green.svg';
+import { CheckCircle as CheckCircleOutlineIcon } from 'lucide-react';
 import { downloadResource } from "../../../../application/tools/downloadResource";
 
 const Overview = ({
@@ -154,7 +154,8 @@ const Overview = ({
                 >
                   <Box display="flex" alignItems="center" gap={1}>
                     <CheckCircleOutlineIcon
-                      style={{ height: "24px", width: "24px" }}
+                      size={24}
+                      style={{ color: "#10B981" }}
                     />
                     <Typography variant="body2">{resource.name}</Typography>
                   </Box>

--- a/Clients/src/presentation/pages/Assessment/NewAssessment/AssessmentQuestions/AssessmentQuestions.tsx
+++ b/Clients/src/presentation/pages/Assessment/NewAssessment/AssessmentQuestions/AssessmentQuestions.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { Info as GreyCircleInfoIcon } from "lucide-react";
 import RichTextEditor from "../../../../components/RichTextEditor";
 import { priorities, PriorityLevel } from "../priorities";
 import { Topic } from "../../../../../application/hooks/useAssessmentAnswers";
@@ -104,7 +104,7 @@ const AssessmentQuestions = ({
                           },
                         }}
                       >
-                        <GreyCircleInfoIcon fontSize="inherit" />
+                        <GreyCircleInfoIcon size={16} />
                       </Tooltip>
                     </Box>
                   )}

--- a/Clients/src/presentation/pages/Authentication/ResetPasswordContinue/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/ResetPasswordContinue/index.tsx
@@ -4,7 +4,7 @@
 
 import { Button, Stack, Typography, useTheme } from "@mui/material";
 import { ReactComponent as Background } from "../../../assets/imgs/background-grid.svg";
-import { ReactComponent as Success } from "../../../assets/icons/check-outlined.svg";
+import { CheckCircle as Success } from "lucide-react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useNavigate } from "react-router-dom";
 
@@ -53,7 +53,7 @@ const ResetPasswordContinue = () => {
             gap: theme.spacing(12),
           }}
         >
-          <Success />
+          <Success size={24} style={{ color: "#10B981" }} />
         </Stack>
         <Stack sx={{ gap: theme.spacing(6), textAlign: "center" }}>
           <Typography sx={{ fontSize: 16, fontWeight: "bold" }}>

--- a/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/SetNewPassword/index.tsx
@@ -8,7 +8,7 @@ import { ReactComponent as Background } from "../../../assets/imgs/background-gr
 import Check from "../../../components/Checks";
 import Field from "../../../components/Inputs/Field";
 import { ArrowLeft as LeftArrowLong } from "lucide-react";
-import { ReactComponent as Lock } from "../../../assets/icons/lock.svg";
+import { Lock } from "lucide-react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { validatePassword } from "../../../../application/validations/formValidation";
@@ -226,7 +226,7 @@ const SetNewPassword: React.FC = () => {
               gap: theme.spacing(12),
             }}
           >
-            <Lock />
+            <Lock size={24} />
           </Stack>
           <Stack sx={{ gap: theme.spacing(6), textAlign: "center" }}>
             <Typography sx={{ fontSize: 16, fontWeight: "bold" }}>

--- a/Clients/src/presentation/pages/FairnessDashboard/FairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/FairnessResultsPage.tsx
@@ -8,8 +8,7 @@ import {
   CircularProgress,
   Tooltip,
 } from "@mui/material";
-import {ReactComponent as ArrowBackIcon} from "../../assets/icons/left-arrow-long.svg";
-import { ReactComponent as GreyCircleInfoIcon } from "../../assets/icons/info-circle-grey.svg";
+import { ArrowLeft as ArrowBackIcon, Info as GreyCircleInfoIcon } from "lucide-react";
 import { BarChart } from "@mui/x-charts";
 import { fairnessService } from "../../../infrastructure/api/fairnessService";
 import singleTheme from "../../themes/v1SingleTheme";
@@ -96,7 +95,7 @@ export default function FairnessResultsPage() {
           onClick={() => navigate("/fairness-dashboard")}
           sx={{ mr: 2 }}
         >
-          <ArrowBackIcon />
+          <ArrowBackIcon size={20} />
         </IconButton>
         <Typography
           sx={{
@@ -137,7 +136,7 @@ export default function FairnessResultsPage() {
                 sx={{ fontSize: 13 }}
               >
                 <IconButton size="small" sx={{ ml: 1 }}>
-                  <GreyCircleInfoIcon fontSize="small" />
+                  <GreyCircleInfoIcon size={16} />
                 </IconButton>
               </Tooltip>
             </Box>
@@ -186,7 +185,7 @@ export default function FairnessResultsPage() {
                 sx={{ fontSize: 13 }}
               >
                 <IconButton size="small" sx={{ ml: 1 }}>
-                  <GreyCircleInfoIcon fontSize="small" />
+                  <GreyCircleInfoIcon size={16} />
                 </IconButton>
               </Tooltip>
             </Box>
@@ -235,7 +234,7 @@ export default function FairnessResultsPage() {
                   sx={{ fontSize: 13 }}
                 >
                   <IconButton size="small" sx={{ ml: 1 }}>
-                    <GreyCircleInfoIcon fontSize="small" />
+                    <GreyCircleInfoIcon size={16} />
                   </IconButton>
                 </Tooltip>
               </Box>

--- a/Clients/src/presentation/pages/PageNotFound/index.tsx
+++ b/Clients/src/presentation/pages/PageNotFound/index.tsx
@@ -1,5 +1,5 @@
 import { ReactComponent as Background } from "../../assets/imgs/background-grid.svg";
-import { ReactComponent as LeftArrowLong } from "../../assets/icons/left-arrow-long.svg";
+import { ArrowLeft as LeftArrowLong } from "lucide-react";
 import { Typography, Stack, useTheme } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
@@ -46,7 +46,7 @@ function PageNotFound() {
             navigate("/");
           }}
         >
-          <LeftArrowLong />
+          <LeftArrowLong size={16} />
           <Typography sx={{ height: 22, fontSize: 13, fontWeight: 500 }}>
             Back to home
           </Typography>


### PR DESCRIPTION
## Summary
• Replace folder-upload.svg with Upload icon in FileUpload component
• Replace trash-grey.svg with Trash2 icon in FileUpload component  
• Replace check-circle-green.svg with CheckCircle in AITrustCentrePublic/Overview
• Replace check-outlined.svg with CheckCircle in ResetPasswordContinue
• Replace left-arrow-long.svg with ArrowLeft in FairnessResultsPage and PageNotFound
• Replace info-circle-grey.svg with Info in FairnessResultsPage and AssessmentQuestions
• Replace update-white.svg with RotateCcw in AddNewRiskForm

## Test plan
- [x] Build passes without TypeScript errors
- [x] All migrated icons display correctly with consistent sizing
- [x] FileUpload component shows upload and delete icons
- [x] Authentication pages show success and navigation icons
- [x] Info tooltips display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)