### PR TITLE
fix: remove sensitive prompt logging in advisor controller

### DIFF
--- a/Servers/controllers/advisor.ctrl.ts
+++ b/Servers/controllers/advisor.ctrl.ts
@@ -72,7 +72,7 @@ export async function runAdvisor(req: Request, res: Response) {
     }
 
     logger.debug(
-      `Running advisor for tenant: ${tenantId}, user: ${userId}, llmKeyId: ${llmKeyId}, prompt: ${prompt.substring(0, 100)}...`,
+      `Running advisor for tenant: ${tenantId}, user: ${userId}, llmKeyId: ${llmKeyId}`,
     );
 
     const clients = await getLLMKeysWithKeyQuery(tenantId);


### PR DESCRIPTION
## Summary

- Removes the logging of user prompts from advisor controller debug logs
- Addresses security concern where sensitive user information could be exposed in log files

## Changes

- Modified `Servers/controllers/advisor.ctrl.ts:74-76` to remove `prompt.substring(0, 100)` from the log message
- Log now only includes tenant ID, user ID, and LLM key ID for debugging purposes

## Related

- Addresses improvement suggestion from #2950 regarding security alerts for logging sensitive information