### PR TITLE
Fix alignment of form fields in ISO 27001 annex drawer

### DIFF
--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -710,12 +710,7 @@ const VWISO27001AnnexDrawerDialog = ({
               </Stack>
             </Stack>
 
-            <Stack
-              sx={{
-                padding: "15px 20px",
-              }}
-              gap={"24px"}
-            >
+            <Stack gap={"24px"} sx={{ marginTop: "15px" }}>
               <Select
                 id="status"
                 label="Status:"


### PR DESCRIPTION
## Summary
- Fix misaligned form fields in the ISO 27001 annex drawer dialog

## Problem
In the ISO 27001 annex drawer, the form fields (Status, Owner, Reviewer, etc.) were narrower than the info boxes above (Requirement Summary, Key Questions, Evidence Examples) due to extra padding being applied.

## Solution
Removed the extra `padding: "15px 20px"` from the form fields Stack since the parent TabPanel already provides the necessary padding. Replaced with `marginTop: "15px"` to maintain spacing between the info boxes and form fields.

## Test plan
- [ ] Navigate to Framework > Controls > ISO 27001 > Annexes
- [ ] Click on any row to open the drawer
- [ ] Verify all elements are properly aligned (left and right edges match)