### PR TITLE
Add app switcher sidebar for multi-module navigation

### DIFF
--- a/Clients/src/application/contexts/EvalsSidebar.context.tsx
+++ b/Clients/src/application/contexts/EvalsSidebar.context.tsx
@@ -1,0 +1,110 @@
+import { createContext, useContext, useState, ReactNode, FC } from "react";
+
+interface RecentExperiment {
+  id: string;
+  name: string;
+  projectId: string;
+}
+
+interface RecentProject {
+  id: string;
+  name: string;
+}
+
+export interface EvalProject {
+  id: string;
+  name: string;
+  description?: string;
+  useCase?: string;
+}
+
+interface EvalsSidebarContextType {
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+  experimentsCount: number;
+  setExperimentsCount: (count: number) => void;
+  datasetsCount: number;
+  setDatasetsCount: (count: number) => void;
+  scorersCount: number;
+  setScorersCount: (count: number) => void;
+  disabled: boolean;
+  setDisabled: (disabled: boolean) => void;
+  recentExperiments: RecentExperiment[];
+  setRecentExperiments: (experiments: RecentExperiment[]) => void;
+  recentProjects: RecentProject[];
+  setRecentProjects: (projects: RecentProject[]) => void;
+  onExperimentClick: ((experimentId: string, projectId: string) => void) | undefined;
+  setOnExperimentClick: (handler: ((experimentId: string, projectId: string) => void) | undefined) => void;
+  onProjectClick: ((projectId: string) => void) | undefined;
+  setOnProjectClick: (handler: ((projectId: string) => void) | undefined) => void;
+  // Project selector
+  currentProject: EvalProject | null;
+  setCurrentProject: (project: EvalProject | null) => void;
+  allProjects: EvalProject[];
+  setAllProjects: (projects: EvalProject[]) => void;
+  onProjectChange: ((projectId: string) => void) | undefined;
+  setOnProjectChange: (handler: ((projectId: string) => void) | undefined) => void;
+}
+
+const EvalsSidebarContext = createContext<EvalsSidebarContextType | null>(null);
+
+export const EvalsSidebarProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const [activeTab, setActiveTab] = useState("overview");
+  const [experimentsCount, setExperimentsCount] = useState(0);
+  const [datasetsCount, setDatasetsCount] = useState(0);
+  const [scorersCount, setScorersCount] = useState(0);
+  const [disabled, setDisabled] = useState(false);
+  const [recentExperiments, setRecentExperiments] = useState<RecentExperiment[]>([]);
+  const [recentProjects, setRecentProjects] = useState<RecentProject[]>([]);
+  const [onExperimentClick, setOnExperimentClick] = useState<((experimentId: string, projectId: string) => void) | undefined>();
+  const [onProjectClick, setOnProjectClick] = useState<((projectId: string) => void) | undefined>();
+  const [currentProject, setCurrentProject] = useState<EvalProject | null>(null);
+  const [allProjects, setAllProjects] = useState<EvalProject[]>([]);
+  const [onProjectChange, setOnProjectChange] = useState<((projectId: string) => void) | undefined>();
+
+  return (
+    <EvalsSidebarContext.Provider
+      value={{
+        activeTab,
+        setActiveTab,
+        experimentsCount,
+        setExperimentsCount,
+        datasetsCount,
+        setDatasetsCount,
+        scorersCount,
+        setScorersCount,
+        disabled,
+        setDisabled,
+        recentExperiments,
+        setRecentExperiments,
+        recentProjects,
+        setRecentProjects,
+        onExperimentClick,
+        setOnExperimentClick,
+        onProjectClick,
+        setOnProjectClick,
+        currentProject,
+        setCurrentProject,
+        allProjects,
+        setAllProjects,
+        onProjectChange,
+        setOnProjectChange,
+      }}
+    >
+      {children}
+    </EvalsSidebarContext.Provider>
+  );
+};
+
+export const useEvalsSidebarContext = () => {
+  const context = useContext(EvalsSidebarContext);
+  if (!context) {
+    throw new Error("useEvalsSidebarContext must be used within EvalsSidebarProvider");
+  }
+  return context;
+};
+
+// Safe version that returns null if not in provider
+export const useEvalsSidebarContextSafe = () => {
+  return useContext(EvalsSidebarContext);
+};

--- a/Clients/src/application/hooks/useActiveModule.ts
+++ b/Clients/src/application/hooks/useActiveModule.ts
@@ -1,0 +1,85 @@
+import { useEffect, useCallback } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { AppModule, setActiveModule } from "../redux/ui/uiSlice";
+import { RootState } from "../redux/store";
+
+const STORAGE_KEY = "verifywise_active_module";
+
+/**
+ * Hook for managing active module state
+ * - Auto-detects module from URL path
+ * - Persists to localStorage
+ * - Syncs with Redux state
+ */
+export function useActiveModule() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const activeModule = useSelector(
+    (state: RootState) => state.ui.appModule?.active ?? "main"
+  );
+
+  // Detect module from URL path
+  const getModuleFromPath = useCallback((pathname: string): AppModule => {
+    if (pathname.startsWith("/evals")) {
+      return "evals";
+    }
+    if (pathname.startsWith("/gateway")) {
+      return "gateway";
+    }
+    return "main";
+  }, []);
+
+  // Sync module state with URL on navigation
+  useEffect(() => {
+    const detectedModule = getModuleFromPath(location.pathname);
+    if (detectedModule !== activeModule) {
+      dispatch(setActiveModule(detectedModule));
+      localStorage.setItem(STORAGE_KEY, detectedModule);
+    }
+  }, [location.pathname, activeModule, dispatch, getModuleFromPath]);
+
+  // Handle module change from AppSwitcher click
+  const handleModuleChange = useCallback(
+    (module: AppModule) => {
+      if (module === activeModule) return;
+
+      dispatch(setActiveModule(module));
+      localStorage.setItem(STORAGE_KEY, module);
+
+      // Navigate to default route for the module
+      switch (module) {
+        case "evals":
+          navigate("/evals");
+          break;
+        case "gateway":
+          navigate("/gateway");
+          break;
+        case "main":
+        default:
+          navigate("/");
+          break;
+      }
+    },
+    [activeModule, dispatch, navigate]
+  );
+
+  // Initialize from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as AppModule | null;
+    if (stored && ["main", "evals", "gateway"].includes(stored)) {
+      // Only set if URL doesn't already indicate a different module
+      const urlModule = getModuleFromPath(location.pathname);
+      if (urlModule === "main" && stored !== "main") {
+        // URL is at root but stored module is different - respect URL
+        dispatch(setActiveModule(urlModule));
+      }
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    activeModule,
+    setActiveModule: handleModuleChange,
+  };
+}

--- a/Clients/src/application/redux/ui/uiSlice.ts
+++ b/Clients/src/application/redux/ui/uiSlice.ts
@@ -1,8 +1,13 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export type AppModule = "main" | "evals" | "gateway";
 
 const initialState = {
   sidebar: {
     collapsed: false,
+  },
+  appModule: {
+    active: "main" as AppModule,
   },
   modelInventory: {
     statusFilter: "all",
@@ -25,6 +30,13 @@ const uiSlice = createSlice({
     setModelInventoryStatusFilter: (state, action) => {
       state.modelInventory.statusFilter = action.payload;
     },
+    setActiveModule: (state, action: PayloadAction<AppModule>) => {
+      if (!state.appModule) {
+        state.appModule = { active: action.payload };
+      } else {
+        state.appModule.active = action.payload;
+      }
+    },
   },
 });
 
@@ -33,4 +45,5 @@ export const {
   setRowsPerPage,
   toggleSidebar,
   setModelInventoryStatusFilter,
+  setActiveModule,
 } = uiSlice.actions;

--- a/Clients/src/presentation/components/AppSwitcher/index.css
+++ b/Clients/src/presentation/components/AppSwitcher/index.css
@@ -1,0 +1,69 @@
+.app-switcher {
+  width: 40px;
+  min-width: 40px;
+  max-width: 40px;
+  flex-shrink: 0;
+  height: 100vh;
+  background-color: #1a1a2e;
+  border-right: 1px solid #2d2d44;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 12px 0;
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+}
+
+.app-switcher-modules {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.app-switcher-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  border: none;
+  background-color: transparent;
+  padding: 0;
+}
+
+.app-switcher-icon svg {
+  color: rgba(255, 255, 255, 0.6);
+  transition: color 0.2s ease;
+}
+
+.app-switcher-icon:hover:not(.disabled) {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.app-switcher-icon:hover:not(.disabled) svg {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.app-switcher-icon.active {
+  background-color: #13715B;
+}
+
+.app-switcher-icon.active svg {
+  color: #ffffff;
+}
+
+.app-switcher-icon.disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.app-switcher-icon.disabled svg {
+  color: rgba(255, 255, 255, 0.3);
+}

--- a/Clients/src/presentation/components/AppSwitcher/index.tsx
+++ b/Clients/src/presentation/components/AppSwitcher/index.tsx
@@ -1,0 +1,92 @@
+import { FC } from "react";
+import { Stack, Tooltip, Box, Typography } from "@mui/material";
+import { Shield, FlaskConical, Network } from "lucide-react";
+import { AppModule } from "../../../application/redux/ui/uiSlice";
+import "./index.css";
+
+interface AppSwitcherProps {
+  activeModule: AppModule;
+  onModuleChange: (module: AppModule) => void;
+}
+
+interface ModuleItem {
+  id: AppModule;
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+  disabled?: boolean;
+}
+
+const modules: ModuleItem[] = [
+  {
+    id: "main",
+    icon: <Shield size={16} strokeWidth={1.5} />,
+    label: "Governance",
+    description: "Centralized AI governance, risk, and compliance platform",
+  },
+  {
+    id: "evals",
+    icon: <FlaskConical size={16} strokeWidth={1.5} />,
+    label: "LLM Evals",
+    description: "Evaluate LLM quality, performance and reliability over time",
+  },
+  {
+    id: "gateway",
+    icon: <Network size={16} strokeWidth={1.5} />,
+    label: "Gateway",
+    description: "Control, monitor, and govern all LLM traffic across your organization.",
+    disabled: true,
+  },
+];
+
+const AppSwitcher: FC<AppSwitcherProps> = ({ activeModule, onModuleChange }) => {
+  return (
+    <Stack className="app-switcher">
+      <Stack className="app-switcher-modules">
+        {modules.map((module) => (
+          <Tooltip
+            key={module.id}
+            title={
+              <Box sx={{ p: 0.5 }}>
+                <Typography sx={{ fontSize: "12px", fontWeight: 600, mb: 0.5 }}>
+                  {module.label}
+                  {module.disabled && " (Coming soon)"}
+                </Typography>
+                <Typography sx={{ fontSize: "11px", opacity: 0.9 }}>
+                  {module.description}
+                </Typography>
+              </Box>
+            }
+            placement="right"
+            arrow
+            enterDelay={1000}
+            enterNextDelay={1000}
+            disableInteractive
+            slotProps={{
+              tooltip: {
+                sx: {
+                  backgroundColor: "#1a1a2e",
+                  maxWidth: 220,
+                  "& .MuiTooltip-arrow": {
+                    color: "#1a1a2e",
+                  },
+                },
+              },
+            }}
+          >
+            <button
+              className={`app-switcher-icon ${activeModule === module.id ? "active" : ""} ${module.disabled ? "disabled" : ""}`}
+              onClick={() => !module.disabled && onModuleChange(module.id)}
+              disabled={module.disabled}
+              aria-label={module.label}
+            >
+              {module.icon}
+            </button>
+          </Tooltip>
+        ))}
+      </Stack>
+    </Stack>
+  );
+};
+
+export default AppSwitcher;

--- a/Clients/src/presentation/components/ContextSidebar/GatewaySidebar.tsx
+++ b/Clients/src/presentation/components/ContextSidebar/GatewaySidebar.tsx
@@ -1,0 +1,62 @@
+import { FC } from "react";
+import { Stack, Typography, Box } from "@mui/material";
+import { Network } from "lucide-react";
+
+const GatewaySidebar: FC = () => {
+  return (
+    <Stack
+      sx={{
+        width: "260px",
+        minWidth: "260px",
+        maxWidth: "260px",
+        flexShrink: 0,
+        height: "100vh",
+        borderRight: "1px solid #d0d5dd",
+        backgroundColor: "#fff",
+        padding: "16px",
+        position: "sticky",
+        top: 0,
+      }}
+    >
+      <Typography
+        variant="subtitle2"
+        sx={{
+          fontWeight: 600,
+          color: "#344054",
+          marginBottom: "16px",
+          fontSize: "13px",
+          textTransform: "uppercase",
+          letterSpacing: "0.5px",
+        }}
+      >
+        LLM Gateway
+      </Typography>
+
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          flex: 1,
+          gap: "12px",
+          color: "#667085",
+        }}
+      >
+        <Network size={32} strokeWidth={1} />
+        <Typography
+          variant="body2"
+          sx={{
+            color: "#667085",
+            textAlign: "center",
+            fontSize: "13px",
+          }}
+        >
+          Coming soon
+        </Typography>
+      </Box>
+    </Stack>
+  );
+};
+
+export default GatewaySidebar;

--- a/Clients/src/presentation/components/ContextSidebar/index.tsx
+++ b/Clients/src/presentation/components/ContextSidebar/index.tsx
@@ -1,0 +1,82 @@
+import { FC } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { AppModule } from "../../../application/redux/ui/uiSlice";
+import { useEvalsSidebarContextSafe } from "../../../application/contexts/EvalsSidebar.context";
+import Sidebar from "../Sidebar";
+import EvalsSidebar from "../../pages/EvalsDashboard/EvalsSidebar";
+import GatewaySidebar from "./GatewaySidebar";
+
+interface ContextSidebarProps {
+  activeModule: AppModule;
+  // Props for main Sidebar
+  onOpenCreateDemoData?: () => void;
+  onOpenDeleteDemoData?: () => void;
+  hasDemoData?: boolean;
+}
+
+/**
+ * ContextSidebar renders the appropriate sidebar based on the active module.
+ * - 'main': Renders the main VerifyWise sidebar
+ * - 'evals': Renders EvalsSidebar (state provided via EvalsSidebarContext)
+ * - 'gateway': Renders the Gateway sidebar placeholder
+ */
+const ContextSidebar: FC<ContextSidebarProps> = ({
+  activeModule,
+  onOpenCreateDemoData,
+  onOpenDeleteDemoData,
+  hasDemoData,
+}) => {
+  const evalsSidebarContext = useEvalsSidebarContextSafe();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Get active tab from URL hash for evals
+  const activeTab = location.hash.replace("#", "") || "overview";
+
+  // Handle tab change by navigating to the new hash
+  const handleTabChange = (newTab: string) => {
+    navigate(`${location.pathname}#${newTab}`, { replace: true });
+  };
+
+  switch (activeModule) {
+    case "main":
+      return (
+        <Sidebar
+          onOpenCreateDemoData={onOpenCreateDemoData}
+          onOpenDeleteDemoData={onOpenDeleteDemoData}
+          hasDemoData={hasDemoData}
+        />
+      );
+    case "evals":
+      // Render EvalsSidebar - use URL hash for active tab, context for counts
+      return (
+        <EvalsSidebar
+          activeTab={activeTab}
+          onTabChange={handleTabChange}
+          experimentsCount={evalsSidebarContext?.experimentsCount ?? 0}
+          datasetsCount={evalsSidebarContext?.datasetsCount ?? 0}
+          scorersCount={evalsSidebarContext?.scorersCount ?? 0}
+          disabled={evalsSidebarContext?.disabled ?? true}
+          recentExperiments={evalsSidebarContext?.recentExperiments ?? []}
+          recentProjects={evalsSidebarContext?.recentProjects ?? []}
+          onExperimentClick={evalsSidebarContext?.onExperimentClick}
+          onProjectClick={evalsSidebarContext?.onProjectClick}
+          currentProject={evalsSidebarContext?.currentProject}
+          allProjects={evalsSidebarContext?.allProjects ?? []}
+          onProjectChange={evalsSidebarContext?.onProjectChange}
+        />
+      );
+    case "gateway":
+      return <GatewaySidebar />;
+    default:
+      return (
+        <Sidebar
+          onOpenCreateDemoData={onOpenCreateDemoData}
+          onOpenDeleteDemoData={onOpenDeleteDemoData}
+          hasDemoData={hasDemoData}
+        />
+      );
+  }
+};
+
+export default ContextSidebar;

--- a/Clients/src/presentation/components/Sidebar/SidebarFooter.tsx
+++ b/Clients/src/presentation/components/Sidebar/SidebarFooter.tsx
@@ -1,0 +1,874 @@
+import { FC, useState, useRef, useEffect, useContext } from "react";
+import {
+  Box,
+  Divider,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Stack,
+  Tooltip,
+  Typography,
+  Menu,
+  MenuItem,
+  Drawer,
+} from "@mui/material";
+import { useTheme } from "@mui/material";
+import { useNavigate, useLocation } from "react-router";
+import {
+  ChevronDown,
+  MoreVertical,
+  Settings,
+  Database,
+  HelpCircle,
+  Newspaper,
+  Users,
+  Headphones,
+  Trash2,
+  FolderCog,
+  LogOut,
+  MessageCircle,
+  Telescope,
+} from "lucide-react";
+import Avatar from "../Avatar/VWAvatar";
+import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
+import { ROLES } from "../../../application/constants/roles";
+import useLogout from "../../../application/hooks/useLogout";
+import { User } from "../../../domain/types/User";
+import { useProfilePhotoFetch } from "../../../application/hooks/useProfilePhotoFetch";
+import ReadyToSubscribeBox from "../ReadyToSubscribeBox/ReadyToSubscribeBox";
+
+interface IManagementItem {
+  name: string;
+  icon: React.ReactNode;
+  path?: string;
+  action?: () => void;
+}
+
+interface SidebarFooterProps {
+  collapsed: boolean;
+  delayedCollapsed: boolean;
+  hasDemoData?: boolean;
+  onOpenCreateDemoData?: () => void;
+  onOpenDeleteDemoData?: () => void;
+  showReadyToSubscribe?: boolean;
+  openUserGuide?: () => void;
+}
+
+const getManagementItems = (
+  hasDemoData?: boolean,
+  onOpenCreateDemoData?: () => void,
+  onOpenDeleteDemoData?: () => void
+): IManagementItem[] => [
+  {
+    name: "Event Tracker",
+    icon: <Telescope size={16} strokeWidth={1.5} />,
+    path: "/event-tracker",
+  },
+  {
+    name: "Settings",
+    icon: <Settings size={16} strokeWidth={1.5} />,
+    path: "/settings",
+  },
+  ...(hasDemoData
+    ? [
+        {
+          name: "Delete demo data",
+          icon: <Database size={16} strokeWidth={1.5} />,
+          action: onOpenDeleteDemoData,
+        },
+      ]
+    : [
+        {
+          name: "Create demo data",
+          icon: <Database size={16} strokeWidth={1.5} />,
+          action: onOpenCreateDemoData,
+        },
+      ]),
+];
+
+interface User_Avatar {
+  firstname: string;
+  lastname: string;
+  email: string;
+  pathToImage: string;
+}
+
+const DEFAULT_USER: User = {
+  id: 1,
+  name: "",
+  surname: "",
+  email: "",
+  roleId: 1,
+};
+
+const SidebarFooter: FC<SidebarFooterProps> = ({
+  collapsed,
+  delayedCollapsed,
+  hasDemoData,
+  onOpenCreateDemoData,
+  onOpenDeleteDemoData,
+  showReadyToSubscribe = false,
+  openUserGuide,
+}) => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const logout = useLogout();
+  const { userId, users, photoRefreshFlag } = useContext(VerifyWiseContext);
+
+  const [managementAnchorEl, setManagementAnchorEl] = useState<null | HTMLElement>(null);
+  const [slideoverOpen, setSlideoverOpen] = useState(false);
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  const user: User = users
+    ? users.find((u: User) => u.id === userId) || DEFAULT_USER
+    : DEFAULT_USER;
+
+  const [avatarUrl, setAvatarUrl] = useState<string>("");
+  const { fetchProfilePhotoAsBlobUrl } = useProfilePhotoFetch();
+
+  useEffect(() => {
+    let cancel = false;
+    let previousUrl: string | null = null;
+    (async () => {
+      const url = await fetchProfilePhotoAsBlobUrl(userId || 0);
+      if (cancel) {
+        if (url) URL.revokeObjectURL(url);
+        return;
+      }
+      if (previousUrl && previousUrl !== url) {
+        URL.revokeObjectURL(previousUrl);
+      }
+
+      previousUrl = url ?? null;
+      setAvatarUrl(url ?? "");
+    })();
+
+    return () => {
+      cancel = true;
+      if (previousUrl) URL.revokeObjectURL(previousUrl);
+    };
+  }, [userId, fetchProfilePhotoAsBlobUrl, photoRefreshFlag]);
+
+  const userAvator: User_Avatar = {
+    firstname: user.name,
+    lastname: user.surname,
+    email: user.email,
+    pathToImage: avatarUrl,
+  };
+
+  const openPopup = () => setSlideoverOpen(true);
+  const closePopup = () => setSlideoverOpen(false);
+
+  // Click outside handler for drawer
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (drawerRef.current && !drawerRef.current.contains(event.target as Node)) {
+        closePopup();
+      }
+    };
+
+    if (slideoverOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [slideoverOpen]);
+
+  const isManagementActive = getManagementItems(hasDemoData, onOpenCreateDemoData, onOpenDeleteDemoData).some(
+    (item) => item.path && (location.pathname.startsWith(`${item.path}/`) || location.pathname === item.path)
+  );
+
+  return (
+    <>
+      <Divider sx={{ mt: "auto", mb: theme.spacing(4) }} />
+      {/* Management Section */}
+      <List
+        component="nav"
+        aria-labelledby="nested-management-subheader"
+        disablePadding
+        sx={{
+          px: theme.spacing(8),
+          flexShrink: 0,
+        }}
+      >
+        <Tooltip
+          sx={{ fontSize: 13 }}
+          placement="right"
+          title={delayedCollapsed ? "Management" : ""}
+          slotProps={{
+            popper: {
+              modifiers: [{ name: "offset", options: { offset: [0, -16] } }],
+            },
+          }}
+          disableInteractive
+        >
+          <ListItemButton
+            disableRipple={theme.components?.MuiListItemButton?.defaultProps?.disableRipple}
+            onClick={(e) => setManagementAnchorEl(e.currentTarget)}
+            sx={{
+              height: "32px",
+              gap: theme.spacing(4),
+              borderRadius: theme.shape.borderRadius,
+              px: theme.spacing(4),
+              background: isManagementActive
+                ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
+                : "transparent",
+              border: isManagementActive
+                ? "1px solid #D8D8D8"
+                : "1px solid transparent",
+              "&:hover": {
+                background: isManagementActive
+                  ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
+                  : "#F9F9F9",
+                border: isManagementActive
+                  ? "1px solid #D8D8D8"
+                  : "1px solid transparent",
+              },
+              "&:hover svg": {
+                color: "#13715B !important",
+                stroke: "#13715B !important",
+              },
+              "&:hover svg path": {
+                stroke: "#13715B !important",
+              },
+            }}
+          >
+            <ListItemIcon
+              sx={{
+                minWidth: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "flex-start",
+                width: "16px",
+                mr: 0,
+                "& svg": {
+                  color: isManagementActive
+                    ? "#13715B !important"
+                    : `${theme.palette.text.tertiary} !important`,
+                  stroke: isManagementActive
+                    ? "#13715B !important"
+                    : `${theme.palette.text.tertiary} !important`,
+                  transition: "color 0.2s ease, stroke 0.2s ease",
+                },
+                "& svg path": {
+                  stroke: isManagementActive
+                    ? "#13715B !important"
+                    : `${theme.palette.text.tertiary} !important`,
+                },
+              }}
+            >
+              <FolderCog size={16} strokeWidth={1.5} />
+            </ListItemIcon>
+            {!delayedCollapsed && (
+              <>
+                <ListItemText
+                  sx={{
+                    "& .MuiListItemText-primary": {
+                      fontSize: "13px",
+                    },
+                  }}
+                >
+                  Management
+                </ListItemText>
+                <ChevronDown
+                  size={16}
+                  strokeWidth={1.5}
+                  style={{
+                    transform: managementAnchorEl ? "rotate(180deg)" : "rotate(0deg)",
+                    transition: "transform 0.2s ease",
+                  }}
+                />
+              </>
+            )}
+          </ListItemButton>
+        </Tooltip>
+
+        {/* Management Dropdown Menu */}
+        <Menu
+          anchorEl={managementAnchorEl}
+          open={Boolean(managementAnchorEl)}
+          onClose={() => setManagementAnchorEl(null)}
+          anchorOrigin={{
+            vertical: "top",
+            horizontal: collapsed ? "right" : "left",
+          }}
+          transformOrigin={{
+            vertical: "bottom",
+            horizontal: collapsed ? "left" : "left",
+          }}
+          slotProps={{
+            paper: {
+              sx: {
+                width: managementAnchorEl ? managementAnchorEl.offsetWidth : "auto",
+                minWidth: collapsed ? "180px" : "auto",
+                borderRadius: theme.shape.borderRadius,
+                boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                border: `1px solid ${theme.palette.divider}`,
+                mt: -1,
+              },
+            },
+          }}
+        >
+          {getManagementItems(hasDemoData, onOpenCreateDemoData, onOpenDeleteDemoData).map((item) => (
+            <MenuItem
+              key={item.path || item.name}
+              onClick={() => {
+                if (item.action) {
+                  item.action();
+                } else if (item.path) {
+                  navigate(item.path);
+                }
+                setManagementAnchorEl(null);
+              }}
+              sx={{
+                display: "flex",
+                gap: theme.spacing(4),
+                px: theme.spacing(4),
+                py: 0,
+                height: "32px",
+                fontSize: "13px",
+                borderRadius: theme.shape.borderRadius,
+                "&:hover": {
+                  backgroundColor: "#F9F9F9",
+                },
+                "&:hover svg": {
+                  color: "#13715B !important",
+                  stroke: "#13715B !important",
+                },
+                "&:hover svg path": {
+                  stroke: "#13715B !important",
+                },
+              }}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "12px",
+                  width: "100%",
+                }}
+              >
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: "16px",
+                    height: "16px",
+                    flexShrink: 0,
+                    "& svg": {
+                      color:
+                        item.path && location.pathname.includes(item.path)
+                          ? "#13715B !important"
+                          : `${theme.palette.text.tertiary} !important`,
+                      stroke:
+                        item.path && location.pathname.includes(item.path)
+                          ? "#13715B !important"
+                          : `${theme.palette.text.tertiary} !important`,
+                      transition: "color 0.2s ease, stroke 0.2s ease",
+                    },
+                    "& svg path": {
+                      stroke:
+                        item.path && location.pathname.includes(item.path)
+                          ? "#13715B !important"
+                          : `${theme.palette.text.tertiary} !important`,
+                    },
+                  }}
+                >
+                  {item.icon}
+                </Box>
+                <Typography
+                  sx={{
+                    fontSize: "13px",
+                    color: theme.palette.text.secondary,
+                  }}
+                >
+                  {item.name}
+                </Typography>
+              </Box>
+            </MenuItem>
+          ))}
+        </Menu>
+      </List>
+
+      {/* Ready To Subscribe Box - only shown when not collapsed and enabled */}
+      {showReadyToSubscribe && !collapsed && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-end",
+            alignItems: "center",
+            flexShrink: 0,
+          }}
+        >
+          <ReadyToSubscribeBox />
+        </Box>
+      )}
+
+      {/* Divider */}
+      <Divider />
+
+      {/* User Profile Section */}
+      <Stack
+        direction="row"
+        height="50px"
+        alignItems="center"
+        py={theme.spacing(4)}
+        px={theme.spacing(8)}
+        gap={theme.spacing(2)}
+        borderRadius={theme.shape.borderRadius}
+        sx={{ flexShrink: 0 }}
+      >
+        {delayedCollapsed ? (
+          <Tooltip
+            sx={{ fontSize: 13 }}
+            title="Options"
+            slotProps={{
+              popper: {
+                modifiers: [{ name: "offset", options: { offset: [0, -10] } }],
+              },
+            }}
+            disableInteractive
+          >
+            <IconButton
+              onClick={openPopup}
+              sx={{
+                p: 0,
+                "&:focus": { outline: "none" },
+                justifyContent: "center",
+                alignItems: "center",
+                marginLeft: theme.spacing(3),
+              }}
+            >
+              <Avatar user={userAvator} size="small" sx={{ margin: "auto" }} />
+            </IconButton>
+          </Tooltip>
+        ) : (
+          <>
+            <Avatar user={userAvator} size="small" sx={{ ml: theme.spacing(2) }} />
+            <Box ml={theme.spacing(2)}>
+              <Typography component="span" fontWeight={500}>
+                {user.name} {user.surname}
+              </Typography>
+              <Typography sx={{ textTransform: "capitalize" }}>
+                {ROLES[user.roleId as keyof typeof ROLES]}
+              </Typography>
+            </Box>
+            <IconButton
+              disableRipple={theme.components?.MuiIconButton?.defaultProps?.disableRipple}
+              sx={{
+                ml: "auto",
+                mr: "-8px",
+                "&:focus": { outline: "none" },
+                "& svg": {
+                  width: "20px",
+                  height: "20px",
+                },
+                "& svg path": {
+                  stroke: theme.palette.other?.icon,
+                },
+              }}
+              onClick={openPopup}
+            >
+              <MoreVertical size={16} strokeWidth={1.5} />
+            </IconButton>
+          </>
+        )}
+
+        {/* User Options Drawer */}
+        <Drawer
+          anchor="bottom"
+          open={slideoverOpen}
+          onClose={closePopup}
+          hideBackdrop={true}
+          transitionDuration={0}
+          PaperProps={{
+            sx: {
+              width: collapsed ? "260px" : "300px",
+              height: "auto",
+              maxHeight: "fit-content",
+              position: "absolute",
+              bottom: "80px",
+              left: collapsed ? "30px" : "30px",
+              borderRadius: "8px",
+              boxShadow: "0 12px 24px rgba(0,0,0,0.15)",
+              border: `1px solid ${theme.palette.divider}`,
+              backgroundColor: "transparent",
+              transition: "none",
+            },
+          }}
+        >
+          <Box
+            ref={drawerRef}
+            sx={{
+              backgroundColor: theme.palette.background.main,
+              borderRadius: "8px",
+              border: `1px solid ${theme.palette.divider}`,
+              overflow: "hidden",
+              p: 1,
+              animation: slideoverOpen ? "fadeIn 0.2s ease-in-out" : "none",
+              "@keyframes fadeIn": {
+                "0%": { opacity: 0 },
+                "100%": { opacity: 1 },
+              },
+            }}
+          >
+            <Stack spacing={2}>
+              {/* Account Section */}
+              <Box>
+                <Typography
+                  variant="overline"
+                  sx={{
+                    fontSize: "11px",
+                    fontWeight: 600,
+                    color: theme.palette.text.disabled,
+                    letterSpacing: "0.5px",
+                    px: theme.spacing(4),
+                    pb: 1,
+                  }}
+                >
+                  ACCOUNT
+                </Typography>
+
+                <Stack spacing={1}>
+                  {/* My Profile */}
+                  <ListItemButton
+                    onClick={() => {
+                      navigate("/settings");
+                      closePopup();
+                    }}
+                    sx={{
+                      minHeight: "48px",
+                      gap: theme.spacing(4),
+                      borderRadius: theme.shape.borderRadius,
+                      px: theme.spacing(4),
+                      py: 1,
+                      "&:hover": {
+                        backgroundColor: "#F9FAFB",
+                      },
+                    }}
+                  >
+                    <Box sx={{ flex: 1 }}>
+                      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 0.5 }}>
+                        <Typography sx={{ fontSize: "13px", fontWeight: 500 }}>
+                          {user.name} {user.surname}
+                        </Typography>
+                        <Typography
+                          sx={{
+                            fontSize: "11px",
+                            color: theme.palette.text.secondary,
+                            textTransform: "capitalize",
+                          }}
+                        >
+                          {ROLES[user.roleId as keyof typeof ROLES]}
+                        </Typography>
+                      </Box>
+                      <Typography
+                        sx={{
+                          fontSize: "11px",
+                          color: theme.palette.text.secondary,
+                        }}
+                      >
+                        {user.email}
+                      </Typography>
+                    </Box>
+                  </ListItemButton>
+
+                  {/* Create Demo Data / Delete Demo Data */}
+                  {hasDemoData ? (
+                    <ListItemButton
+                      onClick={() => {
+                        if (onOpenDeleteDemoData) {
+                          onOpenDeleteDemoData();
+                        }
+                        closePopup();
+                      }}
+                      sx={{
+                        height: "32px",
+                        gap: theme.spacing(4),
+                        borderRadius: theme.shape.borderRadius,
+                        px: theme.spacing(4),
+                        "& svg": {
+                          color: theme.palette.text.tertiary,
+                          stroke: theme.palette.text.tertiary,
+                        },
+                        "&:hover": {
+                          backgroundColor: "#F9FAFB",
+                        },
+                        "&:hover svg": {
+                          color: "#13715B !important",
+                          stroke: "#13715B !important",
+                        },
+                        "&:hover svg path": {
+                          stroke: "#13715B !important",
+                        },
+                      }}
+                    >
+                      <Trash2 size={16} strokeWidth={1.5} />
+                      <Typography sx={{ fontSize: "13px" }}>
+                        Delete demo data
+                      </Typography>
+                    </ListItemButton>
+                  ) : (
+                    <ListItemButton
+                      onClick={() => {
+                        if (onOpenCreateDemoData) {
+                          onOpenCreateDemoData();
+                        }
+                        closePopup();
+                      }}
+                      sx={{
+                        height: "32px",
+                        gap: theme.spacing(4),
+                        borderRadius: theme.shape.borderRadius,
+                        px: theme.spacing(4),
+                        "& svg": {
+                          color: theme.palette.text.tertiary,
+                          stroke: theme.palette.text.tertiary,
+                        },
+                        "&:hover": {
+                          backgroundColor: "#F9FAFB",
+                        },
+                        "&:hover svg": {
+                          color: "#13715B !important",
+                          stroke: "#13715B !important",
+                        },
+                        "&:hover svg path": {
+                          stroke: "#13715B !important",
+                        },
+                      }}
+                    >
+                      <Database size={16} strokeWidth={1.5} />
+                      <Typography sx={{ fontSize: "13px" }}>
+                        Create demo data
+                      </Typography>
+                    </ListItemButton>
+                  )}
+                </Stack>
+              </Box>
+
+              {/* Explore VerifyWise Section */}
+              <Box>
+                <Typography
+                  variant="overline"
+                  sx={{
+                    fontSize: "11px",
+                    fontWeight: 600,
+                    color: theme.palette.text.disabled,
+                    letterSpacing: "0.5px",
+                    px: theme.spacing(4),
+                    pb: 1,
+                  }}
+                >
+                  EXPLORE VERIFYWISE
+                </Typography>
+
+                <Stack spacing={1}>
+                  {/* Help Center */}
+                  <ListItemButton
+                    onClick={() => {
+                      if (openUserGuide) {
+                        openUserGuide();
+                      } else {
+                        window.open("https://verifywise.ai", "_blank", "noreferrer");
+                      }
+                      closePopup();
+                    }}
+                    sx={{
+                      height: "32px",
+                      gap: theme.spacing(4),
+                      borderRadius: theme.shape.borderRadius,
+                      px: theme.spacing(4),
+                      "& svg": {
+                        color: theme.palette.text.tertiary,
+                        stroke: theme.palette.text.tertiary,
+                      },
+                      "&:hover": {
+                        backgroundColor: "#F9FAFB",
+                      },
+                      "&:hover svg": {
+                        color: "#13715B !important",
+                        stroke: "#13715B !important",
+                      },
+                      "&:hover svg path": {
+                        stroke: "#13715B !important",
+                      },
+                    }}
+                  >
+                    <HelpCircle size={16} strokeWidth={1.5} />
+                    <Typography sx={{ fontSize: "13px" }}>Help center</Typography>
+                  </ListItemButton>
+
+                  {/* What's New */}
+                  <ListItemButton
+                    onClick={() => {
+                      window.open("https://verifywise.ai/blog", "_blank", "noreferrer");
+                      closePopup();
+                    }}
+                    sx={{
+                      height: "32px",
+                      gap: theme.spacing(4),
+                      borderRadius: theme.shape.borderRadius,
+                      px: theme.spacing(4),
+                      "& svg": {
+                        color: theme.palette.text.tertiary,
+                        stroke: theme.palette.text.tertiary,
+                      },
+                      "&:hover": {
+                        backgroundColor: "#F9FAFB",
+                      },
+                      "&:hover svg": {
+                        color: "#13715B !important",
+                        stroke: "#13715B !important",
+                      },
+                      "&:hover svg path": {
+                        stroke: "#13715B !important",
+                      },
+                    }}
+                  >
+                    <Newspaper size={16} strokeWidth={1.5} />
+                    <Typography sx={{ fontSize: "13px" }}>What's new?</Typography>
+                  </ListItemButton>
+
+                  {/* User Community */}
+                  <ListItemButton
+                    onClick={() => {
+                      window.open("https://discord.gg/d3k3E4uEpR", "_blank", "noreferrer");
+                      closePopup();
+                    }}
+                    sx={{
+                      height: "32px",
+                      gap: theme.spacing(4),
+                      borderRadius: theme.shape.borderRadius,
+                      px: theme.spacing(4),
+                      "& svg": {
+                        color: theme.palette.text.tertiary,
+                        stroke: theme.palette.text.tertiary,
+                      },
+                      "&:hover": {
+                        backgroundColor: "#F9FAFB",
+                      },
+                      "&:hover svg": {
+                        color: "#13715B !important",
+                        stroke: "#13715B !important",
+                      },
+                      "&:hover svg path": {
+                        stroke: "#13715B !important",
+                      },
+                    }}
+                  >
+                    <Users size={16} strokeWidth={1.5} />
+                    <Typography sx={{ fontSize: "13px" }}>User community</Typography>
+                  </ListItemButton>
+
+                  {/* Get Support */}
+                  <ListItemButton
+                    onClick={() => {
+                      window.open("https://cal.com/verifywise/", "_blank", "noreferrer");
+                      closePopup();
+                    }}
+                    sx={{
+                      height: "32px",
+                      gap: theme.spacing(4),
+                      borderRadius: theme.shape.borderRadius,
+                      px: theme.spacing(4),
+                      "& svg": {
+                        color: theme.palette.text.tertiary,
+                        stroke: theme.palette.text.tertiary,
+                      },
+                      "&:hover": {
+                        backgroundColor: "#F9FAFB",
+                      },
+                      "&:hover svg": {
+                        color: "#13715B !important",
+                        stroke: "#13715B !important",
+                      },
+                      "&:hover svg path": {
+                        stroke: "#13715B !important",
+                      },
+                    }}
+                  >
+                    <Headphones size={16} strokeWidth={1.5} />
+                    <Typography sx={{ fontSize: "13px" }}>Get support</Typography>
+                  </ListItemButton>
+
+                  {/* Give Feedback */}
+                  <ListItemButton
+                    onClick={() => {
+                      window.open("https://verifywise.ai/contact", "_blank", "noreferrer");
+                      closePopup();
+                    }}
+                    sx={{
+                      height: "32px",
+                      gap: theme.spacing(4),
+                      borderRadius: theme.shape.borderRadius,
+                      px: theme.spacing(4),
+                      "& svg": {
+                        color: theme.palette.text.tertiary,
+                        stroke: theme.palette.text.tertiary,
+                      },
+                      "&:hover": {
+                        backgroundColor: "#F9FAFB",
+                      },
+                      "&:hover svg": {
+                        color: "#13715B !important",
+                        stroke: "#13715B !important",
+                      },
+                      "&:hover svg path": {
+                        stroke: "#13715B !important",
+                      },
+                    }}
+                  >
+                    <MessageCircle size={16} strokeWidth={1.5} />
+                    <Typography sx={{ fontSize: "13px" }}>Give feedback</Typography>
+                  </ListItemButton>
+                </Stack>
+              </Box>
+
+              <Divider sx={{ my: 1 }} />
+
+              {/* Logout */}
+              <ListItemButton
+                onClick={() => {
+                  logout();
+                  closePopup();
+                }}
+                sx={{
+                  height: "32px",
+                  gap: theme.spacing(4),
+                  borderRadius: theme.shape.borderRadius,
+                  px: theme.spacing(4),
+                  "& svg": {
+                    color: theme.palette.text.tertiary,
+                    stroke: theme.palette.text.tertiary,
+                  },
+                  "&:hover": {
+                    backgroundColor: "#F9FAFB",
+                  },
+                  "&:hover svg": {
+                    color: "#13715B !important",
+                    stroke: "#13715B !important",
+                  },
+                  "&:hover svg path": {
+                    stroke: "#13715B !important",
+                  },
+                }}
+              >
+                <LogOut size={16} strokeWidth={1.5} />
+                <Typography sx={{ fontSize: "13px" }}>Logout</Typography>
+              </ListItemButton>
+            </Stack>
+          </Box>
+        </Drawer>
+      </Stack>
+    </>
+  );
+};
+
+export default SidebarFooter;

--- a/Clients/src/presentation/components/Sidebar/SidebarShell.tsx
+++ b/Clients/src/presentation/components/Sidebar/SidebarShell.tsx
@@ -1,0 +1,699 @@
+import { FC, useState, useEffect, useRef, useContext } from "react";
+import {
+  Box,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Stack,
+  Tooltip,
+  Typography,
+  Chip,
+  Menu,
+  MenuItem,
+} from "@mui/material";
+import { useTheme } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { Link as RouterLink } from "react-router-dom";
+import { Link as MuiLink } from "@mui/material";
+import { PanelLeftClose, PanelLeftOpen, Heart, ChevronDown, FolderKanban, Plus } from "lucide-react";
+import { toggleSidebar } from "../../../application/redux/ui/uiSlice";
+import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
+import Logo from "../../assets/imgs/logo.png";
+import SidebarFooter from "./SidebarFooter";
+import FlyingHearts from "../FlyingHearts";
+
+declare const __APP_VERSION__: string;
+
+// Types for menu items
+export interface SidebarMenuItem {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  path?: string;
+  value?: string;
+  count?: number;
+  disabled?: boolean;
+  highlightPaths?: string[];
+  onClick?: () => void;
+}
+
+export interface SidebarMenuGroup {
+  name: string;
+  items: SidebarMenuItem[];
+}
+
+export interface RecentSection {
+  title: string;
+  items: { id: string; name: string; onClick: () => void }[];
+}
+
+export interface ProjectSelectorConfig {
+  currentProject: { id: string; name: string } | null;
+  allProjects: { id: string; name: string }[];
+  onProjectChange: (projectId: string) => void;
+}
+
+export interface SidebarShellProps {
+  // Menu configuration
+  topItems?: SidebarMenuItem[];
+  menuGroups?: SidebarMenuGroup[];
+  flatItems?: SidebarMenuItem[];
+  recentSections?: RecentSection[];
+
+  // Project selector (for Evals sidebar)
+  projectSelector?: ProjectSelectorConfig;
+
+  // Active state
+  activeItemId?: string;
+  isItemActive?: (item: SidebarMenuItem) => boolean;
+
+  // Callbacks
+  onItemClick?: (item: SidebarMenuItem) => void;
+
+  // Footer props
+  hasDemoData?: boolean;
+  onOpenCreateDemoData?: () => void;
+  onOpenDeleteDemoData?: () => void;
+  showReadyToSubscribe?: boolean;
+  openUserGuide?: () => void;
+
+  // Enable flying hearts Easter egg (only for main sidebar)
+  enableFlyingHearts?: boolean;
+}
+
+const SidebarShell: FC<SidebarShellProps> = ({
+  topItems = [],
+  menuGroups = [],
+  flatItems = [],
+  recentSections = [],
+  projectSelector,
+  activeItemId,
+  isItemActive,
+  onItemClick,
+  hasDemoData = false,
+  onOpenCreateDemoData,
+  onOpenDeleteDemoData,
+  showReadyToSubscribe = false,
+  openUserGuide,
+  enableFlyingHearts = false,
+}) => {
+  const theme = useTheme();
+  const dispatch = useDispatch();
+
+  // Heart icon state (Easter egg)
+  const [showHeartIcon, setShowHeartIcon] = useState(false);
+  const [showFlyingHearts, setShowFlyingHearts] = useState(false);
+  const [heartReturning, setHeartReturning] = useState(false);
+  const heartTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // VerifyWiseContext available for future use
+  useContext(VerifyWiseContext);
+
+  const collapsed = useSelector((state: any) => state.ui?.sidebar?.collapsed);
+
+  // Delayed collapsed state for smooth animation
+  const [delayedCollapsed, setDelayedCollapsed] = useState(collapsed);
+
+  // Project selector menu state
+  const [projectMenuAnchor, setProjectMenuAnchor] = useState<null | HTMLElement>(null);
+  const projectMenuOpen = Boolean(projectMenuAnchor);
+
+  useEffect(() => {
+    if (collapsed) {
+      setDelayedCollapsed(true);
+      return;
+    } else {
+      const timer = setTimeout(() => {
+        setDelayedCollapsed(false);
+      }, 650);
+      return () => clearTimeout(timer);
+    }
+  }, [collapsed]);
+
+  // Heart hover handler
+  const handleLogoHover = () => {
+    if (!enableFlyingHearts) return;
+    setShowHeartIcon(true);
+    setHeartReturning(false);
+
+    if (heartTimerRef.current) {
+      clearTimeout(heartTimerRef.current);
+    }
+
+    heartTimerRef.current = setTimeout(() => {
+      setHeartReturning(true);
+      setTimeout(() => {
+        setShowHeartIcon(false);
+        setHeartReturning(false);
+      }, 500);
+    }, 5000);
+  };
+
+  const handleHeartClick = () => {
+    setShowFlyingHearts(true);
+    setTimeout(() => {
+      setHeartReturning(true);
+      setTimeout(() => {
+        setShowHeartIcon(false);
+        setHeartReturning(false);
+      }, 500);
+    }, 1500);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (heartTimerRef.current) {
+        clearTimeout(heartTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Check if item is active
+  const checkIsActive = (item: SidebarMenuItem): boolean => {
+    if (isItemActive) {
+      return isItemActive(item);
+    }
+    if (activeItemId) {
+      return item.id === activeItemId || item.value === activeItemId || item.path === activeItemId;
+    }
+    return false;
+  };
+
+  // Handle item click
+  const handleItemClick = (item: SidebarMenuItem) => {
+    if (item.disabled) return;
+    if (item.onClick) {
+      item.onClick();
+    }
+    if (onItemClick) {
+      onItemClick(item);
+    }
+  };
+
+  // Render a single menu item
+  const renderMenuItem = (item: SidebarMenuItem, showTooltip = true) => {
+    const isActive = checkIsActive(item);
+    const isDisabled = item.disabled;
+
+    return (
+      <Tooltip
+        key={item.id}
+        placement="right"
+        title={collapsed && showTooltip ? item.label : ""}
+        slotProps={{
+          popper: {
+            modifiers: [{ name: "offset", options: { offset: [0, -16] } }],
+          },
+        }}
+        disableInteractive
+      >
+        <ListItemButton
+          disableRipple={theme.components?.MuiListItemButton?.defaultProps?.disableRipple}
+          className={isActive ? "selected-path" : "unselected"}
+          onClick={() => handleItemClick(item)}
+          disabled={isDisabled}
+          sx={{
+            height: "32px",
+            gap: collapsed ? 0 : theme.spacing(4),
+            borderRadius: theme.shape.borderRadius,
+            px: theme.spacing(4),
+            justifyContent: collapsed ? "center" : "flex-start",
+            opacity: isDisabled ? 0.5 : 1,
+            cursor: isDisabled ? "not-allowed" : "pointer",
+            "& .MuiListItemText-root": {
+              display: collapsed ? "none" : "block",
+            },
+            background: isActive && !isDisabled
+              ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
+              : "transparent",
+            border: isActive && !isDisabled
+              ? "1px solid #D8D8D8"
+              : "1px solid transparent",
+            "&:hover": {
+              background: isDisabled
+                ? "transparent"
+                : isActive
+                ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
+                : "#F9F9F9",
+              border: isDisabled
+                ? "1px solid transparent"
+                : isActive
+                ? "1px solid #D8D8D8"
+                : "1px solid transparent",
+            },
+            "&:hover svg": isDisabled ? {} : {
+              color: "#13715B !important",
+              stroke: "#13715B !important",
+            },
+            "&:hover svg path": isDisabled ? {} : {
+              stroke: "#13715B !important",
+            },
+            "&.Mui-disabled": {
+              opacity: 0.5,
+            },
+          }}
+        >
+          <ListItemIcon
+            sx={{
+              minWidth: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "16px",
+              mr: 0,
+              "& svg": {
+                color: isDisabled
+                  ? `${theme.palette.text.disabled} !important`
+                  : isActive
+                  ? "#13715B !important"
+                  : `${theme.palette.text.tertiary} !important`,
+                stroke: isDisabled
+                  ? `${theme.palette.text.disabled} !important`
+                  : isActive
+                  ? "#13715B !important"
+                  : `${theme.palette.text.tertiary} !important`,
+                transition: "color 0.2s ease, stroke 0.2s ease",
+              },
+              "& svg path": {
+                stroke: isDisabled
+                  ? `${theme.palette.text.disabled} !important`
+                  : isActive
+                  ? "#13715B !important"
+                  : `${theme.palette.text.tertiary} !important`,
+              },
+            }}
+          >
+            {item.icon}
+          </ListItemIcon>
+          {!delayedCollapsed && (
+            <ListItemText
+              sx={{
+                "& .MuiListItemText-primary": {
+                  fontSize: "13px",
+                  fontWeight: isActive ? 600 : 400,
+                  color: isDisabled
+                    ? theme.palette.text.disabled
+                    : isActive
+                    ? theme.palette.text.primary
+                    : theme.palette.text.secondary,
+                },
+              }}
+            >
+              {item.label}
+            </ListItemText>
+          )}
+          {!collapsed && item.count !== undefined && item.count > 0 && !isDisabled && (
+            <Chip
+              label={item.count > 99 ? "99+" : item.count}
+              size="small"
+              sx={{
+                height: "18px",
+                fontSize: "10px",
+                fontWeight: 500,
+                backgroundColor: isActive ? "#f8fafc" : "#e2e8f0",
+                color: "#475569",
+                borderRadius: "9px",
+                minWidth: "18px",
+                maxWidth: "36px",
+                "& .MuiChip-label": {
+                  px: "6px",
+                  py: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                },
+                ml: "auto",
+              }}
+            />
+          )}
+        </ListItemButton>
+      </Tooltip>
+    );
+  };
+
+  return (
+    <Stack
+      component="aside"
+      className={`sidebar-menu ${collapsed ? "collapsed" : "expanded"}`}
+      py={theme.spacing(6)}
+      gap={theme.spacing(2)}
+      sx={{
+        width: collapsed ? "78px" : "260px",
+        minWidth: collapsed ? "78px" : "260px",
+        maxWidth: collapsed ? "78px" : "260px",
+        flexShrink: 0,
+        height: "100vh",
+        border: "none",
+        borderRight: `1px solid ${theme.palette.border?.dark || "#d0d5dd"}`,
+        borderRadius: 0,
+        backgroundColor: theme.palette.background.main,
+        transition: "width 650ms cubic-bezier(0.36, -0.01, 0, 0.77), min-width 650ms cubic-bezier(0.36, -0.01, 0, 0.77), max-width 650ms cubic-bezier(0.36, -0.01, 0, 0.77)",
+      }}
+    >
+      {/* Logo Header */}
+      <Stack
+        pt={theme.spacing(6)}
+        pb={theme.spacing(12)}
+        sx={{
+          position: "relative",
+          pl: delayedCollapsed ? theme.spacing(8) : `calc(${theme.spacing(8)} + ${theme.spacing(4)})`,
+          pr: theme.spacing(8),
+        }}
+      >
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent={delayedCollapsed ? "center" : "flex-start"}
+          gap={theme.spacing(2)}
+          className="app-title"
+          sx={{ position: "relative", height: "20px" }}
+        >
+          {!delayedCollapsed && (
+            <Box
+              onMouseEnter={handleLogoHover}
+              sx={{ position: "relative", display: "flex", alignItems: "center" }}
+            >
+              {/* Heart Icon Easter Egg */}
+              {enableFlyingHearts && showHeartIcon && (
+                <Tooltip title="Spread some love!">
+                  <IconButton
+                    onClick={handleHeartClick}
+                    sx={{
+                      position: "absolute",
+                      top: "-16px",
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      padding: 0,
+                      zIndex: 10,
+                      "&:hover": { backgroundColor: "transparent" },
+                      animation: heartReturning
+                        ? "slideDownBehind 0.5s ease-in forwards"
+                        : "slideUpFromBehind 0.5s ease-out",
+                      "@keyframes slideUpFromBehind": {
+                        "0%": { opacity: 0, transform: "translateX(-50%) translateY(28px)", zIndex: -1 },
+                        "60%": { zIndex: -1 },
+                        "70%": { opacity: 1, zIndex: 10 },
+                        "100%": { opacity: 1, transform: "translateX(-50%) translateY(0)", zIndex: 10 },
+                      },
+                      "@keyframes slideDownBehind": {
+                        "0%": { opacity: 1, transform: "translateX(-50%) translateY(0)", zIndex: 10 },
+                        "30%": { opacity: 0.7, zIndex: 10 },
+                        "40%": { zIndex: -1 },
+                        "100%": { opacity: 0, transform: "translateX(-50%) translateY(28px)", zIndex: -1 },
+                      },
+                    }}
+                  >
+                    <Heart size={14} color="#FF1493" strokeWidth={1.5} fill="#FF1493" />
+                  </IconButton>
+                </Tooltip>
+              )}
+              <RouterLink to="/" style={{ display: "flex", alignItems: "center" }}>
+                <img
+                  src={Logo}
+                  alt="Logo"
+                  width={20}
+                  height={20}
+                  style={{ position: "relative", zIndex: 1, display: "block" }}
+                />
+              </RouterLink>
+            </Box>
+          )}
+          {!delayedCollapsed && (
+            <MuiLink
+              component={RouterLink}
+              to="/"
+              sx={{ textDecoration: "none", display: "flex", alignItems: "center" }}
+            >
+              <Typography
+                component="span"
+                sx={{ opacity: 0.8, fontWeight: 500, fontSize: "13px", lineHeight: 1 }}
+                className="app-title"
+              >
+                Verify
+                <span style={{ color: "#0f604d" }}>Wise</span>
+                <span style={{ fontSize: "8px", marginLeft: "4px", opacity: 0.6, fontWeight: 400 }}>
+                  {__APP_VERSION__}
+                </span>
+              </Typography>
+            </MuiLink>
+          )}
+          {/* Sidebar Toggle Button */}
+          <IconButton
+            disableRipple={theme.components?.MuiListItemButton?.defaultProps?.disableRipple}
+            sx={{
+              position: "absolute",
+              right: delayedCollapsed ? "50%" : 0,
+              transform: delayedCollapsed ? "translateX(50%)" : "none",
+              top: 0,
+              bottom: 0,
+              display: "flex",
+              alignItems: "center",
+              p: theme.spacing(2),
+              borderRadius: theme.shape.borderRadius,
+              transition: "right 0.65s cubic-bezier(0.36, -0.01, 0, 0.77), transform 0.65s cubic-bezier(0.36, -0.01, 0, 0.77)",
+              "& svg": {
+                opacity: 0.9,
+                "& path": { stroke: theme.palette.text.tertiary },
+              },
+              "&:focus": { outline: "none" },
+              "&:hover": { backgroundColor: "#F9F9F9" },
+              "&:hover svg path": { stroke: "#13715B" },
+            }}
+            onClick={() => dispatch(toggleSidebar())}
+          >
+            {delayedCollapsed ? (
+              <PanelLeftOpen size={16} strokeWidth={1.5} />
+            ) : (
+              <PanelLeftClose size={16} strokeWidth={1.5} />
+            )}
+          </IconButton>
+        </Stack>
+      </Stack>
+
+      {/* Menu */}
+      <List
+        component="nav"
+        disablePadding
+        sx={{
+          px: theme.spacing(8),
+          flex: 1,
+          overflowY: "auto",
+          overflowX: "hidden",
+          "&::-webkit-scrollbar": { width: "4px" },
+          "&::-webkit-scrollbar-track": { background: "transparent" },
+          "&::-webkit-scrollbar-thumb": { background: theme.palette.border?.light || "#e0e0e0", borderRadius: "2px" },
+          "&::-webkit-scrollbar-thumb:hover": { background: theme.palette.border?.dark || "#d0d5dd" },
+        }}
+      >
+        {/* Project Selector (for Evals sidebar) */}
+        {projectSelector && !delayedCollapsed && (
+          <Box sx={{ mb: theme.spacing(4) }}>
+            <Box
+              onClick={(e) => setProjectMenuAnchor(e.currentTarget)}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                px: theme.spacing(4),
+                py: theme.spacing(3),
+                borderRadius: "4px",
+                cursor: "pointer",
+                backgroundColor: "#F9FAFB",
+                border: "1px solid #E5E7EB",
+                transition: "all 0.15s ease",
+                "&:hover": {
+                  backgroundColor: "#F3F4F6",
+                  borderColor: "#D1D5DB",
+                },
+              }}
+            >
+              <FolderKanban size={16} color="#6B7280" strokeWidth={1.5} />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography
+                  sx={{
+                    fontSize: "12px",
+                    fontWeight: 500,
+                    color: "#374151",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {projectSelector.currentProject?.name || "Select project"}
+                </Typography>
+              </Box>
+              <ChevronDown size={14} color="#9CA3AF" />
+            </Box>
+            <Menu
+              anchorEl={projectMenuAnchor}
+              open={projectMenuOpen}
+              onClose={() => setProjectMenuAnchor(null)}
+              anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+              transformOrigin={{ vertical: "top", horizontal: "left" }}
+              slotProps={{
+                paper: {
+                  sx: {
+                    mt: 0.5,
+                    minWidth: 200,
+                    maxHeight: 300,
+                    boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+                    border: "1px solid #E5E7EB",
+                    borderRadius: "6px",
+                  },
+                },
+              }}
+            >
+              {projectSelector.allProjects.map((project) => (
+                <MenuItem
+                  key={project.id}
+                  selected={project.id === projectSelector.currentProject?.id}
+                  onClick={() => {
+                    projectSelector.onProjectChange(project.id);
+                    setProjectMenuAnchor(null);
+                  }}
+                  sx={{
+                    fontSize: "13px",
+                    py: 1,
+                    px: 2,
+                    "&.Mui-selected": {
+                      backgroundColor: "#F0FDF4",
+                      color: "#13715B",
+                      fontWeight: 500,
+                    },
+                    "&.Mui-selected:hover": {
+                      backgroundColor: "#DCFCE7",
+                    },
+                  }}
+                >
+                  {project.name}
+                </MenuItem>
+              ))}
+              {projectSelector.allProjects.length > 0 && (
+                <Box sx={{ borderTop: "1px solid #E5E7EB", mt: 0.5, pt: 0.5 }}>
+                  <MenuItem
+                    onClick={() => {
+                      projectSelector.onProjectChange("create_new");
+                      setProjectMenuAnchor(null);
+                    }}
+                    sx={{
+                      fontSize: "13px",
+                      py: 1,
+                      px: 2,
+                      color: "#13715B",
+                      "&:hover": {
+                        backgroundColor: "#F0FDF4",
+                      },
+                    }}
+                  >
+                    <Plus size={14} style={{ marginRight: 8 }} />
+                    New project
+                  </MenuItem>
+                </Box>
+              )}
+            </Menu>
+          </Box>
+        )}
+
+        {/* Top Items */}
+        {topItems.map((item) => renderMenuItem(item))}
+
+        {/* Flat Items (no groups) */}
+        {flatItems.map((item) => renderMenuItem(item))}
+
+        {/* Grouped Items */}
+        {menuGroups.map((group) => (
+          <Box key={group.name}>
+            <Typography
+              variant="overline"
+              className="sidebar-group-header"
+              sx={{
+                px: theme.spacing(4),
+                pt: theme.spacing(4.5),
+                pb: theme.spacing(1.5),
+                mt: theme.spacing(3),
+                color: "#a0a0a0 !important",
+                fontSize: "11px !important",
+                fontWeight: 400,
+                letterSpacing: "0.5px",
+                textTransform: "uppercase",
+                display: collapsed ? "none" : "block",
+              }}
+            >
+              {group.name}
+            </Typography>
+            {group.items.map((item) => renderMenuItem(item))}
+          </Box>
+        ))}
+
+        {/* Recent Sections - right after menu items */}
+        {recentSections.map((section) => (
+          !delayedCollapsed && section.items.length > 0 && (
+            <Box key={section.title} sx={{ mt: theme.spacing(4) }}>
+              <Typography
+                sx={{
+                  fontSize: "10px",
+                  fontWeight: 500,
+                  color: theme.palette.text.disabled,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.5px",
+                  mb: 0.5,
+                  px: theme.spacing(4),
+                }}
+              >
+                {section.title}
+              </Typography>
+              {section.items.slice(0, 3).map((item) => (
+                <ListItemButton
+                  key={item.id}
+                  onClick={item.onClick}
+                  disableRipple
+                  sx={{
+                    height: "30px",
+                    borderRadius: "4px",
+                    px: theme.spacing(4),
+                    mb: 0.25,
+                    "&:hover": { backgroundColor: "#F9F9F9" },
+                  }}
+                >
+                  <ListItemText
+                    sx={{
+                      "& .MuiListItemText-primary": {
+                        fontSize: "12px",
+                        color: theme.palette.text.secondary,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      },
+                    }}
+                  >
+                    {item.name}
+                  </ListItemText>
+                </ListItemButton>
+              ))}
+            </Box>
+          )
+        ))}
+      </List>
+
+      {/* Shared Footer */}
+      <SidebarFooter
+        collapsed={collapsed}
+        delayedCollapsed={delayedCollapsed}
+        hasDemoData={hasDemoData}
+        onOpenCreateDemoData={onOpenCreateDemoData}
+        onOpenDeleteDemoData={onOpenDeleteDemoData}
+        showReadyToSubscribe={showReadyToSubscribe}
+        openUserGuide={openUserGuide}
+      />
+
+      {/* Flying Hearts Animation */}
+      {enableFlyingHearts && showFlyingHearts && (
+        <FlyingHearts onComplete={() => setShowFlyingHearts(false)} />
+      )}
+    </Stack>
+  );
+};
+
+export default SidebarShell;

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -1,221 +1,27 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  Box,
-  Divider,
-  IconButton,
-  List,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Stack,
-  Tooltip,
-  Typography,
-  Chip,
-  Drawer,
-  Menu,
-  MenuItem,
-} from "@mui/material";
-import "./index.css";
-import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect, useState, useContext } from "react";
 import { useLocation, useNavigate } from "react-router";
-import { useTheme } from "@mui/material";
-import React, { useContext, useState, useEffect, useRef } from "react";
-import { toggleSidebar } from "../../../application/redux/ui/uiSlice";
-
-// Lucide Icons
 import {
-  ChevronDown,
   Home,
   Flag,
-  MoreVertical,
-  LogOut,
   BarChart3,
   AlertTriangle,
   Building,
-  Settings,
   FileText,
-  MessageCircle,
   Brain,
   Shield,
   GraduationCap,
-  Telescope,
   List as ListIcon,
   FolderTree,
   Layers,
   AlertCircle,
-  FolderCog,
-  Database,
-  Beaker,
-  Heart,
-  HelpCircle,
-  Newspaper,
-  Users,
-  Headphones,
-  Trash2,
-  PanelLeftClose,
-  PanelLeftOpen,
 } from "lucide-react";
-
-import Logo from "../../assets/imgs/logo.png";
-
-import Avatar from "../Avatar/VWAvatar";
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
-import { Link as RouterLink } from "react-router-dom";
-import { Link as MuiLink } from "@mui/material";
-import { ROLES } from "../../../application/constants/roles";
-import useLogout from "../../../application/hooks/useLogout";
 import useMultipleOnScreen from "../../../application/hooks/useMultipleOnScreen";
-import ReadyToSubscribeBox from "../ReadyToSubscribeBox/ReadyToSubscribeBox";
-import { User } from "../../../domain/types/User";
 import { getAllTasks } from "../../../application/repository/task.repository";
 import { TaskStatus } from "../../../domain/enums/task.enum";
-import { IMenuGroup, IMenuItem } from "../../../domain/interfaces/i.menu";
-import FlyingHearts from "../FlyingHearts";
 import { useUserGuideSidebarContext } from "../UserGuide";
-import { useProfilePhotoFetch } from "../../../application/hooks/useProfilePhotoFetch";
-
-const getMenuGroups = (): IMenuGroup[] => [
-  {
-    name: "DISCOVERY",
-    items: [
-      {
-        name: "Use Cases",
-        icon: <FolderTree size={16} strokeWidth={1.5} />,
-        path: "/overview",
-        highlightPaths: ["/project-view"],
-      },
-      {
-        name: "Organizational View",
-        icon: <Layers size={16} strokeWidth={1.5} />,
-        path: "/framework",
-      },
-      {
-        name: "Vendors",
-        icon: <Building size={16} strokeWidth={1.5} />,
-        path: "/vendors",
-      },
-      {
-        name: "Model Inventory",
-        icon: <ListIcon size={16} strokeWidth={1.5} />,
-        path: "/model-inventory",
-      },
-    ],
-  },
-  {
-    name: "ASSURANCE",
-    items: [
-      {
-        name: "Risk Management",
-        icon: <AlertTriangle size={16} strokeWidth={1.5} />,
-        path: "/risk-management",
-      },
-      {
-        name: "LLM Evals",
-        icon: <Beaker size={16} strokeWidth={1.5} />,
-        path: "/evals",
-      },
-      {
-        name: "Training Registry",
-        icon: <GraduationCap size={16} strokeWidth={1.5} />,
-        path: "/training",
-      },
-      {
-        name: "Evidence",
-        icon: <FileText size={16} strokeWidth={1.5} />,
-        path: "/file-manager",
-      },
-      {
-        name: "Reporting",
-        icon: <BarChart3 size={16} strokeWidth={1.5} />,
-        path: "/reporting",
-      },
-      {
-        name: "AI Trust Center",
-        icon: <Brain size={16} strokeWidth={1.5} />,
-        path: "/ai-trust-center",
-      },
-    ],
-  },
-  {
-    name: "GOVERNANCE",
-    items: [
-      {
-        name: "Policy Manager",
-        icon: <Shield size={16} strokeWidth={1.5} />,
-        path: "/policies",
-      },
-      {
-        name: "Incident Management",
-        icon: <AlertCircle size={16} strokeWidth={1.5} />,
-        path: "/ai-incident-managements",
-      },
-    ],
-  },
-];
-
-const topItems = (openTasksCount: number): IMenuItem[] => [
-  {
-    name: "Dashboard",
-    icon: <Home size={16} strokeWidth={1.5} />,
-    path: "/",
-  },
-  {
-    name: "Tasks",
-    icon: <Flag size={16} strokeWidth={1.5} />,
-    path: "/tasks",
-    taskCount: openTasksCount,
-  },
-];
-
-const getManagementItems = (
-  hasDemoData: boolean,
-  onOpenCreateDemoData?: () => void,
-  onOpenDeleteDemoData?: () => void
-): IMenuItem[] => [
-  {
-    name: "Event Tracker",
-    icon: <Telescope size={16} strokeWidth={1.5} />,
-    path: "/event-tracker",
-  },
-  {
-    name: "Settings",
-    icon: <Settings size={16} strokeWidth={1.5} />,
-    path: "/settings",
-  },
-  ...(hasDemoData
-    ? [
-        {
-          name: "Delete demo data",
-          icon: <Database size={16} strokeWidth={1.5} />,
-          action: onOpenDeleteDemoData,
-        },
-      ]
-    : [
-        {
-          name: "Create demo data",
-          icon: <Database size={16} strokeWidth={1.5} />,
-          action: onOpenCreateDemoData,
-        },
-      ]),
-];
-
-// Reserved for future use
-// const other: IMenuItem[] = [];
-
-const DEFAULT_USER: User = {
-  id: 1,
-  name: "",
-  surname: "",
-  email: "",
-  roleId: 1,
-};
-
-interface User_Avatar {
-  firstname: string;
-  lastname: string;
-  email: string;
-  pathToImage: string;
-}
+import SidebarShell, { SidebarMenuItem, SidebarMenuGroup } from "./SidebarShell";
+import "./index.css";
 
 interface SidebarProps {
   onOpenCreateDemoData?: () => void;
@@ -228,107 +34,16 @@ const Sidebar: React.FC<SidebarProps> = ({
   onOpenDeleteDemoData,
   hasDemoData = false,
 }) => {
-  const theme = useTheme();
   const navigate = useNavigate();
   const location = useLocation();
-  const dispatch = useDispatch();
-  const [slideoverOpen, setSlideoverOpen] = useState(false);
-  const [managementAnchorEl, setManagementAnchorEl] =
-    useState<null | HTMLElement>(null);
-  const drawerRef = useRef<HTMLDivElement>(null);
-  const logout = useLogout();
   const { open: openUserGuide } = useUserGuideSidebarContext();
+  const { changeComponentVisibility } = useContext(VerifyWiseContext);
 
-  // Heart icon state
-  const [showHeartIcon, setShowHeartIcon] = useState(false);
-  const [showFlyingHearts, setShowFlyingHearts] = useState(false);
-  const [heartReturning, setHeartReturning] = useState(false);
-  const heartTimerRef = useRef<NodeJS.Timeout | null>(null);
-
-  const { userId, changeComponentVisibility, users } =
-    useContext(VerifyWiseContext);
-
-  const { refs, allVisible } = useMultipleOnScreen<HTMLElement>({
+  const { refs: _refs, allVisible } = useMultipleOnScreen<HTMLElement>({
     countToTrigger: 1,
   });
 
-  const user: User = users
-    ? users.find((user: User) => user.id === userId) || DEFAULT_USER
-    : DEFAULT_USER;
-
-  const [avatarUrl, setAvatarUrl] = useState<string>("");
-  const { fetchProfilePhotoAsBlobUrl } = useProfilePhotoFetch();
-  const { photoRefreshFlag } = useContext(VerifyWiseContext);
-
-  useEffect(() => {
-    let cancel = false;
-    let previousUrl: string | null = null;
-    (async () => {
-      const url = await fetchProfilePhotoAsBlobUrl(userId || 0);
-      if (cancel) {
-        if (url) URL.revokeObjectURL(url);
-        return;
-      }
-      if (previousUrl && previousUrl !== url) {
-        URL.revokeObjectURL(previousUrl);
-      }
-
-      previousUrl = url ?? null;
-      setAvatarUrl(url ?? "");
-    })();
-
-    return () => {
-      cancel = true;
-      if (previousUrl) URL.revokeObjectURL(previousUrl);
-    }
-  }, [userId, fetchProfilePhotoAsBlobUrl, photoRefreshFlag]);
-
-  const userAvator: User_Avatar = {
-    firstname: user.name,
-    lastname: user.surname,
-    email: user.email,
-    pathToImage: avatarUrl,
-  };
-
-  const collapsed = useSelector((state: any) => state.ui?.sidebar?.collapsed);
-
-  // Delayed collapsed state for icon - waits for sidebar animation to complete
-  const [delayedCollapsed, setDelayedCollapsed] = useState(collapsed);
-
-  useEffect(() => {
-    if (collapsed) {
-      // When collapsing, change icon immediately
-      setDelayedCollapsed(true);
-      return;
-    } else {
-      // When expanding, wait for animation to complete (650ms)
-      const timer = setTimeout(() => {
-        setDelayedCollapsed(false);
-      }, 650);
-      return () => clearTimeout(timer);
-    }
-  }, [collapsed]);
-
   const [openTasksCount, setOpenTasksCount] = useState(0);
-
-  const menuGroups = getMenuGroups();
-
-  const openPopup = () => {
-    setSlideoverOpen(true);
-  };
-
-  const closePopup = () => {
-    setSlideoverOpen(false);
-  };
-
-  const customMenuHandler = () => {
-    switch (location.pathname) {
-      case "/all-assessments":
-        return "/assessment";
-      default:
-        return null;
-    }
-  };
 
   useEffect(() => {
     if (allVisible) {
@@ -351,1461 +66,154 @@ const Sidebar: React.FC<SidebarProps> = ({
     };
 
     fetchOpenTasksCount();
-    // Refresh count every 5 minutes
     const interval = setInterval(fetchOpenTasksCount, 5 * 60 * 1000);
     return () => clearInterval(interval);
   }, []);
 
-  // Click outside to close drawer
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        slideoverOpen &&
-        drawerRef.current &&
-        !drawerRef.current.contains(event.target as Node)
-      ) {
-        closePopup();
-      }
-    };
+  // Top level items
+  const topItems: SidebarMenuItem[] = [
+    {
+      id: "dashboard",
+      label: "Dashboard",
+      icon: <Home size={16} strokeWidth={1.5} />,
+      path: "/",
+    },
+    {
+      id: "tasks",
+      label: "Tasks",
+      icon: <Flag size={16} strokeWidth={1.5} />,
+      path: "/tasks",
+      count: openTasksCount,
+    },
+  ];
 
-    if (slideoverOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
+  // Menu groups
+  const menuGroups: SidebarMenuGroup[] = [
+    {
+      name: "DISCOVERY",
+      items: [
+        {
+          id: "use-cases",
+          label: "Use Cases",
+          icon: <FolderTree size={16} strokeWidth={1.5} />,
+          path: "/overview",
+          highlightPaths: ["/project-view"],
+        },
+        {
+          id: "organizational-view",
+          label: "Organizational View",
+          icon: <Layers size={16} strokeWidth={1.5} />,
+          path: "/framework",
+        },
+        {
+          id: "vendors",
+          label: "Vendors",
+          icon: <Building size={16} strokeWidth={1.5} />,
+          path: "/vendors",
+        },
+        {
+          id: "model-inventory",
+          label: "Model Inventory",
+          icon: <ListIcon size={16} strokeWidth={1.5} />,
+          path: "/model-inventory",
+        },
+      ],
+    },
+    {
+      name: "ASSURANCE",
+      items: [
+        {
+          id: "risk-management",
+          label: "Risk Management",
+          icon: <AlertTriangle size={16} strokeWidth={1.5} />,
+          path: "/risk-management",
+        },
+        {
+          id: "training-registry",
+          label: "Training Registry",
+          icon: <GraduationCap size={16} strokeWidth={1.5} />,
+          path: "/training",
+        },
+        {
+          id: "evidence",
+          label: "Evidence",
+          icon: <FileText size={16} strokeWidth={1.5} />,
+          path: "/file-manager",
+        },
+        {
+          id: "reporting",
+          label: "Reporting",
+          icon: <BarChart3 size={16} strokeWidth={1.5} />,
+          path: "/reporting",
+        },
+        {
+          id: "ai-trust-center",
+          label: "AI Trust Center",
+          icon: <Brain size={16} strokeWidth={1.5} />,
+          path: "/ai-trust-center",
+        },
+      ],
+    },
+    {
+      name: "GOVERNANCE",
+      items: [
+        {
+          id: "policy-manager",
+          label: "Policy Manager",
+          icon: <Shield size={16} strokeWidth={1.5} />,
+          path: "/policies",
+        },
+        {
+          id: "incident-management",
+          label: "Incident Management",
+          icon: <AlertCircle size={16} strokeWidth={1.5} />,
+          path: "/ai-incident-managements",
+        },
+      ],
+    },
+  ];
+
+  // Check if item is active based on current path
+  const isItemActive = (item: SidebarMenuItem): boolean => {
+    if (item.path === "/" && location.pathname === "/") {
+      return true;
     }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [slideoverOpen]);
-
-  // Handle logo hover to show heart icon
-  const handleLogoHover = () => {
-    setShowHeartIcon(true);
-    setHeartReturning(false); // Reset returning state
-
-    // Clear existing timer
-    if (heartTimerRef.current) {
-      clearTimeout(heartTimerRef.current);
+    if (item.path && item.path !== "/" && location.pathname === item.path) {
+      return true;
     }
-
-    // Set new timer to animate return after 5 seconds
-    heartTimerRef.current = setTimeout(() => {
-      setHeartReturning(true);
-
-      // Hide heart after return animation completes (500ms)
-      setTimeout(() => {
-        setShowHeartIcon(false);
-        setHeartReturning(false);
-      }, 500);
-    }, 5000);
+    if (item.path && location.pathname.startsWith(`${item.path}/`)) {
+      return true;
+    }
+    if (item.highlightPaths?.some((p) => location.pathname.startsWith(p))) {
+      return true;
+    }
+    // Special case for assessments
+    if (location.pathname === "/all-assessments" && item.path === "/assessment") {
+      return true;
+    }
+    return false;
   };
 
-  // Handle heart icon click
-  const handleHeartClick = () => {
-    setShowFlyingHearts(true);
-
-    // Start return animation after a brief delay
-    setTimeout(() => {
-      setHeartReturning(true);
-
-      // Hide heart after return animation completes (500ms)
-      setTimeout(() => {
-        setShowHeartIcon(false);
-        setHeartReturning(false);
-      }, 500);
-    }, 1500);
+  // Handle item click - navigate to path
+  const handleItemClick = (item: SidebarMenuItem) => {
+    if (item.path) {
+      navigate(item.path);
+    }
   };
-
-  // Cleanup timer on unmount
-  useEffect(() => {
-    return () => {
-      if (heartTimerRef.current) {
-        clearTimeout(heartTimerRef.current);
-      }
-    };
-  }, []);
 
   return (
-    <Stack
-      component="aside"
-      className={`sidebar-menu ${collapsed ? "collapsed" : "expanded"}`}
-      py={theme.spacing(6)}
-      gap={theme.spacing(2)}
-      sx={{
-        height: "100vh",
-        border: "none",
-        borderRight: `1px solid ${theme.palette.border.dark}`,
-        borderRadius: 0,
-        backgroundColor: theme.palette.background.main,
-        "& ,selected-path, & >MuiListItemButton-root:hover": {
-          backgroundColor: theme.palette.background.main,
-        },
-        "& .Muilist-root svg path": {
-          stroke: theme.palette.text.tertiary,
-        },
-        "& p, & span, & .MuiListSubheader-root": {
-          color: theme.palette.text.secondary,
-        },
-      }}
-    >
-      <Stack
-        pt={theme.spacing(6)}
-        pb={theme.spacing(12)}
-        sx={{
-          position: "relative",
-          pl: delayedCollapsed ? theme.spacing(8) : `calc(${theme.spacing(8)} + ${theme.spacing(4)})`,
-          pr: theme.spacing(8),
-        }}
-      >
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent={delayedCollapsed ? "center" : "flex-start"}
-          gap={theme.spacing(2)}
-          className="app-title"
-          sx={{ position: "relative", height: "20px" }}
-        >
-          {!delayedCollapsed && (
-            <Box onMouseEnter={handleLogoHover} sx={{ position: "relative", display: "flex", alignItems: "center" }}>
-              {/* Heart Icon - Rises behind and appears above logo */}
-              {showHeartIcon && (
-                <Tooltip title="Spread some love!">
-                  <IconButton
-                    onClick={handleHeartClick}
-                    sx={{
-                      position: "absolute",
-                      top: "-16px",
-                      left: "50%",
-                      transform: "translateX(-50%)",
-                      padding: 0,
-                      zIndex: 10,
-                      "&:hover": {
-                        backgroundColor: "transparent",
-                      },
-                      animation: heartReturning
-                        ? "slideDownBehind 0.5s ease-in forwards"
-                        : "slideUpFromBehind 0.5s ease-out",
-                      "@keyframes slideUpFromBehind": {
-                        "0%": {
-                          opacity: 0,
-                          transform: "translateX(-50%) translateY(28px)",
-                          zIndex: -1,
-                        },
-                        "60%": {
-                          zIndex: -1,
-                        },
-                        "70%": {
-                          opacity: 1,
-                          zIndex: 10,
-                        },
-                        "100%": {
-                          opacity: 1,
-                          transform: "translateX(-50%) translateY(0)",
-                          zIndex: 10,
-                        },
-                      },
-                      "@keyframes slideDownBehind": {
-                        "0%": {
-                          opacity: 1,
-                          transform: "translateX(-50%) translateY(0)",
-                          zIndex: 10,
-                        },
-                        "30%": {
-                          opacity: 0.7,
-                          zIndex: 10,
-                        },
-                        "40%": {
-                          zIndex: -1,
-                        },
-                        "100%": {
-                          opacity: 0,
-                          transform: "translateX(-50%) translateY(28px)",
-                          zIndex: -1,
-                        },
-                      },
-                    }}
-                  >
-                    <Heart
-                      size={14}
-                      color="#FF1493"
-                      strokeWidth={1.5}
-                      fill="#FF1493"
-                    />
-                  </IconButton>
-                </Tooltip>
-              )}
-              <RouterLink to="/" style={{ display: "flex", alignItems: "center" }}>
-                <img
-                  src={Logo}
-                  alt="Logo"
-                  width={20}
-                  height={20}
-                  style={{ position: "relative", zIndex: 1, display: "block" }}
-                />
-              </RouterLink>
-            </Box>
-          )}
-          {!delayedCollapsed && (
-            <MuiLink
-              component={RouterLink}
-              to="/"
-              sx={{ textDecoration: "none", display: "flex", alignItems: "center" }}
-            >
-              <Typography
-                component="span"
-                sx={{ opacity: 0.8, fontWeight: 500, fontSize: "13px", lineHeight: 1 }}
-                className="app-title"
-              >
-                Verify
-                <span
-                  style={{
-                    color: "#0f604d",
-                  }}
-                >
-                  Wise
-                </span>
-                <span
-                  style={{
-                    fontSize: "8px",
-                    marginLeft: "4px",
-                    opacity: 0.6,
-                    fontWeight: 400,
-                  }}
-                >
-                  {__APP_VERSION__}
-                </span>
-              </Typography>
-            </MuiLink>
-          )}
-          {/* Sidebar Toggle Button */}
-          <IconButton
-            disableRipple={
-              theme.components?.MuiListItemButton?.defaultProps?.disableRipple
-            }
-            sx={{
-              position: "absolute",
-              right: delayedCollapsed ? "50%" : 0,
-              transform: delayedCollapsed ? "translateX(50%)" : "none",
-              top: 0,
-              bottom: 0,
-              display: "flex",
-              alignItems: "center",
-              p: theme.spacing(2),
-              borderRadius: theme.shape.borderRadius,
-              transition: "right 0.65s cubic-bezier(0.36, -0.01, 0, 0.77), transform 0.65s cubic-bezier(0.36, -0.01, 0, 0.77)",
-              "& svg": {
-                opacity: 0.9,
-                "& path": {
-                  stroke: theme.palette.text.tertiary,
-                },
-              },
-              "&:focus": { outline: "none" },
-              "&:hover": {
-                backgroundColor: "#F9F9F9",
-              },
-              "&:hover svg path": {
-                stroke: "#13715B",
-              },
-            }}
-            onClick={() => {
-              dispatch(toggleSidebar());
-            }}
-          >
-            {delayedCollapsed ? (
-              <PanelLeftOpen size={16} strokeWidth={1.5} />
-            ) : (
-              <PanelLeftClose size={16} strokeWidth={1.5} />
-            )}
-          </IconButton>
-        </Stack>
-      </Stack>
-
-      {/* menu */}
-      <List
-        component="nav"
-        aria-labelledby="nested-menu-subheader"
-        disablePadding
-        sx={{
-          px: theme.spacing(8),
-          flex: 1,
-          overflowY: "auto",
-          overflowX: "hidden",
-          "&::-webkit-scrollbar": {
-            width: "4px",
-          },
-          "&::-webkit-scrollbar-track": {
-            background: "transparent",
-          },
-          "&::-webkit-scrollbar-thumb": {
-            background: theme.palette.border.light,
-            borderRadius: "2px",
-          },
-          "&::-webkit-scrollbar-thumb:hover": {
-            background: theme.palette.border.dark,
-          },
-        }}
-        data-joyride-id="dashboard-navigation"
-        ref={refs[1]}
-      >
-        {/* Top level items (Dashboard and Tasks) */}
-        {topItems(openTasksCount).map((item) => (
-          <Tooltip
-            sx={{ fontSize: 13 }}
-            key={item.path}
-            placement="right"
-            title={collapsed ? item.name : ""}
-            slotProps={{
-              popper: {
-                modifiers: [
-                  {
-                    name: "offset",
-                    options: {
-                      offset: [0, -16],
-                    },
-                  },
-                ],
-              },
-            }}
-            disableInteractive
-          >
-            <ListItemButton
-              disableRipple={
-                theme.components?.MuiListItemButton?.defaultProps?.disableRipple
-              }
-              className={
-                location.pathname === item.path ||
-                item.highlightPaths?.some((p: string) =>
-                  location.pathname.startsWith(p)
-                ) ||
-                customMenuHandler() === item.path
-                  ? "selected-path"
-                  : "unselected"
-              }
-              onClick={() => navigate(`${item.path}`)}
-              sx={{
-                height: "32px",
-                gap: collapsed ? 0 : theme.spacing(4),
-                borderRadius: theme.shape.borderRadius,
-                px: theme.spacing(4),
-                justifyContent: collapsed ? "center" : "flex-start",
-                "& .MuiListItemText-root": {
-                  display: collapsed ? "none" : "block",
-                },
-                background:
-                  location.pathname === item.path ||
-                  item.highlightPaths?.some((p: string) =>
-                    location.pathname.startsWith(p)
-                  ) ||
-                  customMenuHandler() === item.path
-                    ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
-                    : "transparent",
-                border:
-                  location.pathname === item.path ||
-                  item.highlightPaths?.some((p: string) =>
-                    location.pathname.startsWith(p)
-                  ) ||
-                  customMenuHandler() === item.path
-                    ? "1px solid #D8D8D8"
-                    : "1px solid transparent",
-
-                "&:hover": {
-                  background:
-                    location.pathname === item.path ||
-                    item.highlightPaths?.some((p: string) =>
-                      location.pathname.startsWith(p)
-                    ) ||
-                    customMenuHandler() === item.path
-                      ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
-                      : "#F9F9F9",
-                  border:
-                    location.pathname === item.path ||
-                    item.highlightPaths?.some((p: string) =>
-                      location.pathname.startsWith(p)
-                    ) ||
-                    customMenuHandler() === item.path
-                      ? "1px solid #D8D8D8"
-                      : "1px solid transparent",
-                },
-                "&:hover svg": {
-                  color: "#13715B !important",
-                  stroke: "#13715B !important",
-                },
-                "&:hover svg path": {
-                  stroke: "#13715B !important",
-                },
-              }}
-            >
-              <ListItemIcon
-                sx={{
-                  minWidth: 0,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: "16px",
-                  mr: 0,
-                  "& svg": {
-                    color:
-                      location.pathname === item.path ||
-                      item.highlightPaths?.some((p: string) =>
-                        location.pathname.startsWith(p)
-                      ) ||
-                      customMenuHandler() === item.path ||
-                      location.pathname.startsWith(`${item.path}/`)
-                        ? "#13715B !important"
-                        : `${theme.palette.text.tertiary} !important`,
-                    stroke:
-                      location.pathname === item.path ||
-                      item.highlightPaths?.some((p: string) =>
-                        location.pathname.startsWith(p)
-                      ) ||
-                      customMenuHandler() === item.path ||
-                      location.pathname.startsWith(`${item.path}/`)
-                        ? "#13715B !important"
-                        : `${theme.palette.text.tertiary} !important`,
-                    transition: "color 0.2s ease, stroke 0.2s ease",
-                  },
-                  "& svg path": {
-                    stroke:
-                      location.pathname === item.path ||
-                      item.highlightPaths?.some((p: string) =>
-                        location.pathname.startsWith(p)
-                      ) ||
-                      customMenuHandler() === item.path ||
-                      location.pathname.startsWith(`${item.path}/`)
-                        ? "#13715B !important"
-                        : `${theme.palette.text.tertiary} !important`,
-                  },
-                  "&:hover svg": {
-                    color: "#13715B !important",
-                    stroke: "#13715B !important",
-                  },
-                  "&:hover svg path": {
-                    stroke: "#13715B !important",
-                  },
-                }}
-              >
-                {item.icon}
-              </ListItemIcon>
-              <ListItemText
-                sx={{
-                  "& .MuiListItemText-primary": {
-                    fontSize: "13px",
-                  },
-                }}
-              >
-                {item.name}
-              </ListItemText>
-              {!collapsed && item.taskCount && item.taskCount > 0 && (
-                <Chip
-                  label={item.taskCount > 99 ? "99+" : item.taskCount}
-                  size="small"
-                  sx={{
-                    height: "18px",
-                    fontSize: "10px",
-                    fontWeight: 500,
-                    backgroundColor:
-                      location.pathname === item.path ||
-                      item.highlightPaths?.some((p: string) =>
-                        location.pathname.startsWith(p)
-                      ) ||
-                      customMenuHandler() === item.path ||
-                      location.pathname.startsWith(`${item.path}/`)
-                        ? "#f8fafc"
-                        : "#e2e8f0", // lighter when active, blueish-grayish when inactive
-                    color: "#475569", // darker text for contrast
-                    borderRadius: "9px",
-                    minWidth: "18px",
-                    maxWidth: "36px",
-                    "& .MuiChip-label": {
-                      px: "6px",
-                      py: 0,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    },
-                    ml: "auto",
-                  }}
-                />
-              )}
-            </ListItemButton>
-          </Tooltip>
-        ))}
-
-        {/* Items of the menu */}
-        {menuGroups.map((group) => (
-          <React.Fragment key={group.name}>
-            {/* Group header */}
-            <Typography
-              variant="overline"
-              className="sidebar-group-header"
-              sx={{
-                px: theme.spacing(4),
-                pt: theme.spacing(4.5),
-                pb: theme.spacing(1.5),
-                mt: theme.spacing(3),
-                color: "#a0a0a0 !important",
-                fontSize: "11px !important",
-                fontWeight: 400,
-                letterSpacing: "0.5px",
-                textTransform: "uppercase",
-                display: collapsed ? "none" : "block",
-              }}
-            >
-              {group.name}
-            </Typography>
-
-            {/* Group items */}
-            {group.items.map((item) => (
-              <Tooltip
-                sx={{ fontSize: 13 }}
-                key={item.path}
-                placement="right"
-                title={collapsed ? item.name : ""}
-                slotProps={{
-                  popper: {
-                    modifiers: [
-                      {
-                        name: "offset",
-                        options: {
-                          offset: [0, -16],
-                        },
-                      },
-                    ],
-                  },
-                }}
-                disableInteractive
-              >
-                <ListItemButton
-                  disableRipple={
-                    theme.components?.MuiListItemButton?.defaultProps
-                      ?.disableRipple
-                  }
-                  className={
-                    location.pathname === item.path ||
-                    item.highlightPaths?.some((p: string) =>
-                      location.pathname.startsWith(p)
-                    ) ||
-                    customMenuHandler() === item.path ||
-                    location.pathname.startsWith(`${item.path}/`)
-                      ? "selected-path"
-                      : "unselected"
-                  }
-                  onClick={() => navigate(`${item.path}`)}
-                  sx={{
-                    height: "32px",
-                    gap: collapsed ? 0 : theme.spacing(4),
-                    borderRadius: theme.shape.borderRadius,
-                    px: theme.spacing(4),
-                    justifyContent: collapsed ? "center" : "flex-start",
-                    "& .MuiListItemText-root": {
-                      display: collapsed ? "none" : "block",
-                    },
-                    background:
-                      location.pathname === item.path ||
-                      item.highlightPaths?.some((p: string) =>
-                        location.pathname.startsWith(p)
-                      ) ||
-                      customMenuHandler() === item.path ||
-                      location.pathname.startsWith(`${item.path}/`)
-                        ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
-                        : "transparent",
-                    border:
-                      location.pathname === item.path ||
-                      item.highlightPaths?.some((p: string) =>
-                        location.pathname.startsWith(p)
-                      ) ||
-                      customMenuHandler() === item.path
-                        ? "1px solid #D8D8D8"
-                        : "1px solid transparent",
-
-                    "&:hover": {
-                      background:
-                        location.pathname === item.path ||
-                        item.highlightPaths?.some((p: string) =>
-                          location.pathname.startsWith(p)
-                        ) ||
-                        customMenuHandler() === item.path ||
-                        location.pathname.startsWith(`${item.path}/`)
-                          ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
-                          : "#F9F9F9",
-                      border:
-                        location.pathname === item.path ||
-                        item.highlightPaths?.some((p: string) =>
-                          location.pathname.startsWith(p)
-                        ) ||
-                        customMenuHandler() === item.path ||
-                        location.pathname.startsWith(`${item.path}/`)
-                          ? "1px solid #D8D8D8"
-                          : "1px solid transparent",
-                    },
-                    "&:hover svg": {
-                      color: "#13715B !important",
-                      stroke: "#13715B !important",
-                    },
-                    "&:hover svg path": {
-                      stroke: "#13715B !important",
-                    },
-                  }}
-                >
-                  <ListItemIcon
-                    sx={{
-                      minWidth: 0,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      width: "16px",
-                      mr: 0,
-                      "& svg": {
-                        color:
-                          location.pathname === item.path ||
-                          item.highlightPaths?.some((p: string) =>
-                            location.pathname.startsWith(p)
-                          ) ||
-                          customMenuHandler() === item.path ||
-                          location.pathname.startsWith(`${item.path}/`)
-                            ? "#13715B !important"
-                            : `${theme.palette.text.tertiary} !important`,
-                        stroke:
-                          location.pathname === item.path ||
-                          item.highlightPaths?.some((p: string) =>
-                            location.pathname.startsWith(p)
-                          ) ||
-                          customMenuHandler() === item.path ||
-                          location.pathname.startsWith(`${item.path}/`)
-                            ? "#13715B !important"
-                            : `${theme.palette.text.tertiary} !important`,
-                        transition: "color 0.2s ease, stroke 0.2s ease",
-                      },
-                      "& svg path": {
-                        stroke:
-                          location.pathname === item.path ||
-                          item.highlightPaths?.some((p: string) =>
-                            location.pathname.startsWith(p)
-                          ) ||
-                          customMenuHandler() === item.path ||
-                          location.pathname.startsWith(`${item.path}/`)
-                            ? "#13715B !important"
-                            : `${theme.palette.text.tertiary} !important`,
-                      },
-                      "&:hover svg": {
-                        color: "#13715B !important",
-                        stroke: "#13715B !important",
-                      },
-                      "&:hover svg path": {
-                        stroke: "#13715B !important",
-                      },
-                    }}
-                  >
-                    {item.icon}
-                  </ListItemIcon>
-                  <ListItemText
-                    sx={{
-                      "& .MuiListItemText-primary": {
-                        fontSize: "13px",
-                      },
-                    }}
-                  >
-                    {item.name}
-                  </ListItemText>
-                </ListItemButton>
-              </Tooltip>
-            ))}
-          </React.Fragment>
-        ))}
-      </List>
-      <Divider sx={{ my: theme.spacing(4) }} />
-      {/* Management Section */}
-      <List
-        component={"nav"}
-        aria-labelledby="nested-management-subheader"
-        sx={{
-          px: theme.spacing(8),
-          flexShrink: 0,
-        }}
-      >
-        {/* Management Dropdown Button */}
-        <Tooltip
-          sx={{ fontSize: 13 }}
-          placement="right"
-          title={collapsed ? "Management" : ""}
-          slotProps={{
-            popper: {
-              modifiers: [
-                {
-                  name: "offset",
-                  options: {
-                    offset: [0, -16],
-                  },
-                },
-              ],
-            },
-          }}
-          disableInteractive
-        >
-          <ListItemButton
-            disableRipple={
-              theme.components?.MuiListItemButton?.defaultProps?.disableRipple
-            }
-            onClick={(event) => setManagementAnchorEl(event.currentTarget)}
-            sx={{
-              height: "32px",
-              gap: theme.spacing(4),
-              borderRadius: theme.shape.borderRadius,
-              px: theme.spacing(4),
-              background: getManagementItems(
-                hasDemoData,
-                onOpenCreateDemoData,
-                onOpenDeleteDemoData
-              ).some(
-                (item) =>
-                  location.pathname.startsWith(`${item.path}/`) ||
-                  location.pathname === item.path
-              )
-                ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
-                : "transparent",
-              border: getManagementItems(
-                hasDemoData,
-                onOpenCreateDemoData,
-                onOpenDeleteDemoData
-              ).some(
-                (item) =>
-                  location.pathname.startsWith(`${item.path}/`) ||
-                  location.pathname === item.path
-              )
-                ? "1px solid #D8D8D8"
-                : "1px solid transparent",
-              "&:hover": {
-                background: getManagementItems(
-                  hasDemoData,
-                  onOpenCreateDemoData,
-                  onOpenDeleteDemoData
-                ).some(
-                  (item) =>
-                    location.pathname.startsWith(`${item.path}/`) ||
-                    location.pathname === item.path
-                )
-                  ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
-                  : "#F9F9F9",
-                border: getManagementItems(
-                  hasDemoData,
-                  onOpenCreateDemoData,
-                  onOpenDeleteDemoData
-                ).some(
-                  (item) =>
-                    location.pathname.startsWith(`${item.path}/`) ||
-                    location.pathname === item.path
-                )
-                  ? "1px solid #D8D8D8"
-                  : "1px solid transparent",
-              },
-              "&:hover svg": {
-                color: "#13715B !important",
-                stroke: "#13715B !important",
-              },
-              "&:hover svg path": {
-                stroke: "#13715B !important",
-              },
-            }}
-          >
-            <ListItemIcon
-              sx={{
-                minWidth: 0,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "flex-start",
-                width: "16px",
-                mr: 0,
-                "& svg": {
-                  color: getManagementItems(
-                    hasDemoData,
-                    onOpenCreateDemoData,
-                    onOpenDeleteDemoData
-                  ).some(
-                    (item) => item.path && location.pathname.includes(item.path)
-                  )
-                    ? "#13715B !important"
-                    : `${theme.palette.text.tertiary} !important`,
-                  stroke: getManagementItems(
-                    hasDemoData,
-                    onOpenCreateDemoData,
-                    onOpenDeleteDemoData
-                  ).some(
-                    (item) => item.path && location.pathname.includes(item.path)
-                  )
-                    ? "#13715B !important"
-                    : `${theme.palette.text.tertiary} !important`,
-                  transition: "color 0.2s ease, stroke 0.2s ease",
-                },
-                "& svg path": {
-                  stroke: getManagementItems(
-                    hasDemoData,
-                    onOpenCreateDemoData,
-                    onOpenDeleteDemoData
-                  ).some(
-                    (item) => item.path && location.pathname.includes(item.path)
-                  )
-                    ? "#13715B !important"
-                    : `${theme.palette.text.tertiary} !important`,
-                },
-                "&:hover svg": {
-                  color: "#13715B !important",
-                  stroke: "#13715B !important",
-                },
-                "&:hover svg path": {
-                  stroke: "#13715B !important",
-                },
-              }}
-            >
-              <FolderCog size={16} strokeWidth={1.5} />
-            </ListItemIcon>
-            <ListItemText
-              sx={{
-                "& .MuiListItemText-primary": {
-                  fontSize: "13px",
-                },
-              }}
-            >
-              Management
-            </ListItemText>
-            <ChevronDown
-              size={16}
-              strokeWidth={1.5}
-              style={{
-                transform: managementAnchorEl
-                  ? "rotate(180deg)"
-                  : "rotate(0deg)",
-                transition: "transform 0.2s ease",
-              }}
-            />
-          </ListItemButton>
-        </Tooltip>
-
-        {/* Management Dropdown Menu */}
-        <Menu
-          anchorEl={managementAnchorEl}
-          open={Boolean(managementAnchorEl)}
-          onClose={() => setManagementAnchorEl(null)}
-          anchorOrigin={{
-            vertical: "top",
-            horizontal: collapsed ? "right" : "left",
-          }}
-          transformOrigin={{
-            vertical: "bottom",
-            horizontal: collapsed ? "left" : "left",
-          }}
-          slotProps={{
-            paper: {
-              sx: {
-                width: managementAnchorEl
-                  ? managementAnchorEl.offsetWidth
-                  : "auto",
-                minWidth: collapsed ? "180px" : "auto",
-                borderRadius: theme.shape.borderRadius,
-                boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
-                border: `1px solid ${theme.palette.divider}`,
-                mt: -1,
-              },
-            },
-          }}
-        >
-          {getManagementItems(
-            hasDemoData,
-            onOpenCreateDemoData,
-            onOpenDeleteDemoData
-          ).map((item) => (
-            <MenuItem
-              key={item.path || item.name}
-              onClick={() => {
-                if (item.action) {
-                  item.action();
-                } else if (item.path) {
-                  navigate(item.path);
-                }
-                setManagementAnchorEl(null);
-              }}
-              sx={{
-                display: "flex",
-                gap: theme.spacing(4),
-                px: theme.spacing(4),
-                py: 0,
-                height: "32px",
-                fontSize: "13px",
-                borderRadius: theme.shape.borderRadius,
-                "&:hover": {
-                  backgroundColor: "#F9F9F9",
-                },
-                "&:hover svg": {
-                  color: "#13715B !important",
-                  stroke: "#13715B !important",
-                },
-                "&:hover svg path": {
-                  stroke: "#13715B !important",
-                },
-              }}
-            >
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "12px",
-                  width: "100%",
-                }}
-              >
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    width: "16px",
-                    height: "16px",
-                    flexShrink: 0,
-                    "& svg": {
-                      color:
-                        item.path && location.pathname.includes(item.path)
-                          ? "#13715B !important"
-                          : `${theme.palette.text.tertiary} !important`,
-                      stroke:
-                        item.path && location.pathname.includes(item.path)
-                          ? "#13715B !important"
-                          : `${theme.palette.text.tertiary} !important`,
-                      transition: "color 0.2s ease, stroke 0.2s ease",
-                    },
-                    "& svg path": {
-                      stroke:
-                        item.path && location.pathname.includes(item.path)
-                          ? "#13715B !important"
-                          : `${theme.palette.text.tertiary} !important`,
-                    },
-                  }}
-                >
-                  {item.icon}
-                </Box>
-                <Typography
-                  sx={{
-                    fontSize: "13px",
-                    color: theme.palette.text.secondary,
-                  }}
-                >
-                  {item.name}
-                </Typography>
-              </Box>
-            </MenuItem>
-          ))}
-        </Menu>
-      </List>
-      {!collapsed && (
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "flex-end",
-            alignItems: "center",
-            flexShrink: 0,
-          }}
-        >
-          <ReadyToSubscribeBox />
-        </Box>
-      )}
-      <Divider sx={{ mt: "auto" }} />
-      <Stack
-        direction="row"
-        height="50px"
-        alignItems="center"
-        py={theme.spacing(4)}
-        px={theme.spacing(8)}
-        gap={theme.spacing(2)}
-        borderRadius={theme.shape.borderRadius}
-        sx={{ flexShrink: 0 }}
-      >
-        {collapsed ? (
-          <>
-            <Tooltip
-              sx={{ fontSize: 13 }}
-              title="Options"
-              slotProps={{
-                popper: {
-                  modifiers: [
-                    {
-                      name: "offset",
-                      options: {
-                        offset: [0, -10],
-                      },
-                    },
-                  ],
-                },
-              }}
-              disableInteractive
-            >
-              <IconButton
-                onClick={openPopup}
-                sx={{
-                  p: 0,
-                  "&:focus": { outline: "none" },
-                  justifyContent: "center",
-                  alignItems: "center",
-                  marginLeft: theme.spacing(3),
-                }}
-              >
-                <Avatar
-                  user={userAvator}
-                  size="small"
-                  sx={{ margin: "auto" }}
-                />
-              </IconButton>
-            </Tooltip>
-          </>
-        ) : (
-          <>
-            <Avatar
-              user={userAvator}
-              size="small"
-              sx={{ ml: theme.spacing(2) }}
-            />
-            <Box ml={theme.spacing(2)}>
-              <Typography component="span" fontWeight={500}>
-                {user.name} {user.surname}
-              </Typography>
-              <Typography sx={{ textTransform: "capitalize" }}>
-                {ROLES[user.roleId as keyof typeof ROLES]}
-              </Typography>
-            </Box>
-            <IconButton
-              disableRipple={
-                theme.components?.MuiIconButton?.defaultProps?.disableRipple
-              }
-              sx={{
-                ml: "auto",
-                mr: "-8px",
-                "&:focus": { outline: "none" },
-                "& svg": {
-                  width: "20px",
-                  height: "20px",
-                },
-                "& svg path": {
-                  stroke: theme.palette.other.icon,
-                },
-              }}
-              onClick={openPopup}
-            >
-              <MoreVertical size={16} strokeWidth={1.5} />
-            </IconButton>
-          </>
-        )}
-        <Drawer
-          anchor="bottom"
-          open={slideoverOpen}
-          onClose={closePopup}
-          hideBackdrop={true}
-          transitionDuration={0}
-          PaperProps={{
-            sx: {
-              width: collapsed ? "260px" : "300px", // Single column width
-              height: "auto",
-              maxHeight: "fit-content",
-              position: "absolute",
-              bottom: "80px",
-              left: collapsed ? "30px" : "30px",
-              borderRadius: "8px",
-              boxShadow: "0 12px 24px rgba(0,0,0,0.15)",
-              border: `1px solid ${theme.palette.divider}`,
-              backgroundColor: "transparent",
-              transition: "none",
-            },
-          }}
-        >
-          <Box
-            ref={drawerRef}
-            sx={{
-              backgroundColor: theme.palette.background.main,
-              borderRadius: "8px",
-              border: `1px solid ${theme.palette.divider}`,
-              overflow: "hidden",
-              p: 1, // 8px padding around entire content
-              animation: slideoverOpen ? "fadeIn 0.2s ease-in-out" : "none",
-              "@keyframes fadeIn": {
-                "0%": {
-                  opacity: 0,
-                },
-                "100%": {
-                  opacity: 1,
-                },
-              },
-            }}
-          >
-            {/* Single Column Layout */}
-            <Stack spacing={2}>
-              {/* Account Section */}
-              <Box>
-                <Typography
-                  variant="overline"
-                  sx={{
-                    fontSize: "11px",
-                    fontWeight: 600,
-                    color: theme.palette.text.disabled,
-                    letterSpacing: "0.5px",
-                    px: theme.spacing(4),
-                    pb: 1,
-                  }}
-                >
-                  ACCOUNT
-                </Typography>
-
-                <Stack spacing={1}>
-                  {/* My Profile */}
-                  <ListItemButton
-                    onClick={() => {
-                      navigate("/settings");
-                      closePopup();
-                    }}
-                    sx={{
-                      minHeight: "48px",
-                      gap: theme.spacing(4),
-                      borderRadius: theme.shape.borderRadius,
-                      px: theme.spacing(4),
-                      py: 1,
-                      "&:hover": {
-                        backgroundColor: "#F9FAFB",
-                      },
-                    }}
-                  >
-                    <Box sx={{ flex: 1 }}>
-                      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 0.5 }}>
-                        <Typography sx={{ fontSize: "13px", fontWeight: 500 }}>
-                          {user.name} {user.surname}
-                        </Typography>
-                        <Typography
-                          sx={{
-                            fontSize: "11px",
-                            color: theme.palette.text.secondary,
-                            textTransform: "capitalize",
-                          }}
-                        >
-                          {ROLES[user.roleId as keyof typeof ROLES]}
-                        </Typography>
-                      </Box>
-                      <Typography
-                        sx={{
-                          fontSize: "11px",
-                          color: theme.palette.text.secondary,
-                        }}
-                      >
-                        {user.email}
-                      </Typography>
-                    </Box>
-                  </ListItemButton>
-
-                  {/* Create Demo Data / Delete Demo Data */}
-                  {hasDemoData ? (
-                    <ListItemButton
-                      onClick={() => {
-                        if (onOpenDeleteDemoData) {
-                          onOpenDeleteDemoData();
-                        }
-                        closePopup();
-                      }}
-                      sx={{
-                        height: "32px",
-                        gap: theme.spacing(4),
-                        borderRadius: theme.shape.borderRadius,
-                        px: theme.spacing(4),
-                        "& svg": {
-                          color: theme.palette.text.tertiary,
-                          stroke: theme.palette.text.tertiary,
-                        },
-                        "&:hover": {
-                          backgroundColor: "#F9FAFB",
-                        },
-                        "&:hover svg": {
-                          color: "#13715B !important",
-                          stroke: "#13715B !important",
-                        },
-                        "&:hover svg path": {
-                          stroke: "#13715B !important",
-                        },
-                      }}
-                    >
-                      <Trash2 size={16} strokeWidth={1.5} />
-                      <Typography sx={{ fontSize: "13px" }}>
-                        Delete demo data
-                      </Typography>
-                    </ListItemButton>
-                  ) : (
-                    <ListItemButton
-                      onClick={() => {
-                        if (onOpenCreateDemoData) {
-                          onOpenCreateDemoData();
-                        }
-                        closePopup();
-                      }}
-                      sx={{
-                        height: "32px",
-                        gap: theme.spacing(4),
-                        borderRadius: theme.shape.borderRadius,
-                        px: theme.spacing(4),
-                        "& svg": {
-                          color: theme.palette.text.tertiary,
-                          stroke: theme.palette.text.tertiary,
-                        },
-                        "&:hover": {
-                          backgroundColor: "#F9FAFB",
-                        },
-                        "&:hover svg": {
-                          color: "#13715B !important",
-                          stroke: "#13715B !important",
-                        },
-                        "&:hover svg path": {
-                          stroke: "#13715B !important",
-                        },
-                      }}
-                    >
-                      <Database size={16} strokeWidth={1.5} />
-                      <Typography sx={{ fontSize: "13px" }}>
-                        Create demo data
-                      </Typography>
-                    </ListItemButton>
-                  )}
-                </Stack>
-              </Box>
-
-              {/* Explore VerifyWise Section */}
-              <Box>
-                <Typography
-                  variant="overline"
-                  sx={{
-                    fontSize: "11px",
-                    fontWeight: 600,
-                    color: theme.palette.text.disabled,
-                    letterSpacing: "0.5px",
-                    px: theme.spacing(4),
-                    pb: 1,
-                  }}
-                >
-                  EXPLORE VERIFYWISE
-                </Typography>
-
-                <Stack spacing={1}>
-                  {/* Help Center */}
-                  <ListItemButton
-                    onClick={() => {
-                      openUserGuide();
-                      closePopup();
-                    }}
-                    sx={{
-                      height: "32px",
-                      gap: theme.spacing(4),
-                      borderRadius: theme.shape.borderRadius,
-                      px: theme.spacing(4),
-                      "& svg": {
-                        color: theme.palette.text.tertiary,
-                        stroke: theme.palette.text.tertiary,
-                      },
-                      "&:hover": {
-                        backgroundColor: "#F9FAFB",
-                      },
-                      "&:hover svg": {
-                        color: "#13715B !important",
-                        stroke: "#13715B !important",
-                      },
-                      "&:hover svg path": {
-                        stroke: "#13715B !important",
-                      },
-                    }}
-                  >
-                    <HelpCircle size={16} strokeWidth={1.5} />
-                    <Typography sx={{ fontSize: "13px" }}>
-                      Help center
-                    </Typography>
-                  </ListItemButton>
-
-                  {/* What's New */}
-                  <ListItemButton
-                    onClick={() => {
-                      window.open(
-                        "https://verifywise.ai/blog",
-                        "_blank",
-                        "noreferrer"
-                      );
-                      closePopup();
-                    }}
-                    sx={{
-                      height: "32px",
-                      gap: theme.spacing(4),
-                      borderRadius: theme.shape.borderRadius,
-                      px: theme.spacing(4),
-                      "& svg": {
-                        color: theme.palette.text.tertiary,
-                        stroke: theme.palette.text.tertiary,
-                      },
-                      "&:hover": {
-                        backgroundColor: "#F9FAFB",
-                      },
-                      "&:hover svg": {
-                        color: "#13715B !important",
-                        stroke: "#13715B !important",
-                      },
-                      "&:hover svg path": {
-                        stroke: "#13715B !important",
-                      },
-                    }}
-                  >
-                    <Newspaper size={16} strokeWidth={1.5} />
-                    <Typography sx={{ fontSize: "13px" }}>
-                      What's new?
-                    </Typography>
-                  </ListItemButton>
-
-                  {/* User Community */}
-                  <ListItemButton
-                    onClick={() => {
-                      window.open(
-                        "https://discord.gg/d3k3E4uEpR",
-                        "_blank",
-                        "noreferrer"
-                      );
-                      closePopup();
-                    }}
-                    sx={{
-                      height: "32px",
-                      gap: theme.spacing(4),
-                      borderRadius: theme.shape.borderRadius,
-                      px: theme.spacing(4),
-                      "& svg": {
-                        color: theme.palette.text.tertiary,
-                        stroke: theme.palette.text.tertiary,
-                      },
-                      "&:hover": {
-                        backgroundColor: "#F9FAFB",
-                      },
-                      "&:hover svg": {
-                        color: "#13715B !important",
-                        stroke: "#13715B !important",
-                      },
-                      "&:hover svg path": {
-                        stroke: "#13715B !important",
-                      },
-                    }}
-                  >
-                    <Users size={16} strokeWidth={1.5} />
-                    <Typography sx={{ fontSize: "13px" }}>
-                      User community
-                    </Typography>
-                  </ListItemButton>
-
-                  {/* Get Support */}
-                  <ListItemButton
-                    onClick={() => {
-                      window.open(
-                        "https://verifywise.ai/contact",
-                        "_blank",
-                        "noreferrer"
-                      );
-                      closePopup();
-                    }}
-                    sx={{
-                      height: "32px",
-                      gap: theme.spacing(4),
-                      borderRadius: theme.shape.borderRadius,
-                      px: theme.spacing(4),
-                      "& svg": {
-                        color: theme.palette.text.tertiary,
-                        stroke: theme.palette.text.tertiary,
-                      },
-                      "&:hover": {
-                        backgroundColor: "#F9FAFB",
-                      },
-                      "&:hover svg": {
-                        color: "#13715B !important",
-                        stroke: "#13715B !important",
-                      },
-                      "&:hover svg path": {
-                        stroke: "#13715B !important",
-                      },
-                    }}
-                  >
-                    <Headphones size={16} strokeWidth={1.5} />
-                    <Typography sx={{ fontSize: "13px" }}>
-                      Get support
-                    </Typography>
-                  </ListItemButton>
-
-                  {/* Give Feedback */}
-                  <ListItemButton
-                    onClick={() => {
-                      window.open(
-                        "https://verifywise.ai/contact",
-                        "_blank",
-                        "noreferrer"
-                      );
-                      closePopup();
-                    }}
-                    sx={{
-                      height: "32px",
-                      gap: theme.spacing(4),
-                      borderRadius: theme.shape.borderRadius,
-                      px: theme.spacing(4),
-                      "& svg": {
-                        color: theme.palette.text.tertiary,
-                        stroke: theme.palette.text.tertiary,
-                      },
-                      "&:hover": {
-                        backgroundColor: "#F9FAFB",
-                      },
-                      "&:hover svg": {
-                        color: "#13715B !important",
-                        stroke: "#13715B !important",
-                      },
-                      "&:hover svg path": {
-                        stroke: "#13715B !important",
-                      },
-                    }}
-                  >
-                    <MessageCircle size={16} strokeWidth={1.5} />
-                    <Typography sx={{ fontSize: "13px" }}>
-                      Give feedback
-                    </Typography>
-                  </ListItemButton>
-                </Stack>
-              </Box>
-
-              {/* Divider */}
-              <Divider sx={{ my: 1 }} />
-
-              {/* Logout */}
-              <ListItemButton
-                onClick={logout}
-                sx={{
-                  height: "32px",
-                  gap: theme.spacing(4),
-                  borderRadius: theme.shape.borderRadius,
-                  px: theme.spacing(4),
-                  "& svg": {
-                    color: theme.palette.text.tertiary,
-                    stroke: theme.palette.text.tertiary,
-                  },
-                  "&:hover": {
-                    backgroundColor: "#F9FAFB",
-                  },
-                  "&:hover svg": {
-                    color: "#13715B !important",
-                    stroke: "#13715B !important",
-                  },
-                  "&:hover svg path": {
-                    stroke: "#13715B !important",
-                  },
-                }}
-              >
-                <LogOut size={16} strokeWidth={1.5} />
-                <Typography sx={{ fontSize: "13px" }}>Logout</Typography>
-              </ListItemButton>
-            </Stack>
-          </Box>
-        </Drawer>
-      </Stack>
-
-      {/* Flying Hearts Animation */}
-      {showFlyingHearts && (
-        <FlyingHearts onComplete={() => setShowFlyingHearts(false)} />
-      )}
-    </Stack>
+    <SidebarShell
+      topItems={topItems}
+      menuGroups={menuGroups}
+      isItemActive={isItemActive}
+      onItemClick={handleItemClick}
+      hasDemoData={hasDemoData}
+      onOpenCreateDemoData={onOpenCreateDemoData}
+      onOpenDeleteDemoData={onOpenDeleteDemoData}
+      showReadyToSubscribe={true}
+      openUserGuide={openUserGuide}
+      enableFlyingHearts={true}
+    />
   );
 };
 

--- a/Clients/src/presentation/containers/Dashboard/index.tsx
+++ b/Clients/src/presentation/containers/Dashboard/index.tsx
@@ -1,9 +1,9 @@
 import { Stack, Typography, Box } from "@mui/material";
 import "./index.css";
-import Sidebar from "../../components/Sidebar";
 import { Outlet, useLocation } from "react-router";
 import { useContext, useEffect, FC, useState } from "react";
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
+import { EvalsSidebarProvider } from "../../../application/contexts/EvalsSidebar.context";
 import DemoAppBanner from "../../components/DemoBanner/DemoAppBanner";
 import { getAllProjects } from "../../../application/repository/project.repository";
 import {
@@ -17,6 +17,9 @@ import CustomizableButton from "../../components/Button/CustomizableButton";
 import Alert from "../../components/Alert";
 import { AlertState } from "../../../application/interfaces/appStates";
 import { useDashboard } from "../../../application/hooks/useDashboard";
+import { useActiveModule } from "../../../application/hooks/useActiveModule";
+import AppSwitcher from "../../components/AppSwitcher";
+import ContextSidebar from "../../components/ContextSidebar";
 
 interface DashboardProps {
   reloadTrigger: boolean;
@@ -25,6 +28,7 @@ interface DashboardProps {
 const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
   const { setDashboardValues, setProjects } = useContext(VerifyWiseContext);
   const location = useLocation();
+  const { activeModule, setActiveModule } = useActiveModule();
 
   // Demo data state
   const [showToastNotification, setShowToastNotification] =
@@ -269,32 +273,38 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
   };
 
   return (
-    <Stack
-      maxWidth="100%"
-      className="home-layout"
-      flexDirection="row"
-      gap={0}
-      sx={{ backgroundColor: "#FCFCFD" }}
-    >
-      <Sidebar
-        onOpenCreateDemoData={() => setOpenDemoDataModal(true)}
-        onOpenDeleteDemoData={() => setOpenDeleteDemoDataModal(true)}
-        hasDemoData={hasDemoData}
-      />
-      <Stack>
-        <DemoAppBanner />
-        {alertState && (
-          <Alert
-            variant={alertState.variant}
-            title={alertState.title}
-            body={alertState.body}
-            isToast={true}
-            onClick={() => setAlertState(undefined)}
-          />
-        )}
-        {showToastNotification && <CustomizableToast title={toastMessage} />}
-        <Outlet />
-      </Stack>
+    <EvalsSidebarProvider>
+      <Stack
+        maxWidth="100%"
+        className="home-layout"
+        flexDirection="row"
+        gap={0}
+        sx={{ backgroundColor: "#FCFCFD" }}
+      >
+        <AppSwitcher
+          activeModule={activeModule}
+          onModuleChange={setActiveModule}
+        />
+        <ContextSidebar
+          activeModule={activeModule}
+          onOpenCreateDemoData={() => setOpenDemoDataModal(true)}
+          onOpenDeleteDemoData={() => setOpenDeleteDemoDataModal(true)}
+          hasDemoData={hasDemoData}
+        />
+        <Stack sx={{ flex: 1, minWidth: 0 }}>
+          <DemoAppBanner />
+          {alertState && (
+            <Alert
+              variant={alertState.variant}
+              title={alertState.title}
+              body={alertState.body}
+              isToast={true}
+              onClick={() => setAlertState(undefined)}
+            />
+          )}
+          {showToastNotification && <CustomizableToast title={toastMessage} />}
+          <Outlet />
+        </Stack>
 
       {/* Demo Data Modals */}
       <StandardModal
@@ -438,7 +448,8 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
           </Typography>
         </Stack>
       </StandardModal>
-    </Stack>
+      </Stack>
+    </EvalsSidebarProvider>
   );
 };
 

--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
@@ -1,5 +1,15 @@
-import { Box, List, ListItemButton, ListItemIcon, ListItemText, Chip, useTheme, Typography } from "@mui/material";
-import { LayoutDashboard, FlaskConical, Database, Award, Settings } from "lucide-react";
+import {
+  LayoutDashboard,
+  FlaskConical,
+  Database,
+  Award,
+  Settings,
+} from "lucide-react";
+import SidebarShell, {
+  SidebarMenuItem,
+  RecentSection,
+  ProjectSelectorConfig,
+} from "../../components/Sidebar/SidebarShell";
 
 interface RecentExperiment {
   id: string;
@@ -12,12 +22,9 @@ interface RecentProject {
   name: string;
 }
 
-interface SidebarItem {
-  label: string;
-  value: string;
-  icon: React.ReactNode;
-  count?: number;
-  disabledWhenNoProject?: boolean;
+interface EvalProject {
+  id: string;
+  name: string;
 }
 
 interface EvalsSidebarProps {
@@ -27,11 +34,14 @@ interface EvalsSidebarProps {
   datasetsCount?: number;
   scorersCount?: number;
   disabled?: boolean;
-  // Recent items
   recentExperiments?: RecentExperiment[];
   recentProjects?: RecentProject[];
   onExperimentClick?: (experimentId: string, projectId: string) => void;
   onProjectClick?: (projectId: string) => void;
+  // Project selector props
+  currentProject?: EvalProject | null;
+  allProjects?: EvalProject[];
+  onProjectChange?: (projectId: string) => void;
 }
 
 export default function EvalsSidebar({
@@ -45,256 +55,103 @@ export default function EvalsSidebar({
   recentProjects = [],
   onExperimentClick,
   onProjectClick,
+  currentProject,
+  allProjects = [],
+  onProjectChange,
 }: EvalsSidebarProps) {
-  const theme = useTheme();
-
-  const sidebarItems: SidebarItem[] = [
-    { label: "Overview", value: "overview", icon: <LayoutDashboard size={16} strokeWidth={1.5} />, disabledWhenNoProject: true },
-    { label: "Experiments", value: "experiments", icon: <FlaskConical size={16} strokeWidth={1.5} />, count: experimentsCount, disabledWhenNoProject: true },
-    { label: "Datasets", value: "datasets", icon: <Database size={16} strokeWidth={1.5} />, count: datasetsCount, disabledWhenNoProject: true },
-    { label: "Scorers", value: "scorers", icon: <Award size={16} strokeWidth={1.5} />, count: scorersCount, disabledWhenNoProject: true },
-    { label: "Configuration", value: "configuration", icon: <Settings size={16} strokeWidth={1.5} />, disabledWhenNoProject: true },
+  // Menu items for Evals
+  const flatItems: SidebarMenuItem[] = [
+    {
+      id: "overview",
+      label: "Overview",
+      value: "overview",
+      icon: <LayoutDashboard size={16} strokeWidth={1.5} />,
+      disabled: disabled,
+    },
+    {
+      id: "experiments",
+      label: "Experiments",
+      value: "experiments",
+      icon: <FlaskConical size={16} strokeWidth={1.5} />,
+      count: experimentsCount,
+      disabled: disabled,
+    },
+    {
+      id: "datasets",
+      label: "Datasets",
+      value: "datasets",
+      icon: <Database size={16} strokeWidth={1.5} />,
+      count: datasetsCount,
+      disabled: disabled,
+    },
+    {
+      id: "scorers",
+      label: "Scorers",
+      value: "scorers",
+      icon: <Award size={16} strokeWidth={1.5} />,
+      count: scorersCount,
+      disabled: disabled,
+    },
+    {
+      id: "configuration",
+      label: "Configuration",
+      value: "configuration",
+      icon: <Settings size={16} strokeWidth={1.5} />,
+      disabled: disabled,
+    },
   ];
 
+  // Recent sections
+  const recentSections: RecentSection[] = [
+    {
+      title: "Recent experiments",
+      items: recentExperiments.map((exp) => ({
+        id: exp.id,
+        name: exp.name,
+        onClick: () => onExperimentClick?.(exp.id, exp.projectId),
+      })),
+    },
+    {
+      title: "Recent projects",
+      items: recentProjects.map((proj) => ({
+        id: proj.id,
+        name: proj.name,
+        onClick: () => onProjectClick?.(proj.id),
+      })),
+    },
+  ];
+
+  // Check if item is active based on activeTab
+  const isItemActive = (item: SidebarMenuItem): boolean => {
+    return item.value === activeTab || item.id === activeTab;
+  };
+
+  // Handle item click - change tab
+  const handleItemClick = (item: SidebarMenuItem) => {
+    if (item.value) {
+      onTabChange(item.value);
+    }
+  };
+
+  // Build project selector config if we have the data
+  const projectSelectorConfig: ProjectSelectorConfig | undefined =
+    currentProject && onProjectChange
+      ? {
+          currentProject,
+          allProjects,
+          onProjectChange,
+        }
+      : undefined;
+
   return (
-    <Box
-      sx={{
-        width: "200px",
-        minWidth: "200px",
-        height: "fit-content",
-        border: "1px solid #d0d5dd",
-        borderRadius: "4px",
-        backgroundColor: theme.palette.background.main,
-        py: 1,
-        pr: 1, // 8px right padding
-      }}
-    >
-
-      <List component="nav" disablePadding sx={{ px: 1 }}>
-        {sidebarItems.map((item) => {
-          const isActive = activeTab === item.value;
-          const isItemDisabled = disabled && item.disabledWhenNoProject;
-
-          return (
-            <ListItemButton
-              key={item.value}
-              onClick={() => !isItemDisabled && onTabChange(item.value)}
-              disableRipple
-              disabled={isItemDisabled}
-              sx={{
-                height: "34px",
-                gap: theme.spacing(3),
-                borderRadius: "4px",
-                px: theme.spacing(3),
-                mb: 0.5,
-                opacity: isItemDisabled ? 0.5 : 1,
-                cursor: isItemDisabled ? "not-allowed" : "pointer",
-                background: isActive && !isItemDisabled
-                  ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
-                  : "transparent",
-                border: isActive && !isItemDisabled
-                  ? "1px solid #D8D8D8"
-                  : "1px solid transparent",
-                "&:hover": {
-                  background: isItemDisabled
-                    ? "transparent"
-                    : isActive
-                    ? "linear-gradient(135deg, #ECECEC 0%, #E4E4E4 100%)"
-                    : "#F9F9F9",
-                  border: isItemDisabled
-                    ? "1px solid transparent"
-                    : isActive
-                    ? "1px solid #D8D8D8"
-                    : "1px solid transparent",
-                },
-                "&:hover svg": isItemDisabled ? {} : {
-                  color: "#13715B !important",
-                  stroke: "#13715B !important",
-                },
-                "&:hover svg path": isItemDisabled ? {} : {
-                  stroke: "#13715B !important",
-                },
-                "&.Mui-disabled": {
-                  opacity: 0.5,
-                },
-              }}
-            >
-              <ListItemIcon
-                sx={{
-                  minWidth: 0,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "flex-start",
-                  width: "16px",
-                  mr: 0,
-                  "& svg": {
-                    color: isItemDisabled
-                      ? `${theme.palette.text.disabled} !important`
-                      : isActive
-                      ? "#13715B !important"
-                      : `${theme.palette.text.tertiary} !important`,
-                    stroke: isItemDisabled
-                      ? `${theme.palette.text.disabled} !important`
-                      : isActive
-                      ? "#13715B !important"
-                      : `${theme.palette.text.tertiary} !important`,
-                    transition: "color 0.2s ease, stroke 0.2s ease",
-                  },
-                  "& svg path": {
-                    stroke: isItemDisabled
-                      ? `${theme.palette.text.disabled} !important`
-                      : isActive
-                      ? "#13715B !important"
-                      : `${theme.palette.text.tertiary} !important`,
-                  },
-                }}
-              >
-                {item.icon}
-              </ListItemIcon>
-              <ListItemText
-                sx={{
-                  "& .MuiListItemText-primary": {
-                    fontSize: "13px",
-                    color: isItemDisabled
-                      ? theme.palette.text.disabled
-                      : isActive
-                      ? theme.palette.text.primary
-                      : theme.palette.text.secondary,
-                  },
-                }}
-              >
-                {item.label}
-              </ListItemText>
-              {item.count !== undefined && item.count > 0 && !isItemDisabled && (
-                <Chip
-                  label={item.count > 99 ? "99+" : item.count}
-                  size="small"
-                  sx={{
-                    height: "18px",
-                    fontSize: "10px",
-                    fontWeight: 500,
-                    backgroundColor: isActive ? "#f8fafc" : "#e2e8f0",
-                    color: "#475569",
-                    borderRadius: "9px",
-                    minWidth: "18px",
-                    maxWidth: "36px",
-                    "& .MuiChip-label": {
-                      px: "6px",
-                      py: 0,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    },
-                    ml: "auto",
-                  }}
-                />
-              )}
-            </ListItemButton>
-          );
-        })}
-      </List>
-
-      {/* Recent experiments section */}
-      {recentExperiments.length > 0 && (
-        <Box sx={{ px: 1, marginTop: "16px" }}>
-          <Typography
-            sx={{
-              fontSize: "10px",
-              fontWeight: 500,
-              color: theme.palette.text.disabled,
-              textTransform: "uppercase",
-              letterSpacing: "0.5px",
-              px: theme.spacing(3),
-              mb: 0.5,
-            }}
-          >
-            Recent experiments
-          </Typography>
-          <List component="nav" disablePadding>
-            {recentExperiments.slice(0, 3).map((exp) => (
-              <ListItemButton
-                key={exp.id}
-                onClick={() => onExperimentClick?.(exp.id, exp.projectId)}
-                disableRipple
-                sx={{
-                  height: "30px",
-                  borderRadius: "4px",
-                  px: theme.spacing(3),
-                  mb: 0.25,
-                  "&:hover": {
-                    backgroundColor: "#F9F9F9",
-                  },
-                }}
-              >
-                <ListItemText
-                  sx={{
-                    "& .MuiListItemText-primary": {
-                      fontSize: "12px",
-                      color: theme.palette.text.secondary,
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                    },
-                  }}
-                >
-                  {exp.name}
-                </ListItemText>
-              </ListItemButton>
-            ))}
-          </List>
-        </Box>
-      )}
-
-      {/* Recent projects section */}
-      {recentProjects.length > 0 && (
-        <Box sx={{ px: 1, marginTop: "16px", marginBottom: "16px" }}>
-          <Typography
-            sx={{
-              fontSize: "10px",
-              fontWeight: 500,
-              color: theme.palette.text.disabled,
-              textTransform: "uppercase",
-              letterSpacing: "0.5px",
-              px: theme.spacing(3),
-              mb: 0.5,
-            }}
-          >
-            Recent projects
-          </Typography>
-          <List component="nav" disablePadding>
-            {recentProjects.slice(0, 3).map((proj) => (
-              <ListItemButton
-                key={proj.id}
-                onClick={() => onProjectClick?.(proj.id)}
-                disableRipple
-                sx={{
-                  height: "30px",
-                  borderRadius: "4px",
-                  px: theme.spacing(3),
-                  mb: 0.25,
-                  "&:hover": {
-                    backgroundColor: "#F9F9F9",
-                  },
-                }}
-              >
-                <ListItemText
-                  sx={{
-                    "& .MuiListItemText-primary": {
-                      fontSize: "12px",
-                      color: theme.palette.text.secondary,
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                    },
-                  }}
-                >
-                  {proj.name}
-                </ListItemText>
-              </ListItemButton>
-            ))}
-          </List>
-        </Box>
-      )}
-    </Box>
+    <SidebarShell
+      flatItems={flatItems}
+      recentSections={recentSections}
+      projectSelector={projectSelectorConfig}
+      isItemActive={isItemActive}
+      onItemClick={handleItemClick}
+      showReadyToSubscribe={false}
+      enableFlyingHearts={false}
+    />
   );
 }

--- a/Clients/src/presentation/pages/EvalsDashboard/OrgSettings.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/OrgSettings.tsx
@@ -4,6 +4,7 @@ import { Box, Stack, Typography, IconButton, useTheme, Dialog, DialogTitle, Dial
 import { Home, FlaskConical, Settings, Trash2, Plus } from "lucide-react";
 import PageBreadcrumbs from "../../components/Breadcrumbs/PageBreadcrumbs";
 import PageHeader from "../../components/Layout/PageHeader";
+import HelperIcon from "../../components/HelperIcon";
 import Field from "../../components/Inputs/Field";
 import Select from "../../components/Inputs/Select";
 import CustomizableButton from "../../components/Button/CustomizableButton";
@@ -182,6 +183,7 @@ export default function OrgSettings() {
         <PageHeader
           title="Organization settings"
           description="Configure LLM provider API keys for running evaluations across your organization"
+          rightContent={<HelperIcon articlePath="llm-evals/configuration" />}
         />
       </Box>
 

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectDatasets.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectDatasets.tsx
@@ -39,6 +39,7 @@ import { useFilterBy } from "../../../application/hooks/useFilterBy";
 import singleTheme from "../../themes/v1SingleTheme";
 import TablePaginationActions from "../../components/TablePagination";
 import { getPaginationRowCount, setPaginationRowCount } from "../../../application/utils/paginationStorage";
+import HelperIcon from "../../components/HelperIcon";
 
 type ProjectDatasetsProps = { projectId: string };
 
@@ -1102,9 +1103,12 @@ export function ProjectDatasets({ projectId }: ProjectDatasetsProps) {
 
       {/* Header + description */}
       <Stack spacing={1} mb={4}>
-        <Typography variant="h6" fontSize={15} fontWeight="600" color="#111827">
-          Datasets
-        </Typography>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="h6" fontSize={15} fontWeight="600" color="#111827">
+            Datasets
+          </Typography>
+          <HelperIcon articlePath="llm-evals/managing-datasets" />
+        </Box>
         <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.6, fontSize: "14px" }}>
           Datasets contain the prompts or conversations used to evaluate your models. Create custom datasets or use templates to get started quickly.
         </Typography>

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx
@@ -13,6 +13,7 @@ import SearchBox from "../../components/Search/SearchBox";
 import { FilterBy, type FilterColumn } from "../../components/Table/FilterBy";
 import { GroupBy } from "../../components/Table/GroupBy";
 import { useFilterBy } from "../../../application/hooks/useFilterBy";
+import HelperIcon from "../../components/HelperIcon";
 
 interface ProjectExperimentsProps {
   projectId: string;
@@ -447,9 +448,12 @@ export default function ProjectExperiments({ projectId, onViewExperiment }: Proj
 
       {/* Header + description */}
       <Stack spacing={1} mb={4}>
-        <Typography variant="h6" fontSize={15} fontWeight="600" color="#111827">
-          Experiments
-        </Typography>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="h6" fontSize={15} fontWeight="600" color="#111827">
+            Experiments
+          </Typography>
+          <HelperIcon articlePath="llm-evals/running-experiments" />
+        </Box>
         <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.6, fontSize: "14px" }}>
           Experiments run evaluations on your models using datasets and scorers. Track performance metrics over time and compare different model configurations.
         </Typography>

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectOverview.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectOverview.tsx
@@ -18,6 +18,7 @@ import { experimentsService, monitoringService, type Experiment, type MonitorDas
 import NewExperimentModal from "./NewExperimentModal";
 import type { DeepEvalProject } from "./types";
 import { useNavigate } from "react-router-dom";
+import HelperIcon from "../../components/HelperIcon";
 
 interface ProjectOverviewProps {
   projectId: string;
@@ -233,9 +234,12 @@ export default function ProjectOverview({
     <Box>
       {/* Header + description */}
       <Stack spacing={1} mb={4}>
-        <Typography variant="h6" fontSize={15} fontWeight="600" color="#111827">
-          Overview
-        </Typography>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="h6" fontSize={15} fontWeight="600" color="#111827">
+            Overview
+          </Typography>
+          <HelperIcon articlePath="llm-evals/llm-evals-overview" />
+        </Box>
         <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.6, fontSize: "14px" }}>
           Monitor your project's evaluation performance, track key metrics, and view recent experiments at a glance.
         </Typography>

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectScorers.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectScorers.tsx
@@ -39,6 +39,7 @@ import {
 } from "../../../application/utils/paginationStorage";
 import EmptyState from "../../components/EmptyState";
 import CreateScorerModal, { type ScorerConfig } from "./CreateScorerModal";
+import HelperIcon from "../../components/HelperIcon";
 
 export interface ProjectScorersProps {
   projectId: string;
@@ -374,11 +375,14 @@ export default function ProjectScorers({ projectId }: ProjectScorersProps) {
 
       {/* Header + description */}
       <Stack spacing={1} mb={4}>
-        <Typography variant="h6" fontSize={15} fontWeight="600" color="#111827">
-          Scorers
-        </Typography>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Typography variant="h6" fontSize={15} fontWeight="600" color="#111827">
+            Scorers
+          </Typography>
+          <HelperIcon articlePath="llm-evals/configuring-scorers" />
+        </Box>
         <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.6, fontSize: "14px" }}>
-          Scorers are custom LLM judges that evaluate model outputs using your own criteria. Unlike built-in metrics (Relevancy, Bias, Toxicity), scorers let you define domain-specific evaluation prompts like "Is this response compliant with our guidelines?" or "Does the code follow best practices?". Each scorer calls an LLM (e.g., GPT-4) to judge the model's responses based on your prompt.
+          Define custom LLM judges to evaluate model outputs using your own domain-specific criteria and prompts.
         </Typography>
       </Stack>
 


### PR DESCRIPTION
## Summary
- Add new 40px dark app switcher rail with module icons (Governance, LLM Evals, Gateway)
- Create unified SidebarShell component for consistent sidebar styling across modules
- Integrate project selector dropdown in LLM Evals sidebar
- Add HelperIcon links to LLM Evals tab headers

## New components
| Component | Description |
|-----------|-------------|
| `AppSwitcher` | Dark rail with module icons for switching between Governance, LLM Evals, and Gateway |
| `ContextSidebar` | Renders the appropriate sidebar based on active module |
| `SidebarShell` | Unified sidebar component with consistent styling for all modules |
| `SidebarFooter` | Shared footer with Management dropdown and user profile |
| `GatewaySidebar` | Placeholder for upcoming Gateway module |

## Architecture changes
- Add `appModule` state to Redux for tracking active module
- Add `useActiveModule` hook for URL-based module detection  
- Add `EvalsSidebarContext` for sidebar state management
- Dashboard layout: `[AppSwitcher 40px] + [ContextSidebar] + [Content]`

## Screenshots
The new layout provides:
- Module switching via icons in the dark left rail
- Consistent sidebar styling (bold active items, smooth animations)
- Project selector dropdown in LLM Evals sidebar
- Help icons linking to user guide sections

## Test plan
- [ ] Click module icons to switch between Governance and LLM Evals
- [ ] Verify sidebar collapses/expands smoothly
- [ ] Verify active menu items are bold
- [ ] Test project selector dropdown in LLM Evals
- [ ] Verify HelperIcon links open correct documentation
- [ ] Test recent projects/experiments cleanup (delete a project, verify it's removed from recents)
- [ ] Verify Gateway icon shows "Coming soon" tooltip