### PR TITLE
Redesign user menu with single-column layout and profile improvements

### DIFF
--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -14,7 +14,6 @@ import {
   Drawer,
   Menu,
   MenuItem,
-  Grid,
 } from "@mui/material";
 import "./index.css";
 import { useDispatch, useSelector } from "react-redux";
@@ -50,7 +49,6 @@ import {
   FolderCog,
   Database,
   Heart,
-  User as UserIcon,
   HelpCircle,
   Newspaper,
   Users,
@@ -73,8 +71,6 @@ import { getAllTasks } from "../../../application/repository/task.repository";
 import { TaskStatus } from "../../../domain/enums/task.enum";
 import { IMenuGroup, IMenuItem } from "../../../domain/interfaces/i.menu";
 import FlyingHearts from "../FlyingHearts";
-import { useOnboarding } from "../../../application/hooks/useOnboarding";
-import { RotateCcw } from "lucide-react";
 
 const getMenuGroups = (): IMenuGroup[] => [
   {
@@ -239,7 +235,6 @@ const Sidebar: React.FC<SidebarProps> = ({
     useState<null | HTMLElement>(null);
   const drawerRef = useRef<HTMLDivElement>(null);
   const logout = useLogout();
-  const { resetOnboarding } = useOnboarding();
 
   // Heart icon state
   const [showHeartIcon, setShowHeartIcon] = useState(false);


### PR DESCRIPTION
## Summary

Redesigns the user menu popup with a cleaner single-column layout and improved profile presentation.

<img width="380" height="457" alt="image" src="https://github.com/user-attachments/assets/8fcf69f3-cba1-49b3-9b09-407c761d2199" />

