### PR TITLE
Fix deepeval_projects insert missing tenant column

### DIFF
--- a/EvalServer/src/crud/deepeval_projects.py
+++ b/EvalServer/src/crud/deepeval_projects.py
@@ -39,8 +39,8 @@ async def create_project(
         result = await db.execute(
             text(f'''
                 INSERT INTO "{schema_name}".deepeval_projects
-                (id, name, description, org_id, created_by)
-                VALUES (:id, :name, :description, :org_id, :created_by)
+                (id, name, description, org_id, tenant, created_by)
+                VALUES (:id, :name, :description, :org_id, :tenant, :created_by)
                 RETURNING id, name, description, org_id, created_at, updated_at, created_by
             '''),
             {
@@ -48,6 +48,7 @@ async def create_project(
                 "name": name,
                 "description": description,
                 "org_id": org_id,
+                "tenant": schema_name,
                 "created_by": created_by
             }
         )
@@ -55,14 +56,15 @@ async def create_project(
         result = await db.execute(
             text(f'''
                 INSERT INTO "{schema_name}".deepeval_projects
-                (id, name, description, created_by)
-                VALUES (:id, :name, :description, :created_by)
+                (id, name, description, tenant, created_by)
+                VALUES (:id, :name, :description, :tenant, :created_by)
                 RETURNING id, name, description, NULL::varchar as org_id, created_at, updated_at, created_by
             '''),
             {
                 "id": project_id,
                 "name": name,
                 "description": description,
+                "tenant": schema_name,
                 "created_by": created_by
             }
         )


### PR DESCRIPTION
## Summary
- Fix project creation failing in Evals due to missing tenant column in INSERT statement

## Problem
Creating a new project in Evals failed with:
```
null value in column 'tenant' of relation 'deepeval_projects' violates not-null constraint
```

## Root cause
The `create_project` function in `deepeval_projects.py` was not including the `tenant` column in INSERT statements, but the database schema requires it as NOT NULL.

## Solution
Include the `tenant` column in both INSERT queries (with and without org_id), using the `schema_name` as the value.

## Test plan
- [ ] Create a new project in Evals dashboard
- [ ] Verify project is created successfully without database errors