### PR TITLE
Fix: Remove stale code in paginationStorage.ts File

### DIFF
--- a/Clients/src/application/utils/paginationStorage.ts
+++ b/Clients/src/application/utils/paginationStorage.ts
@@ -26,16 +26,3 @@ export const setPaginationRowCount = (tableKey: string, rowCount: number): void 
     console.warn('Failed to save pagination setting to localStorage:', error);
   }
 };
-
-export const clearAllPaginationSettings = (): void => {
-  try {
-    const keys = Object.keys(localStorage);
-    keys.forEach(key => {
-      if (key.startsWith(PAGINATION_STORAGE_KEY_PREFIX)) {
-        localStorage.removeItem(key);
-      }
-    });
-  } catch (error) {
-    console.warn('Failed to clear all pagination settings from localStorage:', error);
-  }
-};

--- a/Clients/src/application/utils/tests/paginationStorage.test.ts
+++ b/Clients/src/application/utils/tests/paginationStorage.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   getPaginationRowCount,
   setPaginationRowCount,
-  clearAllPaginationSettings,
 } from "../paginationStorage";
 
 function createMockStorage(): Storage {
@@ -118,42 +117,4 @@ describe("paginationStorage", () => {
     });
   });
 
-  describe("clearAllPaginationSettings", () => {
-    it("removes only keys that start with prefix", () => {
-      localStorage.setItem("pagination_rows_users", "10");
-      localStorage.setItem("pagination_rows_projects", "20");
-      localStorage.setItem("something_else", "keep");
-
-      clearAllPaginationSettings();
-
-      expect(localStorage.getItem("pagination_rows_users")).toBeNull();
-      expect(localStorage.getItem("pagination_rows_projects")).toBeNull();
-      expect(localStorage.getItem("something_else")).toBe("keep");
-    });
-
-    it("does nothing when there are no pagination keys", () => {
-      localStorage.setItem("other_key", "x");
-
-      clearAllPaginationSettings();
-
-      expect(localStorage.getItem("other_key")).toBe("x");
-    });
-
-    it("warns when Object.keys(localStorage) throws (without breaking vitest)", () => {
-      const realKeys = Object.keys;
-
-      vi.spyOn(Object, "keys").mockImplementation(((obj: any) => {
-        // Only throw for localStorage; otherwise behave normally
-        if (obj === localStorage) throw new Error("boom");
-        return realKeys(obj);
-      }) as any);
-
-      clearAllPaginationSettings();
-
-      expect(console.warn).toHaveBeenCalledWith(
-        "Failed to clear all pagination settings from localStorage:",
-        expect.any(Error)
-      );
-    });
-  });
 });


### PR DESCRIPTION
## Describe your changes

This PR removes clearPaginationRowCount and clearAllPaginationSettings func from paginationStorage.ts file.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
