### PR TITLE
Make model inventory approver optional and fix API docs

### DIFF
--- a/Clients/src/domain/interfaces/i.modelInventory.ts
+++ b/Clients/src/domain/interfaces/i.modelInventory.ts
@@ -8,7 +8,7 @@ export interface IModelInventory {
   provider: string;
   model: string;
   version?: string;
-  approver: number;
+  approver?: number;
   capabilities: string[];
   security_assessment: boolean;
   status: ModelInventoryStatus;

--- a/Clients/src/domain/models/Common/modelInventory/modelInventory.model.ts
+++ b/Clients/src/domain/models/Common/modelInventory/modelInventory.model.ts
@@ -6,7 +6,7 @@ export class ModelInventoryModel {
   provider!: string;
   model!: string;
   version!: string;
-  approver!: string;
+  approver?: string;
   capabilities!: string;
   security_assessment!: boolean;
   status!: ModelInventoryStatus;

--- a/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
@@ -80,7 +80,7 @@ interface NewModelInventoryFormValues {
   provider: string;
   model: string;
   version: string;
-  approver: number;
+  approver?: number;
   capabilities: string[];
   security_assessment: boolean;
   status: ModelInventoryStatus;
@@ -411,10 +411,6 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
 
     if (!values.version || !String(values.version).trim()) {
       newErrors.version = "Version is required.";
-    }
-
-    if (!values.approver || !String(values.approver).trim()) {
-      newErrors.approver = "Approver is required.";
     }
 
     if (!values.status) {
@@ -774,7 +770,6 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
           label="Approver"
           value={values.approver}
           error={errors.approver}
-          isRequired
           sx={{ width: 220 }}
           items={userOptions}
           onChange={handleOnSelectChange("approver")}

--- a/Servers/domain.layer/interfaces/i.modelInventory.ts
+++ b/Servers/domain.layer/interfaces/i.modelInventory.ts
@@ -6,7 +6,7 @@ export interface IModelInventory {
   provider: string;
   model: string;
   version: string;
-  approver: string;
+  approver?: string;
   capabilities: string;
   security_assessment: boolean;
   status: ModelInventoryStatus;

--- a/Servers/domain.layer/models/modelInventory/modelInventory.model.ts
+++ b/Servers/domain.layer/models/modelInventory/modelInventory.model.ts
@@ -45,9 +45,9 @@ export class ModelInventoryModel
 
   @Column({
     type: DataType.STRING,
-    allowNull: false,
+    allowNull: true,
   })
-  approver!: string;
+  approver?: string;
 
   @Column({
     type: DataType.TEXT,
@@ -150,14 +150,6 @@ export class ModelInventoryModel
         "Version is required",
         "version",
         this.version
-      );
-    }
-
-    if (!this.approver?.trim()) {
-      throw new ValidationException(
-        "Approver is required",
-        "approver",
-        this.approver
       );
     }
 

--- a/Servers/domain.layer/tests/modelInventory.model.spec.ts
+++ b/Servers/domain.layer/tests/modelInventory.model.spec.ts
@@ -27,7 +27,7 @@ class TestModelInventoryModel {
   id?: number;
   provider_model!: string;
   version!: string;
-  approver!: string;
+  approver?: string;
   capabilities!: string;
   security_assessment!: boolean;
   status!: ModelInventoryStatus;

--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -1955,7 +1955,7 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
 
   # Model Inventory
-  /model-inventory:
+  /modelInventory:
     get:
       summary: Get all model inventory entries
       tags: [Model Inventory]
@@ -2000,7 +2000,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
 
-  /model-inventory/{id}:
+  /modelInventory/{id}:
     get:
       summary: Get model inventory entry by ID
       tags: [Model Inventory]
@@ -3545,8 +3545,9 @@ components:
           type: string
           description: Model version
         approver:
-          type: string
-          description: Person who approved the model
+          type: integer
+          nullable: true
+          description: User ID of the person who approved the model (optional)
         capabilities:
           type: array
           items:

--- a/Servers/utils/validations/modelInventoryValidation.utils.ts
+++ b/Servers/utils/validations/modelInventoryValidation.utils.ts
@@ -149,7 +149,7 @@ export const validateVersion = (value: any): ValidationResult => {
  * Validates approver field (user foreign key)
  */
 export const validateApprover = (value: any): ValidationResult => {
-  return validateForeignKey(value, "Approver", true);
+  return validateForeignKey(value, "Approver", false);
 };
 
 /**


### PR DESCRIPTION
## Summary
- Makes the `approver` field optional across the full stack (server model, validation, client interface, UI form) so it can be assigned later in the workflow instead of at creation time
- Fixes swagger.yaml endpoint paths from `/model-inventory` to `/modelInventory` to match the actual route registration
- Updates approver type in swagger schema from `string` to `integer` (nullable) to reflect it's a user ID foreign key

## Test plan
- [ ] Create a new model inventory entry without selecting an approver — should succeed
- [ ] Create a new model inventory entry with an approver — should still work
- [ ] Edit an existing model inventory entry and clear the approver — should save
- [ ] Verify the approver field in the "New model" modal no longer shows a required asterisk
- [ ] Verify swagger docs at `/api-docs` show correct `/modelInventory` paths