### PR TITLE
fix: close modal and switch tab after saving policy from template

### DIFF
--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -957,6 +957,11 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
       }
 
       setIsSaving(false);
+
+      // If creating from template, close modal and notify parent
+      if (isNew && template) {
+        _onSaved("Policy created successfully from template");
+      }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       setIsSaving(false);

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyTemplates.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyTemplates.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { Box, Stack, TableRow, TableCell } from "@mui/material";
 import EmptyState from "../../components/EmptyState";
 import policyTemplates from "../../../application/data/PolicyTemplates.json";
@@ -34,6 +34,7 @@ const PolicyTemplates: React.FC<PolicyTemplatesProps> = ({
   tags,
   fetchAll,
 }) => {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const hasProcessedUrlParam = useRef(false);
   const [showModal, setShowModal] = useState(false);
@@ -90,6 +91,9 @@ const PolicyTemplates: React.FC<PolicyTemplatesProps> = ({
   const handleSaved = (successMessage?: string) => {
     fetchAll();
     handleClose();
+
+    // Navigate to organizational policies tab to show the newly created policy
+    navigate("/policies");
 
     // Show success alert if message is provided
     if (successMessage) {


### PR DESCRIPTION
## Summary
- Fix duplicate policies being created when saving from a template multiple times

## Problem
When opening a policy template and saving it:
1. First save creates the policy correctly
2. Modal stays open (still in "create" mode)
3. Making changes and saving again creates a **duplicate policy**

## Solution
After successfully saving a policy from a template:
1. Close the modal automatically
2. Navigate to the "Organizational policies" tab
3. Show success toast: "Policy created successfully from template"

This ensures the user sees their newly created policy and can continue editing it from the policies list if needed.

## Changes
- `PolicyDetailsModal.tsx`: Call `onSaved` callback after creating a policy from template
- `PolicyTemplates.tsx`: Navigate to `/policies` after save completes