### PR TITLE
fix: validate dataset has prompts before creating experiment

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -444,6 +444,18 @@ export default function NewExperimentModal({
   const handleSubmit = async () => {
     setLoading(true);
     try {
+      // Validate dataset has prompts before creating experiment
+      if (datasetPrompts.length === 0) {
+        setAlert({
+          show: true,
+          variant: "error",
+          title: "No prompts in dataset",
+          body: "Cannot run experiment without prompts. Please select a dataset with prompts or upload a valid dataset file.",
+        });
+        setLoading(false);
+        return;
+      }
+
       // Validate model API key availability before creating experiment
       const modelName = config.model.name;
       const modelProvider = config.model.accessMethod;


### PR DESCRIPTION
## Summary
Add validation to prevent creating experiments with empty datasets.

## Problem
Experiments were being created with empty datasets, which would immediately fail with the error "No prompts or conversations in dataset".

## Solution
Added a validation check at the start of `handleSubmit` in `NewExperimentModal` to verify that `datasetPrompts` array is not empty before proceeding with experiment creation. If empty, an error alert is shown to the user.