### PR TITLE
Potential fix for code scanning alert no. 14: Database query built from user-controlled sources

### DIFF
--- a/Servers/utils/aiTrustCentre.utils.ts
+++ b/Servers/utils/aiTrustCentre.utils.ts
@@ -21,6 +21,16 @@ function isValidTenantSchema(tenant: string): boolean {
   return /^[A-Za-z0-9_]{1,30}$/.test(tenant);
 }
 
+function escapePgIdentifier(ident: string): string {
+  // Accept only identifiers that pass isValidTenantSchema. 
+  // Otherwise throw, to avoid silent failure.
+  if (!isValidTenantSchema(ident)) {
+    throw new Error("Unsafe identifier for SQL query");
+  }
+  // Replace internal double-quotes with two double-quotes (standard PG escaping)
+  return '"' + ident.replace(/"/g, '""') + '"';
+}
+
 export const getIsVisibleQuery = async (
   tenant: string
 ) => {
@@ -29,7 +39,7 @@ export const getIsVisibleQuery = async (
     return false;
   }
   try {
-    const result = await sequelize.query(`SELECT visible FROM "${tenant}".ai_trust_center LIMIT 1;`) as [{ visible: boolean }[], number];
+    const result = await sequelize.query(`SELECT visible FROM ${escapePgIdentifier(tenant)}.ai_trust_center LIMIT 1;`) as [{ visible: boolean }[], number];
     return result[0][0]?.visible || false;
   } catch (error) {
     return false;
@@ -43,7 +53,7 @@ export const getCompanyLogoQuery = async (
     // You could throw, log, or return null as appropriate for unsafe tenant values
     return null;
   }
-  const result = await sequelize.query(`SELECT content, type FROM "${tenant}".ai_trust_center AS ai INNER JOIN "${tenant}".files f ON ai.logo = f.id LIMIT 1;`) as [{ content: Buffer }[], number];
+  const result = await sequelize.query(`SELECT content, type FROM ${escapePgIdentifier(tenant)}.ai_trust_center AS ai INNER JOIN ${escapePgIdentifier(tenant)}.files f ON ai.logo = f.id LIMIT 1;`) as [{ content: Buffer }[], number];
 
   return result[0][0] || null;
 }
@@ -53,7 +63,7 @@ export const getAITrustCentrePublicPageQuery = async (
 ) => {
   const output: Partial<IAITrustCentrePublic> = {};
   const visible = await sequelize.query(
-    `SELECT intro_visible, compliance_badges_visible, company_description_visible, terms_and_contact_visible, resources_visible, subprocessor_visible FROM "${tenant}".ai_trust_center LIMIT 1;`
+    `SELECT intro_visible, compliance_badges_visible, company_description_visible, terms_and_contact_visible, resources_visible, subprocessor_visible FROM ${escapePgIdentifier(tenant)}.ai_trust_center LIMIT 1;`
   ) as [{ intro_visible: boolean, compliance_badges_visible: boolean, company_description_visible: boolean, terms_and_contact_visible: boolean, resources_visible: boolean, subprocessor_visible: boolean }[], number];
 
   type VisibleKeys = "intro_visible" | "compliance_badges_visible" | "company_description_visible" | "terms_and_contact_visible" | "resources_visible" | "subprocessor_visible";
@@ -73,7 +83,7 @@ export const getAITrustCentrePublicPageQuery = async (
         WHEN our_mission_visible THEN our_mission_text
         ELSE NULL
       END AS mission
-      FROM "${tenant}".ai_trust_center_intro LIMIT 1;
+      FROM ${escapePgIdentifier(tenant)}.ai_trust_center_intro LIMIT 1;
     `,
     compliance_badges_visible: `
       SELECT SOC2_Type_I, SOC2_Type_II, ISO_27001, ISO_42001, CCPA, GDPR, HIPAA, EU_AI_Act
@@ -132,7 +142,7 @@ export const getAITrustCentrePublicPageQuery = async (
     }
   }
 
-  const infoQuery = await sequelize.query(`SELECT title, header_color, logo FROM "${tenant}".ai_trust_center LIMIT 1;`) as [{ title: string, header_color: string, logo: number }[], number];
+  const infoQuery = await sequelize.query(`SELECT title, header_color, logo FROM ${escapePgIdentifier(tenant)}.ai_trust_center LIMIT 1;`) as [{ title: string, header_color: string, logo: number }[], number];
 
   output["info"] = infoQuery[0][0] || {};
 


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/14](https://github.com/bluewave-labs/verifywise/security/code-scanning/14)

To fully mitigate the risk of SQL injection via the dynamic tenant schema, we should explicitly escape (quote) the schema/table names using a helper function that correctly quotes SQL identifiers, ensuring that only permitted values are used and injection is impossible (even against reserved words or unexpected input). Most libraries (including Sequelize and under-the-hood PostgreSQL clients) do not allow parameterization for schema/table names, but PostgreSQL allows double-quoting of identifiers (`"schema/table"`). We should create a helper that only allows safe names and always quotes them, following PostgreSQL identifier rules.

**Fix plan:**

- Create a utility function, `escapePgIdentifier`, that validates and safely quotes a string as an SQL identifier using double-quotes, escaping internal double-quotes (by replacing each `"` with `""`).
- Replace all occurrences of `"${tenant}"` in query strings with this escaping function, so they become `escapePgIdentifier(tenant)` instead of direct interpolation.
- Ensure all usages in the file (`getIsVisibleQuery`, `getCompanyLogoQuery`, `getAITrustCentrePublicPageQuery`, and nested in `keysQueryMap` queries and `infoQuery`) use this escaping function.
- Update only the revealed code in `Servers/utils/aiTrustCentre.utils.ts`, since other files do not contain SQL construction logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
