### PR TITLE
Add activity history for Policy Manager

### DIFF
--- a/Clients/src/application/hooks/usePolicyChangeHistory.ts
+++ b/Clients/src/application/hooks/usePolicyChangeHistory.ts
@@ -1,0 +1,18 @@
+/**
+ * Policy Change History Hook
+ *
+ * Wrapper around the generic useEntityChangeHistory hook for policies.
+ */
+
+import { useEntityChangeHistory, EntityChangeHistoryEntry } from "./useEntityChangeHistory";
+
+export interface PolicyChangeHistoryEntry extends EntityChangeHistoryEntry {
+  policy_id?: number;
+}
+
+/**
+ * Hook to fetch policy change history
+ */
+export const usePolicyChangeHistory = (policyId: number | undefined) => {
+  return useEntityChangeHistory("policy", policyId);
+};

--- a/Clients/src/config/changeHistory.config.ts
+++ b/Clients/src/config/changeHistory.config.ts
@@ -13,7 +13,8 @@ export type EntityType =
   | "framework"
   | "evidence_hub"
   | "risk"
-  | "vendor_risk";
+  | "vendor_risk"
+  | "policy";
 
 export interface EntityHistoryConfig {
   entityName: string; // Display name (e.g., "Model", "Vendor")
@@ -71,6 +72,12 @@ export const ENTITY_HISTORY_CONFIGS: {
     emptyStateTitle: "Activity history",
     emptyStateMessage:
       "Automatically tracks every change to this vendor risk. See what your team is working on and what updates they've made, in real time.",
+  },
+  policy: {
+    entityName: "Policy",
+    emptyStateTitle: "Activity history",
+    emptyStateMessage:
+      "Automatically tracks every change to this policy. See what your team is working on and what updates they've made, in real time.",
   },
 };
 

--- a/Clients/src/presentation/components/Common/HistorySidebar/index.tsx
+++ b/Clients/src/presentation/components/Common/HistorySidebar/index.tsx
@@ -30,6 +30,7 @@ interface HistorySidebarProps {
   isOpen: boolean;
   entityType: EntityType;
   entityId?: number;
+  height?: string | number;
 }
 
 /**
@@ -80,6 +81,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({
   isOpen,
   entityType,
   entityId,
+  height = "560px",
 }) => {
   const theme = useTheme();
   const { userId: currentUserId } = useAuth();
@@ -457,7 +459,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({
       sx={{
         display: "flex",
         flexDirection: "column",
-        alignSelf: "flex-start",
+        height: "100%",
       }}
     >
       <Box
@@ -466,12 +468,12 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({
           marginLeft: "16px", // 16px padding from main content
           display: "flex",
           flexDirection: "column",
-          alignSelf: "flex-start",
+          height: "100%",
         }}
       >
         <Box
           sx={{
-            height: "560px",
+            height: height,
             border: `1px solid #E0E4E9`,
             borderRadius: "8px",
             display: "flex",

--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -40,6 +40,7 @@ import {
   Image,
   Redo2,
   Undo2,
+  History as HistoryIcon,
 } from "lucide-react";
 
 const FormatUnderlined = () => <Underline size={16} />;
@@ -49,6 +50,8 @@ import { IconButton, Tooltip, useTheme, Box, Select, MenuItem } from "@mui/mater
 import { Drawer, Stack, Typography, Divider } from "@mui/material";
 import { X as CloseGreyIcon } from "lucide-react";
 import CustomizableButton from "../Button/CustomizableButton";
+import HistorySidebar from "../Common/HistorySidebar";
+import { usePolicyChangeHistory } from "../../../application/hooks/usePolicyChangeHistory";
 import {
   createPolicy,
   updatePolicy,
@@ -75,6 +78,10 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
   const [errors, setErrors] = useState<PolicyFormErrors>({});
   const [openLink, setOpenLink] = useState(false);
   const [openImage, setOpenImage] = useState(false);
+  const [isHistorySidebarOpen, setIsHistorySidebarOpen] = useState(false);
+
+  // Prefetch history data when drawer opens in edit mode
+  usePolicyChangeHistory(!isNew && policy?.id ? policy.id : undefined);
 
   // const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -124,6 +131,7 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
       assignedReviewers: [],
       content: "",
     });
+    setIsHistorySidebarOpen(false);
     onClose();
   }
 
@@ -604,13 +612,14 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
         }}
         anchor="right"
         sx={{
-          width: 900,
+          width: isHistorySidebarOpen ? 1236 : 900,
           "& .MuiDrawer-paper": {
-            width: 900,
+            width: isHistorySidebarOpen ? 1236 : 900,
             borderRadius: 0,
             padding: "15px 20px",
             marginTop: "0",
             overflow: "hidden",
+            transition: "width 300ms ease-in-out",
           },
         }}
       >
@@ -628,24 +637,54 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
               {isNew ? "Create new policy" : formData.title}
             </Typography>
           </Stack>
-          <CloseGreyIcon
-            size={16}
-            style={{ color: "#98A2B3", cursor: "pointer" }}
-            onClick={handleClose}
-          />
+          <Stack direction="row" alignItems="center" gap={1}>
+            {!isNew && policy?.id && (
+              <Tooltip title="View activity history" arrow>
+                <IconButton
+                  onClick={() => setIsHistorySidebarOpen((prev) => !prev)}
+                  size="small"
+                  sx={{
+                    color: isHistorySidebarOpen ? "#13715B" : "#98A2B3",
+                    padding: "4px",
+                    borderRadius: "4px",
+                    backgroundColor: isHistorySidebarOpen ? "#E6F4F1" : "transparent",
+                    "&:hover": {
+                      backgroundColor: isHistorySidebarOpen ? "#D1EDE6" : "#F2F4F7",
+                    },
+                  }}
+                >
+                  <HistoryIcon size={16} />
+                </IconButton>
+              </Tooltip>
+            )}
+            <CloseGreyIcon
+              size={16}
+              style={{ color: "#98A2B3", cursor: "pointer" }}
+              onClick={handleClose}
+            />
+          </Stack>
         </Stack>
 
         <Divider sx={{ my: 2 }} />
 
-        <Stack spacing={2} sx={{ paddingBottom: "16px" }}>
-          <PolicyForm
-            formData={formData}
-            setFormData={setFormData}
-            tags={tags}
-            errors={errors}
-            setErrors={setErrors}
-          />
-          <Stack sx={{ width: "100%", height: "100%" }}>
+        <Stack
+          direction="row"
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            overflow: "hidden",
+          }}
+        >
+          {/* Main Content */}
+          <Stack spacing={2} sx={{ flex: 1, paddingBottom: "16px", minWidth: 0, overflow: "auto" }}>
+            <PolicyForm
+              formData={formData}
+              setFormData={setFormData}
+              tags={tags}
+              errors={errors}
+              setErrors={setErrors}
+            />
+            <Stack sx={{ width: "100%", height: "100%" }}>
             <Box
               sx={{
                 display: "flex",
@@ -780,13 +819,24 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
               </Typography>
             )}
           </Stack>
+          </Stack>
+
+          {/* History Sidebar - Only shown when editing */}
+          {!isNew && policy?.id && (
+            <HistorySidebar
+              isOpen={isHistorySidebarOpen}
+              entityType="policy"
+              entityId={policy.id}
+              height="100%"
+            />
+          )}
         </Stack>
 
         <Box
           sx={{
             position: "fixed",
             bottom: 0,
-            right: 20,
+            right: isHistorySidebarOpen ? 356 : 20,
             left: "auto",
             width: "calc(900px - 40px)",
             pt: 2,
@@ -796,6 +846,7 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
             display: "flex",
             justifyContent: "flex-end",
             zIndex: 1201,
+            transition: "right 300ms ease-in-out",
           }}
         >
           <CustomizableButton

--- a/Servers/config/changeHistory.config.ts
+++ b/Servers/config/changeHistory.config.ts
@@ -20,7 +20,8 @@ export type EntityType =
   | "framework"
   | "evidence_hub"
   | "risk"
-  | "vendor_risk";
+  | "vendor_risk"
+  | "policy";
 
 /**
  * Field formatter function type
@@ -141,6 +142,51 @@ export const GENERIC_FORMATTERS: { [key: string]: FieldFormatter } = {
       return "-";
     }
     return String(value);
+  },
+
+  // User array formatter (resolves array of user IDs to names)
+  userArray: async (value: any): Promise<string> => {
+    if (!value) return "-";
+
+    let userIds: number[] = [];
+    if (Array.isArray(value)) {
+      userIds = value.filter((id) => typeof id === "number");
+    } else if (typeof value === "string") {
+      try {
+        const parsed = JSON.parse(value);
+        if (Array.isArray(parsed)) {
+          userIds = parsed.filter((id) => typeof id === "number");
+        }
+      } catch {
+        return value;
+      }
+    }
+
+    if (userIds.length === 0) return "-";
+
+    try {
+      const users: any[] = await sequelize.query(
+        `SELECT id, name, surname, email FROM public.users WHERE id IN (:userIds)`,
+        {
+          replacements: { userIds },
+          type: QueryTypes.SELECT,
+        }
+      );
+
+      if (users && users.length > 0) {
+        // Map user IDs to names in the original order
+        const userMap = new Map(
+          users.map((u) => [u.id, u.name && u.surname ? `${u.name} ${u.surname}` : u.email || `User #${u.id}`])
+        );
+        return userIds
+          .map((id) => userMap.get(id) || `User #${id}`)
+          .join(", ");
+      }
+      return userIds.map((id) => `User #${id}`).join(", ");
+    } catch (error) {
+      console.error("Error fetching users for IDs", userIds, ":", error);
+      return userIds.map((id) => `User #${id}`).join(", ");
+    }
   },
 };
 
@@ -331,6 +377,30 @@ export const ENTITY_CONFIGS: { [key in EntityType]: EntityConfig } = {
     },
     fieldFormatters: {
       action_owner: GENERIC_FORMATTERS.user,
+    },
+  },
+
+  policy: {
+    tableName: "policy_change_history",
+    foreignKeyField: "policy_id",
+    fieldsToTrack: [
+      "title",
+      "status",
+      "tags",
+      "next_review_date",
+      "assigned_reviewer_ids",
+    ],
+    fieldLabels: {
+      title: "Title",
+      status: "Status",
+      tags: "Tags",
+      next_review_date: "Next review date",
+      assigned_reviewer_ids: "Assigned reviewers",
+    },
+    fieldFormatters: {
+      tags: GENERIC_FORMATTERS.array,
+      next_review_date: GENERIC_FORMATTERS.date,
+      assigned_reviewer_ids: GENERIC_FORMATTERS.userArray,
     },
   },
 };

--- a/Servers/controllers/policyChangeHistory.ctrl.ts
+++ b/Servers/controllers/policyChangeHistory.ctrl.ts
@@ -1,0 +1,60 @@
+import { Request, Response } from "express";
+import { getPolicyChangeHistory } from "../utils/policyChangeHistory.utils";
+import { STATUS_CODE } from "../utils/statusCode.utils";
+import logger, { logStructured } from "../utils/logger/fileLogger";
+
+/**
+ * Get change history for a specific policy with pagination support
+ */
+export async function getPolicyChangeHistoryById(
+  req: Request,
+  res: Response
+): Promise<any> {
+  const policyId = parseInt(req.params.id);
+
+  if (isNaN(policyId) || policyId <= 0) {
+    return res.status(400).json(STATUS_CODE[400]("Invalid policy ID"));
+  }
+
+  const limitParam = req.query.limit ? parseInt(req.query.limit as string) : 100;
+  const offsetParam = req.query.offset ? parseInt(req.query.offset as string) : 0;
+  const limit = isNaN(limitParam) || limitParam < 0 ? 100 : Math.min(limitParam, 500);
+  const offset = isNaN(offsetParam) || offsetParam < 0 ? 0 : offsetParam;
+
+  logStructured(
+    "processing",
+    `fetching change history for policy id: ${policyId} (limit: ${limit}, offset: ${offset})`,
+    "getPolicyChangeHistoryById",
+    "policyChangeHistory.ctrl.ts"
+  );
+  logger.debug(
+    `Fetching change history for policy with id: ${policyId} (limit: ${limit}, offset: ${offset})`
+  );
+
+  try {
+    const result = await getPolicyChangeHistory(
+      policyId,
+      req.tenantId!,
+      limit,
+      offset
+    );
+
+    logStructured(
+      "successful",
+      `change history retrieved for policy id: ${policyId} (${result.data.length} entries, hasMore: ${result.hasMore})`,
+      "getPolicyChangeHistoryById",
+      "policyChangeHistory.ctrl.ts"
+    );
+
+    return res.status(200).json(STATUS_CODE[200](result));
+  } catch (error) {
+    logStructured(
+      "error",
+      "failed to retrieve change history",
+      "getPolicyChangeHistoryById",
+      "policyChangeHistory.ctrl.ts"
+    );
+    logger.error("Error in getPolicyChangeHistoryById:", error);
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+}

--- a/Servers/database/migrations/20251205200000-create-policy-change-history-table.js
+++ b/Servers/database/migrations/20251205200000-create-policy-change-history-table.js
@@ -1,0 +1,126 @@
+'use strict';
+const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // Check if organizations table exists
+      const tableExists = await queryInterface.sequelize.query(
+        `SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_schema = 'public'
+          AND table_name = 'organizations'
+        );`,
+        { transaction, type: Sequelize.QueryTypes.SELECT }
+      );
+
+      // If organizations table doesn't exist, skip migration
+      if (!tableExists[0].exists) {
+        console.log('Organizations table does not exist yet. Skipping policy change history table creation.');
+        await transaction.commit();
+        return;
+      }
+
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (let organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+
+        // Create change history table
+        await queryInterface.sequelize.query(`
+          CREATE TABLE IF NOT EXISTS "${tenantHash}".policy_change_history (
+            id SERIAL PRIMARY KEY,
+            policy_id INTEGER NOT NULL REFERENCES "${tenantHash}".policy_manager(id) ON DELETE CASCADE,
+            action VARCHAR(50) NOT NULL CHECK (action IN ('created', 'updated', 'deleted')),
+            field_name VARCHAR(255),
+            old_value TEXT,
+            new_value TEXT,
+            changed_by_user_id INTEGER REFERENCES public.users(id) ON DELETE SET NULL,
+            changed_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            created_at TIMESTAMP NOT NULL DEFAULT NOW()
+          );
+        `, { transaction });
+
+        // Create index on policy_id for faster lookups
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_policy_change_history_policy_id
+          ON "${tenantHash}".policy_change_history(policy_id);
+        `, { transaction });
+
+        // Create index on changed_at for time-based queries
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_policy_change_history_changed_at
+          ON "${tenantHash}".policy_change_history(changed_at DESC);
+        `, { transaction });
+
+        // Create composite index for policy_id + changed_at (most common query pattern)
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_policy_change_history_policy_changed
+          ON "${tenantHash}".policy_change_history(policy_id, changed_at DESC);
+        `, { transaction });
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // Check if organizations table exists
+      const tableExists = await queryInterface.sequelize.query(
+        `SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_schema = 'public'
+          AND table_name = 'organizations'
+        );`,
+        { transaction, type: Sequelize.QueryTypes.SELECT }
+      );
+
+      if (!tableExists[0].exists) {
+        await transaction.commit();
+        return;
+      }
+
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (let organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+
+        // Drop indexes first
+        await queryInterface.sequelize.query(`
+          DROP INDEX IF EXISTS "${tenantHash}".idx_policy_change_history_policy_changed;
+        `, { transaction });
+
+        await queryInterface.sequelize.query(`
+          DROP INDEX IF EXISTS "${tenantHash}".idx_policy_change_history_changed_at;
+        `, { transaction });
+
+        await queryInterface.sequelize.query(`
+          DROP INDEX IF EXISTS "${tenantHash}".idx_policy_change_history_policy_id;
+        `, { transaction });
+
+        // Drop table
+        await queryInterface.sequelize.query(`
+          DROP TABLE IF EXISTS "${tenantHash}".policy_change_history;
+        `, { transaction });
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};

--- a/Servers/index.ts
+++ b/Servers/index.ts
@@ -61,6 +61,7 @@ import deepEvalRoutes from "./routes/deepEvalRoutes.route";
 import evaluationLlmApiKeyRoutes from "./routes/evaluationLlmApiKey.route";
 import notesRoutes from "./routes/notes.route";
 import vendorRiskChangeHistoryRoutes from "./routes/vendorRiskChangeHistory.route";
+import policyChangeHistoryRoutes from "./routes/policyChangeHistory.route";
 
 const swaggerDoc = YAML.load("./swagger.yaml");
 
@@ -185,6 +186,7 @@ try {
   app.use("/api/evaluation-llm-keys", evaluationLlmApiKeyRoutes);
   app.use("/api/notes", notesRoutes);
   app.use("/api/vendor-risk-change-history", vendorRiskChangeHistoryRoutes);
+  app.use("/api/policy-change-history", policyChangeHistoryRoutes);
 
   app.listen(port, () => {
     console.log(`Server running on port http://${host}:${port}/`);

--- a/Servers/routes/policyChangeHistory.route.ts
+++ b/Servers/routes/policyChangeHistory.route.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { getPolicyChangeHistoryById } from "../controllers/policyChangeHistory.ctrl";
+import authenticateJWT from "../middleware/auth.middleware";
+
+const router = Router();
+
+router.get("/:id", authenticateJWT, getPolicyChangeHistoryById);
+
+export default router;

--- a/Servers/utils/policyChangeHistory.utils.ts
+++ b/Servers/utils/policyChangeHistory.utils.ts
@@ -1,0 +1,130 @@
+/**
+ * Policy Change History Utilities
+ *
+ * Wrapper functions that use the generic change history system.
+ * These functions maintain backward compatibility while leveraging
+ * the new generic utilities.
+ */
+
+import { IPolicy } from "../domain.layer/interfaces/i.policy";
+import { Transaction } from "sequelize";
+import {
+  recordEntityChange,
+  recordMultipleFieldChanges as recordMultipleFieldChangesGeneric,
+  getEntityChangeHistory,
+  trackEntityChanges,
+  recordEntityCreation,
+  recordEntityDeletion,
+} from "./changeHistory.base.utils";
+
+/**
+ * Record a change in policy
+ */
+export const recordPolicyChange = async (
+  policyId: number,
+  action: "created" | "updated" | "deleted",
+  changedByUserId: number,
+  tenant: string,
+  fieldName?: string,
+  oldValue?: string,
+  newValue?: string,
+  transaction?: Transaction
+): Promise<void> => {
+  return recordEntityChange(
+    "policy",
+    policyId,
+    action,
+    changedByUserId,
+    tenant,
+    fieldName,
+    oldValue,
+    newValue,
+    transaction
+  );
+};
+
+/**
+ * Record multiple field changes for a policy
+ */
+export const recordMultipleFieldChanges = async (
+  policyId: number,
+  changedByUserId: number,
+  tenant: string,
+  changes: Array<{ fieldName: string; oldValue: string; newValue: string }>,
+  transaction?: Transaction
+): Promise<void> => {
+  return recordMultipleFieldChangesGeneric(
+    "policy",
+    policyId,
+    changedByUserId,
+    tenant,
+    changes,
+    transaction
+  );
+};
+
+/**
+ * Get change history for a specific policy with pagination support
+ */
+export const getPolicyChangeHistory = async (
+  policyId: number,
+  tenant: string,
+  limit: number = 100,
+  offset: number = 0
+): Promise<{ data: any[]; hasMore: boolean; total: number }> => {
+  return getEntityChangeHistory(
+    "policy",
+    policyId,
+    tenant,
+    limit,
+    offset
+  );
+};
+
+/**
+ * Track changes between old and new policy data
+ */
+export const trackPolicyChanges = async (
+  oldModel: IPolicy,
+  newModel: Partial<IPolicy>
+): Promise<Array<{ fieldName: string; oldValue: string; newValue: string }>> => {
+  return trackEntityChanges("policy", oldModel, newModel);
+};
+
+/**
+ * Record creation of a policy
+ */
+export const recordPolicyCreation = async (
+  policyId: number,
+  changedByUserId: number,
+  tenant: string,
+  policyData: Partial<IPolicy>,
+  transaction?: Transaction
+): Promise<void> => {
+  return recordEntityCreation(
+    "policy",
+    policyId,
+    changedByUserId,
+    tenant,
+    policyData,
+    transaction
+  );
+};
+
+/**
+ * Record deletion of a policy
+ */
+export const recordPolicyDeletion = async (
+  policyId: number,
+  changedByUserId: number,
+  tenant: string,
+  transaction?: Transaction
+): Promise<void> => {
+  return recordEntityDeletion(
+    "policy",
+    policyId,
+    changedByUserId,
+    tenant,
+    transaction
+  );
+};


### PR DESCRIPTION
## Summary
- Add activity history tracking for policies in the Policy Manager
- Display change history in a sidebar when editing a policy
- Track all policy field changes except editor content (for performance)

## Changes

### Backend
- New database migration for `policy_change_history` table (multi-tenant)
- New API endpoint: `GET /api/policy-change-history/:policyId`
- Policy controller now records creation and tracks field changes on update
- Reuses the generic change history infrastructure

### Frontend
- Integrate HistorySidebar component into PolicyDetailsModal
- Add usePolicyChangeHistory hook for data fetching
- Add configurable height prop to HistorySidebar for layout flexibility
- Register policy entity type in change history config

### Tracked fields
- Title
- Status
- Assigned reviewers
- Tags
- Content (shows "updated" without actual content diff)

## Test plan
- [ ] Open a policy in the Policy Manager
- [ ] Click the activity history button (clock icon)
- [ ] Verify the history sidebar opens on the right side
- [ ] Make changes to a policy and save
- [ ] Verify the changes appear in the activity history
- [ ] Verify the sidebar height matches the left column content