### PR TITLE
fix: update automations page grid layout for MUI v7

### DIFF
--- a/Clients/src/presentation/pages/Automations/index.tsx
+++ b/Clients/src/presentation/pages/Automations/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback, Suspense } from "react";
 import { Grid, Box, Stack, useTheme } from "@mui/material";
-import type { GridProps } from "@mui/material";
 import { Settings } from "lucide-react";
 import AutomationList from "./components/AutomationList";
 import AutomationBuilder from "./components/AutomationBuilder";
@@ -1560,7 +1559,7 @@ This notification was sent on {{date_and_time}}.`,
           <Grid container spacing={0} sx={{ height: "100%" }}>
             {/* Left Sidebar - Automation List */}
             <Grid
-              {...({ item: true, xs: 12, md: 3 } as GridProps & { item: boolean; xs: number; md: number })}
+              size={{ xs: 12, md: 3 }}
               sx={{
                 height: "100%",
                 borderRight: `1px solid ${theme.palette.border.dark}`,
@@ -1586,7 +1585,7 @@ This notification was sent on {{date_and_time}}.`,
 
             {/* Center Panel - Automation Builder */}
             <Grid
-              {...({ item: true, xs: 12, md: showConfigurationPanel ? 6 : 9 } as GridProps & { item: boolean; xs: number; md: number })}
+              size={{ xs: 12, md: showConfigurationPanel ? 6 : 9 }}
               sx={{
                 height: "100%",
                 ...(showConfigurationPanel
@@ -1645,7 +1644,7 @@ This notification was sent on {{date_and_time}}.`,
             {/* Right Panel - Configuration (conditional) */}
             {showConfigurationPanel && (
               <Grid
-                {...({ item: true, xs: 12, md: 3 } as GridProps & { item: boolean; xs: number; md: number })}
+                size={{ xs: 12, md: 3 }}
                 sx={{
                   height: "100%",
                   background:


### PR DESCRIPTION
## Summary
- Fixed automations page left panel appearing too wide by updating Grid components to use MUI v7's `size` prop syntax
- Replaced deprecated type assertion hack with proper MUI v7 Grid API

## Changes
- Left sidebar: `size={{ xs: 12, md: 3 }}`
- Center panel: `size={{ xs: 12, md: showConfigurationPanel ? 6 : 9 }}`
- Right panel: `size={{ xs: 12, md: 3 }}`

## Root cause
The previous implementation used a type assertion hack to work around MUI v7's API change:
```typescript
{...({ item: true, xs: 12, md: 3 } as GridProps & { item: boolean; xs: number; md: number })}
```

In MUI v7, the `item` prop and `xs`/`md` sizing props were replaced with the `size` prop. The type assertion allowed compilation but did not correctly apply responsive sizing.

## Test plan
- [ ] Navigate to automations page
- [ ] Verify left panel takes 25% width (3/12 columns) on medium+ screens
- [ ] Verify center panel resizes correctly when configuration panel is shown/hidden
- [ ] Verify layout looks correct on mobile (full width)