### PR TITLE
Potential fix for code scanning alert no. 41: Missing rate limiting

### DIFF
--- a/Servers/routes/fileManager.route.ts
+++ b/Servers/routes/fileManager.route.ts
@@ -132,7 +132,7 @@ router.get("/", fileOperationsLimiter, authenticateJWT, listFiles);
  * @returns {404} File not found
  * @returns {500} Server error
  */
-router.get("/:id", authenticateJWT, downloadFile);
+router.get("/:id", fileOperationsLimiter, authenticateJWT, downloadFile);
 
 /**
  * @route   DELETE /file-manager/:id


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/41](https://github.com/bluewave-labs/verifywise/security/code-scanning/41)

To fix this problem, the rate limiter middleware used for the other file-manager routes (`fileOperationsLimiter`) should also be applied to the file download endpoint (`GET /file-manager/:id`). This is achieved by adding `fileOperationsLimiter` as a middleware for the route in the same way it is used for the other routes. Specifically, in `Servers/routes/fileManager.route.ts`, on line 135, add `fileOperationsLimiter` as the first argument in the middleware chain for `router.get("/:id", ...)`. This fix is self-contained and matches the existing functionality and design decisions in the file.

No new imports or modules are required, since `fileOperationsLimiter` is already imported at the top of the file. No changes to the controller or utility code are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
