### PR TITLE
feat: add onboarding setup modal for new organizations

### DIFF
--- a/Clients/src/App.tsx
+++ b/Clients/src/App.tsx
@@ -26,7 +26,7 @@ import CommandPalette from "./presentation/components/CommandPalette";
 import CommandPaletteErrorBoundary from "./presentation/components/CommandPalette/ErrorBoundary";
 import useCommandPalette from "./application/hooks/useCommandPalette";
 import useUserPreferences from "./application/hooks/useUserPreferences";
-import { OnboardingModal, useOnboarding } from "./presentation/components/Onboarding";
+import { SetupModal, useOnboarding } from "./presentation/components/Onboarding";
 import { SidebarWrapper, UserGuideSidebarProvider, useUserGuideSidebarContext } from "./presentation/components/UserGuide";
 import { AdvisorConversationProvider } from './application/contexts/AdvisorConversation.context';
 import { useNotifications } from "./application/hooks/useNotifications";
@@ -268,7 +268,7 @@ function App() {
                   />
                 </CommandPaletteErrorBoundary>
                 {showModal && (
-                  <OnboardingModal
+                  <SetupModal
                     onComplete={handleOnboardingComplete}
                     onSkip={handleOnboardingSkip}
                   />

--- a/Clients/src/application/hooks/useOnboarding.ts
+++ b/Clients/src/application/hooks/useOnboarding.ts
@@ -1,7 +1,10 @@
 import { useState, useEffect, useCallback, useContext } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import { OnboardingState, UserPreferences, SampleProjectData } from "../../presentation/types/interfaces/i.onboarding";
 import { VerifyWiseContext } from "../contexts/VerifyWise.context";
 import { useAuth } from "./useAuth";
+import { setOnboardingStatus as setReduxOnboardingStatus } from "../redux/auth/authSlice";
+import type { RootState } from "../redux/store";
 
 const getStorageKey = (userId: number) => `verifywise_onboarding_${userId}`;
 
@@ -11,17 +14,23 @@ const initialState: OnboardingState = {
   skippedSteps: [],
   preferences: {},
   sampleProject: {},
-  isComplete: true, // Temporarily set to true to disable onboarding modal
+  isComplete: true, // Default to true, will be overridden by server-side status
   lastUpdated: new Date().toISOString(),
 };
 
 export const useOnboarding = () => {
   const { userId } = useAuth();
   const { users, organizationId } = useContext(VerifyWiseContext);
+  const dispatch = useDispatch();
+
+  // Get server-side onboarding status from Redux
+  const serverOnboardingStatus = useSelector((state: RootState) => state.auth?.onboardingStatus);
+  const isOrgCreator = useSelector((state: RootState) => state.auth?.isOrgCreator);
+
   const [state, setState] = useState<OnboardingState>(initialState);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Load state from localStorage on mount
+  // Load state from localStorage on mount, but use server-side status for isComplete
   useEffect(() => {
     if (!userId) {
       setIsLoading(false);
@@ -31,21 +40,27 @@ export const useOnboarding = () => {
     const storageKey = getStorageKey(userId);
     const savedState = localStorage.getItem(storageKey);
 
+    // Determine isComplete from server-side status
+    // Only show setup modal if:
+    // 1. Server says onboarding is pending
+    // 2. User is the org creator
+    const isCompleteFromServer = serverOnboardingStatus !== "pending" || !isOrgCreator;
+
     if (savedState) {
       try {
         const parsed = JSON.parse(savedState);
-        setState(parsed);
+        // Override isComplete with server-side status
+        setState({ ...parsed, isComplete: isCompleteFromServer });
       } catch (error) {
         console.error("Failed to parse onboarding state:", error);
-        // If parse fails, mark as complete to prevent showing broken state
-        setState({ ...initialState, isComplete: true });
+        setState({ ...initialState, isComplete: isCompleteFromServer });
       }
     } else {
-      // First time for this user - initialize with default state
-      setState(initialState);
+      // First time for this user - initialize with server-side status
+      setState({ ...initialState, isComplete: isCompleteFromServer });
     }
     setIsLoading(false);
-  }, [userId]);
+  }, [userId, serverOnboardingStatus, isOrgCreator]);
 
   // Save state to localStorage whenever it changes
   useEffect(() => {
@@ -161,14 +176,16 @@ export const useOnboarding = () => {
     }));
   }, []);
 
-  // Complete onboarding
+  // Complete onboarding - updates both local state and Redux
   const completeOnboarding = useCallback(() => {
     setState((prev) => ({
       ...prev,
       isComplete: true,
       lastUpdated: new Date().toISOString(),
     }));
-  }, []);
+    // Update Redux to mark onboarding as completed
+    dispatch(setReduxOnboardingStatus("completed"));
+  }, [dispatch]);
 
   // Reset onboarding (for restart)
   const resetOnboarding = useCallback(() => {
@@ -191,6 +208,8 @@ export const useOnboarding = () => {
     isFirstUserInOrg: isFirstUserInOrg(),
     isAdmin: isAdmin(),
     isInvitedUser: isInvitedUser(),
+    isOrgCreator: isOrgCreator ?? false,
+    serverOnboardingStatus: serverOnboardingStatus ?? "completed",
     setCurrentStep,
     completeStep,
     skipStep,

--- a/Clients/src/application/redux/auth/authSlice.ts
+++ b/Clients/src/application/redux/auth/authSlice.ts
@@ -8,6 +8,8 @@ const initialState = {
 	success: null as boolean | null,
 	message: null as string | null,
 	expirationDate: null as number | null,
+	onboardingStatus: "completed" as string,
+	isOrgCreator: false as boolean,
 };
 
 export const register = createAsyncThunk(
@@ -134,6 +136,8 @@ const authSlice = createSlice({
 			state.success = true;
 			state.message = "Logged out successfully";
 			state.expirationDate = null;
+			state.onboardingStatus = "completed";
+			state.isOrgCreator = false;
 		},
 		setAuthToken: (state, action: PayloadAction<string>) => {
 			state.authToken = action.payload;
@@ -144,6 +148,12 @@ const authSlice = createSlice({
 		},
 		setUserExists: (state, action: PayloadAction<boolean>) => {
 			state.userExists = action.payload;
+		},
+		setOnboardingStatus: (state, action: PayloadAction<string>) => {
+			state.onboardingStatus = action.payload;
+		},
+		setIsOrgCreator: (state, action: PayloadAction<boolean>) => {
+			state.isOrgCreator = action.payload;
 		},
 	},
 	extraReducers(builder) {
@@ -200,6 +210,6 @@ const authSlice = createSlice({
 	},
 });
 
-export const { clearAuthState, setAuthToken, setUserExists, setExpiration } =
+export const { clearAuthState, setAuthToken, setUserExists, setExpiration, setOnboardingStatus, setIsOrgCreator } =
 	authSlice.actions;
 export default authSlice.reducer;

--- a/Clients/src/application/repository/organization.repository.ts
+++ b/Clients/src/application/repository/organization.repository.ts
@@ -81,3 +81,20 @@ export async function checkOrganizationExists(): Promise<boolean> {
     throw error;
   }
 }
+
+/**
+ * Updates the onboarding status of an organization to 'completed'.
+ * Called after user selects demo data or blank dashboard option.
+ *
+ * @param {number} organizationId - The ID of the organization to update.
+ * @returns {Promise<any>} The response from the API.
+ * @throws Will throw an error if the request fails.
+ */
+export async function updateOnboardingStatus(organizationId: number): Promise<any> {
+  try {
+    const response = await apiServices.patch(`/organizations/${organizationId}/onboarding-status`);
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/Clients/src/application/repository/user.repository.ts
+++ b/Clients/src/application/repository/user.repository.ts
@@ -162,6 +162,8 @@ export async function checkUserExists(): Promise<UserExistsResponse> {
 interface LoginResponse {
   data: {
     token: string;
+    onboarding_status?: string;
+    is_org_creator?: boolean;
   };
 }
 

--- a/Clients/src/presentation/components/ContextSidebar/index.tsx
+++ b/Clients/src/presentation/components/ContextSidebar/index.tsx
@@ -14,6 +14,8 @@ interface ContextSidebarProps {
   onOpenCreateDemoData?: () => void;
   onOpenDeleteDemoData?: () => void;
   hasDemoData?: boolean;
+  /** Only show demo data options to admins */
+  isAdmin?: boolean;
 }
 
 /**
@@ -28,6 +30,7 @@ const ContextSidebar: FC<ContextSidebarProps> = ({
   onOpenCreateDemoData,
   onOpenDeleteDemoData,
   hasDemoData,
+  isAdmin = false,
 }) => {
   const evalsSidebarContext = useEvalsSidebarContextSafe();
   const aiDetectionSidebarContext = useAIDetectionSidebarContextSafe();
@@ -58,6 +61,7 @@ const ContextSidebar: FC<ContextSidebarProps> = ({
           onOpenCreateDemoData={onOpenCreateDemoData}
           onOpenDeleteDemoData={onOpenDeleteDemoData}
           hasDemoData={hasDemoData}
+          isAdmin={isAdmin}
         />
       );
     case "evals":
@@ -118,6 +122,7 @@ const ContextSidebar: FC<ContextSidebarProps> = ({
           onOpenCreateDemoData={onOpenCreateDemoData}
           onOpenDeleteDemoData={onOpenDeleteDemoData}
           hasDemoData={hasDemoData}
+          isAdmin={isAdmin}
         />
       );
   }

--- a/Clients/src/presentation/components/Onboarding/SetupModal.tsx
+++ b/Clients/src/presentation/components/Onboarding/SetupModal.tsx
@@ -1,0 +1,348 @@
+/**
+ * SetupModal - A simple modal shown to the org creator on their first login
+ *
+ * This modal offers two choices:
+ * - Add demo data (helpful for navigation)
+ * - Start with a blank dashboard
+ *
+ * The modal is only shown when:
+ * 1. User is the org creator (first admin)
+ * 2. Organization onboarding_status is 'pending'
+ * 3. User is on the dashboard route
+ */
+
+import React, { useState } from "react";
+import { Box, Stack, Typography, CircularProgress } from "@mui/material";
+import { Database, LayoutDashboard } from "lucide-react";
+import { useDispatch } from "react-redux";
+import CustomizableButton from "../Button/CustomizableButton";
+import { postAutoDrivers } from "../../../application/repository/entity.repository";
+import { updateOnboardingStatus } from "../../../application/repository/organization.repository";
+import { useAuth } from "../../../application/hooks/useAuth";
+import { setOnboardingStatus } from "../../../application/redux/auth/authSlice";
+
+interface SetupModalProps {
+  /** Callback when setup is complete (either option selected) */
+  onComplete: () => void;
+  /** Callback when user skips/dismisses (treated as "start blank") */
+  onSkip: () => void;
+}
+
+const SetupModal: React.FC<SetupModalProps> = ({ onComplete, onSkip }) => {
+  const { organizationId } = useAuth();
+  const dispatch = useDispatch();
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadingOption, setLoadingOption] = useState<"demo" | "blank" | null>(null);
+  const [isClosing, setIsClosing] = useState(false);
+
+  const handleClose = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    setLoadingOption("blank");
+
+    try {
+      // Update onboarding status to completed (skip = start blank)
+      if (organizationId) {
+        await updateOnboardingStatus(organizationId);
+      }
+
+      // Update Redux state so it persists after reload
+      dispatch(setOnboardingStatus("completed"));
+
+      setIsClosing(true);
+      setTimeout(() => {
+        onSkip();
+      }, 300);
+    } catch (error) {
+      console.error("Error completing setup:", error);
+      setIsLoading(false);
+      setLoadingOption(null);
+    }
+  };
+
+  const handleSelectDemo = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    setLoadingOption("demo");
+
+    try {
+      // Insert demo data
+      await postAutoDrivers();
+
+      // Update onboarding status to completed
+      if (organizationId) {
+        await updateOnboardingStatus(organizationId);
+      }
+
+      // Update Redux state so it persists after reload
+      dispatch(setOnboardingStatus("completed"));
+
+      setIsClosing(true);
+      setTimeout(() => {
+        onComplete();
+        // Reload the page to show the newly created demo data
+        window.location.reload();
+      }, 300);
+    } catch (error) {
+      console.error("Error setting up demo data:", error);
+      setIsLoading(false);
+      setLoadingOption(null);
+    }
+  };
+
+  const handleSelectBlank = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    setLoadingOption("blank");
+
+    try {
+      // Update onboarding status to completed (no demo data)
+      if (organizationId) {
+        await updateOnboardingStatus(organizationId);
+      }
+
+      // Update Redux state so it persists after reload
+      dispatch(setOnboardingStatus("completed"));
+
+      setIsClosing(true);
+      setTimeout(() => {
+        onComplete();
+      }, 300);
+    } catch (error) {
+      console.error("Error completing setup:", error);
+      setIsLoading(false);
+      setLoadingOption(null);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.4)",
+        backdropFilter: "blur(2px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 9999,
+        padding: 2,
+        animation: isClosing ? "fadeOut 0.3s ease-out" : "fadeIn 0.3s ease-in",
+        "@keyframes fadeOut": {
+          from: { opacity: 1 },
+          to: { opacity: 0 },
+        },
+        "@keyframes fadeIn": {
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+        },
+      }}
+      onClick={(e) => {
+        // Only close on backdrop click, not on modal content click
+        if (e.target === e.currentTarget && !isLoading) {
+          handleClose();
+        }
+      }}
+    >
+      <Box
+        sx={{
+          backgroundColor: "white",
+          borderRadius: "12px",
+          boxShadow: "0 20px 60px rgba(0, 0, 0, 0.2)",
+          width: "100%",
+          maxWidth: "520px",
+          overflow: "hidden",
+        }}
+      >
+        {/* Header */}
+        <Stack
+          sx={{
+            padding: "32px 32px 24px",
+            textAlign: "center",
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: 22,
+              fontWeight: 600,
+              color: "#101828",
+              marginBottom: "8px",
+            }}
+          >
+            Welcome to VerifyWise
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: 14,
+              color: "#475467",
+              lineHeight: 1.5,
+            }}
+          >
+            How would you like to get started? You can explore with sample data or begin with a clean slate.
+          </Typography>
+        </Stack>
+
+        {/* Options */}
+        <Stack
+          direction="row"
+          spacing={4}
+          sx={{
+            padding: "0 32px 32px",
+          }}
+        >
+          {/* Demo Data Option */}
+          <Box
+            onClick={handleSelectDemo}
+            sx={{
+              flex: 1,
+              padding: "24px 20px",
+              border: "1px solid #E0E4E9",
+              borderRadius: "4px",
+              cursor: isLoading ? "not-allowed" : "pointer",
+              opacity: isLoading && loadingOption !== "demo" ? 0.5 : 1,
+              transition: "all 0.2s ease",
+              "&:hover": {
+                borderColor: isLoading ? "#E0E4E9" : "#13715B",
+                backgroundColor: isLoading ? "transparent" : "#F8FDFB",
+              },
+            }}
+          >
+            <Stack alignItems="center" spacing={2}>
+              <Box
+                sx={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: "8px",
+                  backgroundColor: "#E8F5F1",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                {loadingOption === "demo" ? (
+                  <CircularProgress size={24} sx={{ color: "#13715B" }} />
+                ) : (
+                  <Database size={24} color="#13715B" />
+                )}
+              </Box>
+              <Stack spacing={0.5} alignItems="center">
+                <Typography
+                  sx={{
+                    fontSize: 15,
+                    fontWeight: 600,
+                    color: "#101828",
+                  }}
+                >
+                  Add demo data
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: 13,
+                    color: "#475467",
+                    textAlign: "center",
+                    lineHeight: 1.4,
+                  }}
+                >
+                  Explore with sample projects and controls
+                </Typography>
+              </Stack>
+            </Stack>
+          </Box>
+
+          {/* Blank Dashboard Option */}
+          <Box
+            onClick={handleSelectBlank}
+            sx={{
+              flex: 1,
+              padding: "24px 20px",
+              border: "1px solid #E0E4E9",
+              borderRadius: "4px",
+              cursor: isLoading ? "not-allowed" : "pointer",
+              opacity: isLoading && loadingOption !== "blank" ? 0.5 : 1,
+              transition: "all 0.2s ease",
+              "&:hover": {
+                borderColor: isLoading ? "#E0E4E9" : "#13715B",
+                backgroundColor: isLoading ? "transparent" : "#F8FDFB",
+              },
+            }}
+          >
+            <Stack alignItems="center" spacing={2}>
+              <Box
+                sx={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: "8px",
+                  backgroundColor: "#F3F5F8",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                {loadingOption === "blank" ? (
+                  <CircularProgress size={24} sx={{ color: "#475467" }} />
+                ) : (
+                  <LayoutDashboard size={24} color="#475467" />
+                )}
+              </Box>
+              <Stack spacing={0.5} alignItems="center">
+                <Typography
+                  sx={{
+                    fontSize: 15,
+                    fontWeight: 600,
+                    color: "#101828",
+                  }}
+                >
+                  Start blank
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: 13,
+                    color: "#475467",
+                    textAlign: "center",
+                    lineHeight: 1.4,
+                  }}
+                >
+                  Begin with a clean dashboard
+                </Typography>
+              </Stack>
+            </Stack>
+          </Box>
+        </Stack>
+
+        {/* Footer */}
+        <Box
+          sx={{
+            padding: "16px 32px",
+            borderTop: "1px solid #E0E4E9",
+            backgroundColor: "#F9FAFB",
+          }}
+        >
+          <Stack direction="row" justifyContent="flex-end">
+            <CustomizableButton
+              variant="text"
+              text="Skip for now"
+              onClick={handleClose}
+              isDisabled={isLoading}
+              sx={{
+                color: "#475467",
+                fontSize: 13,
+                "&:hover": {
+                  backgroundColor: "transparent",
+                  color: "#101828",
+                },
+              }}
+            />
+          </Stack>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default SetupModal;

--- a/Clients/src/presentation/components/Onboarding/index.tsx
+++ b/Clients/src/presentation/components/Onboarding/index.tsx
@@ -1,2 +1,3 @@
 export { default as OnboardingModal } from "./OnboardingModal";
+export { default as SetupModal } from "./SetupModal";
 export { useOnboarding } from "../../../application/hooks/useOnboarding";

--- a/Clients/src/presentation/components/Sidebar/SidebarFooter.tsx
+++ b/Clients/src/presentation/components/Sidebar/SidebarFooter.tsx
@@ -54,12 +54,15 @@ interface SidebarFooterProps {
   onOpenDeleteDemoData?: () => void;
   showReadyToSubscribe?: boolean;
   openUserGuide?: () => void;
+  /** Only show demo data options to admins */
+  isAdmin?: boolean;
 }
 
 const getManagementItems = (
   hasDemoData?: boolean,
   onOpenCreateDemoData?: () => void,
-  onOpenDeleteDemoData?: () => void
+  onOpenDeleteDemoData?: () => void,
+  isAdmin?: boolean
 ): IManagementItem[] => [
   {
     name: "Event Tracker",
@@ -71,21 +74,24 @@ const getManagementItems = (
     icon: <Settings size={16} strokeWidth={1.5} />,
     path: "/settings",
   },
-  ...(hasDemoData
-    ? [
-        {
-          name: "Delete demo data",
-          icon: <Database size={16} strokeWidth={1.5} />,
-          action: onOpenDeleteDemoData,
-        },
-      ]
-    : [
-        {
-          name: "Create demo data",
-          icon: <Database size={16} strokeWidth={1.5} />,
-          action: onOpenCreateDemoData,
-        },
-      ]),
+  // Only show demo data options to admins
+  ...(isAdmin
+    ? hasDemoData
+      ? [
+          {
+            name: "Delete demo data",
+            icon: <Database size={16} strokeWidth={1.5} />,
+            action: onOpenDeleteDemoData,
+          },
+        ]
+      : [
+          {
+            name: "Create demo data",
+            icon: <Database size={16} strokeWidth={1.5} />,
+            action: onOpenCreateDemoData,
+          },
+        ]
+    : []),
 ];
 
 interface User_Avatar {
@@ -111,6 +117,7 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
   onOpenDeleteDemoData,
   showReadyToSubscribe = false,
   openUserGuide,
+  isAdmin = false,
 }) => {
   const theme = useTheme();
   const navigate = useNavigate();
@@ -179,7 +186,7 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
     };
   }, [slideoverOpen]);
 
-  const isManagementActive = getManagementItems(hasDemoData, onOpenCreateDemoData, onOpenDeleteDemoData).some(
+  const isManagementActive = getManagementItems(hasDemoData, onOpenCreateDemoData, onOpenDeleteDemoData, isAdmin).some(
     (item) => item.path && (location.pathname.startsWith(`${item.path}/`) || location.pathname === item.path)
   );
 
@@ -314,7 +321,7 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
             },
           }}
         >
-          {getManagementItems(hasDemoData, onOpenCreateDemoData, onOpenDeleteDemoData).map((item) => (
+          {getManagementItems(hasDemoData, onOpenCreateDemoData, onOpenDeleteDemoData, isAdmin).map((item) => (
             <MenuItem
               key={item.path || item.name}
               onClick={() => {
@@ -580,8 +587,8 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
                     </Box>
                   </ListItemButton>
 
-                  {/* Create Demo Data / Delete Demo Data */}
-                  {hasDemoData ? (
+                  {/* Create Demo Data / Delete Demo Data - Only for admins */}
+                  {isAdmin && (hasDemoData ? (
                     <ListItemButton
                       onClick={() => {
                         if (onOpenDeleteDemoData) {
@@ -649,7 +656,7 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
                         Create demo data
                       </Typography>
                     </ListItemButton>
-                  )}
+                  ))}
                 </Stack>
               </Box>
 

--- a/Clients/src/presentation/components/Sidebar/SidebarShell.tsx
+++ b/Clients/src/presentation/components/Sidebar/SidebarShell.tsx
@@ -89,6 +89,8 @@ export interface SidebarShellProps {
   onOpenDeleteDemoData?: () => void;
   showReadyToSubscribe?: boolean;
   openUserGuide?: () => void;
+  /** Only show demo data options to admins */
+  isAdmin?: boolean;
 
   // Enable flying hearts Easter egg (only for main sidebar)
   enableFlyingHearts?: boolean;
@@ -108,6 +110,7 @@ const SidebarShell: FC<SidebarShellProps> = ({
   onOpenDeleteDemoData,
   showReadyToSubscribe = false,
   openUserGuide,
+  isAdmin = false,
   enableFlyingHearts = false,
 }) => {
   const theme = useTheme();
@@ -1004,6 +1007,7 @@ const SidebarShell: FC<SidebarShellProps> = ({
           onOpenDeleteDemoData={onOpenDeleteDemoData}
           showReadyToSubscribe={showReadyToSubscribe}
           openUserGuide={openUserGuide}
+          isAdmin={isAdmin}
         />
 
         {/* Flying Hearts Animation */}

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -27,12 +27,15 @@ interface SidebarProps {
   onOpenCreateDemoData?: () => void;
   onOpenDeleteDemoData?: () => void;
   hasDemoData?: boolean;
+  /** Only show demo data options to admins */
+  isAdmin?: boolean;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
   onOpenCreateDemoData,
   onOpenDeleteDemoData,
   hasDemoData = false,
+  isAdmin = false,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -218,6 +221,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       onOpenDeleteDemoData={onOpenDeleteDemoData}
       showReadyToSubscribe={true}
       openUserGuide={openUserGuide}
+      isAdmin={isAdmin}
       enableFlyingHearts={true}
     />
   );

--- a/Clients/src/presentation/containers/Dashboard/index.tsx
+++ b/Clients/src/presentation/containers/Dashboard/index.tsx
@@ -21,6 +21,7 @@ import { useDashboard } from "../../../application/hooks/useDashboard";
 import { useActiveModule } from "../../../application/hooks/useActiveModule";
 import AppSwitcher from "../../components/AppSwitcher";
 import ContextSidebar from "../../components/ContextSidebar";
+import { useAuth } from "../../../application/hooks/useAuth";
 
 interface DashboardProps {
   reloadTrigger: boolean;
@@ -30,6 +31,8 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
   const { setDashboardValues, setProjects } = useContext(VerifyWiseContext);
   const location = useLocation();
   const { activeModule, setActiveModule } = useActiveModule();
+  const { userRoleName } = useAuth();
+  const isAdmin = userRoleName === "Admin";
 
   // Demo data state
   const [showToastNotification, setShowToastNotification] =
@@ -292,6 +295,7 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
             onOpenCreateDemoData={() => setOpenDemoDataModal(true)}
             onOpenDeleteDemoData={() => setOpenDeleteDemoDataModal(true)}
             hasDemoData={hasDemoData}
+            isAdmin={isAdmin}
           />
           <Stack 
             className="main-content-area" 

--- a/Clients/src/presentation/pages/Authentication/Login/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/Login/index.tsx
@@ -7,8 +7,7 @@ import singleTheme from "../../../themes/v1SingleTheme";
 import { useNavigate } from "react-router-dom";
 import { logEngine } from "../../../../application/tools/log.engine";
 import { useDispatch } from "react-redux";
-import { setAuthToken } from "../../../../application/redux/auth/authSlice";
-import { setExpiration } from "../../../../application/redux/auth/authSlice";
+import { setAuthToken, setExpiration, setOnboardingStatus, setIsOrgCreator } from "../../../../application/redux/auth/authSlice";
 import Alert from "../../../components/Alert";
 import { ENV_VARs } from "../../../../../env.vars";
 import { loginUser } from "../../../../application/repository/user.repository";
@@ -148,6 +147,8 @@ const Login: React.FC = () => {
 
         if (response.status === 202) {
           const token = response.data.data.token;
+          const onboardingStatus = response.data.data.onboarding_status || "completed";
+          const isOrgCreatorFlag = response.data.data.is_org_creator || false;
 
           if (values.rememberMe) {
             const expirationDate = Date.now() + 30 * 24 * 60 * 60 * 1000;
@@ -157,6 +158,10 @@ const Login: React.FC = () => {
             dispatch(setAuthToken(token));
             dispatch(setExpiration(null));
           }
+
+          // Store onboarding status from server
+          dispatch(setOnboardingStatus(onboardingStatus));
+          dispatch(setIsOrgCreator(isOrgCreatorFlag));
 
           localStorage.setItem("root_version", __APP_VERSION__);
 

--- a/Servers/database/migrations/20260113000000-add-is-demo-to-remaining-tables.js
+++ b/Servers/database/migrations/20260113000000-add-is-demo-to-remaining-tables.js
@@ -1,0 +1,132 @@
+"use strict";
+
+/**
+ * Migration: Add is_demo column to tables that need it for demo data management
+ *
+ * Tables being updated:
+ * - risks (tenant schema)
+ * - model_risks (tenant schema)
+ * - policy_manager (tenant schema)
+ * - trainingregistar (tenant schema)
+ * - ai_incident_managements (tenant schema)
+ * - tasks (tenant schema)
+ * - evidence_hub (tenant schema)
+ * - vendorrisks (tenant schema)
+ */
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const tables = [
+      "risks",
+      "model_risks",
+      "policy_manager",
+      "trainingregistar",
+      "ai_incident_managements",
+      "tasks",
+      "evidence_hub",
+      "vendor_risks",
+    ];
+
+    // Get all tenant schemas (excluding system schemas)
+    const schemas = await queryInterface.sequelize.query(
+      `SELECT schema_name FROM information_schema.schemata
+       WHERE schema_name NOT IN ('public', 'information_schema', 'pg_catalog', 'pg_toast')
+       AND schema_name NOT LIKE 'pg_%'`,
+      { type: Sequelize.QueryTypes.SELECT }
+    );
+
+    for (const { schema_name } of schemas) {
+      for (const table of tables) {
+        try {
+          // Check if the table exists in this schema
+          const [tableExists] = await queryInterface.sequelize.query(
+            `SELECT EXISTS (
+              SELECT FROM information_schema.tables
+              WHERE table_schema = '${schema_name}'
+              AND table_name = '${table}'
+            )`,
+            { type: Sequelize.QueryTypes.SELECT }
+          );
+
+          if (!tableExists.exists) {
+            console.log(
+              `Table ${schema_name}.${table} does not exist, skipping...`
+            );
+            continue;
+          }
+
+          // Check if column already exists
+          const [columns] = await queryInterface.sequelize.query(
+            `SELECT column_name FROM information_schema.columns
+             WHERE table_schema = '${schema_name}'
+             AND table_name = '${table}'
+             AND column_name = 'is_demo'`,
+            { type: Sequelize.QueryTypes.SELECT }
+          );
+
+          if (columns) {
+            console.log(
+              `Column is_demo already exists in ${schema_name}.${table}, skipping...`
+            );
+            continue;
+          }
+
+          // Add the is_demo column
+          await queryInterface.sequelize.query(
+            `ALTER TABLE "${schema_name}"."${table}"
+             ADD COLUMN IF NOT EXISTS is_demo BOOLEAN NOT NULL DEFAULT false`
+          );
+
+          console.log(
+            `Added is_demo column to ${schema_name}.${table}`
+          );
+        } catch (error) {
+          console.error(
+            `Error processing ${schema_name}.${table}:`,
+            error.message
+          );
+        }
+      }
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    const tables = [
+      "risks",
+      "model_risks",
+      "policy_manager",
+      "trainingregistar",
+      "ai_incident_managements",
+      "tasks",
+      "evidence_hub",
+      "vendor_risks",
+    ];
+
+    // Get all tenant schemas
+    const schemas = await queryInterface.sequelize.query(
+      `SELECT schema_name FROM information_schema.schemata
+       WHERE schema_name NOT IN ('public', 'information_schema', 'pg_catalog', 'pg_toast')
+       AND schema_name NOT LIKE 'pg_%'`,
+      { type: Sequelize.QueryTypes.SELECT }
+    );
+
+    for (const { schema_name } of schemas) {
+      for (const table of tables) {
+        try {
+          await queryInterface.sequelize.query(
+            `ALTER TABLE "${schema_name}"."${table}"
+             DROP COLUMN IF EXISTS is_demo`
+          );
+          console.log(
+            `Removed is_demo column from ${schema_name}.${table}`
+          );
+        } catch (error) {
+          console.error(
+            `Error removing column from ${schema_name}.${table}:`,
+            error.message
+          );
+        }
+      }
+    }
+  },
+};

--- a/Servers/database/migrations/20260113000002-add-onboarding-status-to-organizations.js
+++ b/Servers/database/migrations/20260113000002-add-onboarding-status-to-organizations.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * Migration: Add onboarding_status column to organizations table
+ *
+ * This column tracks whether the organization creator has seen the setup modal.
+ * - 'pending': New org, modal should be shown to creator on first login
+ * - 'completed': Modal has been seen/dismissed, don't show again
+ *
+ * Existing organizations are set to 'completed' to prevent modal from showing
+ * after server upgrade (grandfathered).
+ */
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      // Step 1: Add column as nullable first
+      await queryInterface.addColumn(
+        'organizations',
+        'onboarding_status',
+        {
+          type: Sequelize.STRING(20),
+          allowNull: true,
+        },
+        { transaction }
+      );
+
+      // Step 2: Set all existing organizations to 'completed' (grandfathered)
+      // This ensures existing orgs don't see the modal after upgrade
+      await queryInterface.sequelize.query(
+        `UPDATE organizations SET onboarding_status = 'completed' WHERE onboarding_status IS NULL;`,
+        { transaction }
+      );
+
+      // Step 3: Make column NOT NULL with default 'pending' for new orgs
+      await queryInterface.changeColumn(
+        'organizations',
+        'onboarding_status',
+        {
+          type: Sequelize.STRING(20),
+          allowNull: false,
+          defaultValue: 'pending',
+        },
+        { transaction }
+      );
+
+      await transaction.commit();
+      console.log('Successfully added onboarding_status column to organizations table');
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.removeColumn('organizations', 'onboarding_status', {
+        transaction,
+      });
+
+      await transaction.commit();
+      console.log('Successfully removed onboarding_status column from organizations table');
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+};

--- a/Servers/domain.layer/interfaces/i.organization.ts
+++ b/Servers/domain.layer/interfaces/i.organization.ts
@@ -3,4 +3,5 @@ export type IOrganization = {
   name: string;
   logo?: string;
   created_at?: Date;
+  onboarding_status?: string;
 };

--- a/Servers/domain.layer/models/organization/organization.model.ts
+++ b/Servers/domain.layer/models/organization/organization.model.ts
@@ -64,6 +64,13 @@ export class OrganizationModel
   })
   created_at?: Date;
 
+  @Column({
+    type: DataType.STRING(20),
+    allowNull: false,
+    defaultValue: 'pending',
+  })
+  onboarding_status?: string;
+
   /**
    * Creates a new organization with validation
    *
@@ -350,6 +357,7 @@ export class OrganizationModel
       name: this.name,
       logo: this.logo,
       created_at: this.created_at?.toISOString(),
+      onboarding_status: this.onboarding_status,
     };
   }
 
@@ -362,6 +370,7 @@ export class OrganizationModel
       name: this.name,
       logo: this.logo,
       created_at: this.created_at?.toISOString(),
+      onboarding_status: this.onboarding_status,
       ageInDays: this.getAgeInDays(),
     };
   }

--- a/Servers/infrastructure.layer/driver/autoDriver.driver.ts
+++ b/Servers/infrastructure.layer/driver/autoDriver.driver.ts
@@ -70,7 +70,7 @@ export async function insertMockData(
           ai_lifecycle_phase: "Monitoring & maintenance",
           risk_description:
             "Risk of discriminatory outcomes in candidate ranking due to biased training data or model assumptions. The AI system may inadvertently favor or disadvantage candidates based on protected characteristics such as gender, age, ethnicity, or disability status.",
-          risk_category: ["Bias and fairness risk"],
+          risk_category: ["Compliance risk"],
           impact: "High",
           assessment_mapping: "EU AI Act Article 10 - Data Governance",
           controls_mapping: "Bias Testing and Fairness Audits",

--- a/Servers/routes/organization.route.ts
+++ b/Servers/routes/organization.route.ts
@@ -29,6 +29,7 @@ import {
   getOrganizationById,
   updateOrganizationById,
   getOrganizationsExists,
+  updateOnboardingStatus,
 } from "../controllers/organization.ctrl";
 
 import authenticateJWT from "../middleware/auth.middleware";
@@ -101,6 +102,23 @@ router.post("/", /**checkMultiTenancy,**/ createOrganization);
  * @returns {Object} Updated organization object
  */
 router.patch("/:id", authenticateJWT, updateOrganizationById);
+
+/**
+ * PATCH /organizations/:id/onboarding-status
+ *
+ * Updates the onboarding status of an organization to 'completed'.
+ * Called after user selects demo data or blank dashboard option.
+ * Requires authentication.
+ *
+ * @name patch/:id/onboarding-status
+ * @function
+ * @memberof module:routes/organization.route
+ * @inner
+ * @param {express.Request} req - Express request object
+ * @param {express.Response} res - Express response object
+ * @returns {Object} Updated onboarding status
+ */
+router.patch("/:id/onboarding-status", authenticateJWT, updateOnboardingStatus);
 
 /**
  * DELETE /organizations/:id

--- a/Servers/utils/organization.utils.ts
+++ b/Servers/utils/organization.utils.ts
@@ -90,14 +90,18 @@ export const createOrganizationQuery = async (
   organization: Partial<OrganizationModel>,
   transaction: Transaction
 ): Promise<OrganizationModel> => {
+  // Generate a unique slug for the organization
+  const slug = Math.random().toString(36).substring(2, 10);
+
   const result = await sequelize.query(
-    `INSERT INTO organizations(name, logo, created_at) 
-     VALUES (:name, :logo, :created_at) RETURNING *`,
+    `INSERT INTO organizations(name, logo, created_at, slug)
+     VALUES (:name, :logo, :created_at, :slug) RETURNING *`,
     {
       replacements: {
         name: organization.name,
         logo: organization.logo || null,
         created_at: new Date(),
+        slug,
       },
       mapToModel: true,
       model: OrganizationModel,


### PR DESCRIPTION
## Summary
- Add welcome modal for organization creators on first login with two options: explore with demo data or start blank
- Track onboarding status per organization to show modal only once
- Add sidebar button to create/clear demo data after initial setup
- Fix PostgreSQL array formatting for risk category enum

## Changes
### Frontend
- New `SetupModal` component with demo data and blank dashboard options
- Updated Redux auth slice to include `onboarding_status`
- Added `useOnboarding` hook for modal visibility logic
- Sidebar footer now shows "Create demo data" / "Clear demo data" button based on state

### Backend
- Migration to add `onboarding_status` column to organizations table
- New endpoint `PATCH /organizations/:id/onboarding-status`
- Include `onboarding_status` in login response
- Fix risk utils PostgreSQL array literal formatting for enum types

## Behavior
- Modal appears only for the organization creator on first login
- Existing organizations are grandfathered with 'completed' status (no modal)
- Dismissing modal = choosing blank dashboard
- Choice persists across page reloads via Redux state