### PR TITLE
fix: layout width fixes for automations and file manager pages

### DIFF
--- a/Clients/src/presentation/pages/FileManager/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/index.tsx
@@ -344,7 +344,7 @@ const FileManager: React.FC = (): JSX.Element => {
                 value={searchTerm}
                 onChange={setSearchTerm}
                 inputProps={{ "aria-label": "Search files" }}
-                fullWidth={false}
+                sx={{ width: "220px" }}
               />
             </Box>
             {/* RBAC: Only show upload button for non-Auditors */}


### PR DESCRIPTION
## Summary
- Fixed automations page layout with fixed width sidebars (left: 250px, right: 340px, center: flexible)
- Fixed file manager search box width from 160px to 220px to show complete placeholder text "Search files by name..."

## Test plan
- [ ] Navigate to /automations and verify layout displays correctly with fixed sidebars
- [ ] Navigate to /file-manager and verify search box shows full placeholder text
- [ ] Test responsive behavior on different screen sizes