### PR TITLE
Fix advisor chat loading spinner race condition

### DIFF
--- a/Clients/src/presentation/components/AdvisorChat/index.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/index.tsx
@@ -86,10 +86,9 @@ const AdvisorChat = ({
     }
 
     // Prevent duplicate loads for the same domain
-    // But still set isReady to true if loading completed
+    // Set isReady to true only when loading is complete
     if (loadAttemptedRef.current === pageContext) {
-      // Check if loading completed while we were waiting
-      if (!conversationContext.isLoading(pageContext)) {
+      if (conversationContext.isLoaded(pageContext)) {
         setIsReady(true);
       }
       return;


### PR DESCRIPTION
## Summary
- Fixed a race condition where the advisor chat loading spinner could get stuck indefinitely
- The issue occurred on any page with the advisor chat (policies, vendors, risks, tasks, etc.)

## Root cause
The code checked `!isLoading()` instead of `isLoaded()` to determine if the conversation was ready. During transient states, both could be `false`, preventing `isReady` from being set to `true`.

## Fix
Changed the condition to explicitly check `isLoaded()`, ensuring the spinner disappears only when the conversation has actually finished loading.

## Test plan
- [ ] Navigate to /policies and verify advisor loads without getting stuck
- [ ] Navigate between different pages with advisor (vendors, risks, tasks) and verify loading works
- [ ] Refresh pages and verify conversation history loads correctly