### PR TITLE
fix: prevent onboarding modal flash on page load

### DIFF
--- a/Clients/src/application/hooks/useOnboarding.ts
+++ b/Clients/src/application/hooks/useOnboarding.ts
@@ -11,7 +11,7 @@ const initialState: OnboardingState = {
   skippedSteps: [],
   preferences: {},
   sampleProject: {},
-  isComplete: false,
+  isComplete: true, // Temporarily set to true to disable onboarding modal
   lastUpdated: new Date().toISOString(),
 };
 


### PR DESCRIPTION
## Summary
- Fixes the onboarding modal briefly flashing on page reload
- The previous PR (#3040) modified `shouldShowOnboarding()` but App.tsx uses `state.isComplete` directly
- This fix sets `initialState.isComplete` to `true` so the modal never shows

## Root cause
App.tsx line 108-111 determines modal visibility:
```typescript
const showModal = useMemo(
  () => token && userId && !isOnboardingLoading && !state.isComplete && isDashboardRoute,
  ...
);
```

The flash happened because:
1. `isOnboardingLoading` starts `true` → modal hidden
2. Loading finishes, `state.isComplete` is `false` → modal briefly shows
3. Then other logic hides it

## Test plan
- [ ] Reload dashboard page - no modal flash
- [ ] Create new account - no onboarding modal appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)