### PR TITLE
Update Free tier limits to 10 users, 10 projects, unlimited frameworks

### DIFF
--- a/Servers/database/migrations/20251212000000-update-free-tier-limits.js
+++ b/Servers/database/migrations/20251212000000-update-free-tier-limits.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      -- Update Free tier to new limits: 10 users, 10 projects, unlimited frameworks
+      UPDATE tiers
+      SET
+        features = '{"seats": 10, "projects": 10, "frameworks": 0}',
+        updated_at = NOW()
+      WHERE name = 'Free';
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(`
+      -- Revert Free tier to original limits: 2 users, 1 project, 1 framework
+      UPDATE tiers
+      SET
+        features = '{"seats": 2, "projects": 1, "frameworks": 1}',
+        updated_at = NOW()
+      WHERE name = 'Free';
+    `);
+  }
+};


### PR DESCRIPTION
## Summary
- Updates Free tier limits for all organizations
- Seats: 2 → 10
- Projects (use cases): 1 → 10  
- Frameworks: 1 → unlimited

## Test plan
- [ ] Run migration on staging database
- [ ] Verify existing Free tier organizations see new limits
- [ ] Verify new registrations get the updated Free tier limits
- [ ] Check Subscription settings page displays correct limits