### PR TITLE
Refactor: add deprecation notices to entity-specific change history files

### DIFF
--- a/Servers/utils/incidentChangeHistory.utils.ts
+++ b/Servers/utils/incidentChangeHistory.utils.ts
@@ -1,9 +1,18 @@
 /**
  * Incident Change History Utilities
  *
- * Wrapper functions that use the generic change history system.
- * These functions maintain backward compatibility while leveraging
- * the new generic utilities.
+ * @deprecated This file is deprecated and will be removed in a future version.
+ * Use the generic change history functions from `changeHistory.base.utils.ts` directly instead.
+ *
+ * Migration guide:
+ * - Replace `recordIncidentChange()` with `recordEntityChange("incident", ...)`
+ * - Replace `recordMultipleFieldChanges()` with `recordMultipleFieldChanges("incident", ...)`
+ * - Replace `getIncidentChangeHistory()` with `getEntityChangeHistory("incident", ...)`
+ * - Replace `trackIncidentChanges()` with `trackEntityChanges("incident", ...)`
+ * - Replace `recordIncidentCreation()` with `recordEntityCreation("incident", ...)`
+ * - Replace `recordIncidentDeletion()` with `recordEntityDeletion("incident", ...)`
+ *
+ * These wrapper functions are maintained for backward compatibility only.
  */
 
 import { IAIIncidentManagement } from "../domain.layer/interfaces/i.aiIncidentManagement";
@@ -19,6 +28,7 @@ import {
 
 /**
  * Record a change in incident
+ * @deprecated Use `recordEntityChange("incident", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordIncidentChange = async (
   incidentId: number,
@@ -45,6 +55,7 @@ export const recordIncidentChange = async (
 
 /**
  * Record multiple field changes for an incident
+ * @deprecated Use `recordMultipleFieldChanges("incident", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordMultipleFieldChanges = async (
   incidentId: number,
@@ -65,6 +76,7 @@ export const recordMultipleFieldChanges = async (
 
 /**
  * Get change history for a specific incident with pagination support
+ * @deprecated Use `getEntityChangeHistory("incident", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const getIncidentChangeHistory = async (
   incidentId: number,
@@ -83,6 +95,7 @@ export const getIncidentChangeHistory = async (
 
 /**
  * Track changes between old and new incident data
+ * @deprecated Use `trackEntityChanges("incident", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const trackIncidentChanges = async (
   oldModel: IAIIncidentManagement,
@@ -93,6 +106,7 @@ export const trackIncidentChanges = async (
 
 /**
  * Record creation of an incident
+ * @deprecated Use `recordEntityCreation("incident", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordIncidentCreation = async (
   incidentId: number,
@@ -113,6 +127,7 @@ export const recordIncidentCreation = async (
 
 /**
  * Record deletion of an incident
+ * @deprecated Use `recordEntityDeletion("incident", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordIncidentDeletion = async (
   incidentId: number,

--- a/Servers/utils/modelInventoryChangeHistory.utils.ts
+++ b/Servers/utils/modelInventoryChangeHistory.utils.ts
@@ -1,9 +1,21 @@
 /**
  * Model Inventory Change History Utilities
  *
- * Wrapper functions that use the generic change history system.
- * These functions maintain backward compatibility while leveraging
- * the new generic utilities.
+ * @deprecated This file is deprecated and will be removed in a future version.
+ * Use the generic change history functions from `changeHistory.base.utils.ts` directly instead.
+ *
+ * Migration guide:
+ * - Replace `recordModelInventoryChange()` with `recordEntityChange("model_inventory", ...)`
+ * - Replace `recordMultipleFieldChanges()` with `recordMultipleFieldChanges("model_inventory", ...)`
+ * - Replace `getModelInventoryChangeHistory()` with `getEntityChangeHistory("model_inventory", ...)`
+ * - Replace `trackModelInventoryChanges()` with `trackEntityChanges("model_inventory", ...)`
+ * - Replace `recordModelInventoryCreation()` with `recordEntityCreation("model_inventory", ...)`
+ * - Replace `recordModelInventoryDeletion()` with `recordEntityDeletion("model_inventory", ...)`
+ * - Replace `recordEvidenceAddedToModel()` with `recordEvidenceAddedToEntity("model_inventory", ...)`
+ * - Replace `recordEvidenceRemovedFromModel()` with `recordEvidenceRemovedFromEntity("model_inventory", ...)`
+ * - Replace `recordEvidenceFieldChangeForModel()` with `recordEvidenceFieldChangeForEntity("model_inventory", ...)`
+ *
+ * These wrapper functions are maintained for backward compatibility only.
  */
 
 import { ModelInventoryModel } from "../domain.layer/models/modelInventory/modelInventory.model";
@@ -22,6 +34,7 @@ import {
 
 /**
  * Record a change in model inventory
+ * @deprecated Use `recordEntityChange("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordModelInventoryChange = async (
   modelInventoryId: number,
@@ -48,6 +61,7 @@ export const recordModelInventoryChange = async (
 
 /**
  * Record multiple field changes for a model inventory
+ * @deprecated Use `recordMultipleFieldChanges("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordMultipleFieldChanges = async (
   modelInventoryId: number,
@@ -68,6 +82,7 @@ export const recordMultipleFieldChanges = async (
 
 /**
  * Get change history for a specific model inventory with pagination support
+ * @deprecated Use `getEntityChangeHistory("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const getModelInventoryChangeHistory = async (
   modelInventoryId: number,
@@ -86,6 +101,7 @@ export const getModelInventoryChangeHistory = async (
 
 /**
  * Track changes between old and new model inventory data
+ * @deprecated Use `trackEntityChanges("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const trackModelInventoryChanges = async (
   oldModel: ModelInventoryModel,
@@ -96,6 +112,7 @@ export const trackModelInventoryChanges = async (
 
 /**
  * Record creation of a model inventory
+ * @deprecated Use `recordEntityCreation("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordModelInventoryCreation = async (
   modelInventoryId: number,
@@ -116,6 +133,7 @@ export const recordModelInventoryCreation = async (
 
 /**
  * Record deletion of a model inventory
+ * @deprecated Use `recordEntityDeletion("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordModelInventoryDeletion = async (
   modelInventoryId: number,
@@ -134,6 +152,7 @@ export const recordModelInventoryDeletion = async (
 
 /**
  * Record evidence being added to a model
+ * @deprecated Use `recordEvidenceAddedToEntity("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordEvidenceAddedToModel = async (
   modelInventoryId: number,
@@ -156,6 +175,7 @@ export const recordEvidenceAddedToModel = async (
 
 /**
  * Record evidence being removed from a model
+ * @deprecated Use `recordEvidenceRemovedFromEntity("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordEvidenceRemovedFromModel = async (
   modelInventoryId: number,
@@ -178,6 +198,7 @@ export const recordEvidenceRemovedFromModel = async (
 
 /**
  * Record evidence field changes for a specific model
+ * @deprecated Use `recordEvidenceFieldChangeForEntity("model_inventory", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordEvidenceFieldChangeForModel = async (
   modelInventoryId: number,

--- a/Servers/utils/policyChangeHistory.utils.ts
+++ b/Servers/utils/policyChangeHistory.utils.ts
@@ -1,9 +1,18 @@
 /**
  * Policy Change History Utilities
  *
- * Wrapper functions that use the generic change history system.
- * These functions maintain backward compatibility while leveraging
- * the new generic utilities.
+ * @deprecated This file is deprecated and will be removed in a future version.
+ * Use the generic change history functions from `changeHistory.base.utils.ts` directly instead.
+ *
+ * Migration guide:
+ * - Replace `recordPolicyChange()` with `recordEntityChange("policy", ...)`
+ * - Replace `recordMultipleFieldChanges()` with `recordMultipleFieldChanges("policy", ...)`
+ * - Replace `getPolicyChangeHistory()` with `getEntityChangeHistory("policy", ...)`
+ * - Replace `trackPolicyChanges()` with `trackEntityChanges("policy", ...)`
+ * - Replace `recordPolicyCreation()` with `recordEntityCreation("policy", ...)`
+ * - Replace `recordPolicyDeletion()` with `recordEntityDeletion("policy", ...)`
+ *
+ * These wrapper functions are maintained for backward compatibility only.
  */
 
 import { IPolicy } from "../domain.layer/interfaces/i.policy";
@@ -19,6 +28,7 @@ import {
 
 /**
  * Record a change in policy
+ * @deprecated Use `recordEntityChange("policy", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordPolicyChange = async (
   policyId: number,
@@ -45,6 +55,7 @@ export const recordPolicyChange = async (
 
 /**
  * Record multiple field changes for a policy
+ * @deprecated Use `recordMultipleFieldChanges("policy", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordMultipleFieldChanges = async (
   policyId: number,
@@ -65,6 +76,7 @@ export const recordMultipleFieldChanges = async (
 
 /**
  * Get change history for a specific policy with pagination support
+ * @deprecated Use `getEntityChangeHistory("policy", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const getPolicyChangeHistory = async (
   policyId: number,
@@ -83,6 +95,7 @@ export const getPolicyChangeHistory = async (
 
 /**
  * Track changes between old and new policy data
+ * @deprecated Use `trackEntityChanges("policy", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const trackPolicyChanges = async (
   oldModel: IPolicy,
@@ -93,6 +106,7 @@ export const trackPolicyChanges = async (
 
 /**
  * Record creation of a policy
+ * @deprecated Use `recordEntityCreation("policy", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordPolicyCreation = async (
   policyId: number,
@@ -113,6 +127,7 @@ export const recordPolicyCreation = async (
 
 /**
  * Record deletion of a policy
+ * @deprecated Use `recordEntityDeletion("policy", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordPolicyDeletion = async (
   policyId: number,

--- a/Servers/utils/projectRiskChangeHistory.utils.ts
+++ b/Servers/utils/projectRiskChangeHistory.utils.ts
@@ -1,9 +1,18 @@
 /**
  * Project Risk Change History Utilities
  *
- * Wrapper functions that use the generic change history system.
- * These functions maintain backward compatibility while leveraging
- * the new generic utilities.
+ * @deprecated This file is deprecated and will be removed in a future version.
+ * Use the generic change history functions from `changeHistory.base.utils.ts` directly instead.
+ *
+ * Migration guide:
+ * - Replace `recordProjectRiskChange()` with `recordEntityChange("risk", ...)`
+ * - Replace `recordMultipleFieldChanges()` with `recordMultipleFieldChanges("risk", ...)`
+ * - Replace `getProjectRiskChangeHistory()` with `getEntityChangeHistory("risk", ...)`
+ * - Replace `trackProjectRiskChanges()` with `trackEntityChanges("risk", ...)`
+ * - Replace `recordProjectRiskCreation()` with `recordEntityCreation("risk", ...)`
+ * - Replace `recordProjectRiskDeletion()` with `recordEntityDeletion("risk", ...)`
+ *
+ * These wrapper functions are maintained for backward compatibility only.
  */
 
 import { RiskModel } from "../domain.layer/models/risks/risk.model";
@@ -19,6 +28,7 @@ import {
 
 /**
  * Record a change in project risk
+ * @deprecated Use `recordEntityChange("risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordProjectRiskChange = async (
   projectRiskId: number,
@@ -45,6 +55,7 @@ export const recordProjectRiskChange = async (
 
 /**
  * Record multiple field changes for a project risk
+ * @deprecated Use `recordMultipleFieldChanges("risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordMultipleFieldChanges = async (
   projectRiskId: number,
@@ -65,6 +76,7 @@ export const recordMultipleFieldChanges = async (
 
 /**
  * Get change history for a specific project risk with pagination support
+ * @deprecated Use `getEntityChangeHistory("risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const getProjectRiskChangeHistory = async (
   projectRiskId: number,
@@ -83,6 +95,7 @@ export const getProjectRiskChangeHistory = async (
 
 /**
  * Track changes between old and new project risk data
+ * @deprecated Use `trackEntityChanges("risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const trackProjectRiskChanges = async (
   oldProjectRisk: RiskModel,
@@ -93,6 +106,7 @@ export const trackProjectRiskChanges = async (
 
 /**
  * Record creation of a project risk
+ * @deprecated Use `recordEntityCreation("risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordProjectRiskCreation = async (
   projectRiskId: number,
@@ -113,6 +127,7 @@ export const recordProjectRiskCreation = async (
 
 /**
  * Record deletion of a project risk
+ * @deprecated Use `recordEntityDeletion("risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordProjectRiskDeletion = async (
   projectRiskId: number,

--- a/Servers/utils/useCaseChangeHistory.utils.ts
+++ b/Servers/utils/useCaseChangeHistory.utils.ts
@@ -1,9 +1,18 @@
 /**
  * Use Case Change History Utilities
  *
- * Wrapper functions that use the generic change history system.
- * These functions maintain backward compatibility while leveraging
- * the new generic utilities.
+ * @deprecated This file is deprecated and will be removed in a future version.
+ * Use the generic change history functions from `changeHistory.base.utils.ts` directly instead.
+ *
+ * Migration guide:
+ * - Replace `recordUseCaseChange()` with `recordEntityChange("use_case", ...)`
+ * - Replace `recordMultipleFieldChanges()` with `recordMultipleFieldChanges("use_case", ...)`
+ * - Replace `getUseCaseChangeHistory()` with `getEntityChangeHistory("use_case", ...)`
+ * - Replace `trackUseCaseChanges()` with `trackEntityChanges("use_case", ...)`
+ * - Replace `recordUseCaseCreation()` with `recordEntityCreation("use_case", ...)`
+ * - Replace `recordUseCaseDeletion()` with `recordEntityDeletion("use_case", ...)`
+ *
+ * These wrapper functions are maintained for backward compatibility only.
  */
 
 import { IProjectAttributes } from "../domain.layer/interfaces/i.project";
@@ -19,6 +28,7 @@ import {
 
 /**
  * Record a change in use case
+ * @deprecated Use `recordEntityChange("use_case", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordUseCaseChange = async (
   useCaseId: number,
@@ -45,6 +55,7 @@ export const recordUseCaseChange = async (
 
 /**
  * Record multiple field changes for a use case
+ * @deprecated Use `recordMultipleFieldChanges("use_case", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordMultipleFieldChanges = async (
   useCaseId: number,
@@ -65,6 +76,7 @@ export const recordMultipleFieldChanges = async (
 
 /**
  * Get change history for a specific use case with pagination support
+ * @deprecated Use `getEntityChangeHistory("use_case", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const getUseCaseChangeHistory = async (
   useCaseId: number,
@@ -83,6 +95,7 @@ export const getUseCaseChangeHistory = async (
 
 /**
  * Track changes between old and new use case data
+ * @deprecated Use `trackEntityChanges("use_case", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const trackUseCaseChanges = async (
   oldModel: IProjectAttributes,
@@ -93,6 +106,7 @@ export const trackUseCaseChanges = async (
 
 /**
  * Record creation of a use case
+ * @deprecated Use `recordEntityCreation("use_case", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordUseCaseCreation = async (
   useCaseId: number,
@@ -113,6 +127,7 @@ export const recordUseCaseCreation = async (
 
 /**
  * Record deletion of a use case
+ * @deprecated Use `recordEntityDeletion("use_case", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordUseCaseDeletion = async (
   useCaseId: number,

--- a/Servers/utils/vendorChangeHistory.utils.ts
+++ b/Servers/utils/vendorChangeHistory.utils.ts
@@ -1,9 +1,18 @@
 /**
  * Vendor Change History Utilities
  *
- * Wrapper functions that use the generic change history system.
- * These functions maintain backward compatibility while leveraging
- * the new generic utilities.
+ * @deprecated This file is deprecated and will be removed in a future version.
+ * Use the generic change history functions from `changeHistory.base.utils.ts` directly instead.
+ *
+ * Migration guide:
+ * - Replace `recordVendorChange()` with `recordEntityChange("vendor", ...)`
+ * - Replace `recordMultipleFieldChanges()` with `recordMultipleFieldChanges("vendor", ...)`
+ * - Replace `getVendorChangeHistory()` with `getEntityChangeHistory("vendor", ...)`
+ * - Replace `trackVendorChanges()` with `trackEntityChanges("vendor", ...)`
+ * - Replace `recordVendorCreation()` with `recordEntityCreation("vendor", ...)`
+ * - Replace `recordVendorDeletion()` with `recordEntityDeletion("vendor", ...)`
+ *
+ * These wrapper functions are maintained for backward compatibility only.
  */
 
 import { VendorModel } from "../domain.layer/models/vendor/vendor.model";
@@ -19,6 +28,7 @@ import {
 
 /**
  * Record a change in vendor
+ * @deprecated Use `recordEntityChange("vendor", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordVendorChange = async (
   vendorId: number,
@@ -45,6 +55,7 @@ export const recordVendorChange = async (
 
 /**
  * Record multiple field changes for a vendor
+ * @deprecated Use `recordMultipleFieldChanges("vendor", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordMultipleFieldChanges = async (
   vendorId: number,
@@ -65,6 +76,7 @@ export const recordMultipleFieldChanges = async (
 
 /**
  * Get change history for a specific vendor with pagination support
+ * @deprecated Use `getEntityChangeHistory("vendor", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const getVendorChangeHistory = async (
   vendorId: number,
@@ -83,6 +95,7 @@ export const getVendorChangeHistory = async (
 
 /**
  * Track changes between old and new vendor data
+ * @deprecated Use `trackEntityChanges("vendor", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const trackVendorChanges = async (
   oldVendor: VendorModel,
@@ -93,6 +106,7 @@ export const trackVendorChanges = async (
 
 /**
  * Record creation of a vendor
+ * @deprecated Use `recordEntityCreation("vendor", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordVendorCreation = async (
   vendorId: number,
@@ -113,6 +127,7 @@ export const recordVendorCreation = async (
 
 /**
  * Record deletion of a vendor
+ * @deprecated Use `recordEntityDeletion("vendor", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordVendorDeletion = async (
   vendorId: number,

--- a/Servers/utils/vendorRiskChangeHistory.utils.ts
+++ b/Servers/utils/vendorRiskChangeHistory.utils.ts
@@ -1,9 +1,18 @@
 /**
  * Vendor Risk Change History Utilities
  *
- * Wrapper functions that use the generic change history system.
- * These functions maintain backward compatibility while leveraging
- * the new generic utilities.
+ * @deprecated This file is deprecated and will be removed in a future version.
+ * Use the generic change history functions from `changeHistory.base.utils.ts` directly instead.
+ *
+ * Migration guide:
+ * - Replace `recordVendorRiskChange()` with `recordEntityChange("vendor_risk", ...)`
+ * - Replace `recordMultipleFieldChanges()` with `recordMultipleFieldChanges("vendor_risk", ...)`
+ * - Replace `getVendorRiskChangeHistory()` with `getEntityChangeHistory("vendor_risk", ...)`
+ * - Replace `trackVendorRiskChanges()` with `trackEntityChanges("vendor_risk", ...)`
+ * - Replace `recordVendorRiskCreation()` with `recordEntityCreation("vendor_risk", ...)`
+ * - Replace `recordVendorRiskDeletion()` with `recordEntityDeletion("vendor_risk", ...)`
+ *
+ * These wrapper functions are maintained for backward compatibility only.
  */
 
 import { VendorRiskModel } from "../domain.layer/models/vendorRisk/vendorRisk.model";
@@ -19,6 +28,7 @@ import {
 
 /**
  * Record a change in vendor risk
+ * @deprecated Use `recordEntityChange("vendor_risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordVendorRiskChange = async (
   vendorRiskId: number,
@@ -45,6 +55,7 @@ export const recordVendorRiskChange = async (
 
 /**
  * Record multiple field changes for a vendor risk
+ * @deprecated Use `recordMultipleFieldChanges("vendor_risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordMultipleFieldChanges = async (
   vendorRiskId: number,
@@ -65,6 +76,7 @@ export const recordMultipleFieldChanges = async (
 
 /**
  * Get change history for a specific vendor risk with pagination support
+ * @deprecated Use `getEntityChangeHistory("vendor_risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const getVendorRiskChangeHistory = async (
   vendorRiskId: number,
@@ -83,6 +95,7 @@ export const getVendorRiskChangeHistory = async (
 
 /**
  * Track changes between old and new vendor risk data
+ * @deprecated Use `trackEntityChanges("vendor_risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const trackVendorRiskChanges = async (
   oldModel: VendorRiskModel,
@@ -93,6 +106,7 @@ export const trackVendorRiskChanges = async (
 
 /**
  * Record creation of a vendor risk
+ * @deprecated Use `recordEntityCreation("vendor_risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordVendorRiskCreation = async (
   vendorRiskId: number,
@@ -113,6 +127,7 @@ export const recordVendorRiskCreation = async (
 
 /**
  * Record deletion of a vendor risk
+ * @deprecated Use `recordEntityDeletion("vendor_risk", ...)` from `changeHistory.base.utils.ts` instead
  */
 export const recordVendorRiskDeletion = async (
   vendorRiskId: number,


### PR DESCRIPTION
## Summary
- Adds deprecation notices to all 7 entity-specific change history utility files
- Files now delegate to the unified `changeHistory.utils.ts` for consistency
- Prepares codebase for future migration to the consolidated utility

## Changed files
- `Servers/utils/vendorChangeHistory.utils.ts`
- `Servers/utils/policyChangeHistory.utils.ts`
- `Servers/utils/projectRiskChangeHistory.utils.ts`
- `Servers/utils/vendorRiskChangeHistory.utils.ts`
- `Servers/utils/useCaseChangeHistory.utils.ts`
- `Servers/utils/incidentChangeHistory.utils.ts`
- `Servers/utils/modelInventoryChangeHistory.utils.ts`

## Migration path
1. Existing code continues to work via delegation
2. New code should use `changeHistory.utils.ts` directly
3. Deprecated files can be removed once all usages are migrated

## Merge order
This is PR **5 of 6** in the refactoring series. Merge in this order:
1. #2972 - Controller wrapper pattern
2. #2973 - File domain repository
3. #2974 - Change history consolidation
4. #2975 - Replace any types
5. **#2976** - Deprecate entity change history files (this PR)
6. #2977 - Vendor service layer