### PR TITLE
fix: disable export menu when no data is available

### DIFF
--- a/Clients/src/presentation/components/Table/ExportMenu.tsx
+++ b/Clients/src/presentation/components/Table/ExportMenu.tsx
@@ -16,16 +16,21 @@ interface ExportMenuProps {
   columns: ExportColumn[];
   filename?: string;
   title?: string;
+  disabled?: boolean;
 }
 
 export const ExportMenu: React.FC<ExportMenuProps> = ({
   data,
   columns,
   filename = 'export',
-  title
+  title,
+  disabled: disabledProp = false,
 }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [exportAnchorEl, setExportAnchorEl] = useState<null | HTMLElement>(null);
+
+  // Auto-disable when no data is available
+  const disabled = disabledProp || !data || data.length === 0;
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -69,6 +74,7 @@ export const ExportMenu: React.FC<ExportMenuProps> = ({
       <IconButton
         onClick={handleClick}
         aria-label="Export options"
+        disabled={disabled}
         sx={{
           height: '34px',
           width: '34px',
@@ -80,9 +86,14 @@ export const ExportMenu: React.FC<ExportMenuProps> = ({
             backgroundColor: '#f9fafb',
             borderColor: '#d1d5db',
           },
+          '&.Mui-disabled': {
+            backgroundColor: '#f9fafb',
+            borderColor: '#e5e7eb',
+            opacity: 0.5,
+          },
         }}
       >
-        <MoreVertical size={16} color="#6b7280" />
+        <MoreVertical size={16} color={disabled ? "#d1d5db" : "#6b7280"} />
       </IconButton>
       {/* Main Menu */}
       <Menu


### PR DESCRIPTION
## Summary
- Auto-disable the ExportMenu component when there's no data to export
- Applies to all pages: Vendors, Risk Management, Incidents, Training Registry, Tasks, Policies, Model Inventory

## Changes
- Added auto-disable logic in ExportMenu component: `const disabled = disabledProp || !data || data.length === 0`
- Button appears grayed out when data array is empty
- Prevents users from clicking print/export options that would produce empty results

## Test plan
- [ ] Navigate to Vendors page with no vendors - export menu should be disabled
- [ ] Navigate to Risk Management page with no risks - export menu should be disabled
- [ ] Add data to any page - export menu should become enabled
- [ ] Verify export/print still works when data is present