### PR TITLE
Migrate additional SVG icons to Lucide React

### DIFF
--- a/Clients/src/presentation/components/Cards/DashboardHeaderCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/DashboardHeaderCard/index.tsx
@@ -1,6 +1,6 @@
 import { Stack, Typography, Box } from "@mui/material";
 import { useNavigate } from "react-router-dom";
-import { ReactComponent as RightArrow } from "../../../assets/icons/right-arrow.svg";
+import { ArrowRight as RightArrow } from "lucide-react";
 import { useState } from "react";
 
 const HeaderCard = ({ title, count }: { title: string; count: number }) => {
@@ -86,7 +86,7 @@ const HeaderCard = ({ title, count }: { title: string; count: number }) => {
             transition: "opacity 0.2s ease",
           }}
         >
-          <RightArrow />
+          <RightArrow size={16} />
         </Box>
       )}
     </Stack>

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -9,7 +9,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { FileData } from "../../../../domain/types/File";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import { inputStyles } from "../ClauseDrawerDialog";
 import DatePicker from "../../Inputs/Datepicker";
@@ -410,7 +410,7 @@ const VWISO27001AnnexDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack sx={{ padding: "15px 20px", gap: "15px" }}>

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -10,7 +10,7 @@ import {
   Dialog,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import { FileData } from "../../../../domain/types/File";
 import Select from "../../Inputs/Select";
@@ -408,7 +408,7 @@ const VWISO27001ClauseDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {clause?.arrangement + "." + (index + 1)} {displayData?.title}
           </Typography>
-          <CloseIcon onClick={onClose} style={{ cursor: "pointer" }} />
+          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
         </Stack>
         <Divider />
         <Stack

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
+import { X as CloseIcon } from "lucide-react";
 import DropDowns from "../../Inputs/Dropdowns";
 import { useState, Suspense, useEffect } from "react";
 import AuditorFeedback from "../ComplianceFeedback/ComplianceFeedback";
@@ -465,7 +465,7 @@ const NewControlPane = ({
                 },
               }}
             >
-              <CloseIcon />
+              <CloseIcon size={20} />
             </Box>
           </Stack>
           <Typography component="span" fontSize={13}>

--- a/Clients/src/presentation/components/Modals/InviteUser/index.tsx
+++ b/Clients/src/presentation/components/Modals/InviteUser/index.tsx
@@ -27,7 +27,7 @@ import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
-import { ReactComponent as ForwardToInboxIcon } from "../../../assets/icons/email.svg";
+import { Mail as ForwardToInboxIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
 import { useRoles } from "../../../../application/hooks/useRoles";
 import { isValidEmail } from "../../../../application/validations/emailAddress.rule";
@@ -272,7 +272,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({
               border: "1px solid #13715B",
               gap: 2,
             }}
-            icon={<ForwardToInboxIcon />}
+            icon={<ForwardToInboxIcon size={16} />}
             onClick={() => handleSendInvitation()}
           />
         </Stack>

--- a/Clients/src/presentation/components/StatusDropdown/index.tsx
+++ b/Clients/src/presentation/components/StatusDropdown/index.tsx
@@ -21,7 +21,7 @@ import {
   useTheme,
   SelectChangeEvent,
 } from "@mui/material";
-import { ReactComponent as WhiteDownArrowIcon  } from "../../assets/icons/chevron-down-white.svg";
+import { ChevronDown as WhiteDownArrowIcon } from "lucide-react";
 import { getStatusColor } from "../../pages/ISO/style";
 
 interface StatusDropdownProps {

--- a/Clients/src/presentation/pages/AITrustCentrePublic/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCentrePublic/Resources/index.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   Box
 } from '@mui/material';
-import {ReactComponent as CheckCircleOutlineIcon} from '../../../assets/icons/check-circle-green.svg';
+import { CheckCircle as CheckCircleOutlineIcon } from 'lucide-react';
 import { downloadResource } from '../../../../application/tools/downloadResource';
 import { aiTrustCenterTableCell } from '../style';
 
@@ -44,7 +44,7 @@ const Resources = ({ data, loading, error, hash }: { data: any; loading: boolean
               <TableRow key={idx}>
                 <TableCell sx={aiTrustCenterTableCell}>
                   <Box display="flex" alignItems="center" gap={1}>
-                    <CheckCircleOutlineIcon style={{ width: "24px", height:"24px" }} />
+                    <CheckCircleOutlineIcon size={24} style={{ color: "#10B981" }} />
                     <Typography  color="#344054" sx={{ fontSize: 13 }}>{resource.name}</Typography>
                   </Box>
                 </TableCell>


### PR DESCRIPTION
## Summary
• Replace check-circle-green.svg with CheckCircle in AITrustCentrePublic/Resources
• Replace chevron-down-white.svg with ChevronDown in StatusDropdown  
• Replace close.svg with X icon in drawer dialogs (ISO27001Clause, ISO27001Annex, NewControlPane)
• Replace email.svg with Mail in InviteUser modal
• Replace right-arrow.svg with ArrowRight in DashboardHeaderCard

## Test plan
- [x] Build passes without TypeScript errors
- [x] All migrated icons display correctly with consistent sizing
- [x] StatusDropdown chevron functions properly
- [x] Close buttons work in drawer dialogs
- [x] Email and navigation icons render correctly