### PR TITLE
Add Shadow AI onboarding wizard

### DIFF
--- a/Clients/src/presentation/components/Modals/OnboardingWizard/index.tsx
+++ b/Clients/src/presentation/components/Modals/OnboardingWizard/index.tsx
@@ -1,0 +1,370 @@
+/**
+ * OnboardingWizard — Reusable multi-step onboarding modal.
+ *
+ * Dark slate header with green-accent segmented-bar step indicators + light body.
+ * The content area for each step accepts any ReactNode, so consumers can
+ * embed forms, images, or any custom UI widgets.
+ *
+ * @example
+ * ```tsx
+ * <OnboardingWizard
+ *   isOpen={open}
+ *   onClose={() => setOpen(false)}
+ *   title="Set up AI Detection"
+ *   subtitle="3 quick steps to monitor AI tool usage"
+ *   steps={[
+ *     { label: "Connect", content: <ConnectForm /> },
+ *     { label: "Alert",   content: <AlertConfig /> },
+ *     { label: "Monitor", content: <MonitorInfo /> },
+ *   ]}
+ * />
+ * ```
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Box, Modal, Stack, Typography } from "@mui/material";
+import { LucideIcon, Shield, Check, X } from "lucide-react";
+import { CustomizableButton } from "../../button/customizable-button";
+
+export interface OnboardingWizardStep {
+  /** Label shown in the segmented bar */
+  label: string;
+  /** Any React content rendered in the body when this step is active */
+  content: React.ReactNode;
+}
+
+export interface OnboardingWizardProps {
+  /** Controls modal visibility */
+  isOpen: boolean;
+  /** Called when the modal should close (X, Skip, or final action) */
+  onClose: () => void;
+
+  /** Main heading in the dark header */
+  title: string;
+  /** Secondary text below the title */
+  subtitle?: string;
+  /** Small uppercase badge text (top-left, green) */
+  badgeText?: string;
+  /** Icon next to the badge text (defaults to Shield) */
+  badgeIcon?: LucideIcon;
+
+  /** Ordered list of steps — each with a bar label and body content */
+  steps: OnboardingWizardStep[];
+
+  /** Text on the primary button at the last step (default: "Get started") */
+  finishButtonText?: string;
+  /** Text on the secondary button at step 0 (default: "Skip") */
+  skipButtonText?: string;
+  /** Called when the user clicks the finish button on the last step.
+   *  If not provided, onClose is called. */
+  onFinish?: () => void;
+
+  /** Modal width in px (default: 620) */
+  width?: number;
+
+  /** When set, the wizard stores a "completed" flag in localStorage under this
+   *  key. On subsequent renders the modal auto-hides (won't open at all).
+   *  Pass `undefined` to disable persistence. */
+  storageKey?: string;
+}
+
+const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
+  isOpen,
+  onClose,
+  title,
+  subtitle,
+  badgeText = "Getting started",
+  badgeIcon: BadgeIcon = Shield,
+  steps,
+  finishButtonText = "Get started",
+  skipButtonText = "Skip",
+  onFinish,
+  width = 620,
+  storageKey,
+}) => {
+  const [step, setStep] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+  const isLast = step === steps.length - 1;
+
+  // Check localStorage on mount
+  useEffect(() => {
+    if (storageKey) {
+      try {
+        const stored = localStorage.getItem(storageKey);
+        if (stored === "true") {
+          setDismissed(true);
+        }
+      } catch {
+        // localStorage may be unavailable
+      }
+    }
+  }, [storageKey]);
+
+  const markDismissed = useCallback(() => {
+    if (storageKey) {
+      try {
+        localStorage.setItem(storageKey, "true");
+      } catch {
+        // localStorage may be unavailable
+      }
+      setDismissed(true);
+    }
+  }, [storageKey]);
+
+  const handleClose = () => {
+    setStep(0);
+    markDismissed();
+    onClose();
+  };
+
+  const handleFinish = () => {
+    setStep(0);
+    markDismissed();
+    if (onFinish) {
+      onFinish();
+    } else {
+      onClose();
+    }
+  };
+
+  // If already dismissed via localStorage, never render
+  if (dismissed) return null;
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={(_event, reason) => {
+        if (reason !== "backdropClick") {
+          handleClose();
+        }
+      }}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Stack
+        sx={{
+          width,
+          borderRadius: "12px",
+          overflow: "hidden",
+          outline: "none",
+          boxShadow: "0 25px 50px -12px rgba(0,0,0,0.25)",
+        }}
+      >
+        {/* ── Dark header ── */}
+        <Box
+          sx={{
+            background: "linear-gradient(135deg, #1a1f2e 0%, #2d3548 100%)",
+            padding: "32px 32px 28px",
+          }}
+        >
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="flex-start"
+          >
+            <Stack spacing={0}>
+              <Stack direction="row" alignItems="center" spacing={1}>
+                <BadgeIcon size={18} color="#4ADE80" strokeWidth={2} />
+                <Typography
+                  sx={{
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: "#4ADE80",
+                    textTransform: "uppercase",
+                    letterSpacing: 1.2,
+                  }}
+                >
+                  {badgeText}
+                </Typography>
+              </Stack>
+
+              <Box sx={{ height: "16px" }} />
+
+              <Typography
+                sx={{
+                  fontSize: 20,
+                  fontWeight: 600,
+                  color: "#FFFFFF",
+                  lineHeight: 1.3,
+                }}
+              >
+                {title}
+              </Typography>
+              {subtitle && (
+                <Typography
+                  sx={{
+                    fontSize: 13,
+                    color: "#94A3B8",
+                    lineHeight: 1.5,
+                    mt: 0.5,
+                  }}
+                >
+                  {subtitle}
+                </Typography>
+              )}
+            </Stack>
+
+            <Box
+              component="span"
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleClose();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleClose();
+                }
+              }}
+              sx={{
+                cursor: "pointer",
+                color: "#64748B",
+                display: "flex",
+                alignItems: "center",
+                padding: "4px",
+                borderRadius: "4px",
+                "&:hover": {
+                  color: "#94A3B8",
+                  bgcolor: "rgba(255,255,255,0.05)",
+                },
+              }}
+            >
+              <X size={18} />
+            </Box>
+          </Stack>
+
+          <Box sx={{ height: "16px" }} />
+
+          {/* Step indicators — segmented bar */}
+          <Box
+            sx={{
+              display: "flex",
+              borderRadius: "10px",
+              overflow: "hidden",
+              border: "1px solid rgba(255,255,255,0.08)",
+            }}
+          >
+            {steps.map((s, i) => {
+              const isActive = i === step;
+              const isDone = i < step;
+              return (
+                <Box
+                  key={i}
+                  onClick={() => setStep(i)}
+                  sx={{
+                    flex: 1,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: "8px",
+                    height: 40,
+                    cursor: "pointer",
+                    bgcolor: isActive
+                      ? "rgba(74,222,128,0.12)"
+                      : isDone
+                      ? "rgba(74,222,128,0.05)"
+                      : "transparent",
+                    borderRight:
+                      i < steps.length - 1
+                        ? "1px solid rgba(255,255,255,0.06)"
+                        : "none",
+                    transition: "background-color 0.2s",
+                    "&:hover": {
+                      bgcolor: isActive
+                        ? "rgba(74,222,128,0.12)"
+                        : "rgba(255,255,255,0.04)",
+                    },
+                  }}
+                >
+                  {isDone && (
+                    <Box
+                      sx={{
+                        width: 16,
+                        height: 16,
+                        borderRadius: "50%",
+                        bgcolor: "#4ADE80",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        flexShrink: 0,
+                      }}
+                    >
+                      <Check size={10} color="#1a1f2e" strokeWidth={3} />
+                    </Box>
+                  )}
+                  <Typography
+                    sx={{
+                      fontSize: 12,
+                      fontWeight: isActive ? 600 : isDone ? 500 : 400,
+                      color: isDone
+                        ? "#4ADE80"
+                        : isActive
+                        ? "#FFFFFF"
+                        : "#94A3B8",
+                    }}
+                  >
+                    {s.label}
+                  </Typography>
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+
+        {/* ── Light body — renders step content (any ReactNode) ── */}
+        <Box sx={{ bgcolor: "#FFFFFF", padding: "32px" }}>
+          {steps[step]?.content}
+        </Box>
+
+        {/* ── Footer ── */}
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          sx={{
+            bgcolor: "#FAFBFC",
+            borderTop: "1px solid #E0E4E9",
+            padding: "14px 32px",
+          }}
+        >
+          <CustomizableButton
+            variant="outlined"
+            text={step === 0 ? skipButtonText : "Back"}
+            onClick={() => (step === 0 ? handleClose() : setStep(step - 1))}
+            sx={{
+              minWidth: "70px",
+              height: 34,
+              fontSize: 13,
+              border: "1px solid #D0D5DD",
+              color: "#344054",
+              "&:hover": {
+                bgcolor: "#F9FAFB",
+                border: "1px solid #D0D5DD",
+              },
+            }}
+          />
+          <CustomizableButton
+            variant="contained"
+            text={isLast ? finishButtonText : "Continue"}
+            onClick={() => (isLast ? handleFinish() : setStep(step + 1))}
+            sx={{
+              minWidth: "70px",
+              height: 34,
+              fontSize: 13,
+              bgcolor: "#13715B",
+              "&:hover": {
+                bgcolor: "#0F5A47",
+              },
+            }}
+          />
+        </Stack>
+      </Stack>
+    </Modal>
+  );
+};
+
+export default OnboardingWizard;

--- a/Clients/src/presentation/components/Modals/ShadowAIOnboarding/index.tsx
+++ b/Clients/src/presentation/components/Modals/ShadowAIOnboarding/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * ShadowAIOnboarding — 3-step onboarding wizard for the Shadow AI module.
+ *
+ * Thin wrapper around OnboardingWizard with Shadow-AI-specific content.
+ * Persists dismissal in localStorage so it only shows once per browser.
+ */
+
+import React from "react";
+import { Stack, Typography } from "@mui/material";
+import OnboardingWizard from "../OnboardingWizard";
+import { Eye } from "lucide-react";
+
+const STORAGE_KEY = "vw:shadow-ai-onboarding-dismissed";
+
+const StepContent: React.FC<{ title: string; detail: string }> = ({
+  title,
+  detail,
+}) => (
+  <Stack spacing={2.5}>
+    <Typography sx={{ fontSize: 15, fontWeight: 600, color: "#1c2130" }}>
+      {title}
+    </Typography>
+    <Typography sx={{ fontSize: 13, color: "#475467", lineHeight: 1.7 }}>
+      {detail}
+    </Typography>
+  </Stack>
+);
+
+const STEPS = [
+  {
+    label: "Connect",
+    content: (
+      <StepContent
+        title="Step 1: Connect"
+        detail="Connect your SIEM or web proxy to start detecting AI tool usage across your organization. Use the REST API with an API key, or configure a syslog source such as Zscaler, Netskope, or Squid."
+      />
+    ),
+  },
+  {
+    label: "Alert",
+    content: (
+      <StepContent
+        title="Step 2: Alert"
+        detail="Create alert rules to get notified when new AI tools are detected, usage thresholds are exceeded, or sensitive departments access unauthorized AI tools."
+      />
+    ),
+  },
+  {
+    label: "Monitor",
+    content: (
+      <StepContent
+        title="Step 3: Monitor"
+        detail="Monitor your Insights dashboard for real-time visibility into detected AI tools, user activity by department, risk scores, and adoption trends across your organization."
+      />
+    ),
+  },
+];
+
+interface ShadowAIOnboardingProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ShadowAIOnboarding: React.FC<ShadowAIOnboardingProps> = ({
+  isOpen,
+  onClose,
+}) => (
+  <OnboardingWizard
+    isOpen={isOpen}
+    onClose={onClose}
+    title="Shadow AI"
+    subtitle="Detect and monitor unauthorized AI tool usage in your organization"
+    badgeIcon={Eye}
+    steps={STEPS}
+    storageKey={STORAGE_KEY}
+  />
+);
+
+export default ShadowAIOnboarding;

--- a/Clients/src/presentation/pages/ShadowAI/index.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/index.tsx
@@ -6,7 +6,7 @@
  * Follows the same pattern as AIDetectionPage.
  */
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Stack } from "@mui/material";
 import { Eye, BarChart3, Users, Bot, ShieldAlert, Settings } from "lucide-react";
@@ -18,12 +18,14 @@ import UserActivityPage from "./UserActivityPage";
 import AIToolsPage from "./AIToolsPage";
 import RulesPage from "./RulesPage";
 import SettingsPage from "./SettingsPage";
+import ShadowAIOnboarding from "../../components/Modals/ShadowAIOnboarding";
 
 type ActiveTab = "insights" | "users" | "tools" | "rules" | "settings";
 
 export default function ShadowAIPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const [showOnboarding, setShowOnboarding] = useState(true);
   const sidebarContext = useShadowAISidebarContextSafe();
   const setToolsCount = sidebarContext?.setToolsCount;
   const setRecentTools = sidebarContext?.setRecentTools;
@@ -140,6 +142,10 @@ export default function ShadowAIPage() {
     <Stack className="vwhome" gap="16px">
       <PageBreadcrumbs items={getBreadcrumbItems()} />
       {renderContent()}
+      <ShadowAIOnboarding
+        isOpen={showOnboarding}
+        onClose={() => setShowOnboarding(false)}
+      />
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `ShadowAIOnboarding` component using the reusable `OnboardingWizard` modal
- 3 steps: Connect (SIEM/syslog setup), Alert (rule creation), Monitor (insights dashboard)
- Wired into Shadow AI page — shows on first visit, then never again via localStorage

## Test plan
- [ ] Navigate to `/shadow-ai` — onboarding wizard should appear on first visit
- [ ] Click through all 3 steps (Connect → Alert → Monitor) — verify checkmarks and content
- [ ] Click "Get started" or "Skip" — wizard dismisses
- [ ] Reload `/shadow-ai` — wizard should not appear again
- [ ] Clear `vw:shadow-ai-onboarding-dismissed` from localStorage — wizard reappears