### PR TITLE
fix: DatePicker styling for MUI v8 compatibility

### DIFF
--- a/Clients/src/presentation/components/Inputs/Datepicker/index.css
+++ b/Clients/src/presentation/components/Inputs/Datepicker/index.css
@@ -42,9 +42,19 @@
 }
 
 .MuiPickersCalendarHeader-switchViewButton:hover,
-.MuiPickersArrowSwitcher-button:hover,
-.MuiPickersDay-root:hover {
+.MuiPickersArrowSwitcher-button:hover {
   background-color: transparent!important;
+}
+
+/* Regular day hover - light gray background */
+.MuiPickersDay-root:hover {
+  background-color: #f5f5f5 !important;
+}
+
+/* Selected day should keep green background on hover */
+.MuiPickersDay-root.Mui-selected:hover {
+  background-color: #13715B !important;
+  color: #FFFFFF !important;
 }
 
 .MuiButtonBase-root.MuiIconButton-root.MuiIconButton-edgeEnd.MuiPickersArrowSwitcher-previousIconButton{

--- a/Clients/src/presentation/components/Inputs/Datepicker/style.ts
+++ b/Clients/src/presentation/components/Inputs/Datepicker/style.ts
@@ -42,4 +42,22 @@ export const DatePickerStyle = {
     backgroundColor: "#FFFFFF",
     borderRadius: "4px",
   },
+  // Hover state for MUI v8 DatePicker
+  "& .MuiPickersOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline": {
+    borderColor: "#5FA896 !important",
+  },
+  "& .MuiPickersOutlinedInput-root:hover fieldset": {
+    borderColor: "#5FA896 !important",
+  },
+  // Focus state with green border for MUI v8 DatePicker
+  "& .MuiPickersOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    borderColor: "#13715B !important",
+    borderWidth: "2px",
+    boxShadow: "0 0 0 3px rgba(19, 113, 91, 0.1)",
+  },
+  "& .MuiPickersOutlinedInput-root.Mui-focused fieldset": {
+    borderColor: "#13715B !important",
+    borderWidth: "2px",
+    boxShadow: "0 0 0 3px rgba(19, 113, 91, 0.1)",
+  },
 };


### PR DESCRIPTION
## Summary
- Fix date text overlapping calendar icon after MUI v7 to v8 upgrade
- Update DatePicker styles to target MUI v8 class names
- Fix focus and hover border colors to match other input widgets
- Fix selected date hover state in calendar popup

## Changes
- Target MUI v8 specific classes (`MuiPickersOutlinedInput-root`, `MuiPickersInputBase-sectionsContainer`, `MuiPickerPopper-root`)
- Set proper padding (40px) to prevent date text from overlapping the calendar icon
- Position calendar icon correctly (4px from left, vertically centered)
- Add green focus border (#13715B) with box-shadow matching other inputs
- Add green hover border (#5FA896) for consistency
- Fix selected date hover - keep green background and white text instead of turning white/unreadable
- Set font size to 13px for date input and calendar popup elements

## Before/After
**Before:** Date text overlapped calendar icon, focus border was dark gray, hovering selected date made text unreadable

**After:** Proper spacing between icon and date, green focus/hover borders, selected date remains readable on hover