### PR TITLE
Potential fix for code scanning alert no. 12: Database query built from user-controlled sources

### DIFF
--- a/Servers/utils/aiTrustCentre.utils.ts
+++ b/Servers/utils/aiTrustCentre.utils.ts
@@ -15,9 +15,19 @@ import { IAITrustCentrePublic } from "../domain.layer/interfaces/i.aiTrustCentre
 import { ValidationException } from "../domain.layer/exceptions/custom.exception";
 import { deleteFileById, getFileById, uploadFile } from "./fileUpload.utils";
 
+
+function isValidTenantSchema(tenant: string): boolean {
+  // Only letters, digits, and underscores. Length 1-30.
+  return /^[A-Za-z0-9_]{1,30}$/.test(tenant);
+}
+
 export const getIsVisibleQuery = async (
   tenant: string
 ) => {
+  if (!isValidTenantSchema(tenant)) {
+    // You could throw, log, or return false/null as appropriate
+    return false;
+  }
   try {
     const result = await sequelize.query(`SELECT visible FROM "${tenant}".ai_trust_center LIMIT 1;`) as [{ visible: boolean }[], number];
     return result[0][0]?.visible || false;


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/12](https://github.com/bluewave-labs/verifywise/security/code-scanning/12)

The optimal remediation is to validate the user-supplied `tenant` parameter before it is interpolated into the SQL query. Specifically, restrict the value to a safe format for SQL identifiers (letters, digits, underscores), with a length that matches application requirements. The validation logic should be implemented in the `getIsVisibleQuery` function (or as a helper), throwing or returning an error if the tenant name is not valid. This avoids SQL injection by ensuring malicious characters (such as quotes, semicolons, etc.) never reach the query construction step. Preferably, add a reusable, strongly restrictive validation—such as `/^[A-Za-z0-9_]{1,30}$/`—and use it wherever multi-tenant schema identifiers are interpolated.

Changes needed:
- In `Servers/utils/aiTrustCentre.utils.ts`, before the query in `getIsVisibleQuery`, perform validation of the `tenant` parameter.
- If invalid, throw an error or return false.
- Add the validation as a standalone helper function if possible.
- No external package is strictly required for this regex validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
