### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/BiasAndFairnessModule/src/eval_engine/results_summarizer.py
+++ b/BiasAndFairnessModule/src/eval_engine/results_summarizer.py
@@ -60,7 +60,7 @@ def summarize_results(results_path: str = 'artifacts/evaluation_results.json') -
     eo_sex = results['fairness']['equalized_odds_sex']
     eo_race = results['fairness']['equalized_odds_race']
     
-    print(f"   Equalized Odds (Sex): {eo_sex:.3f}")
+    print("   Equalized Odds (Sex): See assessment below")
     if abs(eo_sex) < 0.1:
         print("     ✅ Good: Similar true positive and false positive rates")
     elif abs(eo_sex) < 0.2:


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/4](https://github.com/bluewave-labs/verifywise/security/code-scanning/4)

To fix the problem, we must avoid printing sensitive data (i.e., the value of `eo_sex`) directly in clear-text format. Instead, we should either mask the output, report the qualitative result, or avoid displaying the metric altogether. Given the context – where further descriptions such as "Good", "Moderate", or "High" are printed based on the quantitative value – the most suitable fix is to print only an assessment/label that conveys the fairness status, without reporting the actual value of `eo_sex`.  

Thus:
- On line 63, replace printing the score with a generic string, such as "Equalized Odds (Sex): See assessment below".
- The follow-up assessment (lines 64-69) is descriptive and does not leak sensitive data directly. These can remain.

No additional imports or methods are needed; simply modify the output statement to remove the sensitive value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
