### PR TITLE
fix: convert created_by to int for database operations

### DIFF
--- a/EvalServer/src/crud/evaluation_logs.py
+++ b/EvalServer/src/crud/evaluation_logs.py
@@ -62,13 +62,13 @@ async def create_log(
             "cost": cost,
             "status": status,
             "error_message": error_message,
-            "created_by": str(created_by) if created_by is not None else None,
+            "created_by": int(created_by) if created_by is not None else None,
         }
     )
-    
+
     await db.commit()
     row = result.mappings().first()
-    
+
     if row:
         return {
             "id": str(row["id"]),
@@ -331,7 +331,7 @@ async def create_experiment(
                 "config_json": config_json,
                 "baseline_experiment_id": baseline_experiment_id,
                 "status": "pending",
-                "created_by": str(created_by) if created_by is not None else None,
+                "created_by": int(created_by) if created_by is not None else None,
             }
         )
         


### PR DESCRIPTION
## Summary

Fixes a 500 error when rerunning experiments in the LLM Evals module.

**Problem:** The `created_by` field was being converted to a string with `str(created_by)` but the PostgreSQL column expects an integer, causing the error:
```
invalid input for query argument $8: '1' ('str' object cannot be interpreted as an integer)
```

**Fix:** Changed `str(created_by)` to `int(created_by)` in two places:
- Line 65 (for evaluation logs)
- Line 334 (for experiments)

## Test plan

- [ ] Rerun an existing experiment in LLM Evals
- [ ] Create a new experiment
- [ ] Verify no 500 errors occur