### PR TITLE
fix: hide duplicate date display in MUI v8 DatePicker

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
@@ -47,7 +47,6 @@ const LAYOUT = {
 
 // Constants
 const FORM_FIELD_WIDTH = LAYOUT.FIELD_WIDTH;
-const DATE_INPUT_WIDTH = 85;
 const MIN_HEIGHT = 500;
 const MAX_HEIGHT = 500;
 
@@ -234,24 +233,19 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                   disabled={isEditingDisabled}
                 />
                 {/* Deadline */}
-                <Stack style={{ width: fieldWidth }}>
-                  <DatePicker
-                    label="Deadline"
-                    date={
-                      mitigationValues.deadline
-                        ? dayjs(mitigationValues.deadline)
-                        : dayjs(new Date())
-                    }
-                    handleDateChange={(e) => handleDateChange("deadline", e)}
-                    sx={{
-                      width: fieldWidth,
-                      "& input": { width: DATE_INPUT_WIDTH },
-                    }}
-                    isRequired
-                    error={mitigationErrors?.deadline}
-                    disabled={isEditingDisabled}
-                  />
-                </Stack>
+                <DatePicker
+                  label="Deadline"
+                  date={
+                    mitigationValues.deadline
+                      ? dayjs(mitigationValues.deadline)
+                      : dayjs(new Date())
+                  }
+                  handleDateChange={(e) => handleDateChange("deadline", e)}
+                  sx={{ width: fieldWidth }}
+                  isRequired
+                  error={mitigationErrors?.deadline}
+                  disabled={isEditingDisabled}
+                />
               </Stack>
               {/* Row 2: Mitigation Plan and Implementation Strategy */}
               <Stack sx={formRowStyles}>
@@ -344,24 +338,19 @@ const MitigationSection: FC<MitigationSectionProps> = ({
               error={mitigationErrors?.approvalStatus}
               disabled={isEditingDisabled}
             />
-            <Stack style={{ width: fieldWidth }}>
-              <DatePicker
-                label="Assessment date"
-                date={
-                  mitigationValues.dateOfAssessment
-                    ? dayjs(mitigationValues.dateOfAssessment)
-                    : dayjs(new Date())
-                }
-                handleDateChange={(e) => handleDateChange("dateOfAssessment", e)}
-                sx={{
-                  width: fieldWidth,
-                  "& input": { width: DATE_INPUT_WIDTH },
-                }}
-                isRequired
-                error={mitigationErrors?.dateOfAssessment}
-                disabled={isEditingDisabled}
-              />
-            </Stack>
+            <DatePicker
+              label="Assessment date"
+              date={
+                mitigationValues.dateOfAssessment
+                  ? dayjs(mitigationValues.dateOfAssessment)
+                  : dayjs(new Date())
+              }
+              handleDateChange={(e) => handleDateChange("dateOfAssessment", e)}
+              sx={{ width: fieldWidth }}
+              isRequired
+              error={mitigationErrors?.dateOfAssessment}
+              disabled={isEditingDisabled}
+            />
           </Stack>
           <Stack sx={{ mt: `${LAYOUT.VERTICAL_GAP}px`, width: contentWidth }}>
             <Field

--- a/Clients/src/presentation/components/CreateProjectForm/styles.ts
+++ b/Clients/src/presentation/components/CreateProjectForm/styles.ts
@@ -106,7 +106,6 @@ export const createProjectFormStyles = {
   
   datePicker: {
     width: "130px",
-    "& input": { width: "85px" },
   },
   
   goalField: (theme: Theme) => ({

--- a/Clients/src/presentation/components/Forms/ProjectForm/style.ts
+++ b/Clients/src/presentation/components/Forms/ProjectForm/style.ts
@@ -18,7 +18,6 @@ export const createProjectButtonStyle = {
 
 export const datePickerStyle = {
   width: "130px",
-  "& input": { width: "85px" },
 };
 
 export const teamMembersRenderInputStyle = {

--- a/Clients/src/presentation/components/Inputs/Datepicker/index.css
+++ b/Clients/src/presentation/components/Inputs/Datepicker/index.css
@@ -13,9 +13,13 @@
 .mui-date-picker .MuiPickersOutlinedInput-input {
   padding: 6px 8px 6px 0 !important;
   font-size: 13px !important;
-  position: relative !important;
-  left: auto !important;
-  top: auto !important;
+  position: absolute !important;
+  left: 0 !important;
+  top: 0 !important;
+  opacity: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+  pointer-events: none !important;
 }
 
 /* MUI v8 uses sectionsContainer for date display */

--- a/Clients/src/presentation/components/Inputs/Datepicker/style.ts
+++ b/Clients/src/presentation/components/Inputs/Datepicker/style.ts
@@ -34,9 +34,12 @@ export const DatePickerStyle = {
   "& .MuiPickersInputBase-sectionContent": {
     fontSize: "13px !important",
   },
-  // Fallback for hidden input element
+  // Hide the input element - MUI v8 uses sectionsContainer for visible date display
   "& .MuiPickersInputBase-input, & .MuiPickersOutlinedInput-input": {
     fontSize: "13px !important",
+    position: "absolute !important",
+    opacity: 0,
+    pointerEvents: "none",
   },
   "& .MuiOutlinedInput-root": {
     backgroundColor: "#FFFFFF",

--- a/Clients/src/presentation/components/Policies/PolicyForm.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyForm.tsx
@@ -90,10 +90,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
                 formData.nextReviewDate ? dayjs(formData.nextReviewDate) : null
               }
               handleDateChange={handleDateChange}
-              sx={{
-                width: "100%",
-                "& input": { width: "85px" },
-              }}
+              sx={{ width: "100%" }}
               isRequired
               error={errors.nextReviewDate}
             />

--- a/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
@@ -1020,10 +1020,7 @@ const ProjectSettings = React.memo(
                     label=""
                     date={values.startDate ? dayjs(values.startDate) : null}
                     handleDateChange={handleDateChange}
-                    sx={{
-                      width: "130px",
-                      "& input": { width: "85px" },
-                    }}
+                    sx={{ width: "130px" }}
                     isRequired
                     error={errors.startDate}
                   />


### PR DESCRIPTION
## Summary
- Fix duplicate date display issue in DatePicker when container is too wide
- Hide the input element in MUI v8 DatePicker (uses sectionsContainer for visible display)
- Remove unnecessary `"& input": { width: "85px" }` styling from multiple components

## Details
In MUI X v8, the DatePicker component uses both:
1. A visible `sectionsContainer` for rendering date segments (MM, DD, YYYY)
2. A hidden `input` element for form accessibility/submission

When the DatePicker container was too wide, the input element was becoming visible alongside the sections container, causing a duplicate date display.

## Changes
- `Datepicker/index.css`: Hide input with position:absolute, opacity:0, pointer-events:none
- `Datepicker/style.ts`: Add same hiding styles for consistency
- `MitigationSection/index.tsx`: Remove redundant wrapper Stacks and input width overrides
- `ProjectSettings/index.tsx`: Remove input width override
- `ProjectForm/style.ts`: Remove input width from datePickerStyle
- `CreateProjectForm/styles.ts`: Remove input width from datePicker style
- `PolicyForm.tsx`: Remove input width override

## Test plan
- [ ] Navigate to `/risk-management` → Add new → Mitigation tab
- [ ] Verify DatePicker shows date only once (no duplicate)
- [ ] Test with different container widths
- [ ] Verify DatePicker works correctly in other locations (project settings, policy form, etc.)