### PR TITLE
Potential fix for code scanning alert no. 60: Database query built from user-controlled sources

### DIFF
--- a/Servers/utils/history/modelInventoryHistory.utils.ts
+++ b/Servers/utils/history/modelInventoryHistory.utils.ts
@@ -3,6 +3,17 @@ import { sequelize } from "../../database/db";
 import { ModelInventoryStatus } from "../../domain.layer/enums/model-inventory-status.enum";
 import { Transaction, QueryTypes } from "sequelize";
 
+// Whitelist of allowed parameter names for aggregation
+const ALLOWED_PARAMETERS = [
+  "name",
+  "version",
+  "owner",
+  // add all other safe column names intended to be exposed
+  "type",
+  "created_at",
+  // DO NOT add user-controlled column names unless they're safe
+];
+
 /**
  * Record a snapshot of parameter counts in history
  */
@@ -101,6 +112,9 @@ export async function getCurrentParameterCounts(
       });
     } else {
       // Generic handling for other parameters
+      if (!ALLOWED_PARAMETERS.includes(parameter)) {
+        throw new Error(`Invalid parameter: ${parameter}`);
+      }
       const paramCounts = await sequelize.query(
         `SELECT ${parameter}, COUNT(*) as count
          FROM "${tenant}".model_inventories


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/60](https://github.com/bluewave-labs/verifywise/security/code-scanning/60)

To fix this vulnerability, we need to ensure that only trusted, expected column names can be used for dynamic queries. This is best achieved through *whitelisting*: define a set of allowed values (valid column names), and for all "generic" cases, only allow these. If the input `parameter` is not one of the allowed column names, we should reject the request or handle it safely.

Specifically:
- In `getCurrentParameterCounts` (in `Servers/utils/history/modelInventoryHistory.utils.ts`), before using `${parameter}` in the query string, check if `parameter` is in the whitelist (e.g.: `name`, `version`, `owner`, etc.—all valid model_inventory table columns that you intend to support).
- If the user input is not one of the allowed columns, throw an error or return a value indicating invalid input.
- The whitelist should be set at the top of the file so it's accessible to all relevant logic and easy to maintain.
- No additional imports are required, just a constant and a check.

This fixes *all* variants flagged by CodeQL, as all flows reach the vulnerable SQL construction. No other files need to be altered based on the snippets shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
