### PR TITLE
Fix: resolve DOM nesting warnings

### DIFF
--- a/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
+++ b/Clients/src/presentation/components/Forms/ProjectForm/index.tsx
@@ -462,7 +462,7 @@ const ProjectForm = ({
 
   const renderForm = () => (
     <Stack
-      component="form"
+      {...(!useStandardModal && { component: "form" })}
       onSubmit={(e) => {
         e.preventDefault();
         handleSubmit();

--- a/Clients/src/presentation/pages/Plugins/PluginManagement/index.tsx
+++ b/Clients/src/presentation/pages/Plugins/PluginManagement/index.tsx
@@ -471,33 +471,33 @@ const PluginManagement: React.FC = () => {
                       <Box sx={frameworkDetailsGrid}>
                         {/* Region */}
                         <Box sx={frameworkDetailItem}>
-                          <Typography sx={frameworkDetailLabel}>
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                          <Box component="span" sx={frameworkDetailLabel}>
+                            <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                               <GlobeIcon size={12} />
                               Region
                             </Box>
-                          </Typography>
-                          <Typography sx={frameworkDetailValue}>
+                          </Box>
+                          <Box component="span" sx={frameworkDetailValue}>
                             <span style={{ fontSize: "18px" }}>{getRegionFlag(plugin.region)}</span>
                             {plugin.region || "Global"}
-                          </Typography>
+                          </Box>
                         </Box>
 
                         {/* Framework Type */}
                         <Box sx={frameworkDetailItem}>
-                          <Typography sx={frameworkDetailLabel}>
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                          <Box component="span" sx={frameworkDetailLabel}>
+                            <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                               {plugin.frameworkType === "organizational" ? <BuildingIcon size={12} /> : <LayersIcon size={12} />}
                               Framework Type
                             </Box>
-                          </Typography>
+                          </Box>
                           <Box>
                             <MuiChip
                               size="small"
                               label={plugin.frameworkType === "organizational" ? "Organizational" : "Project-Based"}
                               sx={frameworkTypeChip(plugin.frameworkType === "organizational")}
                             />
-                            <Typography sx={frameworkTypeDescription}>
+                            <Typography component="span" sx={{ ...frameworkTypeDescription, display: "block" }}>
                               {plugin.frameworkType === "organizational"
                                 ? "Organization-wide framework that applies globally across all projects"
                                 : "Project-specific framework that can be applied to individual projects"}


### PR DESCRIPTION
## Summary
- Fixed form inside form warning when opening "Add new" > "use case" from dashboard
- Fixed div inside p warning on plugin management pages (e.g., /plugins/qatar-pdpl/manage)

## Changes
- **ProjectForm**: Only render as form element when not inside StandardModal (since StandardModal already wraps content in a form)
- **PluginManagement**: Changed Typography elements containing Box children to use Box with `component="span"` to avoid invalid div inside p nesting

## Test plan
- [ ] Open dashboard, click "Add new" > "use case" - verify no form nesting warning in console
- [ ] Navigate to /plugins/qatar-pdpl/manage - verify no div inside p warning in console