### PR TITLE
fix: disable onboarding modal temporarily

### DIFF
--- a/Clients/src/application/hooks/useOnboarding.ts
+++ b/Clients/src/application/hooks/useOnboarding.ts
@@ -181,12 +181,9 @@ export const useOnboarding = () => {
 
   // Check if onboarding should be shown
   const shouldShowOnboarding = useCallback(() => {
-    if (!userId || isLoading) return false;
-
-    // Simply check if onboarding is complete in state
-    // No session storage needed - localStorage persistence handles everything
-    return !state.isComplete;
-  }, [state.isComplete, userId, isLoading]);
+    // Onboarding is temporarily disabled
+    return false;
+  }, []);
 
   return {
     state,


### PR DESCRIPTION
## Summary
- Disables the onboarding modal that appears on first login
- This allows testing of other features without the modal blocking the UI

## Changes
- Modified `shouldShowOnboarding()` in `useOnboarding.ts` to always return `false`

## Test plan
- [ ] Create a new user account and verify onboarding modal does not appear
- [ ] Verify existing functionality is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)