### PR TITLE
fix: prevent file manager action buttons from overflowing offscreen

### DIFF
--- a/Clients/src/presentation/pages/FileManager/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/index.tsx
@@ -631,7 +631,7 @@ const FileManager: React.FC = (): JSX.Element => {
         />
 
         {/* File content area */}
-        <Box sx={{ flex: 1, display: "flex", flexDirection: "column", backgroundColor: "#FFFFFF" }}>
+        <Box sx={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", backgroundColor: "#FFFFFF" }}>
           {/* Breadcrumb and actions */}
           <Box
             sx={{
@@ -642,13 +642,15 @@ const FileManager: React.FC = (): JSX.Element => {
               alignItems: "center",
             }}
           >
-            <FolderBreadcrumb
-              selectedFolder={selectedFolder}
-              breadcrumb={breadcrumb}
-              onSelectFolder={setSelectedFolder}
-              loading={loadingBreadcrumb}
-            />
-            <Stack direction="row" gap="8px">
+            <Box sx={{ minWidth: 0, flex: 1, overflow: "hidden" }}>
+              <FolderBreadcrumb
+                selectedFolder={selectedFolder}
+                breadcrumb={breadcrumb}
+                onSelectFolder={setSelectedFolder}
+                loading={loadingBreadcrumb}
+              />
+            </Box>
+            <Stack direction="row" gap="8px" sx={{ flexShrink: 0 }}>
               {canManageFolders && (
                 <CustomizableButton
                   variant="outlined"


### PR DESCRIPTION
## Summary
- "New folder" and "Upload file" buttons were pushed off the right edge on narrower screens
- Added `minWidth: 0` to the file content flex area so it respects container bounds
- Wrapped breadcrumb in a shrinkable container so it truncates instead of pushing buttons out
- Set `flexShrink: 0` on the buttons stack so they always remain visible