### PR TITLE
Fix ISO 27001/42001 subclause lookup query

### DIFF
--- a/Servers/utils/iso27001.utils.ts
+++ b/Servers/utils/iso27001.utils.ts
@@ -280,7 +280,7 @@ export const getSubClausesByClauseIdQuery = async (
 
 export const getSubClauseByIdForProjectQuery = async (
   subClauseId: number,
-  projectFrameworkId: number,
+  _projectFrameworkId: number,
   tenant: string
 ) => {
   const subClause = await getSubClauseByIdQuery(subClauseId, tenant);

--- a/Servers/utils/iso42001.utils.ts
+++ b/Servers/utils/iso42001.utils.ts
@@ -279,7 +279,7 @@ export const getSubClausesByClauseIdQuery = async (
 
 export const getSubClauseByIdForProjectQuery = async (
   subClauseId: number,
-  projectFrameworkId: number,
+  _projectFrameworkId: number,
   tenant: string
 ) => {
   const subClause = await getSubClauseByIdQuery(subClauseId, tenant);


### PR DESCRIPTION
## Summary
- Fix 500 error when saving ISO 27001/42001 clauses with owner

## Problem
When saving an ISO 27001/42001 clause with an owner, the subsequent GET request to refresh data fails with:
```
GET /api/iso-27001/subClause/byId/140?projectFrameworkId=23 500 (Internal Server Error)
```

## Root cause
The `getSubClauseByIdForProjectQuery` function was using the subclause ID as `subclause_meta_id` in the query:
```sql
SELECT id FROM subclauses_iso27001 WHERE subclause_meta_id = :id ...
```

But the frontend passes the tenant subclause table's primary key ID (e.g., 140), not the `subclause_meta_id` (which references the struct table with valid values 1-23 for ISO 27001).

This caused the query to return no results, and accessing `[0][0].id` on an empty array threw an error.

## Solution
Remove the unnecessary intermediate query. The frontend already passes the correct subclause ID, so we can directly call `getSubClauseByIdQuery` with that ID.

## Test plan
- [ ] Open an ISO 27001 project
- [ ] Click on a clause to open the drawer
- [ ] Set an owner and save
- [ ] Verify no 500 error occurs and data refreshes correctly
- [ ] Repeat for ISO 42001