### PR TITLE
Reducing visual noise in the registration page

### DIFF
--- a/Clients/src/domain/interfaces/iWidget.ts
+++ b/Clients/src/domain/interfaces/iWidget.ts
@@ -98,6 +98,7 @@ export interface FieldProps {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onInput?: (event: React.FormEvent<HTMLInputElement>) => void;
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   error?: string;
   disabled?: boolean;
   width?: number | string;

--- a/Clients/src/presentation/components/Inputs/Field/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Field/index.tsx
@@ -58,6 +58,7 @@ const Field = forwardRef(
       onChange,
       onInput,
       onFocus,
+      onBlur,
       error,
       disabled,
       width,
@@ -143,6 +144,7 @@ const Field = forwardRef(
           onInput={onInput}
           onChange={onChange}
           onFocus={onFocus}
+          onBlur={onBlur}
           disabled={disabled}
           inputRef={ref}
           inputProps={{

--- a/Clients/src/presentation/pages/Authentication/RegisterMultiTenant/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/RegisterMultiTenant/index.tsx
@@ -66,6 +66,9 @@ const RegisterMultiTenant: React.FC = () => {
   //state for overlay modal
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // State to track password field focus
+  const [isPasswordFocused, setIsPasswordFocused] = useState(false);
+
   const passwordChecks = validatePassword(values);
 
   const [alert, setAlert] = useState<{
@@ -86,6 +89,19 @@ const RegisterMultiTenant: React.FC = () => {
       setValues({ ...values, [prop]: event.target.value });
       setErrors({ ...errors, [prop]: "" }); // Clear error for the specific field
     };
+
+  // Handle password field focus
+  const handlePasswordFocus = () => {
+    setIsPasswordFocused(true);
+  };
+
+  // Handle password field blur (when input loses focus)
+  const handlePasswordBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    // Hide indicators if field is empty when focus is lost
+    if (!event.target.value) {
+      setIsPasswordFocused(false);
+    }
+  };
 
   // Handle input field changes for organization form
   const handleOrganizationChange =
@@ -137,7 +153,10 @@ const RegisterMultiTenant: React.FC = () => {
       userRoleId: values.roleId,
     };
 
-    const response = await apiServices.post("organizations", requestBody) as any;
+    const response = (await apiServices.post(
+      "organizations",
+      requestBody
+    )) as any;
     setValues(initialState);
     setErrors({});
     setOrganizationValues(initialOrganizationState);
@@ -156,7 +175,7 @@ const RegisterMultiTenant: React.FC = () => {
       setTimeout(() => {
         setIsSubmitting(false);
         dispatch(setUserExists(true));
-        localStorage.setItem('root_version', __APP_VERSION__);
+        localStorage.setItem("root_version", __APP_VERSION__);
         navigate("/");
       }, 3000);
     } else if (response.status === 400) {
@@ -414,6 +433,8 @@ const RegisterMultiTenant: React.FC = () => {
                 value={values.password}
                 onChange={handleChange("password")}
                 error={errors.password}
+                onFocus={handlePasswordFocus}
+                onBlur={handlePasswordBlur}
               />
               <Field
                 label="Confirm password"
@@ -425,33 +446,45 @@ const RegisterMultiTenant: React.FC = () => {
                 onChange={handleChange("confirmPassword")}
                 error={errors.confirmPassword}
               />
-              <Stack
-                sx={{
-                  gap: theme.spacing(6),
-                }}
-              >
-                <Check
-                  text="Must be at least 8 characters"
-                  variant={passwordChecks.length ? "success" : "info"}
-                />
-                <Check
-                  text="Must contain one special character"
-                  variant={passwordChecks.specialChar ? "success" : "info"}
-                />
-                <Check
-                  text="Must contain at least one uppercase letter"
-                  variant={passwordChecks.uppercase ? "success" : "info"}
-                />
-                <Check
-                  text="Must contain atleast one number"
-                  variant={passwordChecks.number ? "success" : "info"}
-                />
-              </Stack>
+              {(isPasswordFocused || values.password || errors.password) && (
+                <Stack
+                  sx={{
+                    gap: theme.spacing(6),
+                    mt: theme.spacing(2),
+                  }}
+                >
+                  <Check
+                    text="Must be at least 8 characters"
+                    variant={passwordChecks.length ? "success" : "info"}
+                  />
+                  <Check
+                    text="Must contain one special character"
+                    variant={passwordChecks.specialChar ? "success" : "info"}
+                  />
+                  <Check
+                    text="Must contain at least one uppercase letter"
+                    variant={passwordChecks.uppercase ? "success" : "info"}
+                  />
+                  <Check
+                    text="Must contain atleast one number"
+                    variant={passwordChecks.number ? "success" : "info"}
+                  />
+                </Stack>
+              )}
               <Button
                 type="submit"
                 disableRipple
                 variant="contained"
-                sx={singleTheme.buttons.primary.contained}
+                sx={{
+                  marginTop: !(
+                    isPasswordFocused ||
+                    values.password ||
+                    errors.password
+                  )
+                    ? 10
+                    : 0,
+                  ...singleTheme.buttons.primary.contained,
+                }}
               >
                 Get started
               </Button>


### PR DESCRIPTION
## Reducing visual noise in the registration page

Now, in the registration page, password strength only appears when user focuses on the password field

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
