### PR TITLE
Fix action buttons alignment and add to dashboard

### DIFF
--- a/Clients/src/presentation/components/Breadcrumbs/PageBreadcrumbs.tsx
+++ b/Clients/src/presentation/components/Breadcrumbs/PageBreadcrumbs.tsx
@@ -50,33 +50,43 @@ const PageBreadcrumbs: React.FC<IPageBreadcrumbsProps> = memo(
           mt: 2,
           mb: 3,
           width: "100%",
+          position: "relative",
           ...sx,
         }}
       >
-        <DashboardActionButtons />
-        <Breadcrumbs
-          items={items}
-          autoGenerate={autoGenerate}
-          showCurrentPage={showCurrentPage}
-          homeLabel={homeLabel}
-          homePath={homePath}
-          truncateLabels={truncateLabels}
-          maxLabelLength={maxLabelLength}
-          onItemClick={onItemClick}
+        <Stack
+          direction="row"
           sx={{
-            py: 0.5,
-            px: 0,
+            width: "100%",
+            justifyContent: "space-between",
+            alignItems: "flex-end",
             mb: 4,
-            "& .MuiBreadcrumbs-separator": {
-              color: theme.palette.text.disabled,
-              mx: 0.5,
-              fontSize: "14px",
-            },
-            "& .MuiBreadcrumbs-ol": {
-              flexWrap: "wrap",
-            },
           }}
-        />
+        >
+          <Breadcrumbs
+            items={items}
+            autoGenerate={autoGenerate}
+            showCurrentPage={showCurrentPage}
+            homeLabel={homeLabel}
+            homePath={homePath}
+            truncateLabels={truncateLabels}
+            maxLabelLength={maxLabelLength}
+            onItemClick={onItemClick}
+            sx={{
+              py: 0.5,
+              px: 0,
+              "& .MuiBreadcrumbs-separator": {
+                color: theme.palette.text.disabled,
+                mx: 0.5,
+                fontSize: "14px",
+              },
+              "& .MuiBreadcrumbs-ol": {
+                flexWrap: "wrap",
+              },
+            }}
+          />
+          <DashboardActionButtons hideOnMainDashboard={false} />
+        </Stack>
         {showDivider && <Divider sx={{ mb: 2 }} />}
       </Stack>
     );

--- a/Clients/src/presentation/components/Layout/DashboardActionButtons.tsx
+++ b/Clients/src/presentation/components/Layout/DashboardActionButtons.tsx
@@ -24,11 +24,7 @@ const DashboardActionButtons: React.FC<DashboardActionButtonsProps> = ({
       direction="row"
       spacing={'8px'}
       sx={{
-        position: 'absolute',
-        top: 24,
-        right: 0,
-        zIndex: 10,
-        marginRight: '32px',
+        alignSelf: 'flex-end',
       }}
     >
       <Button
@@ -39,7 +35,7 @@ const DashboardActionButtons: React.FC<DashboardActionButtonsProps> = ({
           background: 'linear-gradient(135deg, #8B5CF6 0%, #7C3AED 100%)',
           color: 'white',
           fontWeight: 500,
-          fontSize: '14px',
+          fontSize: '13px',
           height: '34px',
           minHeight: '34px',
           maxHeight: '34px',
@@ -64,7 +60,7 @@ const DashboardActionButtons: React.FC<DashboardActionButtonsProps> = ({
           background: 'linear-gradient(135deg, #FB923C 0%, #F97316 100%)',
           color: 'white',
           fontWeight: 500,
-          fontSize: '14px',
+          fontSize: '13px',
           height: '34px',
           minHeight: '34px',
           maxHeight: '34px',

--- a/Clients/src/presentation/containers/Dashboard/index.css
+++ b/Clients/src/presentation/containers/Dashboard/index.css
@@ -20,10 +20,9 @@
 
 .home-layout > div {
   max-width: 1400px;
-  padding: 24px;
+  padding: 8px 24px 24px 8px;
   min-height: calc(100vh - 24px * 2);
   flex: 1;
-  padding-top: 35px;
 }
 .home-layout > div:has(> [class*="fallback__"]) .background-pattern-svg {
   position: absolute;

--- a/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
@@ -50,6 +50,7 @@ import WidgetErrorBoundary from "../../components/Dashboard/WidgetErrorBoundary"
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 import { IStatusData } from "../../../domain/interfaces/i.chart";
+import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
 
 const Alert = lazy(() => import("../../components/Alert"));
 const ResponsiveGridLayout = WidthProvider(Responsive);
@@ -1459,6 +1460,8 @@ const IntegratedDashboard: React.FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
+      <PageBreadcrumbs />
+
       {/* Password notification */}
       {showPasswordNotification && (
         <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
## Changes
- Changed Integrations/Automations buttons from absolute positioning to flexbox
- Aligned buttons with breadcrumbs on same horizontal line
- Reduced button font size from 14px to 13px
- Adjusted main content padding from 35px/24px to 8px/24px/24px/8px
- Made buttons visible on main dashboard page

## Technical Details
- Updated `DashboardActionButtons` to use `alignSelf: 'flex-end'` instead of absolute positioning
- Modified `PageBreadcrumbs` to wrap breadcrumbs and buttons in horizontal Stack with `alignItems: 'flex-end'`
- Added `hideOnMainDashboard={false}` prop to show buttons on dashboard
- Updated main content padding in Dashboard CSS