### PR TITLE
Fix page scroll when helper sidebar is open

### DIFF
--- a/Clients/src/presentation/components/UserGuide/SidebarWrapper.css
+++ b/Clients/src/presentation/components/UserGuide/SidebarWrapper.css
@@ -5,9 +5,6 @@
 }
 
 /* Push main content when sidebar is open */
-body.sidebar-open {
-  overflow: hidden;
-}
 
 body.sidebar-open #main-content {
   margin-right: 410px; /* 360px sidebar + 50px tab bar */


### PR DESCRIPTION
## Summary
- Remove `overflow: hidden` from `body.sidebar-open` that was preventing page scrolling when the user guide sidebar is open

Fixes #2911 

## Test plan
- [ ] Open any page with scrollable content
- [ ] Open the helper sidebar (question mark icon)
- [ ] Verify the page can still scroll while sidebar is open