### PR TITLE
Potential fix for code scanning alert no. 13: Database query built from user-controlled sources

### DIFF
--- a/Servers/utils/aiTrustCentre.utils.ts
+++ b/Servers/utils/aiTrustCentre.utils.ts
@@ -39,6 +39,10 @@ export const getIsVisibleQuery = async (
 export const getCompanyLogoQuery = async (
   tenant: string
 ) => {
+  if (!isValidTenantSchema(tenant)) {
+    // You could throw, log, or return null as appropriate for unsafe tenant values
+    return null;
+  }
   const result = await sequelize.query(`SELECT content, type FROM "${tenant}".ai_trust_center AS ai INNER JOIN "${tenant}".files f ON ai.logo = f.id LIMIT 1;`) as [{ content: Buffer }[], number];
 
   return result[0][0] || null;


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/13](https://github.com/bluewave-labs/verifywise/security/code-scanning/13)

The best fix is to ensure that all user-controlled values interpolated into the SQL query string are validated before use. Because table/schema names can't be used as parameterized values in most SQL engines (including Postgres), the only realistic option is to ensure the inputs are safe through whitelisting, regex, or other validation. There is already an `isValidTenantSchema` function used in the codebase, which is applied to the same kind of value in other query-building functions but missing here. The fix is to use `isValidTenantSchema(tenant)` in `getCompanyLogoQuery` and reject unsafe input (by returning `null` or throwing an error), before building the SQL query, mirroring the validation approach found in other query functions.

Edits should be made in Servers/utils/aiTrustCentre.utils.ts:

- Update `getCompanyLogoQuery` to validate `tenant` using `isValidTenantSchema`. If validation fails, return `null` (or alternatively, throw an error).

No other supporting methods or imports are needed, as `isValidTenantSchema` already exists in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
