### PR TITLE
Add global tooltip font size styling

### DIFF
--- a/Clients/src/presentation/themes/dark.ts
+++ b/Clients/src/presentation/themes/dark.ts
@@ -250,6 +250,13 @@ const dark = createTheme({
         },
       },
     },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          fontSize: '13px',
+        },
+      },
+    },
 
     MuiButtonBase: {
       defaultProps: {

--- a/Clients/src/presentation/themes/light.ts
+++ b/Clients/src/presentation/themes/light.ts
@@ -318,6 +318,13 @@ const light = createTheme({
         },
       },
     },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          fontSize: '13px',
+        },
+      },
+    },
 
     MuiButtonBase: {
       defaultProps: {


### PR DESCRIPTION
## Changes
- Set default MuiTooltip font size to 13px in both light and dark themes
- Ensures consistent tooltip styling across the entire application

## Testing
- Verify all tooltips display with consistent 13px font size