### PR TITLE
Fix React DOM prop warnings in AI Trust Center

### DIFF
--- a/Clients/src/presentation/pages/AITrustCenter/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/index.tsx
@@ -115,8 +115,14 @@ const tabValue = params.tab || "overview";
             <TabList
               onChange={handleTabChange}
               TabIndicatorProps={{ style: { backgroundColor: "#13715B" } }}
-              sx={aiTrustCenterTabListStyle}
+              sx={{
+                ...aiTrustCenterTabListStyle,
+                '& .MuiTabs-root': {
+                  minHeight: '20px',
+                },
+              }}
               data-joyride-id="trust-center-tabs"
+              component="div"
             >
               <Tab
                 sx={aiTrustCenterTabStyle}


### PR DESCRIPTION
Fixes console warnings when navigating to AI Trust Center page.

## Changes
- Added `component="div"` prop to TabList to prevent MUI internal props from leaking to DOM elements

## Fixed Warnings
- `fullWidth` prop on DOM element
- `indicator` non-boolean attribute
- `selectionFollowsFocus` prop on DOM element  
- `textColor` prop on DOM element