### PR TITLE
Add migration for file_manager content and source columns

### DIFF
--- a/Servers/database/migrations/20251216000000-add-content-source-to-file-manager.js
+++ b/Servers/database/migrations/20251216000000-add-content-source-to-file-manager.js
@@ -1,0 +1,72 @@
+'use strict';
+const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // Fetch all organizations
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (let organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+
+        // Add content column (BYTEA for storing file binary data)
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${tenantHash}".file_manager
+           ADD COLUMN IF NOT EXISTS content BYTEA;`,
+          { transaction }
+        );
+
+        // Add source column (VARCHAR for tracking file origin)
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${tenantHash}".file_manager
+           ADD COLUMN IF NOT EXISTS source VARCHAR(50);`,
+          { transaction }
+        );
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (let organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+
+        // Remove the content column
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${tenantHash}".file_manager
+           DROP COLUMN IF EXISTS content;`,
+          { transaction }
+        );
+
+        // Remove the source column
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${tenantHash}".file_manager
+           DROP COLUMN IF EXISTS source;`,
+          { transaction }
+        );
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- Add migration to add `content` and `source` columns to `file_manager` table for existing tenant schemas

## Problem
Upgrading from 1.7 to 1.8 fails when uploading images to policies with a 500 error because the `file_manager` table is missing the `content` and `source` columns.

## Root cause
Commit b22d46e3d added image support to the policy editor which:
- Updated the INSERT query to include `content` and `source` columns
- Updated `createNewTenant.ts` for new installations

But no migration was included for existing installations upgrading from 1.7.

## Solution
Add a migration that runs `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for each tenant schema to add:
- `content BYTEA` - stores the actual file binary data
- `source VARCHAR(50)` - tracks file origin (e.g., 'policy_editor')

## Test plan
- [ ] Run migration on existing 1.7 database
- [ ] Upload an image to a policy in the policy editor
- [ ] Verify image is saved and displayed correctly