### PR TITLE
Fix breadcrumb spacing on bias & fairness results page

### DIFF
--- a/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
+++ b/Clients/src/presentation/pages/FairnessDashboard/BiasAndFairnessResultsPage.tsx
@@ -622,8 +622,14 @@ export default function BiasAndFairnessResultsPage() {
                             sx={{
                               backgroundColor: isGood ? COLORS.SUCCESS : COLORS.WARNING,
                               color: 'white',
-                              fontWeight: 600,
-                              fontSize: '0.75rem'
+                              fontWeight: 500,
+                              fontSize: '11px',
+                              textTransform: 'uppercase',
+                              letterSpacing: '0.5px',
+                              borderRadius: '4px',
+                              '& .MuiChip-label': {
+                                padding: '4px 8px',
+                              },
                             }}
                           />
                         </Box>


### PR DESCRIPTION
## Summary
- Removed height constraint (10px) from breadcrumb wrapper Stack on bias & fairness results page
- Breadcrumbs now use natural sizing consistent with other pages

## Problem
The `/fairness-dashboard/bias-fairness-results/demo` page had the top navigation area appearing too close to the browser top border, making it partially visible.

## Root Cause
Line 526 had a Stack wrapper around PageBreadcrumbs with `sx={{ height: 10 }}`, forcing the breadcrumb area to only 10px height, which compressed the layout.

## Solution
Removed the wrapper Stack and placed PageBreadcrumbs directly in the main container, matching the pattern used on other pages (FileManager, TrainingRegistar, etc.).

## Testing
Navigate to `/fairness-dashboard/bias-fairness-results/demo` and verify the breadcrumbs now have proper spacing from the top.