### PR TITLE
Add localStorage persistence for analytics selections

### DIFF
--- a/Clients/src/presentation/components/AnalyticsDrawer/index.tsx
+++ b/Clients/src/presentation/components/AnalyticsDrawer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Drawer, Box, Typography, Stack, IconButton } from "@mui/material";
 import { X as CloseIcon } from "lucide-react";
 import ModelInventoryHistoryChart from "../Charts/ModelInventoryHistoryChart";
@@ -62,9 +62,24 @@ const AnalyticsDrawer: React.FC<AnalyticsDrawerProps> = ({
   defaultParameter,
   chartType = "model", // Default to model chart for backward compatibility
 }) => {
-  const [selectedParameter, setSelectedParameter] = useState<string>(
-    defaultParameter || availableParameters[0]?.value || ""
-  );
+  // Create localStorage key based on chartType for persistence
+  const storageKey = `analytics_parameter_${chartType}`;
+
+  // Initialize state from localStorage or default
+  const [selectedParameter, setSelectedParameter] = useState<string>(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored && availableParameters.some(p => p.value === stored)) {
+      return stored;
+    }
+    return defaultParameter || availableParameters[0]?.value || "";
+  });
+
+  // Persist to localStorage whenever selection changes
+  useEffect(() => {
+    if (selectedParameter) {
+      localStorage.setItem(storageKey, selectedParameter);
+    }
+  }, [selectedParameter, storageKey]);
 
   const handleParameterChange = (newParameter: string) => {
     setSelectedParameter(newParameter);

--- a/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
@@ -33,10 +33,25 @@ const ModelInventoryHistoryChart: React.FC<ModelInventoryHistoryChartProps> = ({
   parameter = "status",
   height = 400,
 }) => {
-  const [timeframe, setTimeframe] = useState<string>("1month");
+  const storageKey = "analytics_timeframe_model";
+
+  // Initialize timeframe from localStorage or default
+  const [timeframe, setTimeframe] = useState<string>(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored && TIMEFRAME_OPTIONS.some(opt => opt.value === stored)) {
+      return stored;
+    }
+    return "1month";
+  });
+
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [timeseriesData, setTimeseriesData] = useState<any[]>([]);
+
+  // Persist timeframe to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem(storageKey, timeframe);
+  }, [timeframe]);
 
   useEffect(() => {
     fetchTimeseriesData();

--- a/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
@@ -77,10 +77,25 @@ const RiskHistoryChart: React.FC<RiskHistoryChartProps> = ({
   parameter = "risk_level",
   height = 400,
 }) => {
-  const [timeframe, setTimeframe] = useState<string>("1month");
+  const storageKey = "analytics_timeframe_risk";
+
+  // Initialize timeframe from localStorage or default
+  const [timeframe, setTimeframe] = useState<string>(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored && TIMEFRAME_OPTIONS.some(opt => opt.value === stored)) {
+      return stored;
+    }
+    return "1month";
+  });
+
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [timeseriesData, setTimeseriesData] = useState<any[]>([]);
+
+  // Persist timeframe to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem(storageKey, timeframe);
+  }, [timeframe]);
 
   useEffect(() => {
     fetchTimeseriesData();


### PR DESCRIPTION
## Summary

This PR adds localStorage persistence for analytics selections in Risk Management and Model Inventory pages, so user preferences are remembered when navigating away and returning.

## Problem

When users click the Analytics button on `/risk-management` or `/model-inventory`, they can select:
- **Graph type** (e.g., Severity, Likelihood, Risk Level for risks; Status for models)
- **Duration** (e.g., 7 Days, 1 Month, 3 Months, etc.)

However, when navigating to another page and returning, these selections were reset to defaults, requiring users to reconfigure their view each time.

## Solution

Implemented localStorage persistence for both selections:
- Graph type persists per entity (risk/model)
- Duration persists per entity (risk/model)
- Values are validated against available options before use
- Safe fallbacks to defaults if stored values are invalid

## Changes

### AnalyticsDrawer Component
- Added localStorage persistence for selected parameter (graph type)
- Uses entity-specific storage keys: `analytics_parameter_risk` and `analytics_parameter_model`
- Initializes from stored value on mount
- Validates stored value against available parameters
- Auto-persists on every selection change

### RiskHistoryChart Component
- Added localStorage persistence for timeframe (duration)
- Storage key: `analytics_timeframe_risk`
- Initializes from stored value with validation
- Defaults to "1month" if no valid stored value
- Auto-persists on every timeframe change

### ModelInventoryHistoryChart Component
- Added localStorage persistence for timeframe (duration)
- Storage key: `analytics_timeframe_model`
- Initializes from stored value with validation
- Defaults to "1month" if no valid stored value
- Auto-persists on every timeframe change

## Storage Keys

| Key | Purpose |
|-----|---------|
| `analytics_parameter_risk` | Risk analytics graph type selection |
| `analytics_parameter_model` | Model analytics graph type selection |
| `analytics_timeframe_risk` | Risk analytics duration selection |
| `analytics_timeframe_model` | Model analytics duration selection |

## Benefits

✅ Improved user experience - selections persist across navigation  
✅ Separate storage for risk and model analytics  
✅ No need to reconfigure analytics view each time  
✅ Safe validation and fallbacks  
✅ Minimal performance impact

## Testing Steps

1. Go to `/risk-management`
2. Click "Analytics" button
3. Select a graph type (e.g., "Severity")
4. Select a duration (e.g., "3 Months")
5. Navigate to another page (e.g., `/model-inventory`)
6. Return to `/risk-management`
7. Click "Analytics" button
8. ✅ Verify selections are remembered (Severity, 3 Months)

Repeat for `/model-inventory`:
1. Go to `/model-inventory`
2. Click "Analytics" button
3. Select "Status" and a duration
4. Navigate away and return
5. ✅ Verify selections are remembered

## Files Changed

- `src/presentation/components/AnalyticsDrawer/index.tsx`
- `src/presentation/components/Charts/RiskHistoryChart.tsx`
- `src/presentation/components/Charts/ModelInventoryHistoryChart.tsx`

**Total: 3 files changed (+51/-6)**