### PR TITLE
fix: align risk table sorting with actual database enum values

### DIFF
--- a/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
@@ -188,12 +188,14 @@ const VWProjectRisksTable = ({
 
     return sortableRows.sort((a: RiskModel, b: RiskModel) => {
       // Helper functions for sorting
+      // Severity values: Negligible, Minor, Moderate, Major, Catastrophic
       const getSeverityValue = (severity: string) => {
         const severityLower = severity.toLowerCase();
-        if (severityLower.includes("critical")) return 4;
-        if (severityLower.includes("high")) return 3;
-        if (severityLower.includes("medium")) return 2;
-        if (severityLower.includes("low")) return 1;
+        if (severityLower.includes("catastrophic")) return 5;
+        if (severityLower.includes("major")) return 4;
+        if (severityLower.includes("moderate")) return 3;
+        if (severityLower.includes("minor")) return 2;
+        if (severityLower.includes("negligible")) return 1;
         return 0;
       };
 
@@ -207,12 +209,15 @@ const VWProjectRisksTable = ({
         return 0;
       };
 
+      // Risk level values: No risk, Very low risk, Low risk, Medium risk, High risk, Very high risk
       const getRiskLevelValue = (riskLevel: string) => {
         const riskLower = riskLevel.toLowerCase();
-        if (riskLower.includes("critical")) return 4;
-        if (riskLower.includes("high")) return 3;
-        if (riskLower.includes("medium")) return 2;
-        if (riskLower.includes("low")) return 1;
+        if (riskLower.includes("very high")) return 6;
+        if (riskLower.includes("high")) return 5;
+        if (riskLower.includes("medium")) return 4;
+        if (riskLower.includes("low") && !riskLower.includes("very low")) return 3;
+        if (riskLower.includes("very low")) return 2;
+        if (riskLower.includes("no risk")) return 1;
         return 0;
       };
 


### PR DESCRIPTION
## Summary
- Fixed severity sorting to match actual database enum values (Negligible, Minor, Moderate, Major, Catastrophic)
- Fixed risk level sorting to match actual database enum values (No risk, Very low risk, Low risk, Medium risk, High risk, Very high risk)
- Added proper handling for "very high" and "very low" risk level edge cases

## Problem
The sorting functions in the Project Risks table were using incorrect values (`critical/high/medium/low`) that didn't match the actual severity enum values stored in the database (`Negligible/Minor/Moderate/Major/Catastrophic`). This caused the severity column sorting to not work correctly.

Similarly, the risk level sorting didn't properly handle all 6 risk level values, particularly missing proper handling for "very high" and "very low" levels.

## Test plan
- [ ] Verify severity column sorting works correctly in Project Risks table
- [ ] Verify risk level column sorting orders from "No risk" through "Very high risk"
- [ ] Test both ascending and descending sort directions

Closes #2970