### PR TITLE
Rename route from /setting to /settings

### DIFF
--- a/Clients/src/application/commands/registry.ts
+++ b/Clients/src/application/commands/registry.ts
@@ -164,7 +164,7 @@ const NAVIGATION_COMMANDS: Command[] = [
     keywords: ['settings', 'config', 'preferences'],
     group: COMMAND_GROUPS[0],
     icon: Settings,
-    action: { type: 'navigate', payload: '/setting' }
+    action: { type: 'navigate', payload: '/settings' }
   }
 ]
 

--- a/Clients/src/application/config/routes.tsx
+++ b/Clients/src/application/config/routes.tsx
@@ -1,4 +1,4 @@
-import { Route } from "react-router-dom";
+import { Route, Navigate } from "react-router-dom";
 import Dashboard from "../../presentation/containers/Dashboard";
 import Home from "../../presentation/pages/Home";
 import Vendors from "../../presentation/pages/Vendors";
@@ -53,7 +53,8 @@ export const createRoutes = (
     />
     <Route path="/vendors" element={<Vendors />} />
     <Route path="/integrations" element={<Integrations />} />
-    <Route path="/setting" element={<Setting />} />
+    <Route path="/settings" element={<Setting />} />
+    <Route path="/setting" element={<Navigate to="/settings" replace />} />
     <Route path="/organization" element={<Organization />} />
     <Route path="/test/project-view" element={<ProjectView />} />
     <Route path="/file-manager" element={<FileManager />} />

--- a/Clients/src/presentation/components/Breadcrumbs/index.md
+++ b/Clients/src/presentation/components/Breadcrumbs/index.md
@@ -242,7 +242,7 @@ export const routeMapping: Record<string, string> = {
   "/": "Dashboard",
   "/project-view": "Project Overview",
   "/vendors": "Vendor Management",
-  "/setting": "Settings",
+  "/settings": "Settings",
   // ... more mappings
 };
 ```

--- a/Clients/src/presentation/components/Breadcrumbs/routeMapping.ts
+++ b/Clients/src/presentation/components/Breadcrumbs/routeMapping.ts
@@ -45,7 +45,7 @@ export const routeMapping: Record<string, string> = {
   "/vendors": "Vendor Management",
 
   // Settings
-  "/setting": "Settings",
+  "/settings": "Settings",
   "/organization": "Organization Settings",
 
   // File management
@@ -118,7 +118,7 @@ export const routeIconMapping: Record<string, () => React.ReactNode> = {
   "/risk-management": () => React.createElement(AlertTriangle, { size: 14, strokeWidth: 1.5 }),
 
   // Settings
-  "/setting": () => React.createElement(Settings, { size: 14, strokeWidth: 1.5 }),
+  "/settings": () => React.createElement(Settings, { size: 14, strokeWidth: 1.5 }),
   "/organization": () => React.createElement(Settings, { size: 14, strokeWidth: 1.5 }),
 
   // File management

--- a/Clients/src/presentation/components/CommandPalette/index.tsx
+++ b/Clients/src/presentation/components/CommandPalette/index.tsx
@@ -71,7 +71,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChange }) =
       switch (funcName) {
         case 'navigateToSettingsTab':
           // Navigate to settings page with specific tab
-          navigate('/setting', { state: { activeTab: params } })
+          navigate('/settings', { state: { activeTab: params } })
           break
         default:
           console.log('Execute function:', funcName, params)

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -168,7 +168,7 @@ const other: MenuItem[] = [
   {
     name: "Settings",
     icon: <Settings size={16} strokeWidth={1.5} />,
-    path: "/setting",
+    path: "/settings",
   },
 ];
 

--- a/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
@@ -1358,7 +1358,7 @@ const IntegratedDashboard: React.FC = () => {
         <MetricCard
           title="Users"
           value={usersMetrics?.total || 0}
-          onClick={() => navigate("/setting")}
+          onClick={() => navigate("/settings")}
           navigable={true}
           backgroundIcon={Users}
         />

--- a/Servers/controllers/slackWebhook.ctrl.ts
+++ b/Servers/controllers/slackWebhook.ctrl.ts
@@ -154,7 +154,7 @@ async function validateSlackOAuth(code: string): Promise<any> {
       client_id: process.env.SLACK_CLIENT_ID || "",
       client_secret: process.env.SLACK_CLIENT_SECRET || "",
       code: code,
-      redirect_uri: `${process.env.FRONTEND_URL}/setting/?activeTab=slack`,
+      redirect_uri: `${process.env.FRONTEND_URL}/integrations/slack`,
     };
     if (!url) {
       throw new Error("Slack API URL is not configured");


### PR DESCRIPTION
## Changes
- Rename primary route from `/setting` to `/settings`
- Add automatic redirect from old path for backward compatibility
- Update all navigation references across the application
- Fix Slack OAuth redirect URI

## Updated Components
- Routes configuration
- Sidebar navigation
- Command palette
- Breadcrumb mappings
- Dashboard navigation
- Server-side OAuth flow

## Testing
- No TypeScript errors
- Tested in development environment
- All navigation paths working correctly