### PR TITLE
fix: increase Express JSON body size limit to 10MB

### DIFF
--- a/Servers/index.ts
+++ b/Servers/index.ts
@@ -132,7 +132,7 @@ try {
     if (req.url.includes("/api/deepeval/") && !req.url.includes("/experiments") && !req.url.includes("/arena/compare")) {
       return next();
     }
-    express.json()(req, res, next);
+    express.json({ limit: '10mb' })(req, res, next);
   });
   app.use(cookieParser());
   // app.use(csrf());


### PR DESCRIPTION
## Summary
- Increases Express.json() body parser limit from 100KB (default) to 10MB
- Fixes "Payload Too Large" (HTTP 413) error when saving policies with rich content

## Problem
Users encounter "Payload Too Large" error when creating or updating policies that contain:
- Base64-encoded images pasted into the rich text editor
- Extensive formatted text content
- Large tables or embedded media

## Solution
Configure `express.json({ limit: '10mb' })` in `Servers/index.ts` to allow larger request bodies.

## Files changed
- `Servers/index.ts` - Added `limit: '10mb'` option to express.json() middleware