### PR TITLE
Add activity history for Incident Management

### DIFF
--- a/Clients/src/config/changeHistory.config.ts
+++ b/Clients/src/config/changeHistory.config.ts
@@ -14,7 +14,8 @@ export type EntityType =
   | "evidence_hub"
   | "risk"
   | "vendor_risk"
-  | "policy";
+  | "policy"
+  | "incident";
 
 export interface EntityHistoryConfig {
   entityName: string; // Display name (e.g., "Model", "Vendor")
@@ -78,6 +79,12 @@ export const ENTITY_HISTORY_CONFIGS: {
     emptyStateTitle: "Activity history",
     emptyStateMessage:
       "Automatically tracks every change to this policy. See what your team is working on and what updates they've made, in real time.",
+  },
+  incident: {
+    entityName: "Incident",
+    emptyStateTitle: "Activity history",
+    emptyStateMessage:
+      "Automatically tracks every change to this incident. See what your team is working on and what updates they've made, in real time.",
   },
 };
 

--- a/Clients/src/presentation/components/Modals/NewIncident/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewIncident/index.tsx
@@ -10,6 +10,8 @@ import {
     FormLabel,
     useTheme,
     Divider,
+    IconButton,
+    Tooltip,
 } from "@mui/material";
 import Toggle from "../../Inputs/Toggle";
 import Checkbox from "../../Inputs/Checkbox";
@@ -17,6 +19,7 @@ import dayjs, { Dayjs } from "dayjs";
 import CustomizableButton from "../../Button/CustomizableButton";
 import { ReactComponent as CloseIcon } from "../../../assets/icons/close.svg";
 import { ReactComponent as SaveIconSVGWhite } from "../../../assets/icons/save-white.svg";
+import { History as HistoryIcon } from "lucide-react";
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import { getAllProjects } from "../../../../application/repository/project.repository";
 import { User } from "../../../../domain/types/User";
@@ -29,6 +32,7 @@ import {
     IncidentType,
     HarmCategory,
 } from "../../../../domain/enums/aiIncidentManagement.enum";
+import HistorySidebar from "../../Common/HistorySidebar";
 
 // To
 import Field from "../../Inputs/Field";
@@ -42,6 +46,7 @@ interface SideDrawerIncidentProps {
     initialData?: NewIncidentFormValues;
     isEdit?: boolean;
     mode?: string;
+    incidentId?: number;
 }
 
 export interface NewIncidentFormValues {
@@ -134,6 +139,7 @@ const SideDrawerIncident: FC<SideDrawerIncidentProps> = ({
     initialData,
     isEdit = false,
     mode,
+    incidentId,
 }) => {
     const theme = useTheme();
     const [values, setValues] = useState<NewIncidentFormValues>(
@@ -143,6 +149,10 @@ const SideDrawerIncident: FC<SideDrawerIncidentProps> = ({
     const [users, setUsers] = useState<User[]>([]);
     const [projectList, setProjects] = useState<Project[]>([]);
     const [, setIsLoadingUsers] = useState(false);
+    const [isHistorySidebarOpen, setIsHistorySidebarOpen] = useState(false);
+
+    // Calculate drawer width based on history sidebar state
+    const drawerWidth = isHistorySidebarOpen ? 1036 : 700;
 
     // Fetch Users & Projects
     useEffect(() => {
@@ -294,14 +304,24 @@ const SideDrawerIncident: FC<SideDrawerIncidentProps> = ({
     return (
         <Drawer anchor="right" open={isOpen} onClose={handleClose}>
             <Stack
+                direction="row"
                 sx={{
-                    width: 700,
+                    width: drawerWidth,
                     maxHeight: "100vh",
-                    overflowY: "auto",
-                    p: theme.spacing(10),
                     bgcolor: theme.palette.background.paper,
+                    transition: "width 0.3s ease",
                 }}
             >
+                {/* Main Content */}
+                <Stack
+                    sx={{
+                        width: isHistorySidebarOpen ? 700 : "100%",
+                        maxHeight: "100vh",
+                        overflowY: "auto",
+                        p: theme.spacing(10),
+                        transition: "width 0.3s ease",
+                    }}
+                >
                 {/* Header */}
 
                 {mode !== "view" && (
@@ -344,9 +364,25 @@ const SideDrawerIncident: FC<SideDrawerIncidentProps> = ({
                                     </Typography>
                                 )}
                             </Stack>
-                            <Box onClick={handleClose} sx={{ cursor: "pointer" }}>
-                                <CloseIcon />
-                            </Box>
+                            <Stack direction="row" alignItems="center" spacing={1}>
+                                {isEdit && incidentId && (
+                                    <Tooltip title="Activity history">
+                                        <IconButton
+                                            onClick={() => setIsHistorySidebarOpen(!isHistorySidebarOpen)}
+                                            sx={{
+                                                color: isHistorySidebarOpen
+                                                    ? theme.palette.primary.main
+                                                    : theme.palette.text.secondary,
+                                            }}
+                                        >
+                                            <HistoryIcon size={16} />
+                                        </IconButton>
+                                    </Tooltip>
+                                )}
+                                <Box onClick={handleClose} sx={{ cursor: "pointer" }}>
+                                    <CloseIcon />
+                                </Box>
+                            </Stack>
                         </Stack>
                         <Divider sx={{
                             mb: 4,
@@ -831,6 +867,17 @@ const SideDrawerIncident: FC<SideDrawerIncidentProps> = ({
                         )}
                     </Stack>
                 </form>
+                </Stack>
+
+                {/* History Sidebar */}
+                {isEdit && incidentId && (
+                    <HistorySidebar
+                        isOpen={isHistorySidebarOpen}
+                        entityType="incident"
+                        entityId={incidentId}
+                        height="100%"
+                    />
+                )}
             </Stack>
         </Drawer>
     );

--- a/Clients/src/presentation/pages/IncidentManagement/index.tsx
+++ b/Clients/src/presentation/pages/IncidentManagement/index.tsx
@@ -741,6 +741,7 @@ const IncidentManagement: React.FC = () => {
                 }
                 isEdit={!!selectedIncident}
                 mode={mode}
+                incidentId={selectedIncident?.id}
             />
 
             <PageTour steps={IncidentManagementSteps} run={!isLoading} tourKey="incident-management-tour" />

--- a/Servers/config/changeHistory.config.ts
+++ b/Servers/config/changeHistory.config.ts
@@ -21,7 +21,8 @@ export type EntityType =
   | "evidence_hub"
   | "risk"
   | "vendor_risk"
-  | "policy";
+  | "policy"
+  | "incident";
 
 /**
  * Field formatter function type
@@ -409,6 +410,63 @@ export const ENTITY_CONFIGS: { [key in EntityType]: EntityConfig } = {
       tags: GENERIC_FORMATTERS.array,
       next_review_date: GENERIC_FORMATTERS.date,
       assigned_reviewer_ids: GENERIC_FORMATTERS.userArray,
+    },
+  },
+
+  incident: {
+    tableName: "incident_change_history",
+    foreignKeyField: "incident_id",
+    fieldsToTrack: [
+      "ai_project",
+      "type",
+      "severity",
+      "status",
+      "occurred_date",
+      "date_detected",
+      "reporter",
+      "categories_of_harm",
+      "affected_persons_groups",
+      "description",
+      "relationship_causality",
+      "immediate_mitigations",
+      "planned_corrective_actions",
+      "model_system_version",
+      "interim_report",
+      "archived",
+      "approval_status",
+      "approved_by",
+      "approval_date",
+      "approval_notes",
+    ],
+    fieldLabels: {
+      ai_project: "AI use case or framework",
+      type: "Incident type",
+      severity: "Severity",
+      status: "Status",
+      occurred_date: "Occurred date",
+      date_detected: "Detected date",
+      reporter: "Reporter",
+      categories_of_harm: "Categories of harm",
+      affected_persons_groups: "Affected persons / groups",
+      description: "Description",
+      relationship_causality: "Relationship / causality",
+      immediate_mitigations: "Immediate mitigations",
+      planned_corrective_actions: "Planned corrective actions",
+      model_system_version: "Model / system version",
+      interim_report: "Interim report",
+      archived: "Archived",
+      approval_status: "Approval status",
+      approved_by: "Approved by",
+      approval_date: "Approval date",
+      approval_notes: "Approval notes",
+    },
+    fieldFormatters: {
+      occurred_date: GENERIC_FORMATTERS.date,
+      date_detected: GENERIC_FORMATTERS.date,
+      approval_date: GENERIC_FORMATTERS.date,
+      interim_report: GENERIC_FORMATTERS.boolean,
+      archived: GENERIC_FORMATTERS.boolean,
+      categories_of_harm: GENERIC_FORMATTERS.array,
     },
   },
 };

--- a/Servers/controllers/incidentChangeHistory.ctrl.ts
+++ b/Servers/controllers/incidentChangeHistory.ctrl.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from "express";
+import { getIncidentChangeHistory } from "../utils/incidentChangeHistory.utils";
+import { STATUS_CODE } from "../utils/statusCode.utils";
+
+/**
+ * Get change history for a specific incident
+ */
+export const getIncidentHistory = async (req: Request, res: Response) => {
+  try {
+    const incidentId = parseInt(req.params.incidentId, 10);
+    const limit = parseInt(req.query.limit as string) || 100;
+    const offset = parseInt(req.query.offset as string) || 0;
+
+    if (isNaN(incidentId)) {
+      return res.status(400).json(STATUS_CODE[400]("Invalid incident ID"));
+    }
+
+    const result = await getIncidentChangeHistory(
+      incidentId,
+      req.tenantId!,
+      limit,
+      offset
+    );
+
+    return res.status(200).json(STATUS_CODE[200](result));
+  } catch (error) {
+    console.error("Error getting incident change history:", error);
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+};

--- a/Servers/database/migrations/20251205300000-create-incident-change-history-table.js
+++ b/Servers/database/migrations/20251205300000-create-incident-change-history-table.js
@@ -1,0 +1,142 @@
+'use strict';
+const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // Check if organizations table exists
+      const tableExists = await queryInterface.sequelize.query(
+        `SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_schema = 'public'
+          AND table_name = 'organizations'
+        );`,
+        { transaction, type: Sequelize.QueryTypes.SELECT }
+      );
+
+      // If organizations table doesn't exist, skip migration
+      if (!tableExists[0].exists) {
+        console.log('Organizations table does not exist yet. Skipping incident change history table creation.');
+        await transaction.commit();
+        return;
+      }
+
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (let organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+
+        // Check if ai_incident_managements table exists in this tenant schema
+        const incidentTableExists = await queryInterface.sequelize.query(
+          `SELECT EXISTS (
+            SELECT FROM information_schema.tables
+            WHERE table_schema = '${tenantHash}'
+            AND table_name = 'ai_incident_managements'
+          );`,
+          { transaction, type: Sequelize.QueryTypes.SELECT }
+        );
+
+        // If ai_incident_managements table doesn't exist, skip this tenant
+        if (!incidentTableExists[0].exists) {
+          console.log(`ai_incident_managements table does not exist in schema ${tenantHash}. Skipping incident change history table creation for this tenant.`);
+          continue;
+        }
+
+        // Create change history table
+        await queryInterface.sequelize.query(`
+          CREATE TABLE IF NOT EXISTS "${tenantHash}".incident_change_history (
+            id SERIAL PRIMARY KEY,
+            incident_id INTEGER NOT NULL REFERENCES "${tenantHash}".ai_incident_managements(id) ON DELETE CASCADE,
+            action VARCHAR(50) NOT NULL CHECK (action IN ('created', 'updated', 'deleted')),
+            field_name VARCHAR(255),
+            old_value TEXT,
+            new_value TEXT,
+            changed_by_user_id INTEGER REFERENCES public.users(id) ON DELETE SET NULL,
+            changed_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            created_at TIMESTAMP NOT NULL DEFAULT NOW()
+          );
+        `, { transaction });
+
+        // Create index on incident_id for faster lookups
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_incident_change_history_incident_id
+          ON "${tenantHash}".incident_change_history(incident_id);
+        `, { transaction });
+
+        // Create index on changed_at for time-based queries
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_incident_change_history_changed_at
+          ON "${tenantHash}".incident_change_history(changed_at DESC);
+        `, { transaction });
+
+        // Create composite index for incident_id + changed_at (most common query pattern)
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_incident_change_history_incident_changed
+          ON "${tenantHash}".incident_change_history(incident_id, changed_at DESC);
+        `, { transaction });
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // Check if organizations table exists
+      const tableExists = await queryInterface.sequelize.query(
+        `SELECT EXISTS (
+          SELECT FROM information_schema.tables
+          WHERE table_schema = 'public'
+          AND table_name = 'organizations'
+        );`,
+        { transaction, type: Sequelize.QueryTypes.SELECT }
+      );
+
+      if (!tableExists[0].exists) {
+        await transaction.commit();
+        return;
+      }
+
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (let organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+
+        // Drop indexes first
+        await queryInterface.sequelize.query(`
+          DROP INDEX IF EXISTS "${tenantHash}".idx_incident_change_history_incident_changed;
+        `, { transaction });
+
+        await queryInterface.sequelize.query(`
+          DROP INDEX IF EXISTS "${tenantHash}".idx_incident_change_history_changed_at;
+        `, { transaction });
+
+        await queryInterface.sequelize.query(`
+          DROP INDEX IF EXISTS "${tenantHash}".idx_incident_change_history_incident_id;
+        `, { transaction });
+
+        // Drop table
+        await queryInterface.sequelize.query(`
+          DROP TABLE IF EXISTS "${tenantHash}".incident_change_history;
+        `, { transaction });
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};

--- a/Servers/index.ts
+++ b/Servers/index.ts
@@ -63,6 +63,7 @@ import evaluationLlmApiKeyRoutes from "./routes/evaluationLlmApiKey.route";
 import notesRoutes from "./routes/notes.route";
 import vendorRiskChangeHistoryRoutes from "./routes/vendorRiskChangeHistory.route";
 import policyChangeHistoryRoutes from "./routes/policyChangeHistory.route";
+import incidentChangeHistoryRoutes from "./routes/incidentChangeHistory.route";
 
 const swaggerDoc = YAML.load("./swagger.yaml");
 
@@ -189,6 +190,7 @@ try {
   app.use("/api/notes", notesRoutes);
   app.use("/api/vendor-risk-change-history", vendorRiskChangeHistoryRoutes);
   app.use("/api/policy-change-history", policyChangeHistoryRoutes);
+  app.use("/api/incident-change-history", incidentChangeHistoryRoutes);
 
   app.listen(port, () => {
     console.log(`Server running on port http://${host}:${port}/`);

--- a/Servers/routes/incidentChangeHistory.route.ts
+++ b/Servers/routes/incidentChangeHistory.route.ts
@@ -1,0 +1,9 @@
+import express from "express";
+import { getIncidentHistory } from "../controllers/incidentChangeHistory.ctrl";
+import authenticateJWT from "../middleware/auth.middleware";
+
+const router = express.Router();
+
+router.get("/:incidentId", authenticateJWT, getIncidentHistory);
+
+export default router;

--- a/Servers/utils/incidentChangeHistory.utils.ts
+++ b/Servers/utils/incidentChangeHistory.utils.ts
@@ -1,0 +1,130 @@
+/**
+ * Incident Change History Utilities
+ *
+ * Wrapper functions that use the generic change history system.
+ * These functions maintain backward compatibility while leveraging
+ * the new generic utilities.
+ */
+
+import { IAIIncidentManagement } from "../domain.layer/interfaces/i.aiIncidentManagement";
+import { Transaction } from "sequelize";
+import {
+  recordEntityChange,
+  recordMultipleFieldChanges as recordMultipleFieldChangesGeneric,
+  getEntityChangeHistory,
+  trackEntityChanges,
+  recordEntityCreation,
+  recordEntityDeletion,
+} from "./changeHistory.base.utils";
+
+/**
+ * Record a change in incident
+ */
+export const recordIncidentChange = async (
+  incidentId: number,
+  action: "created" | "updated" | "deleted",
+  changedByUserId: number,
+  tenant: string,
+  fieldName?: string,
+  oldValue?: string,
+  newValue?: string,
+  transaction?: Transaction
+): Promise<void> => {
+  return recordEntityChange(
+    "incident",
+    incidentId,
+    action,
+    changedByUserId,
+    tenant,
+    fieldName,
+    oldValue,
+    newValue,
+    transaction
+  );
+};
+
+/**
+ * Record multiple field changes for an incident
+ */
+export const recordMultipleFieldChanges = async (
+  incidentId: number,
+  changedByUserId: number,
+  tenant: string,
+  changes: Array<{ fieldName: string; oldValue: string; newValue: string }>,
+  transaction?: Transaction
+): Promise<void> => {
+  return recordMultipleFieldChangesGeneric(
+    "incident",
+    incidentId,
+    changedByUserId,
+    tenant,
+    changes,
+    transaction
+  );
+};
+
+/**
+ * Get change history for a specific incident with pagination support
+ */
+export const getIncidentChangeHistory = async (
+  incidentId: number,
+  tenant: string,
+  limit: number = 100,
+  offset: number = 0
+): Promise<{ data: any[]; hasMore: boolean; total: number }> => {
+  return getEntityChangeHistory(
+    "incident",
+    incidentId,
+    tenant,
+    limit,
+    offset
+  );
+};
+
+/**
+ * Track changes between old and new incident data
+ */
+export const trackIncidentChanges = async (
+  oldModel: IAIIncidentManagement,
+  newModel: Partial<IAIIncidentManagement>
+): Promise<Array<{ fieldName: string; oldValue: string; newValue: string }>> => {
+  return trackEntityChanges("incident", oldModel, newModel);
+};
+
+/**
+ * Record creation of an incident
+ */
+export const recordIncidentCreation = async (
+  incidentId: number,
+  changedByUserId: number,
+  tenant: string,
+  incidentData: Partial<IAIIncidentManagement>,
+  transaction?: Transaction
+): Promise<void> => {
+  return recordEntityCreation(
+    "incident",
+    incidentId,
+    changedByUserId,
+    tenant,
+    incidentData,
+    transaction
+  );
+};
+
+/**
+ * Record deletion of an incident
+ */
+export const recordIncidentDeletion = async (
+  incidentId: number,
+  changedByUserId: number,
+  tenant: string,
+  transaction?: Transaction
+): Promise<void> => {
+  return recordEntityDeletion(
+    "incident",
+    incidentId,
+    changedByUserId,
+    tenant,
+    transaction
+  );
+};


### PR DESCRIPTION
## Summary
- Adds activity history tracking for incidents in Incident Management
- Follows the same pattern used for policies, vendors, and vendor risks
- Tracks 21 fields including basic info, dates, response details, and approval workflow

## Changes

### Backend
- Add incident_change_history database migration with multi-tenant support
- Add incidentChangeHistory controller, route, and utils
- Register new API route at /api/incident-change-history
- Update incident-management controller to track changes on create/update
- Add incident entity configuration with 21 tracked fields

### Frontend
- Add incident entity type to changeHistory.config.ts
- Integrate HistorySidebar into NewIncident modal
- Pass incidentId prop from IncidentManagement page

### Tracked fields
- Basic info: AI use case, type, severity, status
- Dates: occurred date, detected date
- Details: reporter, categories of harm, affected persons/groups, description
- Response: relationship/causality, immediate mitigations, planned corrective actions
- Technical: model/system version
- Flags: interim report, archived
- Approval workflow: status, approved by, date, notes