### PR TITLE
Potential fix for code scanning alert no. 25: Inefficient regular expression

### DIFF
--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -382,7 +382,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
       }
 
        // Validate URL (accept without http/https)
-      const urlPattern = /^((https?:\/\/)?[\w-]+(\.[\w-]+)+([\/\w-]*)*(\?.*)?(#.*)?)$/i;
+      const urlPattern = /^((https?:\/\/)?[\w-]+(\.[\w-]+)+(\/[\w\-]*)*(\?.*)?(#.*)?)$/i;
       if (!urlPattern.test(form.url)) {
         setEditSubprocessorError("Subprocessor URL must be a valid URL");
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/25](https://github.com/bluewave-labs/verifywise/security/code-scanning/25)

To fix this issue, the regular expression should be refactored to remove the ambiguity inside the repetition. Specifically, `[\/\w-]*` is problematic because within a longer pattern like `[\w-]+(\.[\w-]+)+([\/\w-]*)*`, the alternation of dot, hyphen, and word character is ambiguous (e.g., `-.-.-` substrings can be matched in multiple ways inside the repetition). A good, maintainable solution is to restrict the repetitive matching to non-overlapping patterns or use negative lookahead/character classes that avoid ambiguity, or if possible, simplify validation to a less error-prone standard (e.g., leveraging URL constructor or third-party libraries for validation).

Concrete fix: Update `urlPattern` on line 385 so that the repetition `[\/\w-]*` does not have ambiguous branches (e.g., restrict `/` to only occur in certain places, or replace with a sequence of clearly distinguishable patterns). For basic URL validation, a recommended fix is to use a more robust pattern such as `/^((https?:\/\/)?[\w-]+(\.[\w-]+)+(\/[\w\-]*)*(\?.*)?(#.*)?)$/i;` (so that slashes are always preceded by a word sequence, avoiding ambiguity). Alternatively, for better reliability, consider using the built-in URL constructor for validation, but changing the regular expression achieves the minimal fix required.

Only file Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx, line 385, needs to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
