### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -1,4 +1,6 @@
 name: Backend Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/1](https://github.com/bluewave-labs/verifywise/security/code-scanning/1)

The recommended fix is to explicitly set the minimum required permissions for `GITHUB_TOKEN` within the workflow file. Since none of the steps in the shown workflow require write or administrative access to the repository (they only run code, build, and test), the minimal required permission is `contents: read`. This should be added at the workflow level—immediately after the `name` key (line 1), before `on`—so it applies to all jobs in the workflow. This maintains compatibility and adheres to the principle of least privilege. No further code modifications or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
