### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete multi-character sanitization

### DIFF
--- a/Servers/utils/validations/policiesValidation.utils.ts
+++ b/Servers/utils/validations/policiesValidation.utils.ts
@@ -449,8 +449,8 @@ export const validatePolicyUpdateBusinessRules = (data: any, existingData?: any)
 
   // Validate major content changes for published policies
   if (data.content_html && existingData?.status === 'Published' && existingData?.content_html) {
-    const oldContent = existingData.content_html.replace(/<[^>]*>/g, '').trim();
-    const newContent = data.content_html.replace(/<[^>]*>/g, '').trim();
+    const oldContent = striptags(existingData.content_html).trim();
+    const newContent = striptags(data.content_html).trim();
 
     // Simple check for significant content changes (more than 30% difference)
     const similarity = Math.min(oldContent.length, newContent.length) / Math.max(oldContent.length, newContent.length);


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/22](https://github.com/bluewave-labs/verifywise/security/code-scanning/22)

To fix this problem robustly, the code that strips HTML tags should use a well-tested HTML sanitization/stripping library (such as the already imported `striptags`). This is safer and more reliable than using regular expressions because libraries handle edge cases and complex tag structures that simple regex cannot.  
- Instead of `existingData.content_html.replace(/<[^>]*>/g, '').trim()`, use `striptags(existingData.content_html).trim()`.
- Likewise, replace `data.content_html.replace(/<[^>]*>/g, '').trim()` with `striptags(data.content_html).trim()`.
- The only file requiring changes is `Servers/utils/validations/policiesValidation.utils.ts`, lines 452 and 453.

No new imports are necessary because `striptags` is already imported at the top of the file. No new methods or variable definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
