### PR TITLE
fix: add auto-dismiss for GitHub token toast notifications

### DIFF
--- a/Clients/src/presentation/pages/AIDetection/SettingsPage.tsx
+++ b/Clients/src/presentation/pages/AIDetection/SettingsPage.tsx
@@ -71,6 +71,15 @@ export default function SettingsPage() {
     loadTokenStatus();
   }, [loadTokenStatus]);
 
+  // Auto-dismiss toast after 3 seconds
+  useEffect(() => {
+    if (alert) {
+      const timer = setTimeout(() => setAlert(null), 3000);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [alert]);
+
   const handleTabChange = (_: React.SyntheticEvent, newValue: string) => {
     setActiveTab(newValue);
   };


### PR DESCRIPTION
## Summary
- Fix toast notifications not auto-dismissing on GitHub token settings page

## Problem
Toast notifications for GitHub token save/test/delete operations were not auto-dismissing, requiring users to manually click to close them.

## Solution
Added `useEffect` with `setTimeout` to auto-dismiss toasts after 3 seconds, matching the behavior in other settings pages (e.g., ApiKeys).

## Test plan
- [ ] Save a GitHub token - toast should disappear after 3 seconds
- [ ] Test an invalid token - error toast should disappear after 3 seconds
- [ ] Delete a token - success toast should disappear after 3 seconds
- [ ] Click toast before 3 seconds - should dismiss immediately