### PR TITLE
Fix UI layout issues and page tour behavior

### DIFF
--- a/Clients/src/presentation/components/Inputs/ToggleCard/index.tsx
+++ b/Clients/src/presentation/components/Inputs/ToggleCard/index.tsx
@@ -17,7 +17,7 @@ const ToggleCard: React.FC<ToggleCardProps> = ({ label, checked, onToggle, child
   const CardComponent = checked ? CardActive : CardDisabled;
 
   return (
-    <Stack minWidth={320} flex={1}>
+    <Stack minWidth={280} maxWidth="100%" flex={1} sx={{ overflow: "hidden" }}>
       <Box display="flex" alignItems="center" mb={1}>
         <FormControlLabel
           control={<Toggle checked={checked} onChange={onToggle} disabled={disabled} />}

--- a/Clients/src/presentation/components/PageTour/index.tsx
+++ b/Clients/src/presentation/components/PageTour/index.tsx
@@ -56,6 +56,12 @@ const PageTour: React.FC<IPageTourProps> = ({
           ".__floater__arrow polygon": {
             fill: "#1f1f23 !important",
           },
+          ".react-joyride__beacon": {
+            zIndex: "900 !important",
+          },
+          ".react-joyride__spotlight": {
+            zIndex: "900 !important",
+          },
           ".react-joyride__tooltip": {
             filter: "drop-shadow(0 8px 32px rgba(0, 0, 0, 0.3))",
             animation: "fadeIn 0.3s ease-in-out",
@@ -94,8 +100,8 @@ const PageTour: React.FC<IPageTourProps> = ({
         showSkipButton={false}
         callback={handleCallback}
         disableOverlayClose
-        disableScrolling={false}
-        scrollToFirstStep={true}
+        disableScrolling={true}
+        scrollToFirstStep={false}
         spotlightClicks={false}
         tooltipComponent={tooltipRenderer}
         locale={{
@@ -107,7 +113,7 @@ const PageTour: React.FC<IPageTourProps> = ({
         styles={{
           options: {
             primaryColor: "#13715B",
-            zIndex: 1200,
+            zIndex: 900,
             beaconSize: 30,
           },
           overlay: {

--- a/Clients/src/presentation/components/TipBox/index.tsx
+++ b/Clients/src/presentation/components/TipBox/index.tsx
@@ -7,15 +7,13 @@ interface TipBoxProps {
   entityName: string;
 }
 
-// Fade-in animation
+// Fade-in animation (opacity only to prevent scroll)
 const fadeIn = keyframes`
   from {
     opacity: 0;
-    transform: translateY(-8px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 `;
 

--- a/Clients/src/presentation/components/UserGuide/SidebarWrapper.tsx
+++ b/Clients/src/presentation/components/UserGuide/SidebarWrapper.tsx
@@ -338,7 +338,7 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
         right: 0,
         height: '100vh',
         display: 'flex',
-        zIndex: 1000,
+        zIndex: 1100,
       }}
     >
       {/* Resize Handle - positioned absolutely on the left edge */}

--- a/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
@@ -254,7 +254,7 @@ const AITrustCenterOverview: React.FC = () => {
             handleFieldChange("info", "intro_visible", checked)
           }
         />
-        <Box display="flex" gap={8} mt={2}>
+        <Box display="flex" flexWrap="wrap" gap={8} mt={2}>
           <ToggleCard
             label="Purpose of our trust center"
             checked={localFormData.intro?.purpose_visible || false}
@@ -462,7 +462,7 @@ const AITrustCenterOverview: React.FC = () => {
             handleFieldChange("info", "company_description_visible", checked)
           }
         />
-        <Box display="flex" gap={8} mt={2}>
+        <Box display="flex" flexWrap="wrap" gap={8} mt={2}>
           <ToggleCard
             label="Background"
             checked={


### PR DESCRIPTION
## Summary
- Fix ToggleCard components overflowing when User Guide drawer is open in AI Trust Center
- Fix page auto-scrolling when navigating to pages with TipBox or PageTour
- Fix PageTour beacon appearing above User Guide drawer

## Test plan
- [ ] Open AI Trust Center, then open the User Guide drawer - ToggleCards should wrap properly
- [ ] Navigate to /tasks or /policy-manager - page should not auto-scroll
- [ ] On a page with a tour beacon, open the User Guide drawer - beacon should be behind the drawer