### PR TITLE
fix: expose timestamps in toJSON() for Risk, VendorRisk, and Policy models

### DIFF
--- a/Servers/domain.layer/models/policy/policy.model.ts
+++ b/Servers/domain.layer/models/policy/policy.model.ts
@@ -86,6 +86,7 @@ export class PolicyManagerModel extends Model<PolicyManagerModel> implements IPo
       author_id: this.author_id,
       last_updated_by: this.last_updated_by,
       last_updated_at: this.last_updated_at,
+      created_at: this.created_at?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/risks/risk.model.ts
+++ b/Servers/domain.layer/models/risks/risk.model.ts
@@ -495,6 +495,7 @@ export class RiskModel extends Model<RiskModel> implements IRisk {
       date_of_assessment: this.date_of_assessment,
       is_demo: this.is_demo,
       created_at: this.created_at?.toISOString(),
+      updated_at: this.updated_at?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/vendorRisk/vendorRisk.model.ts
+++ b/Servers/domain.layer/models/vendorRisk/vendorRisk.model.ts
@@ -176,4 +176,26 @@ export class VendorRiskModel
       this.likelihood = updateData.likelihood;
     }
   }
+
+  /**
+   * Convert to JSON representation
+   */
+  toJSON(): any {
+    return {
+      id: this.id,
+      vendor_id: this.vendor_id,
+      order_no: this.order_no,
+      risk_description: this.risk_description,
+      impact_description: this.impact_description,
+      impact: this.impact,
+      likelihood: this.likelihood,
+      risk_severity: this.risk_severity,
+      action_plan: this.action_plan,
+      action_owner: this.action_owner,
+      risk_level: this.risk_level,
+      is_demo: this.is_demo,
+      created_at: this.created_at?.toISOString(),
+      updated_at: this.updated_at?.toISOString(),
+    };
+  }
 }


### PR DESCRIPTION
## Summary
Ensures consistent timestamp exposure across entity APIs for the Recent Activity dashboard.

## Changes

| Model | Change |
|-------|--------|
| Risk (`risk.model.ts`) | Added `updated_at` to `toJSON()` output |
| VendorRisk (`vendorRisk.model.ts`) | Created `toJSON()` method exposing `created_at` and `updated_at` |
| Policy (`policy.model.ts`) | Added `created_at` to `toJSON()` output |

## Context
Part of Phase 2 timestamp consistency work. These models already have timestamp columns in the database but weren't exposing them in API responses.

## Related
- Follows PR #3035 (Recent Activity enhancements)