### PR TITLE
Update application font to Geist with Inter fallback

### DIFF
--- a/Clients/index.html
+++ b/Clients/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Fonts - Geist (primary) and Inter (fallback) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+
     <!-- General meta description for SEO -->
     <link
       rel="icon"

--- a/Clients/src/index.css
+++ b/Clients/src/index.css
@@ -2,5 +2,5 @@
 @import 'react-grid-layout/css/styles.css';
 
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Geist", "Inter", system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif;
 }

--- a/Clients/src/presentation/components/DemoBanner/styles.ts
+++ b/Clients/src/presentation/components/DemoBanner/styles.ts
@@ -19,7 +19,6 @@ export const Container = styled(Box)<ContainerProps>(() => ({
 }));
 
 export const Text = styled(Typography)(() => ({
-  fontFamily: 'Inter, sans-serif',
   fontWeight: 500,
   fontSize: '13px',
   lineHeight: '20px',

--- a/Clients/src/presentation/pages/FairnessDashboard/styles.ts
+++ b/Clients/src/presentation/pages/FairnessDashboard/styles.ts
@@ -23,7 +23,6 @@ export const styles = {
                       fontWeight: 500,
                       textTransform: "capitalize",
                       color: "#4B5563",
-                      fontFamily: "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif",
                       width: "fit-content",
                       minWidth: "unset",
                     },

--- a/Clients/src/presentation/pages/ProjectView/AddNewFramework/styles.ts
+++ b/Clients/src/presentation/pages/ProjectView/AddNewFramework/styles.ts
@@ -78,7 +78,6 @@ export const modalDoneButtonStyle: SxProps<Theme> = {
   backgroundColor: '#13715B',
   color: '#fff',
   border: '1px solid #13715B',
-  fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
   '&:hover': {
     backgroundColor: '#10614d',
   },

--- a/Clients/src/presentation/themes/light.ts
+++ b/Clients/src/presentation/themes/light.ts
@@ -22,7 +22,7 @@ const background = {
 };
 
 const fontFamilyDefault =
-  "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif";
+  "'Geist', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif";
 
 const shadow =
   "0px 4px 24px -4px rgba(16, 24, 40, 0.08), 0px 3px 3px -3px rgba(16, 24, 40, 0.03)";


### PR DESCRIPTION
## Summary
- Updates the primary application font from Inter to Geist
- Adds Inter as a fallback font in case Geist fails to load
- Removes hardcoded font-family declarations from individual components so they inherit from the theme

## Changes
- **index.html**: Added Google Fonts import for both Geist and Inter (weights 400, 500, 600, 700)
- **src/index.css**: Updated CSS root font-family to Geist with proper fallback chain
- **src/presentation/themes/light.ts**: Updated MUI theme font-family default
- **Removed hardcoded fonts from**:
  - `DemoBanner/styles.ts`
  - `FairnessDashboard/styles.ts`
  - `AddNewFramework/styles.ts`

## Test plan
- [ ] Verify Geist font loads correctly on page load
- [ ] Check font rendering across different pages
- [ ] Verify fallback works by blocking Geist in dev tools
- [ ] Test on different browsers (Chrome, Firefox, Safari)