### PR TITLE
Fix React DOM prop warnings in AI Trust Center

### DIFF
--- a/Clients/src/presentation/pages/AITrustCenter/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/index.tsx
@@ -115,14 +115,8 @@ const tabValue = params.tab || "overview";
             <TabList
               onChange={handleTabChange}
               TabIndicatorProps={{ style: { backgroundColor: "#13715B" } }}
-              sx={{
-                ...aiTrustCenterTabListStyle,
-                '& .MuiTabs-root': {
-                  minHeight: '20px',
-                },
-              }}
+              sx={aiTrustCenterTabListStyle}
               data-joyride-id="trust-center-tabs"
-              component="div"
             >
               <Tab
                 sx={aiTrustCenterTabStyle}


### PR DESCRIPTION
Fixes console warnings when navigating to AI Trust Center page.

## Changes
- Restored TabList component from @mui/lab to match codebase pattern
- Ensures consistent tab implementation across all pages

## Fixed Warnings
- `fullWidth` prop on DOM element
- `indicator` non-boolean attribute
- `selectionFollowsFocus` prop on DOM element  
- `textColor` prop on DOM element