### PR TITLE
Potential fix for code scanning alert no. 59: Overly permissive regular expression range

### DIFF
--- a/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx
@@ -763,7 +763,7 @@ const PolicyDetailModal: React.FC<PolicyDetailModalProps> = ({
                     "rowspan",
                   ],
                   ALLOWED_URI_REGEXP:
-                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z.+-]+(?:[^a-z.+-:]|$))/i,
+                    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z.+\-]+(?:[^a-z.+\-:]|$))/i,
                   ADD_ATTR: ["target"],
                   FORBID_TAGS: [
                     "script",


### PR DESCRIPTION
Potential fix for [https://github.com/bluewave-labs/verifywise/security/code-scanning/59](https://github.com/bluewave-labs/verifywise/security/code-scanning/59)

In general, overly permissive ranges inside character classes should be fixed by either (1) escaping the dash `-` when you want it literally (e.g. `[A-Z0-9\-_.]`), or (2) rearranging the characters so `-` is first or last in the class (e.g. `[-A-Z0-9_.]`), which most regex engines interpret as a literal dash rather than a range delimiter.

Here, within `Clients/src/presentation/components/Policies/PolicyDetailsModal.tsx`, the problematic part is the character class `[a-z.+-:]` in the `ALLOWED_URI_REGEXP` on line 766. The clear intent is to allow lowercase letters plus `.`, `+`, and `-` in the scheme before the colon (as in `https`, `mailto`, `tel`, `xmpp`, etc.). To fix this without changing functionality, we should make the dash literal by escaping it: `[a-z.+\-:]`. That keeps exactly the same intended characters but avoids the unintended range. No new imports or methods are needed; we only adjust the regex literal in place.

Concretely: in `PolicyDetailsModal.tsx`, locate the `ALLOWED_URI_REGEXP` assignment and change `/^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z.+-]+(?:[^a-z.+-:]|$))/i` to `/^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z.+\-]+(?:[^a-z.+\-:]|$))/i`, escaping the dash in both character classes (`[a-z.+-]` → `[a-z.+\-]` and `[^a-z.+-:]` → `[^a-z.+\-:]`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
