### PR TITLE
feat: add API key validation and UX improvements for evals

### DIFF
--- a/Clients/src/application/repository/deepEval.repository.ts
+++ b/Clients/src/application/repository/deepEval.repository.ts
@@ -41,10 +41,12 @@ import {
   metricsService,
   experimentsService,
   monitoringService,
+  modelValidationService,
   type EvaluationLog,
   type EvaluationMetric,
   type Experiment,
   type MonitorDashboard,
+  type ModelValidationResult,
 } from "../../infrastructure/api/evaluationLogsService";
 import {
   deepEvalArenaService,
@@ -79,6 +81,7 @@ export type {
   EvaluationMetric,
   Experiment,
   MonitorDashboard,
+  ModelValidationResult,
   // Arena types
   ArenaTestCase,
   ArenaContestant,
@@ -224,6 +227,14 @@ export const getMetrics = (
 export const getMetricAggregates = (
   params: Parameters<typeof metricsService.getMetricAggregates>[0]
 ) => metricsService.getMetricAggregates(params);
+
+// ==================== MODEL VALIDATION ====================
+
+export const validateModel = (modelName: string, provider?: string) =>
+  modelValidationService.validateModel(modelName, provider);
+
+export const validateModelForExperiment = (config: Record<string, unknown>) =>
+  experimentsService.validateModelForExperiment(config);
 
 // ==================== EXPERIMENTS ====================
 

--- a/Clients/src/infrastructure/api/evaluationLogsService.ts
+++ b/Clients/src/infrastructure/api/evaluationLogsService.ts
@@ -150,9 +150,43 @@ export const metricsService = {
   },
 };
 
+// ==================== MODEL VALIDATION ====================
+
+export interface ModelValidationResult {
+  valid: boolean;
+  model_name: string;
+  provider: string | null;
+  has_api_key: boolean;
+  has_openrouter_fallback: boolean;
+  error_message: string | null;
+}
+
+export const modelValidationService = {
+  // Validate that a model's API key is available
+  async validateModel(modelName: string, provider?: string): Promise<ModelValidationResult> {
+    const response = await CustomAxios.post("/deepeval/models/validate", {
+      model_name: modelName,
+      provider,
+    });
+    return response.data;
+  },
+};
+
 // ==================== EXPERIMENTS ====================
 
 export const experimentsService = {
+  // Validate model before creating experiment
+  async validateModelForExperiment(config: Record<string, any>): Promise<ModelValidationResult | null> {
+    const modelName = config?.model?.name;
+    const provider = config?.model?.provider;
+
+    if (!modelName) {
+      return null; // No model to validate
+    }
+
+    return modelValidationService.validateModel(modelName, provider);
+  },
+
   // Create a new experiment
   async createExperiment(data: {
     project_id: string;

--- a/Clients/src/presentation/components/Dialogs/ConfirmationModal/index.tsx
+++ b/Clients/src/presentation/components/Dialogs/ConfirmationModal/index.tsx
@@ -88,12 +88,14 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
             display: "flex",
           }}
         >
-          <CustomizableButton
-            text={cancelText}
-            variant="text"
-            sx={{ color: "#344054", px: "32px", width: 120 }}
-            onClick={onCancel}
-          />
+          {cancelText && (
+            <CustomizableButton
+              text={cancelText}
+              variant="text"
+              sx={{ color: "#344054", px: "32px", width: 120 }}
+              onClick={onCancel}
+            />
+          )}
           <CustomizableButton
             text={proceedText}
             color={proceedButtonColor}

--- a/Clients/src/presentation/components/Table/ArenaTable/ArenaTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ArenaTable/ArenaTableBody.tsx
@@ -384,7 +384,7 @@ const ArenaTableBody: React.FC<ArenaTableBodyProps> = ({
                 },
               }}
             >
-              Download JSON
+              Download results as JSON
             </CustomizableButton>
           )}
           {onCopy && menuRow?.status === "completed" && (
@@ -407,7 +407,7 @@ const ArenaTableBody: React.FC<ArenaTableBodyProps> = ({
                 },
               }}
             >
-              Copy to clipboard
+              Copy results to clipboard
             </CustomizableButton>
           )}
           {onDelete && (

--- a/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
@@ -313,7 +313,7 @@ const EvaluationTableBody: React.FC<IEvaluationTableBodyProps> = ({
                 },
               }}
             >
-              Download JSON
+              Download results as JSON
             </CustomizableButton>
           )}
           {onCopy && menuRow?.status === "Completed" && (
@@ -336,7 +336,7 @@ const EvaluationTableBody: React.FC<IEvaluationTableBodyProps> = ({
                 },
               }}
             >
-              Copy to clipboard
+              Copy results to clipboard
             </CustomizableButton>
           )}
           {onRemoveModel && (


### PR DESCRIPTION
## Summary
- Add pre-flight API key validation before running experiments (warning, not blocking)
- Improve button labels in experiment tables for clarity
- Make error alerts persist until user dismisses them

## Changes

### API key pre-flight validation
- New `/deepeval/models/validate` endpoint checks if API key is available
- Checks both environment variables AND database for stored API keys
- Supports OpenRouter as fallback for major providers
- Shows warning modal with "Cancel" / "Run anyway" options
- Users can proceed even if validation fails (non-blocking)

### UX improvements
- "Download JSON" → "Download results as JSON"
- "Copy to clipboard" → "Copy results to clipboard"  
- Error alerts persist until manually dismissed
- Success alerts auto-dismiss after 3-5 seconds

## Test plan
- [ ] Create new experiment with unconfigured API key → warning modal appears
- [ ] Click "Run anyway" → experiment starts
- [ ] Click "Cancel" → modal closes, experiment not started
- [ ] Rerun experiment with unconfigured key → warning modal appears
- [ ] Verify "Download results as JSON" and "Copy results to clipboard" labels
- [ ] Trigger an error → verify alert persists until dismissed