### PR TITLE
Fix infinite loop in EvalsDashboard useEffect

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsDashboard.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsDashboard.tsx
@@ -492,7 +492,8 @@ export default function EvalsDashboard() {
         navigate(`/evals/${newProjectId}#${tab}`);
       }
     });
-  }, [experimentsCount, datasetsCount, scorersCount, projectId, recentExperiments, recentProjects, currentProject, allProjects, tab, navigate, location.pathname, sidebarContext]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [experimentsCount, datasetsCount, scorersCount, projectId, recentExperiments, recentProjects, currentProject, allProjects, tab, navigate, location.pathname]);
 
   // Note: Tab change is now handled via URL hash in ContextSidebar
   // Note: Project change is now handled via context in sidebar project selector


### PR DESCRIPTION
## Summary
Fix "Maximum update depth exceeded" error in EvalsDashboard caused by infinite re-render loop.

## Problem
The useEffect that syncs sidebar context had `sidebarContext` in its dependency array. Each time the effect ran, it called `sidebarContext.setXXX()` methods which updated context state, causing the context object reference to change, triggering the effect again infinitely.

## Solution
Remove `sidebarContext` from the dependency array. The setter functions from `useState` are stable references and don't need to be tracked as dependencies.

## Test plan
- [ ] Navigate to LLM Evals page
- [ ] Verify no console errors about "Maximum update depth exceeded"
- [ ] Verify sidebar counts and project selector work correctly