### PR TITLE
fix: preserve paragraph formatting when saving policies from templates

### DIFF
--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -599,6 +599,103 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
     return normalized;
   };
 
+  // Convert Plate's serialized HTML output to standard semantic HTML for storage
+  // This ensures proper paragraph formatting when content is displayed outside the editor
+  const normalizeSerializedHtml = (html: string): string => {
+    let normalized = html;
+
+    // Remove nested span wrappers that Plate adds (data-slate-node="text", data-slate-leaf, data-slate-string)
+    // Keep the innermost text content and formatting tags like <strong>, <em>, etc.
+    normalized = normalized.replace(/<span[^>]*data-slate-string="true"[^>]*>([^<]*)<\/span>/gi, '$1');
+    normalized = normalized.replace(/<span[^>]*data-slate-leaf="true"[^>]*>/gi, '');
+    normalized = normalized.replace(/<span[^>]*data-slate-node="text"[^>]*>/gi, '');
+
+    // Remove orphaned closing </span> tags (from the spans we opened above)
+    // Count and remove only the extra ones
+    let spanOpenCount = (normalized.match(/<span[^>]*>/gi) || []).length;
+    let spanCloseCount = (normalized.match(/<\/span>/gi) || []).length;
+    while (spanCloseCount > spanOpenCount) {
+      normalized = normalized.replace(/<\/span>/, '');
+      spanCloseCount--;
+    }
+
+    // Convert element divs to proper semantic HTML based on block-id patterns
+    // Headings: data-block-id starting with "heading-" or "title-"
+    normalized = normalized.replace(/<div[^>]*data-block-id="(?:title|heading)-[^"]*"[^>]*>/gi, '<h2>');
+
+    // Paragraphs: data-block-id starting with "paragraph-" or "summary-"
+    normalized = normalized.replace(/<div[^>]*data-block-id="(?:paragraph|summary)-[^"]*"[^>]*>/gi, '<p>');
+
+    // List containers: data-block-id starting with "bullets-" or "numbered-"
+    normalized = normalized.replace(/<div[^>]*data-block-id="bullets-[^"]*"[^>]*>/gi, '<ul>');
+    normalized = normalized.replace(/<div[^>]*data-block-id="numbered-[^"]*"[^>]*>/gi, '<ol>');
+
+    // List items: data-block-id starting with "li-"
+    normalized = normalized.replace(/<div[^>]*data-block-id="li-[^"]*"[^>]*>/gi, '<li>');
+
+    // Any remaining element divs become paragraphs (generic content blocks)
+    normalized = normalized.replace(/<div[^>]*data-slate-node="element"[^>]*>/gi, '<p>');
+
+    // Now convert closing </div> tags to match the opening tags we converted
+    // Parse through and match them properly
+    const tokens = normalized.split(/(<[^>]+>)/);
+    const tagStack: string[] = [];
+    const result: string[] = [];
+
+    for (const token of tokens) {
+      if (token.startsWith('<') && !token.startsWith('</') && !token.endsWith('/>')) {
+        // Opening tag
+        const tagMatch = token.match(/^<(\w+)/);
+        if (tagMatch) {
+          tagStack.push(tagMatch[1]);
+        }
+        result.push(token);
+      } else if (token.startsWith('</')) {
+        // Closing tag
+        const tagMatch = token.match(/^<\/(\w+)/);
+        if (tagMatch) {
+          const closingTag = tagMatch[1].toLowerCase();
+          if (closingTag === 'div' && tagStack.length > 0) {
+            // Replace </div> with the appropriate closing tag
+            const openTag = tagStack.pop()!.toLowerCase();
+            if (['h1', 'h2', 'h3', 'p', 'ul', 'ol', 'li', 'blockquote'].includes(openTag)) {
+              result.push(`</${openTag}>`);
+            } else {
+              result.push(token);
+            }
+          } else {
+            if (tagStack.length > 0) tagStack.pop();
+            result.push(token);
+          }
+        } else {
+          result.push(token);
+        }
+      } else {
+        result.push(token);
+      }
+    }
+
+    normalized = result.join('');
+
+    // Clean up any remaining data-* attributes
+    normalized = normalized.replace(/\s*data-[a-z-]+="[^"]*"/gi, '');
+
+    // Clean up style attributes with just position:relative
+    normalized = normalized.replace(/\s*style="position:\s*relative;?\s*"/gi, '');
+
+    // Clean up empty attributes
+    normalized = normalized.replace(/\s*style=""\s*/gi, ' ');
+    normalized = normalized.replace(/\s*class=""\s*/gi, ' ');
+
+    // Clean up multiple spaces
+    normalized = normalized.replace(/\s+/g, ' ');
+
+    // Trim whitespace around tags
+    normalized = normalized.replace(/>\s+</g, '><');
+
+    return normalized;
+  };
+
   useEffect(() => {
     if ((policy || template) && editor) {
       const api = editor.api.html;
@@ -919,6 +1016,10 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
     tableMap.forEach((tableNode, placeholder) => {
       html = html.replace(placeholder, serializeTableToHtml(tableNode));
     });
+
+    // Normalize Slate's div-based output to proper semantic HTML with <p> tags
+    // This ensures proper paragraph formatting when displayed outside the editor
+    html = normalizeSerializedHtml(html);
 
     return html;
   };


### PR DESCRIPTION
## Summary
- Add HTML normalization to convert Plate.js output to proper semantic HTML
- Convert element divs to `<p>`, `<h2>`, `<ul>`, `<ol>`, `<li>` tags
- Remove Slate-specific data attributes and wrapper spans

## Problem
When creating a policy from a template and saving it, all paragraphs appeared on one line because Plate.js serializes content as `<div data-slate-node="element">` which lacks default browser paragraph spacing.

## Solution
Added `normalizeSerializedHtml()` function that converts Plate's output to proper semantic HTML before saving to the database.

## Test plan
- [ ] Create a new policy from a template with multiple paragraphs
- [ ] Save the policy
- [ ] Re-open the policy and verify paragraphs are properly separated