### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/Servers/routes/slackWebhook.route.ts
+++ b/Servers/routes/slackWebhook.route.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import rateLimit from "express-rate-limit";
 const router = express.Router();
 
 import authenticateJWT from "../middleware/auth.middleware";
@@ -11,12 +12,20 @@ import {
   deleteSlackWebhookById,
 } from "../controllers/slackWebhook.ctrl";
 
+// Rate limiter for expensive routes (e.g., create webhook)
+const createWebhookLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour window
+  max: 10,                  // limit each IP to 10 create requests per windowMs
+  message: {
+    error: "Too many webhook creation requests from this IP, please try again after an hour."
+  }
+});
 // GET requests
 router.get("/", authenticateJWT, getAllSlackWebhooks);
 router.get("/:id", authenticateJWT, getSlackWebhookById);
 
 // POST, PUT, DELETE requests
-router.post("/", authenticateJWT, createNewSlackWebhook);
+router.post("/", authenticateJWT, createWebhookLimiter, createNewSlackWebhook);
 router.patch("/:id", authenticateJWT, updateSlackWebhookById);
 router.delete("/:id", authenticateJWT, deleteSlackWebhookById);
 


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/8](https://github.com/bluewave-labs/verifywise/security/code-scanning/8)

The best way to fix this problem is to add a rate limiting middleware to the router that limits how many times an authenticated user can perform expensive operations, notably the creation of Slack webhooks. The recommended practice is to use a well-known package such as `express-rate-limit` to control request rates. The required changes are:
- Import `express-rate-limit` (or the corresponding named import if using TypeScript).
- Define a rate limiter with appropriate settings, e.g., allow 10-100 requests per hour per user.
- Apply this middleware specifically on the `POST /` route for creating Slack webhooks (and optionally to other expensive endpoints).
- Include the middleware before the handler in the route definition.

Only the file `Servers/routes/slackWebhook.route.ts` needs to be modified: add the import, define the limiter, and apply it to relevant routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
