### PR TITLE
Potential fix for code scanning alert no. 16: Database query built from user-controlled sources

### DIFF
--- a/Servers/utils/aiTrustCentre.utils.ts
+++ b/Servers/utils/aiTrustCentre.utils.ts
@@ -154,7 +154,7 @@ export const getAITrustCentrePublicResourceByIdQuery = async (
   id: number
 ) => {
   const visible = await sequelize.query(
-    `SELECT visible, file_id FROM "${tenant}".ai_trust_center_resources WHERE id = :id;`,
+    `SELECT visible, file_id FROM ${escapePgIdentifier(tenant)}.ai_trust_center_resources WHERE id = :id;`,
     { replacements: { id } }
   ) as [{ visible: boolean, file_id: number }[], number];
   if (visible[0].length === 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/16](https://github.com/bluewave-labs/verifywise/security/code-scanning/16)

To fix the vulnerability, ensure that every occurrence where the `tenant` value is used in an SQL query as a schema/table name is properly escaped, not simply wrapped in double-quotes. This must be done by replacing `"${tenant}"` in the SQL query with a call to the `escapePgIdentifier` function, which validates and escapes the identifier according to the Postgres standard, as performed in other queries in the file. Concretely, in `getAITrustCentrePublicResourceByIdQuery`, update line 157 to:

- replace `"${tenant}"` in the SQL query string with `${escapePgIdentifier(tenant)}`,

No other change is necessary, as the function is already imported and defined in the same file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
