### PR TITLE
Fix TypeScript errors in style guide sections

### DIFF
--- a/Clients/src/presentation/pages/StyleGuide/sections/AlertsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/AlertsSection.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy, Info, CheckCircle, AlertTriangle, XCircle } from "lucide-react";
-import Alert from "../../../components/Alert";
 import CodeBlock from "../components/CodeBlock";
 
 const alertSnippets = {

--- a/Clients/src/presentation/pages/StyleGuide/sections/BreadcrumbsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/BreadcrumbsSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
-import { Copy, Home, ChevronRight, Settings, FileText } from "lucide-react";
+import { Copy, Home, Settings } from "lucide-react";
 import Breadcrumbs from "../../../components/Breadcrumbs";
 import CodeBlock from "../components/CodeBlock";
 

--- a/Clients/src/presentation/pages/StyleGuide/sections/DosAndDontsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/DosAndDontsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, Stack, Typography, useTheme, Snackbar, Button } from "@mui/material";
+import { Box, Stack, Typography, useTheme, Snackbar } from "@mui/material";
 import { Check, X, Copy } from "lucide-react";
 
 const DosAndDontsSection: React.FC = () => {

--- a/Clients/src/presentation/pages/StyleGuide/sections/FileStructureSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/FileStructureSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Snackbar } from "@mui/material";
-import { Copy, Folder, FolderOpen, FileText, ChevronRight, ChevronDown } from "lucide-react";
+import { Folder, FolderOpen, FileText, ChevronRight, ChevronDown } from "lucide-react";
 
 const FileStructureSection: React.FC = () => {
   const theme = useTheme();
@@ -223,17 +223,17 @@ const FileStructureSection: React.FC = () => {
               <LayerCard
                 name="domain"
                 description="Business logic, TypeScript interfaces, entities"
-                color={theme.palette.status.warning.text}
+                color={theme.palette.status.warning.text || "#f59e0b"}
               />
               <LayerCard
                 name="infrastructure"
                 description="External services, API clients, third-party integrations"
-                color={theme.palette.status.error.text}
+                color={theme.palette.status.error.text || "#ef4444"}
               />
               <LayerCard
                 name="presentation"
                 description="UI components, pages, themes, utilities"
-                color={theme.palette.status.success.text}
+                color={theme.palette.status.success.text || "#22c55e"}
               />
             </Stack>
           </Box>

--- a/Clients/src/presentation/pages/StyleGuide/sections/IconsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/IconsSection.tsx
@@ -165,7 +165,7 @@ const IconsSection: React.FC = () => {
           }}
         >
           {filteredIcons.map((iconName) => {
-            const IconComponent = (LucideIcons as Record<string, React.FC<{ size?: number; color?: string }>>)[iconName];
+            const IconComponent = (LucideIcons as unknown as Record<string, React.FC<{ size?: number; color?: string }>>)[iconName];
             if (!IconComponent) return null;
             return (
               <Box

--- a/Clients/src/presentation/pages/StyleGuide/sections/TabsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/TabsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Snackbar } from "@mui/material";
 import TabContext from "@mui/lab/TabContext";
-import { Copy, User, Users, Settings, FileText, Bell } from "lucide-react";
+import { Copy, Users } from "lucide-react";
 import TabBar, { TabItem } from "../../../components/TabBar";
 import CodeBlock from "../components/CodeBlock";
 


### PR DESCRIPTION
## Summary
- Remove unused imports across multiple style guide section files
- Fix type conversion error in IconsSection
- Add fallback values for optional theme palette colors

## Changes

### AlertsSection.tsx
- Remove unused `Alert` import

### BreadcrumbsSection.tsx
- Remove unused `ChevronRight` and `FileText` imports

### DosAndDontsSection.tsx
- Remove unused `Button` import

### FileStructureSection.tsx
- Remove unused `Copy` import
- Add fallback values for `theme.palette.status.*.text` colors to handle potential undefined values

### IconsSection.tsx
- Fix type conversion using `unknown` intermediary for lucide-react icons

### TabsSection.tsx
- Remove unused `User`, `Settings`, `FileText`, and `Bell` imports

## Test plan
- [ ] Verify `npm run build` passes without TypeScript errors
- [ ] Verify style guide sections render correctly