### PR TITLE
Potential fix for code scanning alert no. 59: Overly permissive regular expression range

### DIFF
--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -449,7 +449,7 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
                     "rel",
                   ],
                   ALLOWED_URI_REGEXP:
-                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z.+-]+(?:[^a-z.+-:]|$))/i,
+                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z.+\-]+(?:[^a-z.+\-:]|$))/i,
                   ADD_ATTR: ["target"],
                   FORBID_TAGS: [
                     "script",


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/59](https://github.com/bluewave-labs/verifywise/security/code-scanning/59)

To address the issue, the character class `[a-z.+-]` in the regular expression should treat the dash as a literal character, not a range. In JavaScript regular expressions, you can do this by either escaping the `-` with a backslash `\-`, or by placing it at the beginning or end of the character class. It’s safest to escape it.

In Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx, locate the regular expression at line 452. Replace any instance of `[a-z.+-]` with `[a-z.+\-]` so that the dash is not treated as a range. Do not change any functionality except to tighten the character class to only those characters intended.

No imports or other method changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
