### PR TITLE
fix: include dynamic properties in model toJSON() methods

### DIFF
--- a/Servers/domain.layer/frameworks/ISO-27001/ISO27001AnnexStruct.model.ts
+++ b/Servers/domain.layer/frameworks/ISO-27001/ISO27001AnnexStruct.model.ts
@@ -57,12 +57,15 @@ export class ISO27001AnnexStructModel
    * Convert annex category model to JSON representation
    */
   toJSON(): any {
+    const dataValues = this.dataValues as any;
     return {
       id: this.id,
       arrangement: this.arrangement,
       title: this.title,
       order_no: this.order_no,
       framework_id: this.framework_id,
+      // Include dynamically added properties from queries
+      subClauses: dataValues?.subClauses,
     };
   }
 

--- a/Servers/domain.layer/models/controlCategory/controlCategory.model.ts
+++ b/Servers/domain.layer/models/controlCategory/controlCategory.model.ts
@@ -270,6 +270,7 @@ export class ControlCategoryModel
    * Convert control category model to JSON representation
    */
   toJSON(): any {
+    const dataValues = this.dataValues as any;
     return {
       id: this.id,
       project_id: this.project_id,
@@ -277,6 +278,8 @@ export class ControlCategoryModel
       order_no: this.order_no,
       created_at: this.created_at?.toISOString(),
       is_demo: this.is_demo,
+      // Include dynamically added properties from queries
+      controls: dataValues?.controls,
     };
   }
 

--- a/Servers/domain.layer/models/project/project.model.ts
+++ b/Servers/domain.layer/models/project/project.model.ts
@@ -155,6 +155,7 @@ export class ProjectModel
    * Convert to JSON representation
    */
   toJSON(): any {
+    const dataValues = this.dataValues as any;
     return {
       id: this.id,
       uc_id: this.uc_id,
@@ -173,6 +174,11 @@ export class ProjectModel
       created_at: this.created_at?.toISOString(),
       is_organizational: this.is_organizational,
       status: this.status,
+      // Include dynamically added properties from queries
+      framework: dataValues?.framework,
+      members: dataValues?.members,
+      has_pending_approval: dataValues?.has_pending_approval,
+      approval_status: dataValues?.approval_status,
     };
   }
 

--- a/Servers/domain.layer/models/subtopic/subtopic.model.ts
+++ b/Servers/domain.layer/models/subtopic/subtopic.model.ts
@@ -205,6 +205,7 @@ export class SubtopicModel extends Model<SubtopicModel> implements ISubtopic {
    * Convert subtopic model to JSON representation
    */
   toJSON(): any {
+    const dataValues = this.dataValues as any;
     return {
       id: this.id,
       title: this.title,
@@ -212,6 +213,8 @@ export class SubtopicModel extends Model<SubtopicModel> implements ISubtopic {
       topic_id: this.topic_id,
       is_demo: this.is_demo,
       created_at: this.created_at?.toISOString(),
+      // Include dynamically added properties from queries
+      questions: dataValues?.questions,
     };
   }
 

--- a/Servers/domain.layer/models/tasks/tasks.model.ts
+++ b/Servers/domain.layer/models/tasks/tasks.model.ts
@@ -8,7 +8,7 @@ import {
 import { UserModel } from "../user/user.model";
 import { TaskPriority } from "../../enums/task-priority.enum";
 import { TaskStatus } from "../../enums/task-status.enum";
-import { ITask, ITaskSafeJSON, ITaskJSON } from "../../interfaces/i.task";
+import { ITask, ITaskSafeJSON } from "../../interfaces/i.task";
 import { stringValidation, enumValidation } from "../../validations/string.valid";
 import { numberValidation } from "../../validations/number.valid";
 import {ValidationException} from "../../exceptions/custom.exception";
@@ -285,7 +285,8 @@ export class TasksModel extends Model<TasksModel> implements ITask {
   /**
    * Convert task model to JSON representation
    */
-  toJSON(): ITaskJSON {
+  toJSON(): any {
+    const dataValues = this.dataValues as any;
     return {
       id: this.id,
       title: this.title,
@@ -299,6 +300,10 @@ export class TasksModel extends Model<TasksModel> implements ITask {
       created_at: this.created_at?.toISOString(),
       updated_at: this.updated_at?.toISOString(),
       isOverdue: this.isOverdue(),
+      // Include dynamically added properties from queries
+      assignees: dataValues?.assignees,
+      creator_name: dataValues?.creator_name,
+      assignee_names: dataValues?.assignee_names,
     };
   }
 


### PR DESCRIPTION
## Summary
- Fixed several Sequelize models where custom `toJSON()` methods were not including dynamically added properties from query utilities
- This caused API responses to be missing important data that was set on `dataValues` during query execution

## Affected models and missing properties
| Model | Missing Properties |
|-------|-------------------|
| ProjectModel | `framework`, `members`, `has_pending_approval`, `approval_status` |
| TasksModel | `assignees`, `creator_name`, `assignee_names` |
| SubtopicModel | `questions` |
| ControlCategoryModel | `controls` |
| ISO27001AnnexStruct | `subClauses` |

## Impact
- Framework dashboard showed "No frameworks enabled" despite frameworks being assigned to the organizational project
- Task assignees were not visible in API responses
- Assessment questions were missing from subtopic responses
- Controls were missing from control category responses
- ISO 27001 annex sub-clauses were missing from responses

## Root cause
When a custom `toJSON()` method explicitly lists properties, Sequelize no longer automatically includes properties added to `dataValues`. The fix accesses `dataValues` and includes these dynamic properties in the serialized output.