### PR TITLE
fix: refresh policy table after saving new or edited policy

### DIFF
--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -958,9 +958,13 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
 
       setIsSaving(false);
 
-      // If creating from template, close modal and notify parent
+      // Close modal and notify parent to refresh the table
       if (isNew && template) {
         _onSaved("Policy created successfully from template");
+      } else if (isNew) {
+        _onSaved("Policy created successfully");
+      } else {
+        _onSaved("Policy updated successfully");
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- Fix policy table not refreshing after saving a new or edited policy

## Problem
When saving a policy, the table was not refreshing and the modal stayed open:
- New policy (without template): table not refreshed, modal stayed open
- Edited policy: table not refreshed, modal stayed open

The `onSaved` callback was only being called for policies created from templates.

## Solution
Call `onSaved` for all successful saves with appropriate messages:
- From template: "Policy created successfully from template"
- New policy: "Policy created successfully"  
- Edit: "Policy updated successfully"

This ensures:
1. Modal closes after save
2. Table refreshes to show the new/updated policy
3. Success toast is displayed