### PR TITLE
fix: change 'Evidences' to 'Evidence' in control pane sidebar

### DIFF
--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -905,7 +905,7 @@ const NewControlPane = ({
       icon: "FileText" as keyof typeof LucideIcons,
     },
     {
-      label: "Evidences",
+      label: "Evidence",
       value: "evidences",
       icon: "FolderOpen" as keyof typeof LucideIcons,
     },


### PR DESCRIPTION
## Summary
- Changed sidebar tab label from "Evidences" to "Evidence" (singular) in the project view controls modal

## Test plan
- [ ] Navigate to /project-view?projectId=2 → Controls
- [ ] Open a control's sidebar
- [ ] Verify the tab is labeled "Evidence" (not "Evidences")