### PR TITLE
Fix React key prop warning in Autocomplete components

### DIFF
--- a/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
@@ -747,11 +747,13 @@ const ProjectForm = ({
                         : "No options"
                     }
                     renderOption={(props, option) => {
+                      const { key, ...optionProps } = props;
                       const isComingSoon = option.name.includes("coming soon");
                       return (
                         <Box
+                          key={key}
                           component="li"
-                          {...props}
+                          {...optionProps}
                           sx={{
                             opacity: isComingSoon ? 0.5 : 1,
                             cursor: isComingSoon ? "not-allowed" : "pointer",
@@ -860,11 +862,13 @@ const ProjectForm = ({
                     : "No options"
                 }
                 renderOption={(props, option) => {
+                  const { key, ...optionProps } = props;
                   const isComingSoon = option.name.includes("coming soon");
                   return (
                     <Box
+                      key={key}
                       component="li"
-                      {...props}
+                      {...optionProps}
                       sx={{
                         opacity: isComingSoon ? 0.5 : 1,
                         cursor: isComingSoon ? "not-allowed" : "pointer",


### PR DESCRIPTION
## Summary
- Fix React warning about spreading key prop in Autocomplete renderOption callbacks
- Extract key from props before spreading and pass it directly to Box component
- Applies to both Applicable regulations Autocomplete components in ProjectForm

## Test plan
- [ ] Open Framework page and click "New project"
- [ ] Click on "Applicable regulations" dropdown
- [ ] Verify no React key warning appears in console
- [ ] Select regulations and verify dropdown behavior works correctly