### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/BiasAndFairnessModule/run_full_evaluation.py
+++ b/BiasAndFairnessModule/run_full_evaluation.py
@@ -388,7 +388,7 @@ def _print_pipeline_summary(comprehensive_results: dict, clean_results: dict):
     if fairness_values:
         max_disparity_sex = max(fairness_values.values())
         max_metric_sex = max(fairness_values, key=fairness_values.get)
-        print(f"   Highest sex-based disparity: {max_metric_sex} = {max_disparity_sex:.4f}")
+        print(f"   Sex-based disparities detected. (Metric name and value omitted for privacy.)")
     
     fairness_values_race = {k: v for k, v in comprehensive_results['fairness_metrics'].items() 
                            if v is not None and 'race' in k}


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/7](https://github.com/bluewave-labs/verifywise/security/code-scanning/7)

To address the issue, we should avoid directly logging the highest sex-based disparity value and metric to general-purpose logs in cleartext.  
- Instead of printing exact sensitive metric values, we can replace the output with a generic message indicating that fairness disparities exist, or summarize without reporting the specific values.  
- If detailed reporting is absolutely needed, it should be gated behind a strict debug setting, written to a dedicated secure audit report, or filtered before display—none of which can be assumed or implemented here as we only see this snippet.  
- For this fix: on line 391, remove or redact the logging of specific values, replacing it with a non-detailed message.  
- Only make changes in the shown `_print_pipeline_summary` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
