### PR TITLE
Add migration for subcontrols_eu__risks table

### DIFF
--- a/Servers/database/migrations/20251216100000-add-subcontrols-eu-risks-table.js
+++ b/Servers/database/migrations/20251216100000-add-subcontrols-eu-risks-table.js
@@ -1,0 +1,69 @@
+'use strict';
+const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (const organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+
+        // Create subcontrols_eu__risks table if it doesn't exist
+        await queryInterface.sequelize.query(
+          `CREATE TABLE IF NOT EXISTS "${tenantHash}".subcontrols_eu__risks (
+            subcontrol_id INTEGER NOT NULL,
+            projects_risks_id INTEGER NOT NULL,
+            PRIMARY KEY (subcontrol_id, projects_risks_id),
+            FOREIGN KEY (subcontrol_id) REFERENCES "${tenantHash}".subcontrols_eu(id) ON DELETE CASCADE ON UPDATE CASCADE,
+            FOREIGN KEY (projects_risks_id) REFERENCES "${tenantHash}".risks(id) ON DELETE CASCADE ON UPDATE CASCADE
+          );`,
+          { transaction }
+        );
+
+        // Add indexes for query optimization
+        await queryInterface.sequelize.query(
+          `CREATE INDEX IF NOT EXISTS idx_subcontrols_eu_risks_risk_id ON "${tenantHash}".subcontrols_eu__risks(projects_risks_id);`,
+          { transaction }
+        );
+        await queryInterface.sequelize.query(
+          `CREATE INDEX IF NOT EXISTS idx_subcontrols_eu_subcontrol_id ON "${tenantHash}".subcontrols_eu__risks(subcontrol_id);`,
+          { transaction }
+        );
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (const organization of organizations[0]) {
+        const tenantHash = getTenantHash(organization.id);
+        await queryInterface.sequelize.query(
+          `DROP TABLE IF EXISTS "${tenantHash}".subcontrols_eu__risks;`,
+          { transaction }
+        );
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};

--- a/Servers/scripts/createNewTenant.ts
+++ b/Servers/scripts/createNewTenant.ts
@@ -1530,6 +1530,7 @@ export const createNewTenant = async (
         `CREATE INDEX IF NOT EXISTS idx_annexcategories_iso_risks_risk_id ON "${tenantHash}".annexcategories_iso__risks(projects_risks_id);`,
         `CREATE INDEX IF NOT EXISTS idx_controls_eu_risks_risk_id ON "${tenantHash}".controls_eu__risks(projects_risks_id);`,
         `CREATE INDEX IF NOT EXISTS idx_answers_eu_risks_risk_id ON "${tenantHash}".answers_eu__risks(projects_risks_id);`,
+        `CREATE INDEX IF NOT EXISTS idx_subcontrols_eu_risks_risk_id ON "${tenantHash}".subcontrols_eu__risks(projects_risks_id);`,
         `CREATE INDEX IF NOT EXISTS idx_annexcontrols_iso27001_risks_risk_id ON "${tenantHash}".annexcontrols_iso27001__risks(projects_risks_id);`,
         `CREATE INDEX IF NOT EXISTS idx_subclauses_iso27001_risks_risk_id ON "${tenantHash}".subclauses_iso27001__risks(projects_risks_id);`,
 
@@ -1538,6 +1539,7 @@ export const createNewTenant = async (
         `CREATE INDEX IF NOT EXISTS idx_annexcategories_iso_annexcategory_id ON "${tenantHash}".annexcategories_iso__risks(annexcategory_id);`,
         `CREATE INDEX IF NOT EXISTS idx_controls_eu_control_id ON "${tenantHash}".controls_eu__risks(control_id);`,
         `CREATE INDEX IF NOT EXISTS idx_answers_eu_answer_id ON "${tenantHash}".answers_eu__risks(answer_id);`,
+        `CREATE INDEX IF NOT EXISTS idx_subcontrols_eu_subcontrol_id ON "${tenantHash}".subcontrols_eu__risks(subcontrol_id);`,
         `CREATE INDEX IF NOT EXISTS idx_annexcontrols_iso27001_annexcontrol_id ON "${tenantHash}".annexcontrols_iso27001__risks(annexcontrol_id);`,
         `CREATE INDEX IF NOT EXISTS idx_subclauses_iso27001_subclause_id ON "${tenantHash}".subclauses_iso27001__risks(subclause_id);`,
       ].map((query) => sequelize.query(query, { transaction }))


### PR DESCRIPTION
## Summary
- Add migration to create `subcontrols_eu__risks` table for existing tenant schemas
- Add missing indexes to `createNewTenant.ts` for new tenants

## Problem
Creating a use-case fails with:
```
{
    "message": "Internal Server Error",
    "error": "relation \"TslZn8ID0X.subcontrols_eu__risks\" does not exist"
}
```

## Root cause
Commit d60d52a2b (December 12, 2025) added the `subcontrols_eu__risks` table to `createNewTenant.ts` for linking risks to EU subcontrols, but no migration was created for existing tenants.

When the EU framework code tries to query this table during use-case operations on upgraded tenants, it fails because the table doesn't exist.

## Solution
1. Add migration that creates the `subcontrols_eu__risks` table for all existing tenant schemas
2. Add indexes for query performance optimization
3. Add the missing indexes to `createNewTenant.ts` so new tenants also get them

## Test plan
- [ ] Run migration on existing database
- [ ] Create a new use-case
- [ ] Verify no error about missing table
- [ ] Test linking risks to EU subcontrols