### PR TITLE
Fix dashboard greeting flickering on initial load

### DIFF
--- a/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
@@ -111,8 +111,10 @@ const getTimeBasedGreeting = (userName?: string, userToken?: any): { icon: React
     ];
 
     if (hour >= 1 && hour <= 4) {
-      const randomMessage = lateNightMessages[Math.floor(Math.random() * lateNightMessages.length)];
-      greetingText = randomMessage;
+      // Use stable index based on current minute to prevent flickering on re-renders
+      // Changes only once per minute, which is acceptable behavior
+      const stableIndex = now.getMinutes() % lateNightMessages.length;
+      greetingText = lateNightMessages[stableIndex];
     } else {
       greetingText = "Good night";
     }


### PR DESCRIPTION
## Summary

Fixes the dashboard greeting message flickering rapidly between different late night messages (e.g., "Still up? You're dedicated" and "Night owl mode activated") on initial page load.

## Root cause

The `getTimeBasedGreeting` function used `Math.random()` to select a late night greeting message. This function was called via `useMemo` with `[userName, userToken]` as dependencies. During initial load, when user data updates from the API, the memo recalculates and picks a different random message each time - causing rapid flickering.

## Solution

Replaced `Math.random()` with a stable index based on current minute:
```javascript
const stableIndex = now.getMinutes() % lateNightMessages.length;
```

This ensures:
- Consistent message during re-renders (no flickering)
- Message still rotates every minute for variety

## Test plan

- [ ] Visit dashboard between 1:00 AM and 4:00 AM
- [ ] Verify greeting message does not flicker on load
- [ ] Verify greeting message changes if you wait a minute and refresh