### PR TITLE
Standardize table empty state backgrounds to white

### DIFF
--- a/Clients/src/presentation/components/Table/EvaluationTable/styles.ts
+++ b/Clients/src/presentation/components/Table/EvaluationTable/styles.ts
@@ -54,4 +54,5 @@ export const emptyData = {
   textAlign: "center" as const,
   padding: "40px 20px",
   border: "none",
+  backgroundColor: "#FFFFFF", // Ensure white background
 };

--- a/Clients/src/presentation/components/Table/FairnessTable/styles.ts
+++ b/Clients/src/presentation/components/Table/FairnessTable/styles.ts
@@ -45,5 +45,6 @@
   export const emptyData = ( theme:any ) => ({
     padding: theme.spacing(15, 5),
     paddingBottom: theme.spacing(20),
+    backgroundColor: "#FFFFFF", // Ensure white background
   })
   

--- a/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
@@ -9,11 +9,13 @@ import {
   TableFooter,
   Typography,
   useTheme,
+  Stack,
 } from "@mui/material";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useMemo, useState, useEffect } from "react";
 import TablePaginationActions from "../../TablePagination";
 import { ChevronsUpDown } from "lucide-react";
+import { emptyStateStyles } from "../../../themes/components";
 
 const SelectorVertical = (props: any) => <ChevronsUpDown size={16} {...props} />;
 import placeholderImage from "../../../assets/imgs/empty-state.svg";
@@ -94,18 +96,13 @@ const VWProjectRisksTable = ({
         ) : (
           <TableBody>
             <TableRow>
-              <TableCell
-                colSpan={columns.length}
-                align="center"
-                style={{
-                  padding: theme.spacing(15, 5),
-                  paddingBottom: theme.spacing(20),
-                }}
-              >
-                <img src={placeholderImage} alt="Placeholder" />
-                <Typography sx={{ fontSize: "13px", color: "#475467" }}>
-                  There is currently no data in this table.
-                </Typography>
+              <TableCell colSpan={columns.length} sx={{ border: "none", p: 0 }}>
+                <Stack sx={emptyStateStyles.tableContainer(theme)}>
+                  <img src={placeholderImage} alt="Placeholder" />
+                  <Typography sx={{ fontSize: "13px", color: "#475467" }}>
+                    There is currently no data in this table.
+                  </Typography>
+                </Stack>
               </TableCell>
             </TableRow>
           </TableBody>

--- a/Clients/src/presentation/themes/components.ts
+++ b/Clients/src/presentation/themes/components.ts
@@ -440,7 +440,23 @@ export const emptyStateStyles = {
     width: { xs: "90%", sm: "90%", md: "1056px" },
     maxWidth: "100%",
     height: { xs: "100%", md: "418px" },
-    backgroundColor: theme.palette.background.main,
+    backgroundColor: "#FFFFFF", // Explicitly ensure white background
+  }),
+
+  // Compact version for table placeholders
+  tableContainer: (theme: Theme): SxProps<Theme> => ({
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    textAlign: "center",
+    padding: theme.spacing(15, 5),
+    paddingBottom: theme.spacing(20),
+    gap: theme.spacing(10),
+    border: "1px solid #EEEEEE",
+    borderRadius: "4px",
+    minHeight: 200,
+    backgroundColor: "#FFFFFF", // Explicitly ensure white background
   }),
 
   image: (): SxProps<Theme> => ({


### PR DESCRIPTION
## Summary
Ensure all table placeholder components consistently use white backgrounds

## Changes
- Added explicit white background to centralized emptyStateStyles
- Updated VWProjectRisksTable to use Stack with centralized styling
- Fixed EvaluationTable and FairnessTable empty state styles

Resolves visual inconsistency where some table placeholders had grayish backgrounds.