### PR TITLE
fix: Reduce Slack button width from 139px to 120px

### DIFF
--- a/Clients/src/presentation/pages/Integrations/SlackManagement/SlackIntegrationsTable.tsx
+++ b/Clients/src/presentation/pages/Integrations/SlackManagement/SlackIntegrationsTable.tsx
@@ -195,7 +195,7 @@ const SlackIntegrationsTable = ({
           <img
             alt="Add to Slack"
             height="34"
-            width="139"
+            width="120"
             src="https://platform.slack-edge.com/img/add_to_slack.png"
             srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
           />


### PR DESCRIPTION
## Summary
- Update Add to Slack button width from 139px to 120px for better visual alignment
- Maintains button height (34px) and all functionality
- Improves UI consistency in the Slack integration settings

## Changes
- Modified `SlackIntegrationsTable.tsx` to update button width attribute
- No functional changes, only visual improvement

## Test Plan
- [x] Verify Slack button displays correctly at 120px width
- [x] Confirm button still functions properly for Slack integration
- [x] Check visual alignment in integration settings page