### PR TITLE
UI: Fix command palette accessibility and standardize risk chip styling

### DIFF
--- a/Clients/package-lock.json
+++ b/Clients/package-lock.json
@@ -18,6 +18,8 @@
         "@mui/x-date-pickers": "^7.29.4",
         "@platejs/basic-nodes": "^49.0.0",
         "@platejs/basic-styles": "^49.0.0",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-visually-hidden": "^1.2.3",
         "@reduxjs/toolkit": "^2.2.7",
         "@svgr/rollup": "^8.1.0",
         "@tanstack/react-query": "^5.84.2",
@@ -3870,6 +3872,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/Clients/package.json
+++ b/Clients/package.json
@@ -22,6 +22,8 @@
     "@mui/x-date-pickers": "^7.29.4",
     "@platejs/basic-nodes": "^49.0.0",
     "@platejs/basic-styles": "^49.0.0",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-visually-hidden": "^1.2.3",
     "@reduxjs/toolkit": "^2.2.7",
     "@svgr/rollup": "^8.1.0",
     "@tanstack/react-query": "^5.84.2",

--- a/Clients/src/application/commands/registry.ts
+++ b/Clients/src/application/commands/registry.ts
@@ -1,19 +1,21 @@
 import { Command, CommandGroup, CommandContext, CommandRegistry } from './types'
 import allowedRoles from '../constants/permissions'
 import {
-  Home as HomeOutlined,
-  AlertTriangle as WarningAmberOutlined,
-  Building as BusinessOutlined,
-  GitBranch as AccountTreeOutlined,
-  GraduationCap as SchoolOutlined,
-  Folder as FolderOutlined,
-  Activity as TimelineOutlined,
-  Landmark as AccountBalanceOutlined,
-  Scale as BalanceOutlined,
-  Settings as SettingsOutlined,
-  ClipboardList as AssignmentOutlined,
-  FileText as PolicyOutlined,
-  ShieldCheck as VerifiedUserOutlined,
+  Home,
+  Flag,
+  AlertTriangle,
+  Building,
+  List as ListIcon,
+  GraduationCap,
+  FileText,
+  BarChart3,
+  Brain,
+  Shield,
+  Telescope,
+  Scale,
+  Settings,
+  FolderTree,
+  Layers,
   Users as GroupOutlined
 } from 'lucide-react'
 
@@ -35,17 +37,35 @@ const NAVIGATION_COMMANDS: Command[] = [
     description: 'Go to main dashboard',
     keywords: ['home', 'overview', 'main'],
     group: COMMAND_GROUPS[0],
-    icon: HomeOutlined,
+    icon: Home,
     action: { type: 'navigate', payload: '/' }
   },
   {
-    id: 'nav-risk-management',
-    label: 'Risk Management',
-    description: 'Manage and monitor risks',
-    keywords: ['risks', 'threats', 'vulnerabilities'],
+    id: 'nav-tasks',
+    label: 'Tasks',
+    description: 'Task management',
+    keywords: ['tasks', 'todo', 'assignments'],
     group: COMMAND_GROUPS[0],
-    icon: WarningAmberOutlined,
-    action: { type: 'navigate', payload: '/risk-management' }
+    icon: Flag,
+    action: { type: 'navigate', payload: '/tasks' }
+  },
+  {
+    id: 'nav-project-view',
+    label: 'Project oriented view',
+    description: 'Project-based organizational view',
+    keywords: ['projects', 'overview', 'project view'],
+    group: COMMAND_GROUPS[0],
+    icon: FolderTree,
+    action: { type: 'navigate', payload: '/overview' }
+  },
+  {
+    id: 'nav-framework',
+    label: 'Organizational view',
+    description: 'Organizational framework view',
+    keywords: ['compliance', 'frameworks', 'iso', 'eu ai act', 'organizational'],
+    group: COMMAND_GROUPS[0],
+    icon: Layers,
+    action: { type: 'navigate', payload: '/framework' }
   },
   {
     id: 'nav-vendors',
@@ -53,7 +73,7 @@ const NAVIGATION_COMMANDS: Command[] = [
     description: 'Manage vendor relationships',
     keywords: ['suppliers', 'partners', 'third-party'],
     group: COMMAND_GROUPS[0],
-    icon: BusinessOutlined,
+    icon: Building,
     action: { type: 'navigate', payload: '/vendors' }
   },
   {
@@ -62,44 +82,17 @@ const NAVIGATION_COMMANDS: Command[] = [
     description: 'AI/ML model management',
     keywords: ['models', 'ai', 'ml', 'machine learning'],
     group: COMMAND_GROUPS[0],
-    icon: AccountTreeOutlined,
+    icon: ListIcon,
     action: { type: 'navigate', payload: '/model-inventory' }
   },
   {
-    id: 'nav-training',
-    label: 'Training Registry',
-    description: 'AI training programs',
-    keywords: ['training', 'education', 'courses'],
+    id: 'nav-risk-management',
+    label: 'Risk Management',
+    description: 'Manage and monitor risks',
+    keywords: ['risks', 'threats', 'vulnerabilities'],
     group: COMMAND_GROUPS[0],
-    icon: SchoolOutlined,
-    action: { type: 'navigate', payload: '/training' }
-  },
-  {
-    id: 'nav-file-manager',
-    label: 'File Manager',
-    description: 'Evidence and documents',
-    keywords: ['files', 'documents', 'evidence'],
-    group: COMMAND_GROUPS[0],
-    icon: FolderOutlined,
-    action: { type: 'navigate', payload: '/file-manager' }
-  },
-  {
-    id: 'nav-event-tracker',
-    label: 'Event Tracker',
-    description: 'Event tracking and audit logs',
-    keywords: ['logs', 'events', 'audit', 'monitoring', 'watch', 'tower'],
-    group: COMMAND_GROUPS[0],
-    icon: TimelineOutlined,
-    action: { type: 'navigate', payload: '/event-tracker' }
-  },
-  {
-    id: 'nav-framework',
-    label: 'Framework',
-    description: 'Organizational framework view',
-    keywords: ['compliance', 'frameworks', 'iso', 'eu ai act', 'organizational'],
-    group: COMMAND_GROUPS[0],
-    icon: AccountBalanceOutlined,
-    action: { type: 'navigate', payload: '/framework' }
+    icon: AlertTriangle,
+    action: { type: 'navigate', payload: '/risk-management' }
   },
   {
     id: 'nav-fairness',
@@ -107,35 +100,35 @@ const NAVIGATION_COMMANDS: Command[] = [
     description: 'AI bias and fairness dashboard',
     keywords: ['bias', 'fairness', 'ml', 'evaluation', 'ethics'],
     group: COMMAND_GROUPS[0],
-    icon: BalanceOutlined,
+    icon: Scale,
     action: { type: 'navigate', payload: '/fairness-dashboard' }
   },
   {
-    id: 'nav-settings',
-    label: 'Settings',
-    description: 'System configuration',
-    keywords: ['settings', 'config', 'preferences'],
+    id: 'nav-training',
+    label: 'Training Registry',
+    description: 'AI training programs',
+    keywords: ['training', 'education', 'courses'],
     group: COMMAND_GROUPS[0],
-    icon: SettingsOutlined,
-    action: { type: 'navigate', payload: '/setting' }
+    icon: GraduationCap,
+    action: { type: 'navigate', payload: '/training' }
   },
   {
-    id: 'nav-tasks',
-    label: 'Tasks',
-    description: 'Task management',
-    keywords: ['tasks', 'todo', 'assignments'],
+    id: 'nav-file-manager',
+    label: 'Evidence',
+    description: 'Evidence and documents',
+    keywords: ['files', 'documents', 'evidence'],
     group: COMMAND_GROUPS[0],
-    icon: AssignmentOutlined,
-    action: { type: 'navigate', payload: '/tasks' }
+    icon: FileText,
+    action: { type: 'navigate', payload: '/file-manager' }
   },
   {
-    id: 'nav-policies',
-    label: 'Policy Manager',
-    description: 'Manage organizational policies',
-    keywords: ['policies', 'policy', 'governance'],
+    id: 'nav-reporting',
+    label: 'Reporting',
+    description: 'Reports and analytics',
+    keywords: ['reports', 'analytics', 'charts'],
     group: COMMAND_GROUPS[0],
-    icon: PolicyOutlined,
-    action: { type: 'navigate', payload: '/policies' }
+    icon: BarChart3,
+    action: { type: 'navigate', payload: '/reporting' }
   },
   {
     id: 'nav-ai-trust',
@@ -143,8 +136,35 @@ const NAVIGATION_COMMANDS: Command[] = [
     description: 'AI transparency and trust',
     keywords: ['trust', 'transparency', 'ai'],
     group: COMMAND_GROUPS[0],
-    icon: VerifiedUserOutlined,
+    icon: Brain,
     action: { type: 'navigate', payload: '/ai-trust-center' }
+  },
+  {
+    id: 'nav-policies',
+    label: 'Policy Manager',
+    description: 'Manage organizational policies',
+    keywords: ['policies', 'policy', 'governance'],
+    group: COMMAND_GROUPS[0],
+    icon: Shield,
+    action: { type: 'navigate', payload: '/policies' }
+  },
+  {
+    id: 'nav-event-tracker',
+    label: 'Event Tracker',
+    description: 'Event tracking and audit logs',
+    keywords: ['logs', 'events', 'audit', 'monitoring', 'watch', 'tower'],
+    group: COMMAND_GROUPS[0],
+    icon: Telescope,
+    action: { type: 'navigate', payload: '/event-tracker' }
+  },
+  {
+    id: 'nav-settings',
+    label: 'Settings',
+    description: 'System configuration',
+    keywords: ['settings', 'config', 'preferences'],
+    group: COMMAND_GROUPS[0],
+    icon: Settings,
+    action: { type: 'navigate', payload: '/setting' }
   }
 ]
 

--- a/Clients/src/presentation/components/CommandPalette/index.tsx
+++ b/Clients/src/presentation/components/CommandPalette/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useCallback, useMemo } from 'react'
 import { Command } from 'cmdk'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { Box, Typography, IconButton } from '@mui/material'
-import { X as CloseIcon } from 'lucide-react'
+import { Box, Typography } from '@mui/material'
+import * as Dialog from '@radix-ui/react-dialog'
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
 import { useAuth } from '../../../application/hooks/useAuth'
 import commandRegistry from '../../../application/commands/registry'
 import CommandActionHandler, { CommandActionHandlers } from '../../../application/commands/actionHandler'
@@ -16,7 +17,6 @@ interface CommandPaletteProps {
 
 const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChange }) => {
   const [search, setSearch] = useState('')
-  const [showWhatsNew, setShowWhatsNew] = useState(true)
   const navigate = useNavigate()
   const location = useLocation()
   const { userRoleName } = useAuth()
@@ -29,12 +29,6 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChange }) =
     searchTerm: search
   }), [location.pathname, userRoleName, search])
 
-  // What's new data - could be fetched from API or stored in context
-  const whatsNewData = useMemo(() => ({
-    title: 'VerifyWise 1.4 Released',
-    description: 'Introducing AI Trust Center, Bias & Fairness Dashboard, and the new Command Palette for faster navigation. Enhanced ML bias detection tools and improved transparency features.',
-    date: 'Released on 17 September, 2025'
-  }), [])
 
   // Get filtered commands
   const commands = useMemo(() => {
@@ -118,15 +112,12 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChange }) =
       onOpenChange={onOpenChange}
       className="command-dialog"
       onKeyDown={handleKeyDown}
-      aria-label="Command palette"
       aria-describedby="command-palette-description"
     >
-      <div
-        className="command-dialog-content"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="command-palette-title"
-      >
+      <Dialog.Title asChild>
+        <VisuallyHidden>Command Palette</VisuallyHidden>
+      </Dialog.Title>
+      <div className="command-dialog-content">
         <div id="command-palette-description" className="sr-only">
           Search for commands, navigate to pages, or perform actions using keyboard shortcuts.
           Use arrow keys to navigate, Enter to select, and Escape to close.
@@ -155,57 +146,6 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChange }) =
             </Typography>
           </Command.Empty>
 
-          {/* What's New Section - Only show when no search and not dismissed */}
-          {!search && whatsNewData && showWhatsNew && (
-            <div className="whats-new-section" role="region" aria-labelledby="whats-new-title">
-              <div className="whats-new-big-block">
-                <Box sx={{ padding: '20px 24px' }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 2 }}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-                      <Typography
-                        id="whats-new-title"
-                        variant="h6"
-                        fontWeight={600}
-                        sx={{ color: '#fff', fontSize: '18px' }}
-                      >
-                        {whatsNewData.title}
-                      </Typography>
-                      <Typography
-                        variant="caption"
-                        sx={{ color: 'rgba(255, 255, 255, 0.7)', fontSize: '12px' }}
-                        aria-label={`Release date: ${whatsNewData.date}`}
-                      >
-                        {whatsNewData.date}
-                      </Typography>
-                    </Box>
-                    <IconButton
-                      size="small"
-                      onClick={() => setShowWhatsNew(false)}
-                      aria-label="Dismiss what's new section"
-                      sx={{
-                        color: 'rgba(255, 255, 255, 0.7)',
-                        '&:hover': {
-                          color: 'rgba(255, 255, 255, 0.9)',
-                          backgroundColor: 'rgba(255, 255, 255, 0.1)'
-                        },
-                        width: 24,
-                        height: 24
-                      }}
-                    >
-                      <CloseIcon size={16}/>
-                    </IconButton>
-                  </Box>
-
-                  <Typography variant="body2" sx={{
-                    color: 'rgba(255, 255, 255, 0.9)',
-                    lineHeight: 1.5
-                  }}>
-                    {whatsNewData.description}
-                  </Typography>
-                </Box>
-              </div>
-            </div>
-          )}
 
           {groupedCommands.map(({ group, commands: groupCommands }: { group: any, commands: CommandType[] }) => (
             <Command.Group key={group.id} heading={group.label} className="command-group">
@@ -222,16 +162,14 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChange }) =
                     {command.icon && (
                       <Box
                         sx={{
-                          fontSize: 18,
                           color: '#7B9A7A',
-                          strokeWidth: 0.5,
                           opacity: 0.8,
                           display: 'flex',
                           alignItems: 'center'
                         }}
                         aria-hidden="true"
                       >
-                        <command.icon />
+                        <command.icon size={16} strokeWidth={1.5} />
                       </Box>
                     )}
                     <Typography variant="body2" fontWeight={500} sx={{ flex: 0, whiteSpace: 'nowrap' }}>

--- a/Clients/src/presentation/components/CommandPalette/styles.css
+++ b/Clients/src/presentation/components/CommandPalette/styles.css
@@ -50,7 +50,6 @@
   outline: none;
   background: transparent;
   color: #000;
-  border-bottom: 1px solid #e5e5e5;
 }
 
 .command-input::placeholder {
@@ -141,40 +140,6 @@
   opacity: 0.9 !important;
 }
 
-/* What's New Section */
-.whats-new-section {
-  border-bottom: 1px solid #e5e5e5;
-  margin-bottom: 12px;
-}
-
-.whats-new-big-block {
-  background: linear-gradient(135deg, #1e2a1e 0%, #2d4a2d 50%, #0f1a0f 100%);
-  border-radius: 8px;
-  margin: 8px;
-  border: 1px solid rgba(123, 154, 122, 0.2);
-  transition: all 0.2s ease;
-  cursor: default;
-  position: relative;
-  overflow: hidden;
-}
-
-.whats-new-big-block::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg, rgba(123, 154, 122, 0.1) 0%, rgba(107, 138, 106, 0.05) 100%);
-  pointer-events: none;
-}
-
-.whats-new-big-block:hover {
-  background: linear-gradient(135deg, #22312a 0%, #2f4f2f 50%, #152115 100%);
-  border-color: rgba(123, 154, 122, 0.3);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15), 0 0 10px rgba(123, 154, 122, 0.08);
-}
 
 /* Custom scrollbar */
 .command-list::-webkit-scrollbar {
@@ -248,8 +213,7 @@
 
 /* Focus styles for accessibility */
 .command-input:focus-visible {
-  outline: 2px solid #007acc;
-  outline-offset: 2px;
+  outline: none;
 }
 
 .command-item:focus-visible {
@@ -374,20 +338,6 @@
     background: #555;
   }
 
-  /* What's New Section - Dark Mode */
-  .whats-new-section {
-    border-bottom-color: #333;
-  }
-
-  .whats-new-big-block {
-    background: linear-gradient(135deg, #1e1e1e 0%, #0e0e0e 100%);
-    border-color: rgba(255, 255, 255, 0.08);
-  }
-
-  .whats-new-big-block:hover {
-    background: linear-gradient(135deg, #252525 0%, #151515 100%);
-    border-color: rgba(255, 255, 255, 0.12);
-  }
 }
 
 /* Navigation hints footer */

--- a/Clients/src/presentation/components/RiskLevel/RiskChip.tsx
+++ b/Clients/src/presentation/components/RiskLevel/RiskChip.tsx
@@ -23,7 +23,6 @@ const RiskChip: React.FC<RiskChipProps> = React.memo(({ label }) => {
         sx={{
           ...getRiskChipStyle(),
           backgroundColor,
-          borderRadius: "4px !important",
         }}
       />
     );

--- a/Clients/src/presentation/components/RiskLevel/index.tsx
+++ b/Clients/src/presentation/components/RiskLevel/index.tsx
@@ -83,7 +83,7 @@ const RiskLevel: FC<RiskLevelProps> = ({
             color: theme.palette.background.main,
             p: "0 8px",
             height: 34,
-            borderRadius: theme.shape.borderRadius,
+            borderRadius: "4px",
             justifyContent: "center",
           }}
         >


### PR DESCRIPTION
## Summary
- Fixed command palette DialogTitle accessibility error using proper Radix UI components
- Standardized risk level chips to use consistent 4px border radius
- Updated command palette icons to match sidebar styling

## Changes
### Command Palette Improvements
- Resolved accessibility error by implementing proper DialogTitle with VisuallyHidden
- Updated icon registry to match sidebar icons exactly
- Standardized icon sizing to 16px with 1.5 strokeWidth
- Removed visual distractions (blue input borders, promotional blocks)

### Risk Level Components
- Fixed RiskLevel component to use 4px border radius instead of theme default
- Cleaned up RiskChip component by removing redundant border radius declaration
- Ensured consistent styling across all risk level displays

## Dependencies
- Added @radix-ui/react-dialog and @radix-ui/react-visually-hidden for proper accessibility

## Test Plan
- [x] Build passes without errors
- [x] Command palette opens without console accessibility warnings
- [x] Risk level chips display with consistent 4px border radius
- [x] Icons in command palette match sidebar icons in size and style
- [x] No visual regressions in existing functionality