### PR TITLE
Fix: React key prop warning in approval workflow form

### DIFF
--- a/Clients/src/presentation/components/Modals/NewApprovalWorkflow/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewApprovalWorkflow/index.tsx
@@ -275,13 +275,16 @@ const CreateNewApprovalWorkflow: FC<ICreateApprovalWorkflowProps> = ({
                                                     setWorkflowSteps(newSteps);
                                                 }}
                                                 getOptionLabel={(user) => `${user.name}${user.surname ? ` ${user.surname}` : ""}`}
-                                                renderOption={(props, option) => (
-                                                    <Box component="li" {...props}>
-                                                        <Typography sx={{ fontSize: "13px", color: "#1c2130" }}>
-                                                            {option.name}{option.surname ? ` ${option.surname}` : ""}
-                                                        </Typography>
-                                                    </Box>
-                                                )}
+                                                renderOption={(props, option) => {
+                                                    const { key, ...otherProps } = props;
+                                                    return (
+                                                        <Box component="li" key={key} {...otherProps}>
+                                                            <Typography sx={{ fontSize: "13px", color: "#1c2130" }}>
+                                                                {option.name}{option.surname ? ` ${option.surname}` : ""}
+                                                            </Typography>
+                                                        </Box>
+                                                    );
+                                                }}
                                                 filterSelectedOptions
                                                 noOptionsText={
                                                     (step.approver_ids || []).length === users.length


### PR DESCRIPTION
## Summary
Fixed React warning about spreading a key prop in Autocomplete's renderOption

## Problem
When filling out the "Add new workflow" form in /approval-workflows, a React warning appeared:
> A props object containing a "key" prop is being spread into JSX

## Solution
Extract `key` from `props` and pass it directly to the JSX element instead of spreading it with other props.

## Test plan
- [ ] Go to /approval-workflows
- [ ] Click "Add new workflow"
- [ ] Fill out the form, including selecting approvers
- [ ] Verify no React key warning in console