### PR TITLE
Potential fix for code scanning alert no. 63: Inefficient regular expression

### DIFF
--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -331,7 +331,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
       }
 
       // Validate URL (accept without http/https)
-      const urlPattern = /^((https?:\/\/)?[\w-]+(\.[\w-]+)+([\/\w]*)*(\?.*)?(#.*)?)$/i;
+      const urlPattern = /^((https?:\/\/)?[\w-]+(\.[\w-]+)+(\/[^\s?#]*)?(\?.*)?(#.*)?)$/i;
       if (!urlPattern.test(newSubprocessor.url)) {
         setEditSubprocessorError("Subprocessor URL must be a valid URL");
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/63](https://github.com/bluewave-labs/verifywise/security/code-scanning/63)

**General strategy:**  
To fix the problem, we need to rewrite the regular expression so that there is no ambiguity causing excessive backtracking. In particular, the ambiguous part is `[\/\w]*`, which can match an empty string and all the same substrings as the previous sequences (e.g., `/` and `\w` are almost always part of URL "paths"). The goal is to explicitly and unambiguously describe the allowed path segment. One common approach is to replace ambiguous character classes or repetitions (`[\/\w]*`) inside a complicated group with a more constrained alternative—such as a negated character class that matches until the next "delimiter" (e.g., `?`, `#`).

**Detailed fix:**  
- Locate line 334 in Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx.
- Replace the problematic regex with an improved version.
- The old regex:  
  ```js
  /^((https?:\/\/)?[\w-]+(\.[\w-]+)+([\/\w]*)*(\?.*)?(#.*)?)$/i
  ```
- Improved version (for basic URL validation, safer for performance and retains original intent):  
  ```js
  /^((https?:\/\/)?[\w-]+(\.[\w-]+)+(\/[^\s?#]*)?(\?.*)?(#.*)?)$/i
  ```
  - Change: Replace `([\/\w]*)*` with `(\/[^\s?#]*)?`
    - This now matches zero or one path sections of slashes followed by non-"?", "#", or whitespace characters, eliminating catastrophic backtracking.

- The rest of the code remains unchanged.

**Required edits and imports:**  
- Only a single line needs editing.
- No new imports or complex logic required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
