### PR TITLE
Fix: Edit API key modal and allow updating existing keys

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsDashboard.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsDashboard.tsx
@@ -237,6 +237,7 @@ export default function EvalsDashboard() {
 
   // API key modal state
   const [apiKeyModalOpen, setApiKeyModalOpen] = useState(false);
+  const [isEditingApiKey, setIsEditingApiKey] = useState(false);
   const [selectedProvider, setSelectedProvider] = useState("");
   const [newApiKey, setNewApiKey] = useState("");
   const [apiKeyError, setApiKeyError] = useState<string | null>(null);
@@ -1187,7 +1188,10 @@ export default function EvalsDashboard() {
                       variant="contained"
                       text="Add API key"
                       icon={<PlusIcon size={16} />}
-                      onClick={() => setApiKeyModalOpen(true)}
+                      onClick={() => {
+                        setIsEditingApiKey(false);
+                        setApiKeyModalOpen(true);
+                      }}
                       isDisabled={!canManageApiKeys}
                       sx={{
                         backgroundColor: "#13715B",
@@ -1237,7 +1241,10 @@ export default function EvalsDashboard() {
                       variant="contained"
                       text="Add API key"
                       icon={<PlusIcon size={16} />}
-                      onClick={() => setApiKeyModalOpen(true)}
+                      onClick={() => {
+                        setIsEditingApiKey(false);
+                        setApiKeyModalOpen(true);
+                      }}
                       isDisabled={!canManageApiKeys}
                       sx={{
                         backgroundColor: "#13715B",
@@ -1358,6 +1365,7 @@ export default function EvalsDashboard() {
                             <Stack direction="row" spacing={1} alignItems="center">
                               <IconButton
                                 onClick={() => {
+                                  setIsEditingApiKey(true);
                                   setSelectedProvider(key.provider);
                                   setNewApiKey("");
                                   setApiKeyModalOpen(true);
@@ -1967,24 +1975,29 @@ export default function EvalsDashboard() {
         </Stack>
       </ModalStandard>
 
-      {/* Add API Key Modal - Using ModalStandard like experiment creation */}
+      {/* Add/Edit API Key Modal - Using ModalStandard like experiment creation */}
       <ModalStandard
         isOpen={apiKeyModalOpen}
         onClose={() => {
           setApiKeyModalOpen(false);
+          setIsEditingApiKey(false);
           setSelectedProvider("");
           setNewApiKey("");
           setApiKeyError(null);
           setApiKeyAlert(null);
         }}
-        title="Add API key"
-        description="Configure API keys for LLM providers to run evaluations. Your keys are encrypted and stored securely."
+        title={isEditingApiKey ? "Edit API key" : "Add API key"}
+        description={isEditingApiKey
+          ? `Update the API key for ${LLM_PROVIDERS.find(p => p._id === selectedProvider)?.name || selectedProvider}. Your keys are encrypted and stored securely.`
+          : "Configure API keys for LLM providers to run evaluations. Your keys are encrypted and stored securely."
+        }
         onSubmit={handleAddApiKey}
-        submitButtonText={verifyingApiKey ? "Verifying..." : apiKeySaving ? "Saving..." : "Add API key"}
+        submitButtonText={verifyingApiKey ? "Verifying..." : apiKeySaving ? "Saving..." : isEditingApiKey ? "Update API key" : "Add API key"}
         isSubmitting={verifyingApiKey || apiKeySaving || !selectedProvider || !newApiKey.trim() || !!apiKeyError}
       >
         <Stack spacing={3}>
-          {/* Provider Selection Grid - show ALL providers */}
+          {/* Provider Selection Grid - show ALL providers (hidden when editing) */}
+          {!isEditingApiKey && (
           <Box>
             <Typography sx={{ mb: 2, fontSize: "14px", fontWeight: 500, color: "#374151" }}>
               Select Provider
@@ -2101,6 +2114,7 @@ export default function EvalsDashboard() {
               })}
             </Grid>
           </Box>
+          )}
 
           {/* API Key Input */}
           {selectedProvider && (

--- a/Servers/controllers/evaluationLlmApiKey.ctrl.ts
+++ b/Servers/controllers/evaluationLlmApiKey.ctrl.ts
@@ -46,7 +46,7 @@ export const getAllKeys = async (req: Request, res: Response) => {
 };
 
 /**
- * Add a new LLM API key
+ * Add or update an LLM API key
  *
  * Request body:
  * - provider: string (openai, anthropic, google, xai, mistral, huggingface)
@@ -66,7 +66,7 @@ export const addKey = async (req: Request, res: Response) => {
       throw new ValidationException('API key is required', 'apiKey', apiKey);
     }
 
-    // Create key
+    // Create or update key
     const keyData = await createKeyQuery(
       req.tenantId!,
       provider as LLMProvider,
@@ -76,7 +76,7 @@ export const addKey = async (req: Request, res: Response) => {
 
     await logSuccess({
       eventType: 'Create',
-      description: `Added LLM API key for provider: ${provider} by user: ${req.userId}`,
+      description: `Added/updated LLM API key for provider: ${provider} by user: ${req.userId}`,
       functionName: 'addKey',
       fileName: 'evaluationLlmApiKey.ctrl.ts',
       userId: req.userId!,
@@ -86,11 +86,11 @@ export const addKey = async (req: Request, res: Response) => {
     await transaction.commit();
     return res.status(201).json({
       success: true,
-      message: 'API key added successfully',
+      message: 'API key saved successfully',
       data: keyData,
     });
   } catch (error: any) {
-    console.error('Error adding LLM API key:', error);
+    console.error('Error adding/updating LLM API key:', error);
     await transaction.rollback();
     if (error instanceof ValidationException) {
       return res.status(400).json({
@@ -102,7 +102,7 @@ export const addKey = async (req: Request, res: Response) => {
 
     return res.status(500).json({
       success: false,
-      message: 'Failed to add API key',
+      message: 'Failed to save API key',
       error: error.message,
     });
   }

--- a/Servers/utils/evaluationLlmApiKey.utils.ts
+++ b/Servers/utils/evaluationLlmApiKey.utils.ts
@@ -123,13 +123,13 @@ export const getAllKeysForOrganizationQuery = async (
 };
 
 /**
- * Create a new LLM API key entry
+ * Create or update an LLM API key entry (upsert)
  *
  * @param tenant - Tenant schema name
  * @param provider - LLM provider name
  * @param apiKey - Plain text API key (will be encrypted)
  * @param transaction - Optional transaction
- * @returns Created key data
+ * @returns Created/updated key data
  */
 export const createKeyQuery = async (
   tenant: string,
@@ -150,6 +150,9 @@ export const createKeyQuery = async (
     throw new ValidationException(formatError, 'apiKey', apiKey);
   }
 
+  // Encrypt the API key
+  const encryptedKey = encrypt(apiKey.trim());
+
   // Check if key already exists for this provider
   const existing = await sequelize.query(
     `SELECT id FROM "${tenant}".llm_evals_api_keys WHERE provider = :provider`,
@@ -159,38 +162,46 @@ export const createKeyQuery = async (
     }
   ) as [IEvaluationLlmApiKey[], number];
 
+  let result: [IEvaluationLlmApiKey[], number];
+
   if (existing[0].length > 0) {
-    throw new ValidationException(
-      `API key for provider '${provider}' already exists. Delete it first to add a new one.`,
-      'provider',
-      provider
-    );
+    // Update existing key
+    result = await sequelize.query(
+      `UPDATE "${tenant}".llm_evals_api_keys
+       SET encrypted_api_key = :encrypted_api_key, updated_at = NOW()
+       WHERE provider = :provider
+       RETURNING id, provider, encrypted_api_key, created_at, updated_at`,
+      {
+        replacements: {
+          provider,
+          encrypted_api_key: encryptedKey,
+        },
+        transaction,
+      }
+    ) as [IEvaluationLlmApiKey[], number];
+  } else {
+    // Insert new key
+    result = await sequelize.query(
+      `INSERT INTO "${tenant}".llm_evals_api_keys (provider, encrypted_api_key)
+       VALUES (:provider, :encrypted_api_key)
+       RETURNING id, provider, encrypted_api_key, created_at, updated_at`,
+      {
+        replacements: {
+          provider,
+          encrypted_api_key: encryptedKey,
+        },
+        transaction,
+      }
+    ) as [IEvaluationLlmApiKey[], number];
   }
 
-  // Encrypt the API key
-  const encryptedKey = encrypt(apiKey.trim());
-
-  // Insert new key
-  const result = await sequelize.query(
-    `INSERT INTO "${tenant}".llm_evals_api_keys (provider, encrypted_api_key)
-     VALUES (:provider, :encrypted_api_key)
-     RETURNING id, provider, encrypted_api_key, created_at, updated_at`,
-    {
-      replacements: {
-        provider,
-        encrypted_api_key: encryptedKey,
-      },
-      transaction,
-    }
-  ) as [IEvaluationLlmApiKey[], number];
-
-  const createdKey = result[0][0];
+  const savedKey = result[0][0];
 
   return {
-    provider: createdKey.provider,
+    provider: savedKey.provider,
     maskedKey: maskApiKey(apiKey.trim()),
-    createdAt: createdKey.created_at,
-    updatedAt: createdKey.updated_at,
+    createdAt: savedKey.created_at,
+    updatedAt: savedKey.updated_at,
   };
 };
 


### PR DESCRIPTION
## Summary
- Fixed the edit API key modal showing "Add API key" instead of "Edit API key" when clicking the edit icon
- Hidden provider selection when editing since the provider is already known
- Changed backend to allow updating existing API keys instead of requiring deletion first

## Changes
- Added `isEditingApiKey` state to track add vs edit mode in the modal
- Updated modal title, description, and submit button text based on mode
- Hidden provider selection grid when editing an existing key
- Changed `createKeyQuery` to use upsert logic (update if exists, insert if not)
- Updated controller comments and log messages to reflect add/update behavior

## Test plan
- [ ] Navigate to `/evals/project_xxx#settings`
- [ ] Click edit icon on an existing API key - verify modal shows "Edit API key"
- [ ] Verify provider selection is hidden when editing
- [ ] Update an existing API key - verify it updates successfully (no 400 error)
- [ ] Add a new API key for a different provider - verify modal shows "Add API key" with provider selection