### PR TITLE
Make vendor review fields optional

### DIFF
--- a/Clients/src/presentation/components/Modals/NewVendor/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewVendor/index.tsx
@@ -267,14 +267,17 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
     if (!vendorWebsite.accepted) {
       newErrors.website = vendorWebsite.message;
     }
-    const vendorReviewResult = checkStringValidation(
-      "Vendor review result",
-      values.vendorDetails.reviewResult,
-      1,
-      256
-    );
-    if (!vendorReviewResult.accepted) {
-      newErrors.reviewResult = vendorReviewResult.message;
+    // Review result is now optional
+    if (values.vendorDetails.reviewResult) {
+      const vendorReviewResult = checkStringValidation(
+        "Vendor review result",
+        values.vendorDetails.reviewResult,
+        1,
+        256
+      );
+      if (!vendorReviewResult.accepted) {
+        newErrors.reviewResult = vendorReviewResult.message;
+      }
     }
     if (
       !values.vendorDetails.projectIds ||
@@ -305,18 +308,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
     if (!vendorContactPerson.accepted) {
       newErrors.vendorContactPerson = vendorContactPerson.message;
     }
-    if (
-      !values.vendorDetails.reviewStatus ||
-      Number(values.vendorDetails.reviewStatus) === 0
-    ) {
-      newErrors.reviewStatus = "Please select a status from the dropdown";
-    }
-    if (
-      !values.vendorDetails.reviewer ||
-      Number(values.vendorDetails.reviewer) === 0
-    ) {
-      newErrors.reviewer = "Please select a reviewer from the dropdown";
-    }
+    // Review status, reviewer, and review date are now optional
     if (
       !values.vendorDetails.assignee ||
       Number(values.vendorDetails.assignee) === 0
@@ -324,7 +316,7 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
       newErrors.assignee = "Please select an assignee from the dropdown";
     }
 
-     // New validation: reviewer and assignee can't be the same
+     // New validation: reviewer and assignee can't be the same (only if reviewer is provided)
       if (
         values.vendorDetails.reviewer &&
         values.vendorDetails.assignee &&
@@ -716,7 +708,6 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
             width: 220,
           }}
           error={errors.reviewStatus}
-          isRequired
           disabled={isEditingDisabled}
         />
         <Select // reviewer
@@ -731,7 +722,6 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
           sx={{
             width: 220,
           }}
-          isRequired
           disabled={isEditingDisabled}
         />
         <DatePicker // reviewDate
@@ -745,7 +735,6 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
               : dayjs(new Date())
           }
           handleDateChange={handleDateChange}
-          isRequired
           disabled={isEditingDisabled}
         />
       </Stack>
@@ -762,7 +751,6 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
           value={values.vendorDetails.reviewResult}
           error={errors.reviewResult}
           onChange={(e) => handleOnChange("reviewResult", e.target.value)}
-          isRequired
           disabled={isEditingDisabled}
           placeholder="Summarize the outcome of the review (e.g., approved, rejected, pending more info, or risk concerns identified)."
           rows={2}

--- a/Servers/database/migrations/20251020000000-make-reviewer-optional.js
+++ b/Servers/database/migrations/20251020000000-make-reviewer-optional.js
@@ -1,0 +1,55 @@
+'use strict';
+const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (let organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+        await queryInterface.sequelize.query(`
+          ALTER TABLE "${tenantHash}".vendors
+          ALTER COLUMN reviewer DROP NOT NULL;
+        `, { transaction });
+      }
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (let organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+        // Set a default value for NULL reviewers before making the column NOT NULL
+        await queryInterface.sequelize.query(`
+          UPDATE "${tenantHash}".vendors
+          SET reviewer = assignee
+          WHERE reviewer IS NULL;
+        `, { transaction });
+        await queryInterface.sequelize.query(`
+          ALTER TABLE "${tenantHash}".vendors
+          ALTER COLUMN reviewer SET NOT NULL;
+        `, { transaction });
+      }
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
Made Review status, Reviewer, Review date, and Review result fields optional in the Add New Vendor modal.

## Changes
- **Frontend**: Removed required validation and UI indicators for review-related fields
- **Backend**: Added database migration to make reviewer column nullable
- **Validation**: Fields are still validated when values are provided, but no longer required to submit the form

## Testing
- Verify vendors can be created without filling review fields
- Confirm validation still works when review fields are filled
- Check that existing vendors with review data are unaffected