### PR TITLE
Revert theme tooltip styling from develop-saas

### DIFF
--- a/Clients/src/presentation/themes/dark.ts
+++ b/Clients/src/presentation/themes/dark.ts
@@ -250,13 +250,6 @@ const dark = createTheme({
         },
       },
     },
-    MuiTooltip: {
-      styleOverrides: {
-        tooltip: {
-          fontSize: '13px',
-        },
-      },
-    },
 
     MuiButtonBase: {
       defaultProps: {

--- a/Clients/src/presentation/themes/light.ts
+++ b/Clients/src/presentation/themes/light.ts
@@ -318,13 +318,6 @@ const light = createTheme({
         },
       },
     },
-    MuiTooltip: {
-      styleOverrides: {
-        tooltip: {
-          fontSize: '13px',
-        },
-      },
-    },
 
     MuiButtonBase: {
       defaultProps: {


### PR DESCRIPTION
## Changes
- Remove MuiTooltip styling from light and dark themes
- Theme changes belong in develop branch only (PR #2560)
- Keeps subscription page tooltip text changes intact

## Reason
PR #2559 was merged with both subscription and theme changes. Theme styling should only be in develop branch.