### PR TITLE
Fix vendor form spacing for better alignment

### DIFF
--- a/Clients/src/presentation/components/Modals/NewVendor/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewVendor/index.tsx
@@ -715,19 +715,21 @@ const AddNewVendor: React.FC<AddNewVendorProps> = ({
           }}
           disabled={isEditingDisabled}
         />
-        <DatePicker // reviewDate
-          label="Review date"
-          sx={{
-            width: 220,
-          }}
-          date={
-            values.vendorDetails.reviewDate
-              ? dayjs(values.vendorDetails.reviewDate)
-              : dayjs(new Date())
-          }
-          handleDateChange={handleDateChange}
-          disabled={isEditingDisabled}
-        />
+        <Stack sx={{ flex: 1 }}>
+          <DatePicker // reviewDate
+            label="Review date"
+            sx={{
+              width: "100%",
+            }}
+            date={
+              values.vendorDetails.reviewDate
+                ? dayjs(values.vendorDetails.reviewDate)
+                : dayjs(new Date())
+            }
+            handleDateChange={handleDateChange}
+            disabled={isEditingDisabled}
+          />
+        </Stack>
       </Stack>
       <Stack
         display={"flex"}


### PR DESCRIPTION
## Summary
- Fixed inconsistent spacing in vendor add/edit form
- Standardized vertical spacing between rows to 8px
- Standardized horizontal spacing between form elements to 16px
- Fixed Review Status row alignment using consistent gap instead of space-between

## Changes
- Changed all vertical spacing (marginBottom/mt) from 16px to 8px
- Added consistent gap of 16px to all form rows
- Removed justifyContent="space-between" from Review Status row for consistent alignment