### PR TITLE
Add ENCRYPTION_KEY to Docker environment configuration

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -31,6 +31,10 @@ REFRESH_TOKEN_SECRET=e628d7938c76308774cecf87dcb9bee6b8cae80ed2d20731ef94e211cf9
 # Encryption Settings
 ENCRYPTION_ALGORITHM=YOUR_ENCRYPTION_ALGORITHM
 ENCRYPTION_PASSWORD=YOUR_ENCRYPTION_PASSWORD
+# ENCRYPTION_KEY is used for encrypting/decrypting LLM API keys (must be consistent across deployments)
+# If not set, defaults to a hardcoded key. For production, set a unique 32+ character key.
+# WARNING: Changing this after API keys are saved will make them unreadable - re-save keys after changing.
+# ENCRYPTION_KEY=your-unique-32-character-key-here
 
 SLACK_CLIENT_ID=YOUR_SLACK_CLIENT_ID
 SLACK_CLIENT_SECRET=YOUR_SLACK_CLIENT_SECRET

--- a/.env.prod
+++ b/.env.prod
@@ -33,6 +33,10 @@ REFRESH_TOKEN_SECRET=e628d7938c76308774cecf87dcb9bee6b8cae80ed2d20731ef94e211cf9
 # Encryption Settings
 ENCRYPTION_ALGORITHM=YOUR_ENCRYPTION_ALGORITHM
 ENCRYPTION_PASSWORD=YOUR_ENCRYPTION_PASSWORD
+# ENCRYPTION_KEY is used for encrypting/decrypting LLM API keys (must be consistent across deployments)
+# If not set, defaults to a hardcoded key. For production, set a unique 32+ character key.
+# WARNING: Changing this after API keys are saved will make them unreadable - re-save keys after changing.
+# ENCRYPTION_KEY=your-unique-32-character-key-here
 
 SLACK_CLIENT_ID=YOUR_SLACK_CLIENT_ID
 SLACK_CLIENT_SECRET=YOUR_SLACK_CLIENT_SECRET

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - SMTP_PORT=587
       - FAIRNESS_AND_BIAS_URL=http://eval_server:8000
       - REDIS_URL=redis://redis:6379/0
+      - ENCRYPTION_KEY=$ENCRYPTION_KEY
   frontend:
     depends_on:
       - backend
@@ -69,6 +70,7 @@ services:
       - DB_NAME=$DB_NAME
       - JWT_SECRET=$JWT_SECRET
       - REDIS_URL=redis://redis:6379/0
+      - ENCRYPTION_KEY=$ENCRYPTION_KEY
     restart: unless-stopped
   eval_server:
     depends_on:


### PR DESCRIPTION
## Summary
- Add ENCRYPTION_KEY environment variable to backend and worker services in docker-compose.yml
- Add ENCRYPTION_KEY placeholder to .env.dev and .env.prod with documentation

## Problem
LLM API keys stored in the database were being decrypted with the wrong key in Docker deployments, causing 401 Unauthorized errors when calling LLM APIs (e.g., Mistral).

## Root cause
The ENCRYPTION_KEY environment variable was not being passed to Docker containers. Without it, the backend falls back to a hardcoded default key, which differs from the key used to encrypt the stored API keys.

## Deployment note
After deploying this fix, users must:
1. Set a real ENCRYPTION_KEY value in their environment file
2. Re-save their LLM API keys in Organization Settings (since old keys were encrypted with a different key)


  | Scenario                        | Behavior                            | Safe? |                                                                           
  |---------------------------------|-------------------------------------|-------|                                                                           
  | New installation                | Uses default key (or custom if set) | ✅    |                                                                           
  | Upgrade (no key set before)     | Continues using default key         | ✅    |                                                                           
  | Upgrade (custom key set before) | Uses same custom key                | ✅    |                                                                           
                                                                                                                                                              
  Key changes:                                                                                                                                                
  - ENCRYPTION_KEY is commented out in .env.dev and .env.prod (documentation only)                                                                            
  - docker-compose.yml passes $ENCRYPTION_KEY if set, otherwise backend uses hardcoded default                                                                
  - Added warning comment about re-saving API keys if the key is changed                                                                                      