### PR TITLE
Potential fix for code scanning alert no. 29: Missing rate limiting

### DIFF
--- a/Servers/routes/fileManager.route.ts
+++ b/Servers/routes/fileManager.route.ts
@@ -149,6 +149,7 @@ const handleMulterError = (err: any, req: Request, res: Response, next: NextFunc
  */
 router.post(
   "/",
+  fileOperationsLimiter,
   authenticateJWT,
   authorize(["Admin", "Reviewer", "Editor"]),
   upload.single("file"),


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/29](https://github.com/bluewave-labs/verifywise/security/code-scanning/29)

To fix the problem, add rate limiting to the file upload route so requests to POST `/file-manager` are throttled. The most direct and consistent approach is to use the already-imported `fileOperationsLimiter` middleware (line 23), which is also used for the GET (list) route. Insert `fileOperationsLimiter` into the middleware stack for the POST route (before mutating operations and error handling). Only update the lines specifying middleware array for `router.post("/", ...)` as shown, ensuring existing authentication and authorization checks are preserved.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
