### PR TITLE
Hide helper sidebar on authentication pages

### DIFF
--- a/Clients/src/App.tsx
+++ b/Clients/src/App.tsx
@@ -29,9 +29,29 @@ import useUserPreferences from "./application/hooks/useUserPreferences";
 import { OnboardingModal, useOnboarding } from "./presentation/components/Onboarding";
 import { SidebarWrapper, UserGuideSidebarProvider, useUserGuideSidebarContext } from "./presentation/components/UserGuide";
 
+// Auth routes where the helper sidebar should not be shown
+const AUTH_ROUTES = [
+  '/login',
+  '/admin-reg',
+  '/user-reg',
+  '/register',
+  '/forgot-password',
+  '/reset-password',
+  '/set-new-password',
+  '/reset-password-continue',
+];
+
 // Component for User Guide Sidebar that uses the context
 const UserGuideSidebarContainer = () => {
+  const location = useLocation();
   const userGuideSidebar = useUserGuideSidebarContext();
+
+  // Don't show the helper sidebar on auth pages
+  const isAuthPage = AUTH_ROUTES.some(route => location.pathname === route);
+  if (isAuthPage) {
+    return null;
+  }
+
   return (
     <SidebarWrapper
       isOpen={userGuideSidebar.isOpen}


### PR DESCRIPTION
## Summary
- Hide the user guide helper sidebar on authentication pages (login, registration, password reset, etc.)
- The sidebar was appearing on pages where it's not needed and could be confusing for users

## Changes
- Added `AUTH_ROUTES` constant listing all authentication-related routes
- Modified `UserGuideSidebarContainer` to check current route and return null on auth pages

## Affected routes
- `/login`
- `/admin-reg`
- `/user-reg`
- `/register`
- `/forgot-password`
- `/reset-password`
- `/set-new-password`
- `/reset-password-continue`

## Test plan
- [ ] Navigate to login page - helper sidebar should not appear
- [ ] Navigate to registration page - helper sidebar should not appear
- [ ] Navigate to forgot password page - helper sidebar should not appear
- [ ] Navigate to dashboard (when logged in) - helper sidebar should still work normally