### PR TITLE
Potential fix for code scanning alert no. 18: Database query built from user-controlled sources

### DIFF
--- a/Servers/utils/task.utils.ts
+++ b/Servers/utils/task.utils.ts
@@ -317,10 +317,25 @@ export const getTasksQuery = async (
     baseQueryParts.push("WHERE " + whereConditions.join(" AND "));
   }
 
+  // Validate sort_order first to ensure we have a valid sortOrder for both cases
+  const sortOrders = {
+    ASC: "ASC",
+    DESC: "DESC",
+  } as const;
+
+  if (!(sort_order in sortOrders)) {
+    throw new ValidationException(
+      "Invalid sort order provided",
+      "sort_order",
+      sort_order
+    );
+  }
+
+  const sortOrder = sortOrders[sort_order as keyof typeof sortOrders];
+
   // Build ORDER clause for sorts (due_date, priority, created_at)
   if (sort_by === "priority") {
     // Custom priority ordering: High=1, Medium=2, Low=3
-    // Use safe mapped sortOrder value to prevent injection
     baseQueryParts.push(`ORDER BY CASE
       WHEN t.priority = :priorityHigh THEN 1
       WHEN t.priority = :priorityMedium THEN 2
@@ -329,15 +344,11 @@ export const getTasksQuery = async (
     replacements.priorityHigh = TaskPriority.HIGH;
     replacements.priorityMedium = TaskPriority.MEDIUM;
     replacements.priorityLow = TaskPriority.LOW;
+  } else {
     // Use hardcoded mapping for sort fields to avoid SQL injection
     const allowedSortFields = {
       due_date: "due_date",
       created_at: "created_at",
-    } as const;
-
-    const sortOrders = {
-      ASC: "ASC",
-      DESC: "DESC",
     } as const;
 
     if (!(sort_by in allowedSortFields)) {
@@ -348,18 +359,9 @@ export const getTasksQuery = async (
       );
     }
 
-    if (!(sort_order in sortOrders)) {
-      throw new ValidationException(
-        "Invalid sort order provided",
-        "sort_order",
-        sort_order
-      );
-    }
-
     // We can safely interpolate these as they come strictly from the defined mappings
     const safeSortBy =
       allowedSortFields[sort_by as keyof typeof allowedSortFields];
-    const sortOrder = sortOrders[sort_order as keyof typeof sortOrders];
     const orderClause = `ORDER BY t.${safeSortBy} ${sortOrder}`;
 
     if (safeSortBy !== "created_at") {


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/18](https://github.com/bluewave-labs/verifywise/security/code-scanning/18)

To fix the problem, ensure that only values derived from trusted, validated, and mapped sources—not raw user input—are interpolated into SQL. Specifically, use the internal `sortOrder` variable (derived from the safe mapping), rather than direct user-provided `sort_order`, in the `"ORDER BY ... END ..."` clause.

- In the `"priority"` sorting branch (where the SQL currently uses `${sort_order}`), change the interpolation to `${sortOrder}`.
- This ensures whitelisted values are always used in the SQL, never trusting user input directly, even if validations occur earlier.
- No additional library or dependency is needed, only a code snippet change in `Servers/utils/task.utils.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
