### PR TITLE
Remove unused @mui/icons-material dependency

### DIFF
--- a/Clients/package-lock.json
+++ b/Clients/package-lock.json
@@ -11,7 +11,6 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@fontsource/roboto": "^5.1.0",
-        "@mui/icons-material": "^6.5.0",
         "@mui/lab": "^6.0.0-beta.10",
         "@mui/material": "^6.1.6",
         "@mui/styled-engine-sc": "^6.1.0",
@@ -2647,32 +2646,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/@mui/icons-material": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.5.0.tgz",
-      "integrity": "sha512-VPuPqXqbBPlcVSA0BmnoE4knW4/xG6Thazo8vCLWkOKusko6DtwFV6B665MMWJ9j0KFohTIf3yx2zYtYacvG1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@mui/material": "^6.5.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@mui/lab": {

--- a/Clients/package.json
+++ b/Clients/package.json
@@ -15,7 +15,6 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@fontsource/roboto": "^5.1.0",
-    "@mui/icons-material": "^6.5.0",
     "@mui/lab": "^6.0.0-beta.10",
     "@mui/material": "^6.1.6",
     "@mui/styled-engine-sc": "^6.1.0",


### PR DESCRIPTION
## Summary
Remove @mui/icons-material package as all icons have been migrated to Lucide React

## Changes
- Removed @mui/icons-material from package.json dependencies
- Updated package-lock.json

Reduces bundle size by eliminating unused dependency after complete icon migration.