### PR TITLE
fix: reorder model risks toolbar widgets

### DIFF
--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -2154,6 +2154,15 @@ const ModelInventory: React.FC = () => {
                     onFilterChange={handleModelRiskFilterChange}
                   />
                 </div>
+                <GroupBy
+                  options={[
+                    { id: "risk_level", label: "Risk level" },
+                    { id: "status", label: "Status" },
+                    { id: "model_name", label: "Model" },
+                    { id: "owner", label: "Owner" },
+                  ]}
+                  onGroupChange={handleGroupChangeRisk}
+                />
                 <SelectComponent
                   id="risk-status-filter"
                   value={modelRiskStatusFilter}
@@ -2170,15 +2179,6 @@ const ModelInventory: React.FC = () => {
                     }
                     return `Show: ${selectedItem.name.toLowerCase()}`;
                   }}
-                />
-                <GroupBy
-                  options={[
-                    { id: "risk_level", label: "Risk level" },
-                    { id: "status", label: "Status" },
-                    { id: "model_name", label: "Model" },
-                    { id: "owner", label: "Owner" },
-                  ]}
-                  onGroupChange={handleGroupChangeRisk}
                 />
               </Stack>
               <Stack direction="row" gap="8px" alignItems="center">


### PR DESCRIPTION
## Summary
- Moved GroupBy widget next to FilterBy on the model risks tab
- The status filter dropdown is now positioned after GroupBy for consistent toolbar ordering

## Before
Filter → Status dropdown → Group by

## After  
Filter → Group by → Status dropdown

## Test plan
- [ ] Navigate to /model-inventory/model-risks
- [ ] Verify FilterBy and GroupBy widgets are adjacent
- [ ] Verify status dropdown (Active only/Active + deleted/Deleted only) appears after GroupBy