### PR TITLE
Unify status summary cards with reusable StatusTileCards component

### DIFF
--- a/Clients/src/presentation/components/Cards/StatusTileCards/index.tsx
+++ b/Clients/src/presentation/components/Cards/StatusTileCards/index.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Stack, Typography, Tooltip, Box } from "@mui/material";
+import {
+  projectRisksCard,
+  projectRisksTileCard,
+  projectRisksTileCardKey,
+  projectRisksTileCardvalue,
+} from "../RisksCard/style";
+
+export interface StatusTileItem {
+  key: string;
+  label: string;
+  count: number;
+  color: string;
+}
+
+interface StatusTileCardsProps {
+  items: StatusTileItem[];
+  /** Optional: custom tooltip format. Default: "{count} {label}" */
+  tooltipFormat?: (item: StatusTileItem) => string;
+  /** Optional: entity name for pluralization in tooltip (e.g., "task", "model") */
+  entityName?: string;
+  /** Optional: custom styles to override individual card styling */
+  cardSx?: Record<string, unknown>;
+}
+
+const StatusTileCards: React.FC<StatusTileCardsProps> = ({
+  items,
+  tooltipFormat,
+  entityName = "item",
+  cardSx,
+}) => {
+  const getTooltip = (item: StatusTileItem): string => {
+    if (tooltipFormat) {
+      return tooltipFormat(item);
+    }
+    const plural = item.count !== 1 ? "s" : "";
+    return `${item.count} ${item.label.toLowerCase()} ${entityName}${plural}`;
+  };
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Stack className="vw-status-tile-cards" sx={projectRisksCard}>
+        {items.map((item) => (
+          <Tooltip
+            key={item.key}
+            title={getTooltip(item)}
+            arrow
+            placement="top"
+          >
+            <Stack
+              className="vw-status-tile"
+              sx={{
+                ...projectRisksTileCard,
+                color: item.color,
+                border: "1px solid #d0d5dd",
+                cursor: "default",
+                ...cardSx,
+              }}
+            >
+              <Typography sx={projectRisksTileCardKey}>{item.label}</Typography>
+              <Typography sx={projectRisksTileCardvalue}>{item.count}</Typography>
+            </Stack>
+          </Tooltip>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export default StatusTileCards;

--- a/Clients/src/presentation/pages/ModelInventory/ModelInventorySummary.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelInventorySummary.tsx
@@ -1,62 +1,20 @@
 import React from "react";
-import { Stack, Typography, Tooltip, Box } from "@mui/material";
+import StatusTileCards, { StatusTileItem } from "../../components/Cards/StatusTileCards";
 import { ModelInventorySummary as Summary } from "../../../domain/interfaces/i.modelInventory";
-import {
-  projectRisksCard,
-  projectRisksTileCard,
-  projectRisksTileCardKey,
-  projectRisksTileCardvalue,
-} from "../../components/Cards/RisksCard/style";
 
 interface ModelInventorySummaryProps {
   summary: Summary;
 }
 
-const ModelInventorySummary: React.FC<ModelInventorySummaryProps> = ({
-  summary,
-}) => {
-  const statusLevels = [
-    { key: "approved", label: "Approved", color: "#4CAF50" },
-    { key: "restricted", label: "Restricted", color: "#FF5722" },
-    { key: "pending", label: "Pending", color: "#FF9800" },
-    { key: "blocked", label: "Blocked", color: "#F44336" },
+const ModelInventorySummary: React.FC<ModelInventorySummaryProps> = ({ summary }) => {
+  const items: StatusTileItem[] = [
+    { key: "approved", label: "Approved", count: summary.approved, color: "#4CAF50" },
+    { key: "restricted", label: "Restricted", count: summary.restricted, color: "#FF5722" },
+    { key: "pending", label: "Pending", count: summary.pending, color: "#FF9800" },
+    { key: "blocked", label: "Blocked", count: summary.blocked, color: "#F44336" },
   ];
 
-  // Map summary data to status counts
-  const statusCounts = statusLevels.map((level) => ({
-    ...level,
-    count: summary[level.key as keyof Summary],
-  }));
-
-  return (
-    <Box sx={{ width: "100%" }}>
-      <Stack className="vw-model-inventory-summary" sx={projectRisksCard}>
-        {statusCounts.map((level) => (
-          <Tooltip
-            key={level.key}
-            title={`${level.count} ${level.label} Model${level.count !== 1 ? 's' : ''}`}
-            arrow
-            placement="top"
-          >
-            <Stack
-              className="vw-model-inventory-tile"
-              sx={{
-                ...projectRisksTileCard,
-                color: level.color,
-                border: `1px solid #E5E7EB`,
-                cursor: "default",
-              }}
-            >
-              <Typography sx={projectRisksTileCardKey}>{level.label}</Typography>
-              <Typography sx={projectRisksTileCardvalue}>
-                {level.count}
-              </Typography>
-            </Stack>
-          </Tooltip>
-        ))}
-      </Stack>
-    </Box>
-  );
+  return <StatusTileCards items={items} entityName="model" />;
 };
 
 export default ModelInventorySummary;

--- a/Clients/src/presentation/pages/ModelInventory/ModelRiskSummary.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelRiskSummary.tsx
@@ -1,11 +1,5 @@
-import { Stack, Typography, Tooltip, Box } from "@mui/material";
-import {
-  projectRisksCard,
-  projectRisksTileCard,
-  projectRisksTileCardKey,
-  projectRisksTileCardvalue,
-} from "../../components/Cards/RisksCard/style";
-
+import React from "react";
+import StatusTileCards, { StatusTileItem } from "../../components/Cards/StatusTileCards";
 import { ModelRiskLevel } from "../../../domain/interfaces/i.modelRisk";
 import { ModelRiskSummaryProps } from "../../../domain/interfaces/i.modelInventory";
 
@@ -17,41 +11,14 @@ const ModelRiskSummary: React.FC<ModelRiskSummaryProps> = ({ modelRisks }) => {
     { key: ModelRiskLevel.CRITICAL, label: "Critical", color: "#F44336" },
   ];
 
-  // Count how many risks per level
-  const riskCounts = riskLevels.map((level) => ({
-    ...level,
+  const items: StatusTileItem[] = riskLevels.map((level) => ({
+    key: level.key,
+    label: level.label,
     count: modelRisks.filter((risk) => risk.risk_level === level.key).length,
+    color: level.color,
   }));
 
-  return (
-    <Box sx={{ width: "100%" }}>
-      <Stack className="vw-model-risk-summary" sx={projectRisksCard}>
-        {riskCounts.map((level) => (
-          <Tooltip
-            key={level.key}
-            title={`${level.count} ${level.label} Risk${level.count !== 1 ? 's' : ''}`}
-            arrow
-            placement="top"
-          >
-            <Stack
-              className="vw-model-risk-tile"
-              sx={{
-                ...projectRisksTileCard,
-                color: level.color,
-                border: `1px solid #E5E7EB`,
-                cursor: "default",
-              }}
-            >
-              <Typography sx={projectRisksTileCardKey}>{level.label}</Typography>
-              <Typography sx={projectRisksTileCardvalue}>
-                {level.count}
-              </Typography>
-            </Stack>
-          </Tooltip>
-        ))}
-      </Stack>
-    </Box>
-  );
+  return <StatusTileCards items={items} entityName="risk" />;
 };
 
 export default ModelRiskSummary;

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyStatusCard.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyStatusCard.tsx
@@ -1,58 +1,30 @@
-import { Stack, Typography, Tooltip, Box } from "@mui/material";
-import {
-  projectRisksCard,
-  projectRisksTileCard,
-  projectRisksTileCardKey,
-  projectRisksTileCardvalue,
-} from "../../components/Cards/RisksCard/style"; // ✅ reuse same styles as ProjectRiskView Cards
+import React from "react";
+import StatusTileCards, { StatusTileItem } from "../../components/Cards/StatusTileCards";
 import { PolicyStatusCardProps } from "../../../domain/interfaces/IPolicy";
-
 
 const PolicyStatusCard: React.FC<PolicyStatusCardProps> = ({ policies }) => {
   const statusLevels = [
     { key: "Draft", label: "Draft", color: "#9E9E9E" },
-    { key: "Under Review", label: "Under Review", color: "#FF9800" },
+    { key: "Under Review", label: "Under review", color: "#FF9800" },
     { key: "Approved", label: "Approved", color: "#4CAF50" },
     { key: "Published", label: "Published", color: "#2196F3" },
     { key: "Archived", label: "Archived", color: "#757575" },
     { key: "Deprecated", label: "Deprecated", color: "#F44336" },
   ];
 
-  // Count how many policies per status
-  const statusCounts = statusLevels.map((level) => ({
-    ...level,
+  const items: StatusTileItem[] = statusLevels.map((level) => ({
+    key: level.key,
+    label: level.label,
     count: policies.filter((p) => p.status === level.key).length,
+    color: level.color,
   }));
 
   return (
-    <Box sx={{ width: "100%" }}>
-      <Stack className="vw-policy-status" sx={projectRisksCard}>
-        {statusCounts.map((level) => (
-          <Tooltip
-            key={level.key}
-            title={`${level.count} ${level.label} Policy`}
-            arrow
-            placement="top"
-          >
-            <Stack
-              className="vw-policy-status-tile"
-              sx={{
-                ...projectRisksTileCard,
-                color: level.color,
-                border: `1px solid #d0d5dd`,
-                cursor: "default",
-                paddingX: { xs: "15px", sm: "20px" }, // Reduced from 30px to prevent text wrapping
-              }}
-            >
-              <Typography sx={projectRisksTileCardKey}>{level.label}</Typography>
-              <Typography sx={projectRisksTileCardvalue}>
-                {level.count}
-              </Typography>
-            </Stack>
-          </Tooltip>
-        ))}
-      </Stack>
-    </Box>
+    <StatusTileCards
+      items={items}
+      entityName="policy"
+      cardSx={{ paddingX: { xs: "15px", sm: "20px" } }}
+    />
   );
 };
 

--- a/Clients/src/presentation/pages/Tasks/TaskSummaryCards.tsx
+++ b/Clients/src/presentation/pages/Tasks/TaskSummaryCards.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import StatusTileCards, { StatusTileItem } from "../../components/Cards/StatusTileCards";
+import { TaskSummary } from "../../../domain/interfaces/i.task";
+
+interface TaskSummaryCardsProps {
+  summary: TaskSummary;
+}
+
+const TaskSummaryCards: React.FC<TaskSummaryCardsProps> = ({ summary }) => {
+  const items: StatusTileItem[] = [
+    { key: "total", label: "Total", count: summary.total, color: "#4B5563" },
+    { key: "overdue", label: "Overdue", count: summary.overdue, color: "#F44336" },
+    { key: "inProgress", label: "In progress", count: summary.inProgress, color: "#FF9800" },
+    { key: "completed", label: "Completed", count: summary.completed, color: "#4CAF50" },
+  ];
+
+  return <StatusTileCards items={items} entityName="task" />;
+};
+
+export default TaskSummaryCards;

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -25,13 +25,10 @@ import {
   restoreTask,
   hardDeleteTask,
 } from "../../../application/repository/task.repository";
-import HeaderCard from "../../components/Cards/DashboardHeaderCard";
+import TaskSummaryCards from "./TaskSummaryCards";
 import CreateTask from "../../components/Modals/CreateTask";
 import useUsers from "../../../application/hooks/useUsers";
-import {
-  vwhomeHeaderCards,
-  vwhomeBody,
-} from "../Home/1.0Home/style";
+import { vwhomeBody } from "../Home/1.0Home/style";
 import Toggle from "../../components/Inputs/Toggle";
 import { TaskPriority, TaskStatus } from "../../../domain/enums/task.enum";
 import PageTour from "../../components/PageTour";
@@ -527,13 +524,8 @@ const Tasks: React.FC = () => {
       {/* Tips */}
       <TipBox entityName="tasks" />
 
-      {/* Header Cards */}
-      <Stack sx={vwhomeHeaderCards} data-joyride-id="task-summary-cards">
-        <HeaderCard title="Tasks" count={summary.total} />
-        <HeaderCard title="Overdue" count={summary.overdue} />
-        <HeaderCard title="In progress" count={summary.inProgress} />
-        <HeaderCard title="Completed" count={summary.completed} />
-      </Stack>
+      {/* Summary Cards */}
+      <TaskSummaryCards summary={summary} />
 
 
       {/* Filter Controls */}


### PR DESCRIPTION
## Summary

- Create reusable `StatusTileCards` component for consistent status summary cards across the app
- Unify the card design between Tasks, Model Inventory, and Policy Dashboard pages
- Remove duplicated card rendering code from 4 different files

## Changes

### New component
`components/Cards/StatusTileCards/index.tsx`
- Accepts array of status items with label, count, and color
- Supports custom tooltips and style overrides via `cardSx` prop
- Uses existing `RisksCard/style.ts` for consistent styling

### Refactored files
| File | Before | After |
|------|--------|-------|
| `ModelInventorySummary.tsx` | 63 lines | 20 lines |
| `ModelRiskSummary.tsx` | 57 lines | 24 lines |
| `PolicyStatusCard.tsx` | 60 lines | 31 lines |
| `Tasks/index.tsx` | Used HeaderCard | Uses StatusTileCards |

### Usage example
```tsx
<StatusTileCards
  items={[
    { key: "approved", label: "Approved", count: 5, color: "#4CAF50" },
    { key: "pending", label: "Pending", count: 3, color: "#FF9800" },
  ]}
  entityName="model"
/>
```

## Test plan
- [ ] Verify Tasks page shows summary cards with correct counts
- [ ] Verify Model Inventory page shows model status cards
- [ ] Verify Model Inventory risks tab shows risk level cards
- [ ] Verify Policy Dashboard shows policy status cards
- [ ] Verify tooltips display correctly on hover