### PR TITLE
Fix TypeScript errors in approval workflow components

### DIFF
--- a/Clients/src/presentation/components/Modals/NewApprovalWorkflow/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewApprovalWorkflow/index.tsx
@@ -11,7 +11,6 @@ import {
     stepNumberStyle,
 } from "./style";
 import { ApprovalWorkflowStepModel } from "../../../../domain/models/Common/approvalWorkflow/approvalWorkflowStepModel";
-import { logEngine } from "../../../../application/tools/log.engine";
 
 
 const APPROVERS = [
@@ -63,13 +62,12 @@ const CreateNewApprovalWorkflow: FC<ICreateApprovalWorkflowProps> = ({
     setIsOpen,
     initialData,
     isEdit = false,
-    mode,
     onSuccess
 }) => {
 
     const theme = useTheme();
     const [errors, setErrors] = useState<NewApprovalWorkflowFormErrors>({ steps: [] });
-    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isSubmitting] = useState(false);
 
     const [stepsCount, setStepsCount] = useState(1);
     const [workflowTitle, setWorkflowTitle] = useState("");

--- a/Clients/src/presentation/components/Modals/RequestorApprovalModal/index.tsx
+++ b/Clients/src/presentation/components/Modals/RequestorApprovalModal/index.tsx
@@ -1,16 +1,13 @@
 // Lucide Icons
 import {
-    Building,
-    List as ListIcon,
     Layers,
 } from "lucide-react";
 
-import { Box, Divider, List, ListItemButton, ListItemIcon, ListItemText, Stack, Tooltip, Typography } from "@mui/material";
+import { Box, Divider, List, ListItemButton, ListItemText, Stack, Tooltip, Typography } from "@mui/material";
 import StandardModal from "../StandardModal";
 import { useTheme } from "@mui/material";
 import type { FC } from "react";
 import { IMenuGroup } from "../../../../domain/interfaces/i.menu";
-import { title } from "process";
 import React from "react";
 
 

--- a/Clients/src/presentation/pages/ApprovalWorkflows/index.tsx
+++ b/Clients/src/presentation/pages/ApprovalWorkflows/index.tsx
@@ -18,7 +18,7 @@ const ApprovalWorkflows: React.FC = () => {
     const [workflowData, setWorkflowData] = useState<ApprovalWorkflowModel[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [selectWorkflow, setSelectWorkflow] = useState<ApprovalWorkflowModel | null>(null);
-    const [selectWorkflowId, setSelectWorkflowId] = useState<string | null>(null);
+    const [, setSelectWorkflowId] = useState<string | null>(null);
     const [modalMode, setModalMode] = useState("")
 
     const MOCK_WORKFLOWS: ApprovalWorkflowModel[] = [


### PR DESCRIPTION
## Summary
- Fix unused variable/import TypeScript errors in approval workflow components introduced in PR #2751

## Changes
- **NewApprovalWorkflow/index.tsx**: Remove unused `logEngine` import, `mode` prop, and `setIsSubmitting` setter
- **RequestorApprovalModal/index.tsx**: Remove unused `Building`, `ListIcon`, `ListItemIcon` imports and `title` import
- **ApprovalWorkflows/index.tsx**: Fix unused `selectWorkflowId` variable

## Test plan
- [ ] Verify build passes without TypeScript errors
- [ ] Verify approval workflow functionality still works as expected