### PR TITLE
Fix terminology: Change 'Evidences' to 'Evidence' in file manager

### DIFF
--- a/Clients/src/presentation/helpers/evidences-help.html
+++ b/Clients/src/presentation/helpers/evidences-help.html
@@ -1,7 +1,7 @@
 <div>
-  <h3>Evidences & Documents Management</h3>
+  <h3>Evidence & Documents Management</h3>
   <p>
-    The Evidences & Documents section serves as a centralized repository for all
+    The Evidence & Documents section serves as a centralized repository for all
     files uploaded to the VerifyWise platform. This system allows you to store,
     organize, and manage evidence files, compliance documents, and other
     supporting materials in one secure location. It's a critical component for
@@ -11,7 +11,7 @@
   <section>
     <h3>Overview</h3>
     <p>
-      The Evidences & Documents page provides a comprehensive file management
+      The Evidence & Documents page provides a comprehensive file management
       system with the following key features:
     </p>
     <ul>
@@ -282,7 +282,7 @@
   <section>
     <h3>Security and Compliance</h3>
     <p>
-      The Evidences & Documents system is designed with security and compliance
+      The Evidence & Documents system is designed with security and compliance
       in mind:
     </p>
     <ul>

--- a/Clients/src/presentation/pages/FileManager/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/index.tsx
@@ -101,7 +101,7 @@ const FileManager: React.FC = (): JSX.Element => {
       <HelperDrawer
         open={isHelperDrawerOpen}
         onClose={() => setIsHelperDrawerOpen(false)}
-        title="Evidences & documents"
+        title="Evidence & documents"
         description="Centralize compliance documentation and audit evidence management"
         whatItDoes="Store and organize all *governance documentation*, *audit evidence*, and *compliance artifacts*. View file details, filter by project, and download individual files."
         whyItMatters="**Evidence management** is critical for demonstrating *compliance* during *audits* and *regulatory reviews*. It provides a centralized view of all uploaded documents and their sources."
@@ -186,7 +186,7 @@ const FileManagerHeader: React.FC<FileManagerHeaderProps> = ({
   onHelperClick,
 }) => (
   <PageHeader
-    title="Evidences & documents"
+    title="Evidence & documents"
     description="This table lists all the files uploaded to the system."
     rightContent={
       onHelperClick && <HelperIcon onClick={onHelperClick} size="small" />


### PR DESCRIPTION
## Summary
- Updated terminology from 'Evidences' to 'Evidence' in file manager section
- Fixed page header and helper drawer title in FileManager component
- Updated all references in evidence help documentation

## Changes
- **FileManager component**: Updated page title and helper drawer title from "Evidences & documents" to "Evidence & documents"
- **Help documentation**: Updated all references to "Evidences & Documents" to "Evidence & Documents" throughout the help content

## Impact
- Improved consistency in terminology across the file management section
- Better alignment with standard English usage (evidence is typically used as a mass noun)

## Testing
- Verified all occurrences of "Evidences" have been replaced
- No functional changes, only text updates