### PR TITLE
Fix: Remove Dead Date Functions

### DIFF
--- a/Clients/src/application/utils/dateFormatter.ts
+++ b/Clients/src/application/utils/dateFormatter.ts
@@ -14,17 +14,3 @@ export const formatRelativeDate = (dateString: string): string => {
 
   return formatDistanceToNow(date, { addSuffix: true });
 };
-
-/**
- * Format a date string to a locale date and time string
- * @param dateString - ISO date string or date-parseable string
- * @returns Formatted locale date and time string
- */
-export const formatLocaleDateTime = (dateString: string): string => {
-  if (!dateString) return "Unknown";
-
-  const date = new Date(dateString);
-  if (isNaN(date.getTime())) return "Unknown";
-
-  return date.toLocaleString();
-};

--- a/Clients/src/application/utils/tests/dateFormatter.test.ts
+++ b/Clients/src/application/utils/tests/dateFormatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { formatLocaleDateTime, formatRelativeDate } from "../dateFormatter";
+import { formatRelativeDate } from "../dateFormatter";
 
 // Mock date-fns to make formatRelativeDate deterministic
 vi.mock("date-fns", () => ({
@@ -43,27 +43,6 @@ describe("dateFormatter utils", () => {
       expect(passedDate).toBeInstanceOf(Date);
       expect((passedDate as Date).toISOString()).toBe(input);
       expect(passedOptions).toEqual({ addSuffix: true });
-    });
-  });
-
-  describe("formatLocaleDateTime", () => {
-    it('returns "Unknown" when dateString is empty', () => {
-      expect(formatLocaleDateTime("")).toBe("Unknown");
-    });
-
-    it('returns "Unknown" when dateString is invalid', () => {
-      expect(formatLocaleDateTime("not-a-date")).toBe("Unknown");
-    });
-
-    it("returns date.toLocaleString() when valid", () => {
-      const spy = vi.spyOn(Date.prototype, "toLocaleString").mockReturnValue("01/22/2026, 12:00:00");
-
-      const result = formatLocaleDateTime("2026-01-22T12:00:00.000Z");
-
-      expect(result).toBe("01/22/2026, 12:00:00");
-      expect(spy).toHaveBeenCalledTimes(1);
-
-      spy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Describe your changes

Remove unused `formatLocaleDate` and `formatLocaleDateTime` functions and their tests from dateFormatter utility as they were dead code with no usages in the codebase.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
