### PR TITLE
Split NIST AI RMF dashboard stats by function

### DIFF
--- a/Clients/src/presentation/pages/Framework/Dashboard/AssignmentStatusCard.tsx
+++ b/Clients/src/presentation/pages/Framework/Dashboard/AssignmentStatusCard.tsx
@@ -38,6 +38,12 @@ interface ExtendedFrameworkData extends BaseFrameworkData {
     totalSubcategories: number;
     assignedSubcategories: number;
   };
+  nistAssignmentsByFunction?: {
+    govern: { total: number; assigned: number };
+    map: { total: number; assigned: number };
+    measure: { total: number; assigned: number };
+    manage: { total: number; assigned: number };
+  };
 }
 
 /** Component props */
@@ -263,9 +269,15 @@ const AssignmentStatusCard = ({ frameworksData }: AssignmentStatusCardProps) => 
 
           // Handle NIST AI RMF separately - uses pre-fetched data from Dashboard
           if (isNISTAIRMF) {
-            const nistAssignments = framework.nistAssignments;
-            const subcategoryAssigned = nistAssignments?.assignedSubcategories || 0;
-            const subcategoryTotal = nistAssignments?.totalSubcategories || 0;
+            const nistAssignmentsByFunction = framework.nistAssignmentsByFunction;
+
+            // Function display order and labels
+            const functions = [
+              { key: 'govern' as const, label: 'Govern' },
+              { key: 'map' as const, label: 'Map' },
+              { key: 'measure' as const, label: 'Measure' },
+              { key: 'manage' as const, label: 'Manage' },
+            ];
 
             return (
               <Box key={framework.frameworkId}>
@@ -281,33 +293,38 @@ const AssignmentStatusCard = ({ frameworksData }: AssignmentStatusCardProps) => 
                 </Typography>
 
                 <Stack spacing={1.5}>
-                  {/* Subcategories Assignment Display */}
-                  <Box
-                    sx={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Typography sx={{ fontSize: 12, color: "#666666" }}>
-                      Subcategories
-                    </Typography>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                      {getAssignmentIcon(subcategoryAssigned, subcategoryTotal)}
-                      <Typography sx={{ fontSize: 12, color: "#000000", fontWeight: 500 }}>
-                        {subcategoryAssigned}
-                      </Typography>
-                      <Typography sx={{ fontSize: 12, color: "#000000", fontWeight: 500 }}>
-                        /
-                      </Typography>
-                      <Typography sx={{ fontSize: 12, color: "#999999", fontWeight: 500 }}>
-                        {subcategoryTotal}
-                      </Typography>
-                      <Typography sx={{ fontSize: 12, color: "#666666", fontWeight: 400, ml: 1 }}>
-                        assigned
-                      </Typography>
-                    </Box>
-                  </Box>
+                  {functions.map((func) => {
+                    const data = nistAssignmentsByFunction?.[func.key] || { total: 0, assigned: 0 };
+                    return (
+                      <Box
+                        key={func.key}
+                        sx={{
+                          display: "flex",
+                          justifyContent: "space-between",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Typography sx={{ fontSize: 12, color: "#666666" }}>
+                          {func.label}
+                        </Typography>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                          {getAssignmentIcon(data.assigned, data.total)}
+                          <Typography sx={{ fontSize: 12, color: "#000000", fontWeight: 500 }}>
+                            {data.assigned}
+                          </Typography>
+                          <Typography sx={{ fontSize: 12, color: "#000000", fontWeight: 500 }}>
+                            /
+                          </Typography>
+                          <Typography sx={{ fontSize: 12, color: "#999999", fontWeight: 500 }}>
+                            {data.total}
+                          </Typography>
+                          <Typography sx={{ fontSize: 12, color: "#666666", fontWeight: 400, ml: 1 }}>
+                            assigned
+                          </Typography>
+                        </Box>
+                      </Box>
+                    );
+                  })}
                 </Stack>
               </Box>
             );

--- a/Clients/src/presentation/pages/Framework/Dashboard/FrameworkProgressCard.tsx
+++ b/Clients/src/presentation/pages/Framework/Dashboard/FrameworkProgressCard.tsx
@@ -23,6 +23,12 @@ interface FrameworkData {
     totalSubcategories: number;
     doneSubcategories: number;
   };
+  nistProgressByFunction?: {
+    govern: { total: number; done: number };
+    map: { total: number; done: number };
+    measure: { total: number; done: number };
+    manage: { total: number; done: number };
+  };
 }
 
 interface FrameworkProgressCardProps {
@@ -79,11 +85,17 @@ const FrameworkProgressCard = ({ frameworksData }: FrameworkProgressCardProps) =
           const isISO42001 = framework.frameworkName.toLowerCase().includes("iso 42001");
           const isNISTAIRMF = framework.frameworkName.toLowerCase().includes("nist ai rmf");
 
-          // For NIST AI RMF, show subcategories progress
+          // For NIST AI RMF, show progress by function (Govern, Map, Measure, Manage)
           if (isNISTAIRMF) {
-            const subcategoryDone = framework.nistProgress?.doneSubcategories || 0;
-            const subcategoryTotal = framework.nistProgress?.totalSubcategories || 0;
-            const subcategoryPercent = calculateProgress(subcategoryDone, subcategoryTotal);
+            const progressByFunction = framework.nistProgressByFunction;
+
+            // Function display order and labels
+            const functions = [
+              { key: 'govern' as const, label: 'Govern' },
+              { key: 'map' as const, label: 'Map' },
+              { key: 'measure' as const, label: 'Measure' },
+              { key: 'manage' as const, label: 'Manage' },
+            ];
 
             return (
               <Box key={framework.frameworkId}>
@@ -98,57 +110,65 @@ const FrameworkProgressCard = ({ frameworksData }: FrameworkProgressCardProps) =
                   {framework.frameworkName}
                 </Typography>
 
-                {/* Subcategories Progress */}
-                <Box>
-                  <Box
-                    sx={{
-                      display: "grid",
-                      gridTemplateColumns: "1fr auto 1fr",
-                      alignItems: "center",
-                      mb: 1,
-                    }}
-                  >
-                    <Typography sx={{ fontSize: 12, color: "#666666" }}>
-                      Subcategories
-                    </Typography>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, justifyContent: "flex-end" }}>
-                      <Typography sx={{ fontSize: 12, color: "#000000", fontWeight: 500 }}>
-                        {subcategoryDone}
-                      </Typography>
-                      <Typography sx={{ fontSize: 12, color: "#000000", fontWeight: 500 }}>
-                        /
-                      </Typography>
-                      <Typography sx={{ fontSize: 12, color: "#999999", fontWeight: 500 }}>
-                        {subcategoryTotal}
-                      </Typography>
-                    </Box>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, justifyContent: "flex-end" }}>
-                      {getProgressIcon(subcategoryPercent)}
-                      <Typography
-                        sx={{
-                          fontSize: 12,
-                          color: subcategoryPercent === 100 ? "#13715B" : "#666666",
-                          fontWeight: 500,
-                        }}
-                      >
-                        {subcategoryPercent}%
-                      </Typography>
-                    </Box>
-                  </Box>
-                  <LinearProgress
-                    variant="determinate"
-                    value={subcategoryPercent}
-                    sx={{
-                      height: 6,
-                      borderRadius: 3,
-                      backgroundColor: "#F3F4F6",
-                      "& .MuiLinearProgress-bar": {
-                        backgroundColor: getProgressColor(subcategoryPercent),
-                        borderRadius: 3,
-                      },
-                    }}
-                  />
-                </Box>
+                <Stack spacing={2}>
+                  {functions.map((func) => {
+                    const data = progressByFunction?.[func.key] || { total: 0, done: 0 };
+                    const percent = calculateProgress(data.done, data.total);
+
+                    return (
+                      <Box key={func.key}>
+                        <Box
+                          sx={{
+                            display: "grid",
+                            gridTemplateColumns: "1fr auto 1fr",
+                            alignItems: "center",
+                            mb: 1,
+                          }}
+                        >
+                          <Typography sx={{ fontSize: 12, color: "#666666" }}>
+                            {func.label}
+                          </Typography>
+                          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, justifyContent: "flex-end" }}>
+                            <Typography sx={{ fontSize: 12, color: "#000000", fontWeight: 500 }}>
+                              {data.done}
+                            </Typography>
+                            <Typography sx={{ fontSize: 12, color: "#000000", fontWeight: 500 }}>
+                              /
+                            </Typography>
+                            <Typography sx={{ fontSize: 12, color: "#999999", fontWeight: 500 }}>
+                              {data.total}
+                            </Typography>
+                          </Box>
+                          <Box sx={{ display: "flex", alignItems: "center", gap: 1, justifyContent: "flex-end" }}>
+                            {getProgressIcon(percent)}
+                            <Typography
+                              sx={{
+                                fontSize: 12,
+                                color: percent === 100 ? "#13715B" : "#666666",
+                                fontWeight: 500,
+                              }}
+                            >
+                              {percent}%
+                            </Typography>
+                          </Box>
+                        </Box>
+                        <LinearProgress
+                          variant="determinate"
+                          value={percent}
+                          sx={{
+                            height: 6,
+                            borderRadius: 3,
+                            backgroundColor: "#F3F4F6",
+                            "& .MuiLinearProgress-bar": {
+                              backgroundColor: getProgressColor(percent),
+                              borderRadius: 3,
+                            },
+                          }}
+                        />
+                      </Box>
+                    );
+                  })}
+                </Stack>
               </Box>
             );
           }

--- a/Clients/src/presentation/pages/Framework/Dashboard/index.tsx
+++ b/Clients/src/presentation/pages/Framework/Dashboard/index.tsx
@@ -44,6 +44,18 @@ interface FrameworkData {
     totalSubcategories: number;
     assignedSubcategories: number;
   };
+  nistAssignmentsByFunction?: {
+    govern: { total: number; assigned: number };
+    map: { total: number; assigned: number };
+    measure: { total: number; assigned: number };
+    manage: { total: number; assigned: number };
+  };
+  nistProgressByFunction?: {
+    govern: { total: number; done: number };
+    map: { total: number; done: number };
+    measure: { total: number; done: number };
+    manage: { total: number; done: number };
+  };
   nistStatusBreakdown?: {
     notStarted: number;
     draft: number;
@@ -125,7 +137,7 @@ const FrameworkDashboard = ({
           const isNISTAIRMF = framework.name.toLowerCase().includes("nist ai rmf");
 
           let clauseProgress, annexProgress, assignmentStatus, statusBreakdown;
-          let nistProgress, nistAssignments, nistStatusBreakdown;
+          let nistProgress, nistProgressByFunction, nistAssignments, nistAssignmentsByFunction, nistStatusBreakdown;
 
           if (isNISTAIRMF) {
             // Fetch NIST AI RMF data
@@ -147,6 +159,19 @@ const FrameworkDashboard = ({
             }
 
             try {
+              const progressByFunctionRes = await getEntityById({
+                routeUrl: `/nist-ai-rmf/progress-by-function`,
+              });
+              if (progressByFunctionRes?.data) {
+                nistProgressByFunction = progressByFunctionRes.data;
+              }
+            } catch (error) {
+              if (!abortController.signal.aborted) {
+                console.error(`Error fetching NIST AI RMF progress by function:`, error);
+              }
+            }
+
+            try {
               const assignmentsRes = await getEntityById({
                 routeUrl: `/nist-ai-rmf/assignments`,
               });
@@ -161,6 +186,19 @@ const FrameworkDashboard = ({
                 console.error(`Error fetching NIST AI RMF assignments:`, error);
               }
               nistAssignments = { totalSubcategories: 0, assignedSubcategories: 0 };
+            }
+
+            try {
+              const assignmentsByFunctionRes = await getEntityById({
+                routeUrl: `/nist-ai-rmf/assignments-by-function`,
+              });
+              if (assignmentsByFunctionRes?.data) {
+                nistAssignmentsByFunction = assignmentsByFunctionRes.data;
+              }
+            } catch (error) {
+              if (!abortController.signal.aborted) {
+                console.error(`Error fetching NIST AI RMF assignments by function:`, error);
+              }
             }
 
             try {
@@ -298,7 +336,9 @@ const FrameworkDashboard = ({
             clauseProgress,
             annexProgress,
             nistProgress,
+            nistProgressByFunction,
             nistAssignments,
+            nistAssignmentsByFunction,
             nistStatusBreakdown,
             assignmentStatus,
             statusBreakdown,

--- a/Servers/controllers/nist_ai_rmf.subcategory.ctrl.ts
+++ b/Servers/controllers/nist_ai_rmf.subcategory.ctrl.ts
@@ -7,6 +7,8 @@ import {
   updateNISTAIRMFSubcategoryStatusByIdQuery,
   countNISTAIRMFSubcategoriesProgress,
   countNISTAIRMFSubcategoriesAssignments,
+  countNISTAIRMFSubcategoriesAssignmentsByFunction,
+  countNISTAIRMFSubcategoriesProgressByFunction,
   getNISTAIRMFSubcategoriesStatusBreakdown,
   getNISTAIRMFDashboardOverview,
 } from "../utils/nist_ai_rmf.subcategory.utils";
@@ -423,6 +425,88 @@ export async function getNISTAIRMFAssignments(
       eventType: "Read",
       description: `Failed to get NIST AI RMF assignments: ${(error as Error).message}`,
       functionName: "getNISTAIRMFAssignments",
+      fileName: "nist_ai_rmf.subcategory.ctrl.ts",
+      error: error as Error,
+    });
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+}
+
+/**
+ * Get NIST AI RMF subcategories assignments grouped by function (Govern, Map, Measure, Manage)
+ */
+export async function getNISTAIRMFAssignmentsByFunction(
+  req: Request,
+  res: Response
+): Promise<any> {
+  logProcessing({
+    description: "starting getNISTAIRMFAssignmentsByFunction",
+    functionName: "getNISTAIRMFAssignmentsByFunction",
+    fileName: "nist_ai_rmf.subcategory.ctrl.ts",
+  });
+  logger.debug("📊 Calculating NIST AI RMF assignments by function");
+
+  try {
+    const assignments = await countNISTAIRMFSubcategoriesAssignmentsByFunction(req.tenantId!);
+
+    await logSuccess({
+      eventType: "Read",
+      description: "Successfully retrieved NIST AI RMF assignments by function",
+      functionName: "getNISTAIRMFAssignmentsByFunction",
+      fileName: "nist_ai_rmf.subcategory.ctrl.ts",
+    });
+
+    return res.status(200).json(STATUS_CODE[200](assignments));
+  } catch (error) {
+    await logEvent(
+      "Error",
+      `Failed to get NIST AI RMF assignments by function: ${(error as Error).message}`
+    );
+    await logFailure({
+      eventType: "Read",
+      description: `Failed to get NIST AI RMF assignments by function: ${(error as Error).message}`,
+      functionName: "getNISTAIRMFAssignmentsByFunction",
+      fileName: "nist_ai_rmf.subcategory.ctrl.ts",
+      error: error as Error,
+    });
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+}
+
+/**
+ * Get NIST AI RMF subcategories progress grouped by function (Govern, Map, Measure, Manage)
+ */
+export async function getNISTAIRMFProgressByFunction(
+  req: Request,
+  res: Response
+): Promise<any> {
+  logProcessing({
+    description: "starting getNISTAIRMFProgressByFunction",
+    functionName: "getNISTAIRMFProgressByFunction",
+    fileName: "nist_ai_rmf.subcategory.ctrl.ts",
+  });
+  logger.debug("📊 Calculating NIST AI RMF progress by function");
+
+  try {
+    const progress = await countNISTAIRMFSubcategoriesProgressByFunction(req.tenantId!);
+
+    await logSuccess({
+      eventType: "Read",
+      description: "Successfully retrieved NIST AI RMF progress by function",
+      functionName: "getNISTAIRMFProgressByFunction",
+      fileName: "nist_ai_rmf.subcategory.ctrl.ts",
+    });
+
+    return res.status(200).json(STATUS_CODE[200](progress));
+  } catch (error) {
+    await logEvent(
+      "Error",
+      `Failed to get NIST AI RMF progress by function: ${(error as Error).message}`
+    );
+    await logFailure({
+      eventType: "Read",
+      description: `Failed to get NIST AI RMF progress by function: ${(error as Error).message}`,
+      functionName: "getNISTAIRMFProgressByFunction",
       fileName: "nist_ai_rmf.subcategory.ctrl.ts",
       error: error as Error,
     });

--- a/Servers/routes/nist_ai_rmf.route.ts
+++ b/Servers/routes/nist_ai_rmf.route.ts
@@ -13,7 +13,9 @@ import {
   updateNISTAIRMFSubcategoryById,
   updateNISTAIRMFSubcategoryStatus,
   getNISTAIRMFProgress,
+  getNISTAIRMFProgressByFunction,
   getNISTAIRMFAssignments,
+  getNISTAIRMFAssignmentsByFunction,
   getNISTAIRMFStatusBreakdown,
   getNISTAIRMFOverview,
 } from "../controllers/nist_ai_rmf.subcategory.ctrl";
@@ -65,7 +67,9 @@ router.patch(
 
 // Dashboard calculation endpoints
 router.get("/progress", authenticateJWT, getNISTAIRMFProgress); // get total and completed subcategories
+router.get("/progress-by-function", authenticateJWT, getNISTAIRMFProgressByFunction); // get progress grouped by function (Govern, Map, Measure, Manage)
 router.get("/assignments", authenticateJWT, getNISTAIRMFAssignments); // get total and assigned subcategories
+router.get("/assignments-by-function", authenticateJWT, getNISTAIRMFAssignmentsByFunction); // get assignments grouped by function (Govern, Map, Measure, Manage)
 router.get("/status-breakdown", authenticateJWT, getNISTAIRMFStatusBreakdown); // get status breakdown
 router.get("/overview", authenticateJWT, getNISTAIRMFOverview); // get all functions with categories and subcategories
 


### PR DESCRIPTION
## Summary
- Update Framework Progress card to show NIST AI RMF progress split by function (Govern, Map, Measure, Manage) instead of single "Subcategories" row
- Update Assignment Status card to show NIST AI RMF assignments split by function instead of single "Subcategories" row
- Add backend API endpoints for fetching progress and assignments by function

## Test plan
- [ ] Verify Framework Progress card shows 4 progress bars for NIST AI RMF (Govern, Map, Measure, Manage)
- [ ] Verify Assignment Status card shows 4 rows for NIST AI RMF (Govern, Map, Measure, Manage)
- [ ] Verify ISO frameworks still display correctly (Clauses, Annexes)
- [ ] Verify counts match between individual function rows and total subcategories