### PR TITLE
Potential fix for code scanning alert no. 19: Type confusion through parameter tampering

### DIFF
--- a/Servers/controllers/iso27001.ctrl.ts
+++ b/Servers/controllers/iso27001.ctrl.ts
@@ -644,7 +644,15 @@ export async function saveAnnexes(
       `Processing annex control data: ${JSON.stringify(annexControl)}`
     );
     logger.debug(`Files to delete: ${annexControl.delete}`);
-    logger.debug(`Files in request: ${req.files ? req.files.length : 0}`);
+    logger.debug(
+      `Files in request: ${
+        Array.isArray(req.files)
+          ? req.files.length
+          : req.files
+          ? 1
+          : 0
+      }`
+    );
 
     const filesToDelete = JSON.parse(annexControl.delete || "[]") as number[];
     await deleteFiles(filesToDelete, req.tenantId!, transaction);


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/19](https://github.com/bluewave-labs/verifywise/security/code-scanning/19)

The best fix is to ensure that before accessing properties such as `.length` or otherwise operating on `req.files`, the code explicitly checks that `req.files` is an actual array. This should use `Array.isArray(req.files)`, and possibly also handle the case where `req.files` is a single file object or undefined. For logging, display the array's length if it is an array; otherwise, if it's a single file object (not null/undefined), log `1`; if it's not present, log `0`. This ensures robust handling regardless of how `req.files` is constructed by upstream middleware. The fix must be applied directly at the lines using `req.files.length`, in this case, line 647 in `Servers/controllers/iso27001.ctrl.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
