### PR TITLE
fix: update chart legend direction to use new MUI X Charts API

### DIFF
--- a/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
@@ -214,7 +214,7 @@ const ModelInventoryHistoryChart: React.FC<ModelInventoryHistoryChartProps> = ({
               margin={{ top: 10, right: 30, bottom: 30, left: 70 }}
               slotProps={{
                 legend: {
-                  direction: "row" as any,
+                  direction: "horizontal",
                   position: { vertical: "bottom", horizontal: "center" },
                 },
               }}

--- a/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
@@ -264,7 +264,7 @@ const RiskHistoryChart: React.FC<RiskHistoryChartProps> = ({
               margin={{ top: 10, right: 30, bottom: 30, left: 70 }}
               slotProps={{
                 legend: {
-                  direction: "row" as any,
+                  direction: "horizontal",
                   position: { vertical: "bottom", horizontal: "center" },
                 },
               }}


### PR DESCRIPTION
## Summary
- Update `legendDirection` from deprecated `"row"` to `"horizontal"` in RiskHistoryChart
- Update `legendDirection` from deprecated `"row"` to `"horizontal"` in ModelInventoryHistoryChart

## Why
MUI X Charts updated their API - `legendDirection` now expects `"horizontal"` or `"vertical"` instead of `"row"` or `"column"`. This fixes the console warning about invalid prop type.