### PR TITLE
fix: add rate limiting to sensitive authentication endpoints

### DIFF
--- a/Servers/routes/user.route.ts
+++ b/Servers/routes/user.route.ts
@@ -33,6 +33,7 @@ const multer = require("multer");
 const upload = multer({ storage: multer.memoryStorage() });
 
 import rateLimit from "express-rate-limit";
+import { authLimiter } from "../middleware/rateLimit.middleware";
 
 import {
   checkUserExists,
@@ -108,7 +109,7 @@ router.get("/:id", authenticateJWT, getUserById);
  * @param {express.Request} req - Express request object
  * @param {express.Response} res - Express response object
  */
-router.post("/register", registerJWT, createNewUser);
+router.post("/register", authLimiter, registerJWT, createNewUser);
 
 /**
  * POST /users/login
@@ -131,7 +132,7 @@ const loginLimiter = rateLimit({
 });
 router.post("/login", loginLimiter, loginUser);
 
-router.post("/refresh-token", refreshAccessToken);
+router.post("/refresh-token", authLimiter, refreshAccessToken);
 
 /**
  * POST /users/reset-password
@@ -145,7 +146,7 @@ router.post("/refresh-token", refreshAccessToken);
  * @param {express.Request} req - Express request object
  * @param {express.Response} res - Express response object
  */
-router.post("/reset-password", resetPasswordMiddleware, resetPassword);
+router.post("/reset-password", authLimiter, resetPasswordMiddleware, resetPassword);
 
 /**
  * PATCH /users/:id
@@ -161,7 +162,7 @@ router.post("/reset-password", resetPasswordMiddleware, resetPassword);
  */
 router.patch("/:id", authenticateJWT, updateUserById);
 
-router.patch("/chng-pass/:id", ChangePassword);
+router.patch("/chng-pass/:id", authLimiter, authenticateJWT, ChangePassword);
 
 /**
  * DELETE /users/:id


### PR DESCRIPTION
## Summary

- Add rate limiting to sensitive authentication endpoints to prevent brute-force attacks
- Add missing authentication middleware to password change endpoint

## Changes

**File:** `Servers/routes/user.route.ts`

Added `authLimiter` (5 requests/15min) to:
- `/users/register` - Prevents spam account creation
- `/users/refresh-token` - Prevents token abuse
- `/users/reset-password` - Prevents email enumeration
- `/users/chng-pass/:id` - Prevents password brute-force

Also added `authenticateJWT` middleware to `/users/chng-pass/:id` which was previously unprotected.

## Rate limit configuration

The `authLimiter` is defined in `Servers/middleware/rateLimit.middleware.ts`:
- Window: 15 minutes
- Max requests: 5 per IP