### PR TITLE
Potential fix for code scanning alert no. 53: Overly permissive regular expression range

### DIFF
--- a/Clients/temp/test-xss-protection.js
+++ b/Clients/temp/test-xss-protection.js
@@ -70,7 +70,7 @@ var sanitizeConfig = {
     "rel",
   ],
   ALLOWED_URI_REGEXP:
-    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i,
+    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z+\.\-]+(?:[^a-z+\.\-:]|$))/i,
   ADD_ATTR: ["target"],
   FORBID_TAGS: [
     "script",


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/53](https://github.com/bluewave-labs/verifywise/security/code-scanning/53)

To make the regular expression character class unambiguous and safe, each of the special characters intended to be allowed (such as `+`, `.`, and `-`) should be listed explicitly and not as a range. Specifically:
- In `[a-z+.-]`, the dash (`-`) should be either escaped (`\-`) or moved to the start or end of the character class so it is not interpreted as a range. This avoids creating the unintended `.-:` range.
- The other usages should also be checked (in this regex and elsewhere), but only code snippets provided should be changed.

For this file, edit line 73 of Clients/temp/test-xss-protection.js so that inside the regex, the dash `-` is placed at the start or end of the character class or escaped as `\-`, so that `[a-z+.-]` becomes `[a-z+.\-]` or `[-a-z+.]`. This change does not alter the intended matches or break existing functionality, but it prevents the ambiguous and dangerous character range. No new imports or dependencies are needed; only the regex itself needs to be rewritten.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
