### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/Servers/routes/vwmailer.route.ts
+++ b/Servers/routes/vwmailer.route.ts
@@ -6,14 +6,24 @@ import { generateToken } from "../utils/jwt.utils";
 import { frontEndUrl } from "../config/constants";
 import { invite } from "../controllers/vwmailer.ctrl";
 import { logProcessing, logSuccess, logFailure } from "../utils/logger/logHelper";
+import rateLimit from "express-rate-limit";
 
 const router = express.Router();
+
+// Rate limiter: max 5 requests per minute per IP for password reset
+const resetPasswordLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000,    // 1 minute
+  max: 5,                     // limit each IP to 5 requests per windowMs
+  message: {
+    error: "Too many password reset requests from this IP, please try again later."
+  }
+});
 
 router.post("/invite", async (req, res) => {
   await invite(req, res, req.body);
 });
 
-router.post("/reset-password", async (req, res) => {
+router.post("/reset-password", resetPasswordLimiter, async (req, res) => {
   const { to, name, email } = req.body;
 
   logProcessing({


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/10](https://github.com/bluewave-labs/verifywise/security/code-scanning/10)

To fix the missing rate limiting issue, a rate limiting middleware should be added to the router or the specific sensitive route (`/reset-password`). The `express-rate-limit` package is a well-known solution for this purpose.  
The fix involves:
- Importing `express-rate-limit` at the top of the file.
- Creating a limiter instance with reasonable defaults (e.g., max 5 requests per minute per IP).
- Applying the limiter specifically to the `/reset-password` POST route (to minimize risk of unintended effects elsewhere).

No existing functionalities are changed; we're only adding protection against excessive requests.

**Where to change:**
- `Servers/routes/vwmailer.route.ts`
  - Add import for `express-rate-limit`
  - Add rate limiter instance definition (above route definitions)
  - Insert limiter as middleware for `/reset-password` route

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
