### PR TITLE
Potential fix for code scanning alert no. 61: Use of externally-controlled format string

### DIFF
--- a/Servers/utils/history/modelInventoryHistory.utils.ts
+++ b/Servers/utils/history/modelInventoryHistory.utils.ts
@@ -40,7 +40,7 @@ export async function recordHistorySnapshot(
 
     return result[0];
   } catch (error) {
-    console.error(`Error recording history snapshot for parameter ${parameter}:`, error);
+    console.error('Error recording history snapshot for parameter %s:', parameter, error);
     throw error;
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/61](https://github.com/bluewave-labs/verifywise/security/code-scanning/61)

To fix this issue, make sure that untrusted user input is not directly interpolated into the format string when logging. Instead, supply the format string with static text and use the `%s` format specifier for the potentially unsafe variable, passing the variable as an extra argument to `console.error`. Specifically, replace `` `Error recording history snapshot for parameter ${parameter}:` `` with `'Error recording history snapshot for parameter %s:'` and pass `parameter` as the second argument to `console.error`. This is analogous to the recommended fix in the background documentation. There are no required import changes or additional methods needed for implementation — only an adjustment of the logging invocation in `recordHistorySnapshot` (at line 43 in Servers/utils/history/modelInventoryHistory.utils.ts).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
