### PR TITLE
fix: add missing tenant column to evaluation CRUD operations

### DIFF
--- a/EvalServer/src/crud/evaluation_logs.py
+++ b/EvalServer/src/crud/evaluation_logs.py
@@ -37,13 +37,13 @@ async def create_log(
     
     result = await db.execute(
         text(f'''
-            INSERT INTO "{tenant}".evaluation_logs 
+            INSERT INTO "{tenant}".evaluation_logs
             (id, project_id, experiment_id, trace_id, parent_trace_id, span_name,
              input_text, output_text, model_name, metadata, latency_ms, token_count,
-             cost, status, error_message, created_by)
+             cost, status, error_message, created_by, tenant)
             VALUES (:id, :project_id, :experiment_id, CAST(:trace_id AS uuid), CAST(:parent_trace_id AS uuid), :span_name,
                     :input_text, :output_text, :model_name, CAST(:metadata_json AS jsonb), :latency_ms, :token_count,
-                    :cost, :status, :error_message, :created_by)
+                    :cost, :status, :error_message, :created_by, :tenant)
             RETURNING id, project_id, experiment_id, trace_id, timestamp, status
         '''),
         {
@@ -63,6 +63,7 @@ async def create_log(
             "status": status,
             "error_message": error_message,
             "created_by": int(created_by) if created_by is not None else None,
+            "tenant": tenant,
         }
     )
 
@@ -211,9 +212,9 @@ async def create_metric(
     
     result = await db.execute(
         text(f'''
-            INSERT INTO "{tenant}".evaluation_metrics 
-            (id, project_id, experiment_id, metric_name, metric_type, value, dimensions)
-            VALUES (:id, :project_id, :experiment_id, :metric_name, :metric_type, :value, CAST(:dimensions_json AS jsonb))
+            INSERT INTO "{tenant}".evaluation_metrics
+            (id, project_id, experiment_id, metric_name, metric_type, value, dimensions, tenant)
+            VALUES (:id, :project_id, :experiment_id, :metric_name, :metric_type, :value, CAST(:dimensions_json AS jsonb), :tenant)
             RETURNING id, project_id, metric_name, value, timestamp
         '''),
         {
@@ -224,6 +225,7 @@ async def create_metric(
             "metric_type": metric_type,
             "value": value,
             "dimensions_json": dimensions_json,
+            "tenant": tenant,
         }
     )
     
@@ -318,9 +320,9 @@ async def create_experiment(
         
         result = await db.execute(
             text(f'''
-                INSERT INTO "{tenant}".experiments 
-                (id, project_id, name, description, config, baseline_experiment_id, status, created_by)
-                VALUES (:id, :project_id, :name, :description, CAST(:config_json AS jsonb), :baseline_experiment_id, :status, :created_by)
+                INSERT INTO "{tenant}".experiments
+                (id, project_id, name, description, config, baseline_experiment_id, status, created_by, tenant)
+                VALUES (:id, :project_id, :name, :description, CAST(:config_json AS jsonb), :baseline_experiment_id, :status, :created_by, :tenant)
                 RETURNING id, name, status, created_at
             '''),
             {
@@ -331,7 +333,8 @@ async def create_experiment(
                 "config_json": config_json,
                 "baseline_experiment_id": baseline_experiment_id,
                 "status": "pending",
-                "created_by": str(created_by) if created_by is not None else None,
+                "created_by": int(created_by) if created_by is not None else None,
+                "tenant": tenant,
             }
         )
         


### PR DESCRIPTION
## Summary
- Fix experiment creation failures due to NOT NULL constraint violations on tenant column
- Add tenant column to experiments, evaluation_logs, and evaluation_metrics INSERT statements
- Fix created_by type conversion (str → int) for experiments table

## Test plan
- [ ] Create a new experiment in the evals dashboard
- [ ] Verify experiment runs to completion without database errors
- [ ] Check that evaluation logs and metrics are properly saved