### PR TITLE
Complete final SVG icon migration to Lucide React

### DIFF
--- a/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
@@ -41,7 +41,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import selectValidation from "../../../../application/validations/selectValidation";
 import CustomizableToast from "../../Toast";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { extractUserToken } from "../../../../application/tools/extractToken";
 import { useSelector } from "react-redux";
 import Checkbox from "../../../components/Inputs/Checkbox";
@@ -742,7 +742,7 @@ const ProjectForm = ({
                   );
                 }}
                 filterSelectedOptions
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={16} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}
@@ -838,7 +838,7 @@ const ProjectForm = ({
                       option.name.includes("coming soon")
                     }
                     filterSelectedOptions
-                    popupIcon={<GreyDownArrowIcon />}
+                    popupIcon={<GreyDownArrowIcon size={16} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}
@@ -950,7 +950,7 @@ const ProjectForm = ({
                   option.name.includes("coming soon")
                 }
                 filterSelectedOptions
-                popupIcon={<GreyDownArrowIcon />}
+                popupIcon={<GreyDownArrowIcon size={16} />}
                 renderInput={(params) => (
                   <TextField
                     {...params}

--- a/Clients/src/presentation/components/Modals/CreateTask/index.tsx
+++ b/Clients/src/presentation/components/Modals/CreateTask/index.tsx
@@ -19,7 +19,7 @@ import { lazy } from "react";
 const Field = lazy(() => import("../../Inputs/Field"));
 const DatePicker = lazy(() => import("../../Inputs/Datepicker"));
 import SelectComponent from "../../Inputs/Select";
-import { ReactComponent as GreyDownArrowIcon } from "../../../assets/icons/chevron-down-grey.svg";
+import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import { Save as SaveIcon, X as CloseIcon } from "lucide-react";
 import CustomizableButton from "../../Button/CustomizableButton";
 import { ITask } from "../../../../domain/interfaces/i.task";
@@ -477,7 +477,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                         : "No options"
                     }
                     filterSelectedOptions
-                    popupIcon={<GreyDownArrowIcon />}
+                    popupIcon={<GreyDownArrowIcon size={16} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}
@@ -565,7 +565,7 @@ const CreateTask: FC<CreateTaskProps> = ({
                     }}
                     getOptionLabel={(option: string) => option}
                     filterSelectedOptions
-                    popupIcon={<GreyDownArrowIcon />}
+                    popupIcon={<GreyDownArrowIcon size={16} />}
                     renderInput={(params) => (
                       <TextField
                         {...params}

--- a/Clients/src/presentation/components/Table/AuditRiskTable/AuditRiskTableBody.tsx
+++ b/Clients/src/presentation/components/Table/AuditRiskTable/AuditRiskTableBody.tsx
@@ -10,7 +10,7 @@ import {
 import { useCallback, useState } from "react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { Square as CheckboxOutline } from "lucide-react";
-import { ReactComponent as CheckboxFilled } from "../../../assets/icons/checkbox-filled.svg";
+import { CheckSquare as CheckboxFilled } from "lucide-react";
 import { ChevronsUpDown } from "lucide-react";
 
 const SelectorVertical = (props: any) => <ChevronsUpDown size={16} {...props} />;
@@ -113,7 +113,7 @@ export const AuditRiskTableBody: React.FC<AuditRiskTableBodyProps> = ({
                     }
                     onChange={(e) => handleChange(row, e)}
                     onClick={(e) => e.stopPropagation()}
-                    checkedIcon={<CheckboxFilled />}
+                    checkedIcon={<CheckboxFilled size={16} />}
                     icon={<CheckboxOutline size={16} />}
                     sx={{
                       borderRadius: "4px",

--- a/Clients/src/presentation/components/Table/FairnessTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/FairnessTable/TableBody/index.tsx
@@ -1,6 +1,6 @@
 import { TableBody, TableRow, TableCell, Box } from "@mui/material";
 import singleTheme from '../../../../themes/v1SingleTheme';
-import {ReactComponent as DeleteIconGrey} from "../../../../assets/icons/trash-grey.svg"
+import { Trash2 as DeleteIconGrey } from "lucide-react";
 import Button from '../../../../components/Button/index';
 import ConfirmableDeleteIconButton from "../../../../components/Modals/ConfirmableDeleteIconButton";
 
@@ -99,7 +99,7 @@ const FairnessTableBody: React.FC<FairnessTableBodyProps> = ({
             onConfirm={() => onRemoveModel.onConfirm(row.id)}
             title={`Delete this fairness check?`}
             message={`Are you sure you want to delete fairness check ID ${row.id}? This action is non-recoverable.`}
-            customIcon={<DeleteIconGrey/>}
+            customIcon={<DeleteIconGrey size={16} />}
           />
           </TableCell>
         </TableRow>


### PR DESCRIPTION
## Summary
• Replace chevron-down-grey.svg with ChevronDown in ProjectForm and CreateTask modals
• Replace trash-grey.svg with Trash2 in FairnessTable
• Replace checkbox-filled.svg with CheckSquare in AuditRiskTable

All remaining non-placeholder SVG icons have been migrated to Lucide React with consistent sizing. Only background-grid.svg remains as a large placeholder SVG asset.