### PR TITLE
Clean up onboarding modal UI

### DIFF
--- a/Clients/src/presentation/components/Onboarding/steps/AdminSetupStep.tsx
+++ b/Clients/src/presentation/components/Onboarding/steps/AdminSetupStep.tsx
@@ -2,30 +2,29 @@ import React from "react";
 import { Box, Typography, Stack } from "@mui/material";
 import { OnboardingStepProps } from "../../../../domain/interfaces/i.onboarding";
 import { UserPlus, Settings, Shield } from "lucide-react";
-import Alert from "../../Alert";
 import onboardingBanner from "../../../assets/onboarding-banner.svg";
 
 const AdminSetupStep: React.FC<OnboardingStepProps> = () => {
   const setupTasks = [
     {
       icon: <UserPlus size={24} />,
-      title: "Invite Team Members",
+      title: "Invite team members",
+      hint: "Settings → Team",
       description: "Add colleagues to collaborate on compliance and risk management tasks.",
-      action: "Go to Settings → Team to send invitations",
       color: "#3B82F6",
     },
     {
       icon: <Shield size={24} />,
-      title: "Enable Frameworks",
+      title: "Enable frameworks",
+      hint: "Settings → Frameworks",
       description: "Activate the compliance frameworks relevant to your organization.",
-      action: "Visit Framework Settings to enable EU AI Act, ISO standards, and more",
       color: "#8B5CF6",
     },
     {
       icon: <Settings size={24} />,
-      title: "Configure Organization Settings",
+      title: "Configure organization settings",
+      hint: "Settings → Organization",
       description: "Customize branding, notifications, and organizational preferences.",
-      action: "Access these options in Settings → Organization",
       color: "#10B981",
     },
   ];
@@ -95,7 +94,7 @@ const AdminSetupStep: React.FC<OnboardingStepProps> = () => {
               },
             }}
           >
-            <Stack direction="row" spacing={2} marginBottom={2}>
+            <Stack direction="row" spacing={2}>
               <Box
                 sx={{
                   width: "48px",
@@ -112,46 +111,33 @@ const AdminSetupStep: React.FC<OnboardingStepProps> = () => {
                 {task.icon}
               </Box>
               <Box flex={1}>
-                <Typography
-                  sx={{
-                    fontSize: "15px",
-                    fontWeight: 600,
-                    color: "#111827",
-                    marginBottom: 0.5,
-                  }}
-                >
-                  {task.title}
-                </Typography>
+                <Stack direction="row" alignItems="center" spacing={1} marginBottom={0.5}>
+                  <Typography
+                    sx={{
+                      fontSize: "15px",
+                      fontWeight: 600,
+                      color: "#111827",
+                    }}
+                  >
+                    {task.title}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: "15px",
+                      color: "#6B7280",
+                    }}
+                  >
+                    ({task.hint})
+                  </Typography>
+                </Stack>
                 <Typography sx={{ fontSize: "13px", color: "#6B7280" }}>
                   {task.description}
                 </Typography>
               </Box>
             </Stack>
-            <Box
-              sx={{
-                padding: 1.5,
-                backgroundColor: "#F9FAFB",
-                borderRadius: "6px",
-                borderLeft: `3px solid ${task.color}`,
-              }}
-            >
-              <Typography sx={{ fontSize: "12px", color: "#374151", fontStyle: "italic" }}>
-                💡 {task.action}
-              </Typography>
-            </Box>
           </Box>
         ))}
       </Stack>
-
-      <Alert
-        variant="info"
-        body="You can complete these setup tasks at any time after onboarding. They're available in your Settings menu."
-        hasIcon={false}
-        sx={{
-          position: "static",
-          padding: "12px 16px",
-        }}
-      />
     </Stack>
   );
 };

--- a/Clients/src/presentation/components/Onboarding/steps/SampleProjectStep.tsx
+++ b/Clients/src/presentation/components/Onboarding/steps/SampleProjectStep.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Box, Typography, Stack, FormControl, Checkbox, FormControlLabel, SelectChangeEvent } from "@mui/material";
+import { Box, Typography, Stack, FormControl, Checkbox, SelectChangeEvent } from "@mui/material";
 import { OnboardingStepProps } from "../../../../domain/interfaces/i.onboarding";
 import { DEMO_PROJECT_BANNER } from "../onboardingConstants";
 import Select from "../../../components/Inputs/Select";
@@ -128,19 +128,17 @@ const SampleProjectStep: React.FC<OnboardingStepProps> = ({
               marginBottom: 1,
             }}
           >
-            Select a use case template <span style={{ color: "#DC2626" }}>*</span>
+            Demo use case <span style={{ color: "#DC2626" }}>*</span>
           </Typography>
           <Select
             id="use-case-select"
             label=""
+            placeholder="Select a use case template"
             value={sampleProject?.useCaseName || ""}
             onChange={handleUseCaseChange}
             items={USE_CASE_TEMPLATES}
             sx={{ width: "100%" }}
           />
-          <Typography sx={{ fontSize: "12px", color: "#6B7280", marginTop: 1 }}>
-            This will be the name of your demo project
-          </Typography>
         </FormControl>
 
         {/* Framework Selection */}
@@ -153,110 +151,84 @@ const SampleProjectStep: React.FC<OnboardingStepProps> = ({
               marginBottom: 2,
             }}
           >
-            Select framework(s) to apply <span style={{ color: "#DC2626" }}>*</span>
+            Select regulations/frameworks to apply <span style={{ color: "#DC2626" }}>*</span>
           </Typography>
 
-          <Stack spacing={1.5}>
-            {hasFrameworks ? (
-              allFrameworks.map((framework: Framework) => (
-                <FormControlLabel
+          {hasFrameworks ? (
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(4, 1fr)",
+                gap: 2,
+              }}
+            >
+              {allFrameworks.map((framework: Framework) => (
+                <Box
                   key={framework.id}
-                  control={
-                    <Checkbox
-                      checked={selectedFrameworks.includes(Number(framework.id))}
-                      onChange={() => handleFrameworkToggle(Number(framework.id))}
-                      sx={{
-                        color: "#D0D5DD",
-                        "&.Mui-checked": {
-                          color: "#13715B",
-                        },
-                      }}
-                    />
-                  }
-                  label={
-                    <Box>
-                      <Typography sx={{ fontSize: "13px", color: "#111827", fontWeight: 500 }}>
-                        {framework.name}
-                      </Typography>
-                      <Typography sx={{ fontSize: "12px", color: "#6B7280" }}>
-                        {framework.description || "Compliance framework for AI governance"}
-                      </Typography>
-                    </Box>
-                  }
+                  onClick={() => handleFrameworkToggle(Number(framework.id))}
                   sx={{
-                    margin: 0,
                     padding: 2,
-                    border: "1px solid #E5E7EB",
+                    border: selectedFrameworks.includes(Number(framework.id))
+                      ? "2px solid #13715B"
+                      : "1px solid #E5E7EB",
                     borderRadius: "4px",
+                    cursor: "pointer",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: 1,
+                    backgroundColor: selectedFrameworks.includes(Number(framework.id))
+                      ? "#F0FDF4"
+                      : "white",
+                    transition: "all 0.2s",
                     "&:hover": {
-                      backgroundColor: "#F9FAFB",
+                      backgroundColor: selectedFrameworks.includes(Number(framework.id))
+                        ? "#F0FDF4"
+                        : "#F9FAFB",
+                      borderColor: "#13715B",
                     },
                   }}
-                />
-              ))
-            ) : (
-              <Box
-                sx={{
-                  padding: 2,
-                  backgroundColor: "#FEF2F2",
-                  border: "1px solid #FECACA",
-                  borderRadius: "4px",
-                }}
-              >
-                <Typography sx={{ fontSize: "12px", color: "#991B1B" }}>
-                  No frameworks available. Please contact support if this issue persists.
-                </Typography>
-              </Box>
-            )}
-          </Stack>
-
-          <Typography sx={{ fontSize: "12px", color: "#6B7280", marginTop: 1 }}>
-            You can select multiple frameworks. At least one is required.
-          </Typography>
+                >
+                  <Checkbox
+                    checked={selectedFrameworks.includes(Number(framework.id))}
+                    onChange={() => handleFrameworkToggle(Number(framework.id))}
+                    sx={{
+                      padding: 0,
+                      color: "#D0D5DD",
+                      "&.Mui-checked": {
+                        color: "#13715B",
+                      },
+                    }}
+                  />
+                  <Typography
+                    sx={{
+                      fontSize: "12px",
+                      color: "#111827",
+                      fontWeight: 500,
+                      textAlign: "center",
+                    }}
+                  >
+                    {framework.name}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                padding: 2,
+                backgroundColor: "#FEF2F2",
+                border: "1px solid #FECACA",
+                borderRadius: "4px",
+              }}
+            >
+              <Typography sx={{ fontSize: "12px", color: "#991B1B" }}>
+                No frameworks available. Please contact support if this issue persists.
+              </Typography>
+            </Box>
+          )}
         </FormControl>
-
-        {/* Demo Risks Info */}
-        <Box
-          sx={{
-            padding: 3,
-            backgroundColor: "#F0FDF4",
-            border: "1px solid #D1FAE5",
-            borderRadius: "4px",
-          }}
-        >
-          <Typography
-            sx={{
-              fontSize: "13px",
-              fontWeight: 600,
-              color: "#13715B",
-              marginBottom: 1,
-            }}
-          >
-            What's included in your demo project:
-          </Typography>
-          <Stack spacing={0.5} sx={{ paddingLeft: 2 }}>
-            {[
-              "Sample risks mapped to your selected framework(s)",
-              "Pre-configured risk severity and likelihood levels",
-              "Example mitigation controls and strategies",
-              "Simulated compliance status and tracking",
-            ].map((item, index) => (
-              <Box key={index} sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                <Box
-                  sx={{
-                    width: "4px",
-                    height: "4px",
-                    borderRadius: "50%",
-                    backgroundColor: "#13715B",
-                  }}
-                />
-                <Typography sx={{ fontSize: "12px", color: "#344054" }}>
-                  {item}
-                </Typography>
-              </Box>
-            ))}
-          </Stack>
-        </Box>
 
         {/* Validation Message */}
         {!hasRequiredSelections && (


### PR DESCRIPTION
## Summary
- Move action hints next to headers in AdminSetupStep (e.g., "Invite team members (Settings → Team)")
- Remove bottom helper texts and Alert component from AdminSetupStep
- Convert framework selection to 4-in-a-row grid layout in SampleProjectStep
- Remove framework descriptions for cleaner UI
- Rename "Select a use case template" to "Demo use case"
- Add placeholder text to use case select dropdown
- Remove "What's included in your demo project" section

## Test plan
- [ ] Verify onboarding modal displays hints next to headers
- [ ] Verify framework selection shows 4 items per row
- [ ] Verify demo use case dropdown has placeholder text
- [ ] Verify "What's included" section is removed