### PR TITLE
Fix migration errors by adding IF NOT EXISTS

### DIFF
--- a/Servers/database/migrations/20251122165467-add-ce-marking-associations.js
+++ b/Servers/database/migrations/20251122165467-add-ce-marking-associations.js
@@ -13,7 +13,7 @@ module.exports = {
       for (let organization of organizations[0]) {
         const tenantHash = getTenantHash(organization.id);
         // Create ce_marking_policies association table
-        await queryInterface.sequelize.query(`CREATE TABLE "${tenantHash}".ce_marking_policies (
+        await queryInterface.sequelize.query(`CREATE TABLE IF NOT EXISTS "${tenantHash}".ce_marking_policies (
         id SERIAL PRIMARY KEY,
         ce_marking_id INTEGER NOT NULL,
         policy_id INTEGER NOT NULL,
@@ -27,7 +27,7 @@ module.exports = {
         );`, { transaction })
 
         // Create ce_marking_evidences association table
-        await queryInterface.sequelize.query(`CREATE TABLE "${tenantHash}".ce_marking_evidences (
+        await queryInterface.sequelize.query(`CREATE TABLE IF NOT EXISTS "${tenantHash}".ce_marking_evidences (
           id SERIAL PRIMARY KEY,
           ce_marking_id INTEGER NOT NULL,
           file_id INTEGER NOT NULL,

--- a/Servers/database/migrations/20251122165512-add-ce-marking-incidents.js
+++ b/Servers/database/migrations/20251122165512-add-ce-marking-incidents.js
@@ -13,7 +13,7 @@ module.exports = {
       for (let organization of organizations[0]) {
         const tenantHash = getTenantHash(organization.id);
         // Create ce_marking_incidents association table
-        await queryInterface.sequelize.query(`CREATE TABLE "${tenantHash}".ce_marking_incidents (
+        await queryInterface.sequelize.query(`CREATE TABLE IF NOT EXISTS "${tenantHash}".ce_marking_incidents (
           id SERIAL PRIMARY KEY,
           ce_marking_id INTEGER NOT NULL,
           incident_id INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
Fix migration errors when tables already exist in the database.

## Changes
- Add `IF NOT EXISTS` to CREATE TABLE statements in:
  - `20251122165467-add-ce-marking-associations.js`
  - `20251122165512-add-ce-marking-incidents.js`

## Test plan
- [ ] Run migrations on a database where tables already exist
- [ ] Verify migrations complete without errors