### PR TITLE
Fix: Prevent 406 errors on first dashboard load

### DIFF
--- a/Clients/src/main.tsx
+++ b/Clients/src/main.tsx
@@ -12,7 +12,14 @@ import { queryClient } from './application/config/queryClient';
 
 createRoot(document.getElementById("root")!).render(
   <Provider store={store}>
-    <PersistGate loading={null} persistor={persistor}>
+    <PersistGate
+      loading={
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+          Loading...
+        </div>
+      }
+      persistor={persistor}
+    >
       <QueryClientProvider client={queryClient}>
         <Router>
           <App />


### PR DESCRIPTION
## Summary

Fixes race condition causing 406 errors on first dashboard load.

## Problem

On first dashboard load, multiple API calls returned 406 (Not Acceptable) errors:
- `GET /api/users`
- `GET /api/user-preferences/{id}`  
- `GET /api/eu-ai-act/all/compliances/progress`
- `GET /api/users/check/exists`

Subsequent page loads worked fine.

## Root Cause

React hooks fired API requests before Redux finished rehydrating the auth token from localStorage. The `PersistGate` was configured with `loading={null}`, which rendered the app immediately without waiting for state restoration.

## Solution

Added a loading state to `PersistGate` so the app waits for Redux rehydration before mounting components that make authenticated API calls.

## Changes

- `Clients/src/main.tsx` - Added loading prop to PersistGate