### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/BiasAndFairnessModule/run_full_evaluation.py
+++ b/BiasAndFairnessModule/run_full_evaluation.py
@@ -252,7 +252,7 @@ def _run_metric(metric_name: str, y_true: np.ndarray, y_pred: np.ndarray,
         race_value = convert_metric_to_float(race_result, metric_name)
         all_results[f"{metric_name}_race"] = race_value
         
-        print(f"      ✅ {metric_name}: sex={sex_value:.4f}, race={race_value:.4f}")
+        print(f"      ✅ {metric_name}: computed for sex and race (values not logged for privacy)")
         
     except Exception as e:
         print(f"      ❌ {metric_name}: Error - {str(e)}")


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/6](https://github.com/bluewave-labs/verifywise/security/code-scanning/6)

The best way to fix the problem is to avoid logging sensitive metric values in clear text. You should either log only the fact that the metric calculation succeeded or failed, or mask/redact/obfuscate the metric values when logging.  
Specifically, in file `BiasAndFairnessModule/run_full_evaluation.py`, line 255:  
- Change the `print` statement to avoid logging the metric values directly. Instead, log only the successful calculation of the metric, or log the metric names without the values.
- No additional imports or helper methods are needed, unless masking/aggregation is required.
- Only change the logging line in the `_run_metric` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
