### PR TITLE
fix: disable tour beacon on tasks deadline view

### DIFF
--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -953,7 +953,7 @@ const Tasks: React.FC = () => {
       )}
 
       {/* Page Tour */}
-      <PageTour steps={TasksSteps} run={true} tourKey="tasks-tour" />
+      <PageTour steps={TasksSteps} run={activeTab === "list"} tourKey="tasks-tour" />
     </Stack>
   );
 };


### PR DESCRIPTION
## Summary
- Tour steps only target list view elements, so switching to deadline view left a disconnected beacon animation
- The tour now only runs when the active tab is "list"