### PR TITLE
Fix EvalServer dataset paths for Docker and local development

### DIFF
--- a/.github/workflows/docker-image-saas.yml
+++ b/.github/workflows/docker-image-saas.yml
@@ -84,7 +84,8 @@ jobs:
       - name: Build and push EvalServer image
         uses: docker/build-push-action@v4
         with:
-          context: ./EvalServer
+          context: .
+          file: ./EvalServer/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Build and push EvalServer image
         uses: docker/build-push-action@v4
         with:
-          context: ./EvalServer
+          context: .
+          file: ./EvalServer/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/EvalServer/Dockerfile
+++ b/EvalServer/Dockerfile
@@ -4,10 +4,13 @@ FROM python:3.10
 WORKDIR /app
 
 # Copy requirements first for better caching
-COPY ./src/requirements.txt requirements.txt
+COPY ./EvalServer/src/requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the rest of the application
-COPY ./src .
+# Copy the application source
+COPY ./EvalServer/src .
+
+# Copy the datasets from EvaluationModule
+COPY ./EvaluationModule/data/datasets /app/datasets
 
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Update Docker build context to repository root to access EvaluationModule datasets
- Copy built-in datasets to /app/datasets in Docker image
- Add Docker-aware path resolution in deepeval.py controller
- Separate path handling for user uploads vs built-in datasets

## Test plan
- [ ] Verify built-in datasets load in New Experiment modal on deployed server
- [ ] Verify user-uploaded datasets load correctly locally
- [ ] Verify Docker build succeeds with new context
- [ ] Test path traversal security still blocks invalid paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)