### PR TITLE
feat: add estimated time display and UX improvements for evals

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/ExperimentDetailContent.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ExperimentDetailContent.tsx
@@ -246,8 +246,11 @@ export default function ExperimentDetailContent({ experimentId, projectId, onBac
 
       setExperiment((prev) => prev ? { ...prev, name: editedName.trim() } : prev);
       setIsEditingName(false);
+      setAlert({ variant: "success", body: "Name saved" });
+      setTimeout(() => setAlert(null), 3000);
     } catch (err) {
       console.error("Failed to update experiment name:", err);
+      setAlert({ variant: "error", body: "Failed to save name" });
     } finally {
       setSaving(false);
     }
@@ -264,8 +267,11 @@ export default function ExperimentDetailContent({ experimentId, projectId, onBac
 
       setExperiment((prev) => prev ? { ...prev, description: editedDescription.trim() } : prev);
       setIsEditingDescription(false);
+      setAlert({ variant: "success", body: "Description saved" });
+      setTimeout(() => setAlert(null), 3000);
     } catch (err) {
       console.error("Failed to update experiment description:", err);
+      setAlert({ variant: "error", body: "Failed to save description" });
     } finally {
       setSaving(false);
     }
@@ -945,7 +951,7 @@ export default function ExperimentDetailContent({ experimentId, projectId, onBac
                 <BackgroundIcon size={96} color="#374151" />
               </Box>
 
-              <CardContent sx={{ p: 2, position: "relative", zIndex: 1, "&:last-child": { pb: 2 } }}>
+              <CardContent sx={{ p: "16px", position: "relative", zIndex: 1, "&:last-child": { pb: "16px" } }}>
                 <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1.5 }}>
                   <Typography variant="body2" sx={{ fontSize: "13px", fontWeight: 400, color: "#6B7280" }}>
                     {metric.label}
@@ -1009,7 +1015,7 @@ export default function ExperimentDetailContent({ experimentId, projectId, onBac
                 <Typography variant="h6" sx={{ fontSize: "15px", fontWeight: 600, mb: 2 }}>
                   Quality metrics
                 </Typography>
-                <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: 2 }}>
+                <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "16px" }}>
                   {qualityMetrics.map(renderMetricCard)}
                 </Box>
               </Box>
@@ -1024,7 +1030,7 @@ export default function ExperimentDetailContent({ experimentId, projectId, onBac
                     (multi-turn)
                   </Typography>
                 </Typography>
-                <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: 2 }}>
+                <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "16px" }}>
                   {conversationalMetrics.map(renderMetricCard)}
                 </Box>
               </Box>
@@ -1036,7 +1042,7 @@ export default function ExperimentDetailContent({ experimentId, projectId, onBac
                 <Typography variant="h6" sx={{ fontSize: "15px", fontWeight: 600, mb: 2 }}>
                   Safety metrics
                 </Typography>
-                <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: 2 }}>
+                <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "16px" }}>
                   {safetyMetrics.map(renderMetricCard)}
                 </Box>
               </Box>
@@ -1048,7 +1054,7 @@ export default function ExperimentDetailContent({ experimentId, projectId, onBac
                 <Typography variant="h6" sx={{ fontSize: "15px", fontWeight: 600, mb: 2 }}>
                   Custom scorers
                 </Typography>
-                <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: 2 }}>
+                <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "16px" }}>
                   {customScorerMetrics.map(renderMetricCard)}
                 </Box>
               </Box>

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -18,7 +18,7 @@ import {
   FormHelperText,
   Chip as MuiChip,
 } from "@mui/material";
-import { Check, Database, ExternalLink, Upload, Sparkles, Settings, Plus, Layers, ChevronDown, FileSearch, MessageSquare, Bot } from "lucide-react";
+import { Check, Database, ExternalLink, Upload, Sparkles, Settings, Plus, Layers, ChevronDown, FileSearch, MessageSquare, Bot, Clock } from "lucide-react";
 import StepperModal from "../../components/Modals/StepperModal";
 import SelectableCard from "../../components/SelectableCard";
 import Field from "../../components/Inputs/Field";
@@ -839,6 +839,19 @@ export default function NewExperimentModal({
   const availableModelProviders = allModelProviders;
 
   const selectedModelProvider = availableModelProviders.find(p => p.id === config.model.accessMethod);
+
+  // Helper function to estimate experiment duration based on prompt count
+  // Each prompt takes ~20-30 seconds (model call + judge evaluations for each metric)
+  const getEstimatedTimeRange = (promptCount: number): string => {
+    if (promptCount <= 0) return "";
+    if (promptCount <= 3) return "~1-2 minutes";
+    if (promptCount <= 5) return "~2-3 minutes";
+    if (promptCount <= 10) return "~4-6 minutes";
+    if (promptCount <= 20) return "~7-12 minutes";
+    if (promptCount <= 30) return "~12-18 minutes";
+    if (promptCount <= 50) return "~18-30 minutes";
+    return "~30+ minutes";
+  };
 
   const renderStepContent = () => {
     switch (activeStep) {
@@ -1858,10 +1871,35 @@ export default function NewExperimentModal({
                   No metrics available
                 </Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 400, mx: "auto" }}>
-                  Standard metrics require a Judge LLM. 
+                  Standard metrics require a Judge LLM.
                   <br /> Your custom scorer will be used instead.
                 </Typography>
               </Box>
+
+              {/* Estimated time display */}
+              {datasetPrompts.length > 0 && (
+                <Box
+                  sx={{
+                    p: "8px",
+                    borderRadius: "4px",
+                    backgroundColor: "#F0FDF4",
+                    border: "1px solid #BBF7D0",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                  }}
+                >
+                  <Clock size={16} color="#13715B" />
+                  <Box>
+                    <Typography sx={{ fontSize: "13px", fontWeight: 500, color: "#13715B" }}>
+                      Estimated time: {getEstimatedTimeRange(datasetPrompts.length)}
+                    </Typography>
+                    <Typography sx={{ fontSize: "11px", color: "#16A34A" }}>
+                      Based on {datasetPrompts.length} prompt{datasetPrompts.length !== 1 ? "s" : ""} in your dataset
+                    </Typography>
+                  </Box>
+                </Box>
+              )}
             </Stack>
           );
         }
@@ -2318,6 +2356,32 @@ export default function NewExperimentModal({
                     </Stack>
                   </Box>
                 ))}
+              </Box>
+            )}
+
+            {/* Estimated time display */}
+            {datasetPrompts.length > 0 && (
+              <Box
+                sx={{
+                  mt: "16px",
+                  p: "8px",
+                  borderRadius: "4px",
+                  backgroundColor: "#F0FDF4",
+                  border: "1px solid #BBF7D0",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                }}
+              >
+                <Clock size={16} color="#13715B" />
+                <Box>
+                  <Typography sx={{ fontSize: "13px", fontWeight: 500, color: "#13715B" }}>
+                    Estimated time: {getEstimatedTimeRange(datasetPrompts.length)}
+                  </Typography>
+                  <Typography sx={{ fontSize: "11px", color: "#16A34A" }}>
+                    Based on {datasetPrompts.length} prompt{datasetPrompts.length !== 1 ? "s" : ""} in your dataset
+                  </Typography>
+                </Box>
               </Box>
             )}
           </Stack>


### PR DESCRIPTION
## Summary
- Add estimated time display in New Experiment modal showing how long the evaluation will take
- Add rerun confirmation modal with estimated time before rerunning experiments
- Add success/error toast notifications when saving experiment name or description
- Use explicit 16px padding and gap for metric cards

## Changes
- **NewExperimentModal.tsx**: Added estimated time card in final step (Metrics) with time ranges based on prompt count
- **ProjectExperiments.tsx**: Added rerun confirmation modal that shows before rerunning, displays estimated time
- **ExperimentDetailContent.tsx**: Added toast feedback for name/description saves, fixed card padding/gap to explicit 16px

## Test plan
- [ ] Create new experiment, verify estimated time shows in final step
- [ ] Click rerun on an experiment, verify confirmation modal appears with estimated time
- [ ] Edit experiment name, verify "Name saved" toast appears
- [ ] Edit experiment description, verify "Description saved" toast appears
- [ ] Verify metric cards have consistent 16px padding and gap