### PR TITLE
fix: prevent sidebar from shrinking on browser resize

### DIFF
--- a/Clients/src/presentation/containers/Dashboard/index.css
+++ b/Clients/src/presentation/containers/Dashboard/index.css
@@ -8,6 +8,8 @@
 .home-layout aside {
   position: sticky;
   height: 100vh;
+  width: 230px;
+  min-width: 230px;
   max-width: 230px;
   top: 0;
   left: 0;


### PR DESCRIPTION
## Summary
• Added fixed width constraints to sidebar to maintain consistent 230px width
• Prevents text wrapping issues when browser window is resized
• Sidebar now maintains rigid width regardless of viewport size

## Test plan
- [x] Verify sidebar maintains 230px width at different browser sizes
- [x] Confirm text does not wrap when shrinking browser window
- [x] Test horizontal scrollbar appears when viewport is too narrow