### PR TITLE
fix: handle 404 gracefully when organization logo doesn't exist

### DIFF
--- a/Clients/src/application/repository/aiTrustCentre.repository.ts
+++ b/Clients/src/application/repository/aiTrustCentre.repository.ts
@@ -300,7 +300,11 @@ export async function getAITrustCentreLogo(tenantId: string): Promise<any> {
       responseType: "json",
     });
     return response.data;
-  } catch (error) {
+  } catch (error: any) {
+    // 404 is expected when no logo has been uploaded - don't log as error
+    if (error?.response?.status === 404 || error?.status === 404) {
+      return null;
+    }
     console.error("Error fetching AI Trust Center logo:", error);
     throw error;
   }


### PR DESCRIPTION
## Summary

Fixes console error spam when no organization logo has been uploaded. The sidebar tries to fetch the organization logo and logs an error when the API returns 404.

## Changes

- Return `null` instead of throwing when the logo endpoint returns 404
- Allows sidebar to silently fall back to the default VerifyWise logo
- Other errors (500, network issues) still logged and thrown

## Test plan

- [ ] Load app without an organization logo uploaded
- [ ] Verify no console errors about logo fetch
- [ ] Verify VerifyWise logo displays in sidebar