### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/Servers/routes/vwmailer.route.ts
+++ b/Servers/routes/vwmailer.route.ts
@@ -19,7 +19,16 @@ const resetPasswordLimiter = rateLimit({
   }
 });
 
-router.post("/invite", async (req, res) => {
+// Rate limiter: max 5 requests per minute per IP for invite route
+const inviteLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000,    // 1 minute
+  max: 5,                     // limit each IP to 5 requests per windowMs
+  message: {
+    error: "Too many invite requests from this IP, please try again later."
+  }
+});
+
+router.post("/invite", inviteLimiter, async (req, res) => {
   await invite(req, res, req.body);
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/10](https://github.com/bluewave-labs/verifywise/security/code-scanning/10)

To fix the missing rate limiting issue for the `/invite` POST endpoint, a rate limiting middleware (e.g., using `express-rate-limit`, which is already imported) should be applied to requests targeting this endpoint. The configuration can be similar to the `resetPasswordLimiter`: we can define a new rate limiter (e.g., `inviteLimiter`) with sensible values (such as 5 requests per minute per IP).  
Steps:
- Define a new `inviteLimiter` using `rateLimit` (similar to `resetPasswordLimiter`), with an appropriate error message for invites.
- Apply `inviteLimiter` as middleware to only the `/invite` route handler.
- No changes are needed outside the code snippet already shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
