### PR TITLE
fixes-highlighting-side-bars

### DIFF
--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -507,7 +507,8 @@ const Sidebar = () => {
                       item.highlightPaths?.some((p: string) =>
                         location.pathname.startsWith(p)
                       ) ||
-                      customMenuHandler() === item.path
+                      customMenuHandler() === item.path ||
+                      location.pathname.startsWith(`${item.path}/`)
                         ? "#13715B !important"
                         : `${theme.palette.text.tertiary} !important`,
                     stroke:
@@ -515,7 +516,8 @@ const Sidebar = () => {
                       item.highlightPaths?.some((p: string) =>
                         location.pathname.startsWith(p)
                       ) ||
-                      customMenuHandler() === item.path
+                      customMenuHandler() === item.path ||
+                      location.pathname.startsWith(`${item.path}/`)
                         ? "#13715B !important"
                         : `${theme.palette.text.tertiary} !important`,
                     transition: "color 0.2s ease, stroke 0.2s ease",
@@ -526,7 +528,8 @@ const Sidebar = () => {
                       item.highlightPaths?.some((p: string) =>
                         location.pathname.startsWith(p)
                       ) ||
-                      customMenuHandler() === item.path
+                      customMenuHandler() === item.path ||
+                      location.pathname.startsWith(`${item.path}/`)
                         ? "#13715B !important"
                         : `${theme.palette.text.tertiary} !important`,
                   },
@@ -563,7 +566,8 @@ const Sidebar = () => {
                       item.highlightPaths?.some((p: string) =>
                         location.pathname.startsWith(p)
                       ) ||
-                      customMenuHandler() === item.path
+                      customMenuHandler() === item.path ||
+                      location.pathname.startsWith(`${item.path}/`)
                         ? "#f8fafc"
                         : "#e2e8f0", // lighter when active, blueish-grayish when inactive
                     color: "#475569", // darker text for contrast
@@ -642,7 +646,8 @@ const Sidebar = () => {
                     item.highlightPaths?.some((p: string) =>
                       location.pathname.startsWith(p)
                     ) ||
-                    customMenuHandler() === item.path
+                    customMenuHandler() === item.path ||
+                    location.pathname.startsWith(`${item.path}/`)
                       ? "selected-path"
                       : "unselected"
                   }
@@ -657,7 +662,8 @@ const Sidebar = () => {
                       item.highlightPaths?.some((p: string) =>
                         location.pathname.startsWith(p)
                       ) ||
-                      customMenuHandler() === item.path
+                      customMenuHandler() === item.path ||
+                      location.pathname.startsWith(`${item.path}/`)
                         ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
                         : "transparent",
                     border:
@@ -675,7 +681,8 @@ const Sidebar = () => {
                         item.highlightPaths?.some((p: string) =>
                           location.pathname.startsWith(p)
                         ) ||
-                        customMenuHandler() === item.path
+                        customMenuHandler() === item.path ||
+                        location.pathname.startsWith(`${item.path}/`)
                           ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
                           : "#F9F9F9",
                       border:
@@ -683,7 +690,8 @@ const Sidebar = () => {
                         item.highlightPaths?.some((p: string) =>
                           location.pathname.startsWith(p)
                         ) ||
-                        customMenuHandler() === item.path
+                        customMenuHandler() === item.path ||
+                        location.pathname.startsWith(`${item.path}/`)
                           ? "1px solid #D8D8D8"
                           : "1px solid transparent",
                     },
@@ -710,7 +718,8 @@ const Sidebar = () => {
                           item.highlightPaths?.some((p: string) =>
                             location.pathname.startsWith(p)
                           ) ||
-                          customMenuHandler() === item.path
+                          customMenuHandler() === item.path ||
+                          location.pathname.startsWith(`${item.path}/`)
                             ? "#13715B !important"
                             : `${theme.palette.text.tertiary} !important`,
                         stroke:
@@ -718,7 +727,8 @@ const Sidebar = () => {
                           item.highlightPaths?.some((p: string) =>
                             location.pathname.startsWith(p)
                           ) ||
-                          customMenuHandler() === item.path
+                          customMenuHandler() === item.path ||
+                          location.pathname.startsWith(`${item.path}/`)
                             ? "#13715B !important"
                             : `${theme.palette.text.tertiary} !important`,
                         transition: "color 0.2s ease, stroke 0.2s ease",
@@ -729,7 +739,8 @@ const Sidebar = () => {
                           item.highlightPaths?.some((p: string) =>
                             location.pathname.startsWith(p)
                           ) ||
-                          customMenuHandler() === item.path
+                          customMenuHandler() === item.path ||
+                          location.pathname.startsWith(`${item.path}/`)
                             ? "#13715B !important"
                             : `${theme.palette.text.tertiary} !important`,
                       },
@@ -798,17 +809,17 @@ const Sidebar = () => {
               gap: theme.spacing(4),
               borderRadius: theme.shape.borderRadius,
               px: theme.spacing(4),
-              background: managementItems.some(item => location.pathname.includes(item.path))
+              background: managementItems.some(item => location.pathname.startsWith(`${item.path}/`) || location.pathname === item.path)
                 ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
                 : "transparent",
-              border: managementItems.some(item => location.pathname.includes(item.path))
+              border: managementItems.some(item => location.pathname.startsWith(`${item.path}/`) || location.pathname === item.path)
                 ? "1px solid #D8D8D8"
                 : "1px solid transparent",
               "&:hover": {
-                background: managementItems.some(item => location.pathname.includes(item.path))
+                background: managementItems.some(item => location.pathname.startsWith(`${item.path}/`) || location.pathname === item.path)
                   ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
                   : "#F9F9F9",
-                border: managementItems.some(item => location.pathname.includes(item.path))
+                border: managementItems.some(item =>location.pathname.startsWith(`${item.path}/`) || location.pathname === item.path)
                   ? "1px solid #D8D8D8"
                   : "1px solid transparent",
               },


### PR DESCRIPTION
Fix sidebar highlight calculations when a new tabbar selection is done

Fixes #2566 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 19 PM" src="https://github.com/user-attachments/assets/c622638e-1626-40fe-8868-04a969087446" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 21 PM" src="https://github.com/user-attachments/assets/41447fdd-8c5e-4cbf-81c3-238f1cb59e51" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 25 PM" src="https://github.com/user-attachments/assets/db599156-17e7-4f8f-8153-bfdbc824a6a3" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 27 PM" src="https://github.com/user-attachments/assets/a84f0b99-000b-4abf-8782-297c7de4154e" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 29 PM" src="https://github.com/user-attachments/assets/f35441a5-d519-4ba3-bd4a-11387490ded2" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 36 PM" src="https://github.com/user-attachments/assets/981415f2-0ca8-4b19-957b-3c5c656a4ef4" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 40 PM" src="https://github.com/user-attachments/assets/310705e2-915b-46b9-8bc1-9d3e228c4339" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 43 PM" src="https://github.com/user-attachments/assets/fd726a10-94a8-4bde-b832-1403abe41e15" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 44 PM" src="https://github.com/user-attachments/assets/e3e694ff-734b-4534-b413-aacccd8a70dc" />
<img width="1440" height="932" alt="Screenshot 2025-10-30 at 9 26 46 PM" src="https://github.com/user-attachments/assets/2c5440c3-a338-4a1a-8dfb-33d39c5e194b" />

