### PR TITLE
Potential fix for code scanning alert no. 51: Overly permissive regular expression range

### DIFF
--- a/Clients/src/presentation/components/PlateEditor.tsx
+++ b/Clients/src/presentation/components/PlateEditor.tsx
@@ -93,7 +93,7 @@ const PlateEditor: React.FC<PlateEditorProps> = ({
           "rel",
         ],
         ALLOWED_URI_REGEXP:
-          /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i,
+          /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
         ADD_ATTR: ["target"],
         FORBID_TAGS: [
           "script",


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/51](https://github.com/bluewave-labs/verifywise/security/code-scanning/51)

To fix this issue, we need to rewrite the regular expression to make the character class explicit and unambiguous. Specifically, in `[a-z+.-]`, the dash (`-`) should be either escaped (`\-`) or placed at the beginning or end of the character class to remove ambiguity; likewise, for `[a-z+.-:]`, every character meant to be matched individually should be listed explicitly (not as part of a range).

In file `Clients/src/presentation/components/PlateEditor.tsx`, change line 96 so that `ALLOWED_URI_REGEXP` uses an explicit character class for `+`, `.`, and `-`. The correct fix is to replace `[a-z+.-]` with `[a-z+.\-]` and similar in all relevant places in the pattern, so that only the intended characters are matched. No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
