### PR TITLE
Fix: include selectedScorers in frontend experiment config request

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -15,7 +15,6 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  ListItemText,
   FormHelperText,
 } from "@mui/material";
 import { Check, Database, ExternalLink, Upload, Sparkles, Settings, Plus, Layers, ChevronDown } from "lucide-react";


### PR DESCRIPTION
## Describe your changes

Scope: frontend only. No breaking changes.

#### Problem
The frontend was not sending the selectedScorers field in the experiment config request, causing all enabled scorers to run regardless of user selection.

#### Solution
This PR adds selectedScorers to the frontend request payload. The backend already consumes this field, so no backend changes were required.

## Write your issue number after "Fixes "

This PR does not intend to solve any predetermined issue.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
