### PR TITLE
Remove non-functional demo project step from onboarding

### DIFF
--- a/Clients/src/presentation/components/Onboarding/onboardingConstants.ts
+++ b/Clients/src/presentation/components/Onboarding/onboardingConstants.ts
@@ -49,17 +49,6 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
     requiresInput: false,
   },
   {
-    id: 8,
-    title: "Create Your First Demo Project",
-    description: "Let's create a sample project to explore VerifyWise features hands-on.",
-    componentName: "SampleProjectStep",
-    illustration: IllustrationType.GEOMETRIC_SHAPES,
-    showForAdmin: true,
-    showForUser: true,
-    canSkip: true,
-    requiresInput: true,
-  },
-  {
     id: 9,
     title: "Invite Team Members",
     description: "Invite up to 5 people to your organization",


### PR DESCRIPTION
## Summary
- Remove "Create your first demo project" step from onboarding flow
- The step collected user input (use case template, frameworks) but never actually created a project