### PR TITLE
Potential fix for code scanning alert no. 62: Use of externally-controlled format string

### DIFF
--- a/Servers/utils/history/modelInventoryHistory.utils.ts
+++ b/Servers/utils/history/modelInventoryHistory.utils.ts
@@ -119,7 +119,7 @@ export async function getCurrentParameterCounts(
 
     return counts;
   } catch (error) {
-    console.error(`Error getting current parameter counts for ${parameter}:`, error);
+    console.error('Error getting current parameter counts for %s:', parameter, error);
     throw error;
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/62](https://github.com/bluewave-labs/verifywise/security/code-scanning/62)

To prevent any user-controlled input from being interpreted as a format string by `console.error`, the recommended approach is to use a static format string and provide the user-controlled value as an argument, using a `%s` placeholder. This method ensures that any format specifiers in the user input are not parsed by the logging mechanism.  

Specifically, in Servers/utils/history/modelInventoryHistory.utils.ts, line 122, change  
```ts
console.error(`Error getting current parameter counts for ${parameter}:`, error);
```  
to  
```ts
console.error('Error getting current parameter counts for %s:', parameter, error);
```
This change leaves the logged information and functionality unchanged but eliminates the risk that user input could be treated as a format string.

No imports or additional dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
