### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete string escaping or encoding

### DIFF
--- a/Servers/utils/automation/automation.utils.ts
+++ b/Servers/utils/automation/automation.utils.ts
@@ -4,7 +4,7 @@ export function replaceTemplateVariables(
 ): string {
   let result = template;
   Object.entries(replacements).forEach(([key, value]) => {
-    const escapedKey = key.replace(/\./g, '\\.');
+    const escapedKey = key.replace(/\\/g, '\\\\').replace(/\./g, '\\.');
     const regex = new RegExp(`\\{\\{${escapedKey}\\}\\}`, 'g');
     result = result.replace(regex, String(value ?? ''));
   });


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/20](https://github.com/bluewave-labs/verifywise/security/code-scanning/20)

To fix this problem, we must escape any backslash (`\`) characters in the variable `key` before embedding it in a RegExp pattern, in addition to escaping periods. The best approach is to first globally replace each backslash in the key with two backslashes (i.e., `\\`), and then perform the existing period replacement. This technique ensures that any backslashes in the original key are double-escaped, thus producing the intended pattern and preventing RegExp injection or misbehavior. The ideal place for this change is on line 7, in the assignment of `escapedKey`. Only familiar standard library methods are required (`replace`, with the global flag and a RegExp for backslashes).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
