### PR TITLE
Fix task modal form layout alignment

### DIFF
--- a/Clients/src/presentation/components/Modals/CreateTask/index.tsx
+++ b/Clients/src/presentation/components/Modals/CreateTask/index.tsx
@@ -310,7 +310,7 @@ const CreateTask: FC<ICreateTaskProps> = ({
     >
       <Stack spacing={6}>
         {/* Row 1: Task title | Assignees */}
-        <Stack direction="row" spacing={6}>
+        <Stack direction="row" spacing={6} sx={{ width: "748px" }}>
           <Suspense fallback={<div>Loading...</div>}>
             <Field
               id="title"
@@ -454,7 +454,7 @@ const CreateTask: FC<ICreateTaskProps> = ({
         </Stack>
 
         {/* Row 2: Status | Categories */}
-        <Stack direction="row" spacing={6}>
+        <Stack direction="row" spacing={6} sx={{ width: "748px" }}>
           <SelectComponent
             items={statusOptions}
             value={values.status}
@@ -488,7 +488,7 @@ const CreateTask: FC<ICreateTaskProps> = ({
         </Stack>
 
         {/* Row 3: Priority | Due date */}
-        <Stack direction="row" spacing={6}>
+        <Stack direction="row" spacing={6} sx={{ width: "748px" }}>
           <SelectComponent
             items={priorityOptions}
             value={values.priority}
@@ -521,19 +521,22 @@ const CreateTask: FC<ICreateTaskProps> = ({
         </Stack>
 
         {/* Row 4: Description (full width = 350px + 350px + 48px gap) */}
-        <Suspense fallback={<div>Loading...</div>}>
-          <Field
-            id="description"
-            label="Description"
-            width="748px"
-            type="description"
-            value={values.description}
-            onChange={handleOnTextFieldChange("description")}
-            error={errors.description}
-            sx={fieldStyle}
-            placeholder="Enter description"
-          />
-        </Suspense>
+        <Stack direction="row" spacing={6}>
+          <Suspense fallback={<div>Loading...</div>}>
+            <Field
+              id="description"
+              label="Description"
+              width="350px"
+              type="description"
+              value={values.description}
+              onChange={handleOnTextFieldChange("description")}
+              error={errors.description}
+              sx={fieldStyle}
+              placeholder="Enter description"
+            />
+          </Suspense>
+          <Box sx={{ width: "350px" }} />
+        </Stack>
       </Stack>
     </StandardModal>
   );


### PR DESCRIPTION
## Summary
- Set consistent 748px width on all form rows in Create/Edit task modal
- Ensure description field aligns with other form rows
- Maintain uniform layout structure across all form sections

## Test plan
- [ ] Open Task manager and click "Add new task"
- [ ] Verify all form rows (Title/Assignees, Status/Categories, Priority/Due date, Description) align properly
- [ ] Edit an existing task and verify the same alignment
- [ ] Check on different screen sizes