### PR TITLE
Fix ISO 27001/42001 subclause ID queries and add NIST migration

### DIFF
--- a/Servers/database/migrations/20251216150000-add-implementation-description-nist.js
+++ b/Servers/database/migrations/20251216150000-add-implementation-description-nist.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      console.log('🔧 Adding implementation_description column to NIST AI RMF subcategories for all tenants...');
+
+      const organizations = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      for (const org of organizations[0]) {
+        const tenantHash = getTenantHash(org.id);
+
+        // Check if table exists
+        const [tableExists] = await queryInterface.sequelize.query(
+          `SELECT 1 FROM information_schema.tables
+           WHERE table_schema = '${tenantHash}' AND table_name = 'nist_ai_rmf_subcategories'`,
+          { transaction, type: queryInterface.sequelize.QueryTypes.SELECT }
+        );
+
+        if (!tableExists) {
+          console.log(`Table nist_ai_rmf_subcategories does not exist for tenant ${tenantHash}, skipping`);
+          continue;
+        }
+
+        // Add column if it doesn't exist
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${tenantHash}".nist_ai_rmf_subcategories
+           ADD COLUMN IF NOT EXISTS implementation_description TEXT;`,
+          { transaction }
+        );
+        console.log(`✅ Ensured implementation_description column exists for ${tenantHash}`);
+      }
+
+      await transaction.commit();
+      console.log('✅ Migration completed successfully');
+    } catch (error) {
+      await transaction.rollback();
+      console.error('❌ Migration failed:', error);
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    // No-op - don't remove the column in down migration
+    console.log('ℹ️ Down migration - no operation');
+  }
+};

--- a/Servers/utils/iso27001.utils.ts
+++ b/Servers/utils/iso27001.utils.ts
@@ -180,7 +180,7 @@ export const getAllClausesWithSubClauseQuery = async (
 
   for (let clause of clauses[0]) {
     const subClauses = (await sequelize.query(
-      `SELECT scs.id, scs.title, scs.order_no, sc.status, sc.owner FROM public.subclauses_struct_iso27001 scs JOIN "${tenant}".subclauses_iso27001 sc ON scs.id = sc.subclause_meta_id WHERE scs.clause_id = :id AND sc.projects_frameworks_id = :projects_frameworks_id ORDER BY id;`,
+      `SELECT sc.id, scs.title, scs.order_no, sc.status, sc.owner FROM public.subclauses_struct_iso27001 scs JOIN "${tenant}".subclauses_iso27001 sc ON scs.id = sc.subclause_meta_id WHERE scs.clause_id = :id AND sc.projects_frameworks_id = :projects_frameworks_id ORDER BY scs.id;`,
       {
         replacements: {
           id: clause.id,
@@ -266,8 +266,9 @@ export const getSubClausesByClauseIdQuery = async (
   transaction: Transaction | null = null
 ) => {
   const subClauses = await sequelize.query(
-    `SELECT scs.*, sc.owner AS owner, sc.reviewer AS reviewer, sc.due_date 
-    FROM "${tenant}".subclauses_iso27001 sc JOIN public.subclauses_struct_iso27001 scs ON 
+    `SELECT sc.id, scs.title, scs.order_no, scs.clause_id, scs.requirement_summary, scs.key_questions, scs.evidence_examples,
+            sc.owner AS owner, sc.reviewer AS reviewer, sc.due_date, sc.status
+    FROM "${tenant}".subclauses_iso27001 sc JOIN public.subclauses_struct_iso27001 scs ON
     sc.subclause_meta_id = scs.id WHERE scs.clause_id = :id ORDER BY scs.id;`,
     {
       replacements: { id: clauseId },
@@ -320,6 +321,9 @@ export const getSubClauseByIdQuery = async (
     number,
   ];
   const subClause = subClauses[0][0];
+  if (!subClause) {
+    return null;
+  }
   (subClause as any).risks = [];
   const risks = (await sequelize.query(
     `SELECT projects_risks_id FROM "${tenant}".subclauses_iso27001__risks WHERE subclause_id = :id`,
@@ -372,9 +376,11 @@ export const getMainClausesQuery = async (
       tenant,
       transaction
     );
-    (clausesStruct as any)[
-      clausesStructMap.get(subClause.clause_id!)
-    ].dataValues.subClauses.push(subClause);
+    if (subClause) {
+      (clausesStruct as any)[
+        clausesStructMap.get(subClause.clause_id!)
+      ].dataValues.subClauses.push(subClause);
+    }
   }
   return clausesStruct;
 };
@@ -524,6 +530,9 @@ export const getAnnexControlsByIdQuery = async (
     number,
   ];
   const annexControl = annexControls[0][0];
+  if (!annexControl) {
+    return null;
+  }
   (annexControl as any).risks = [];
   const risks = (await sequelize.query(
     `SELECT projects_risks_id FROM "${tenant}".annexcontrols_iso27001__risks WHERE annexcontrol_id = :id`,
@@ -576,9 +585,11 @@ export const getAnnexControlsQuery = async (
       tenant,
       transaction
     );
-    (annexesStruct as any)[
-      annexStructMap.get(annex.annex_id!)
-    ].dataValues.subClauses.push(annex);
+    if (annex) {
+      (annexesStruct as any)[
+        annexStructMap.get(annex.annex_id!)
+      ].dataValues.subClauses.push(annex);
+    }
   }
   return annexesStruct;
 };

--- a/Servers/utils/iso42001.utils.ts
+++ b/Servers/utils/iso42001.utils.ts
@@ -184,7 +184,7 @@ export const getAllClausesWithSubClauseQuery = async (
 
   for (let clause of clauses[0]) {
     const subClauses = (await sequelize.query(
-      `SELECT scs.id, scs.title, scs.order_no, sc.status, sc.owner FROM public.subclauses_struct_iso scs JOIN "${tenant}".subclauses_iso sc ON scs.id = sc.subclause_meta_id WHERE scs.clause_id = :id AND sc.projects_frameworks_id = :projects_frameworks_id ORDER BY id;`,
+      `SELECT sc.id, scs.title, scs.order_no, sc.status, sc.owner FROM public.subclauses_struct_iso scs JOIN "${tenant}".subclauses_iso sc ON scs.id = sc.subclause_meta_id WHERE scs.clause_id = :id AND sc.projects_frameworks_id = :projects_frameworks_id ORDER BY scs.id;`,
       {
         replacements: {
           id: clause.id,
@@ -265,8 +265,9 @@ export const getSubClausesByClauseIdQuery = async (
   transaction: Transaction | null = null
 ) => {
   const subClauses = await sequelize.query(
-    `SELECT scs.*, sc.owner AS owner, sc.reviewer AS reviewer, sc.due_date
-    FROM "${tenant}".subclauses_iso sc JOIN public.subclauses_struct_iso scs ON 
+    `SELECT sc.id, scs.title, scs.order_no, scs.clause_id, scs.summary, scs.questions, scs.evidence_examples,
+            sc.owner AS owner, sc.reviewer AS reviewer, sc.due_date, sc.status
+    FROM "${tenant}".subclauses_iso sc JOIN public.subclauses_struct_iso scs ON
     sc.subclause_meta_id = scs.id WHERE scs.clause_id = :id ORDER BY scs.id;`,
     {
       replacements: { id: clauseId },
@@ -316,6 +317,9 @@ export const getSubClauseByIdQuery = async (
     }
   )) as [Partial<SubClauseStructISOModel & SubClauseISOModel>[], number];
   const subClause = subClauses[0][0];
+  if (!subClause) {
+    return null;
+  }
   (subClause as any).risks = [];
   const risks = (await sequelize.query(
     `SELECT projects_risks_id FROM "${tenant}".subclauses_iso__risks WHERE subclause_id = :id`,
@@ -368,9 +372,11 @@ export const getManagementSystemClausesQuery = async (
       tenant,
       transaction
     );
-    (clausesStruct as any)[
-      clausesStructMap.get(subClause.clause_id!)
-    ].dataValues.subClauses.push(subClause);
+    if (subClause) {
+      (clausesStruct as any)[
+        clausesStructMap.get(subClause.clause_id!)
+      ].dataValues.subClauses.push(subClause);
+    }
   }
   return clausesStruct;
 };


### PR DESCRIPTION
## Summary
- Fix ISO 27001 & 42001 subclause queries to return correct tenant table ID instead of meta_id
- Fix ISO 42001 column name references (`summary`/`questions` vs `requirement_summary`/`key_questions`)
- Add null safety checks to prevent crashes when subclauses are not found
- Add migration to ensure `implementation_description` column exists for NIST AI RMF subcategories

## Details

### Subclause ID Fix
The queries `getAllClausesWithSubClauseQuery` and `getSubClausesByClauseIdQuery` were returning `scs.id` (meta_id from public struct table) instead of `sc.id` (tenant table primary key). This caused 500 errors when opening subclause sidebars because the frontend was sending the meta_id to endpoints expecting the tenant table ID.

### NIST Migration
Existing tenants may be missing the `implementation_description` column in `nist_ai_rmf_subcategories` table. This migration ensures the column exists for all tenants.

## Test plan
- [ ] Open ISO 27001 framework, expand a clause, click on a subclause - sidebar should load
- [ ] Open ISO 42001 framework, expand a clause, click on a subclause - sidebar should load  
- [ ] Edit and save a subclause in both frameworks
- [ ] Open NIST AI RMF, click on a subcategory, edit implementation description - should save