### PR TITLE
Restrict evaluation LLM API key management to Admin only

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/OrgSettings.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/OrgSettings.tsx
@@ -10,6 +10,7 @@ import Select from "../../components/Inputs/Select";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import Alert from "../../components/Alert";
 import { getAllLlmApiKeys, addLlmApiKey, deleteLlmApiKey } from "../../../application/repository/deepEval.repository";
+import { useIsAdmin } from "../../../application/hooks/useIsAdmin";
 
 interface SavedKey {
   provider: string;
@@ -90,6 +91,7 @@ function validateApiKeyFormat(provider: string, apiKey: string): string | null {
 export default function OrgSettings() {
   const navigate = useNavigate();
   const theme = useTheme();
+  const isAdmin = useIsAdmin();
   const [saving, setSaving] = useState(false);
   const [alert, setAlert] = useState<{
     variant: "success" | "error";
@@ -109,6 +111,13 @@ export default function OrgSettings() {
     { label: "LLM Evals", path: "/evals", icon: <FlaskConical size={14} strokeWidth={1.5} />, onClick: () => navigate("/evals") },
     { label: "Organization settings", icon: <Settings size={14} strokeWidth={1.5} /> },
   ];
+
+  // Redirect non-admin users to the evals dashboard
+  useEffect(() => {
+    if (!isAdmin) {
+      navigate("/evals", { replace: true });
+    }
+  }, [isAdmin, navigate]);
 
   // Fetch saved keys on mount
   useEffect(() => {

--- a/Servers/routes/evaluationLlmApiKey.route.ts
+++ b/Servers/routes/evaluationLlmApiKey.route.ts
@@ -3,12 +3,16 @@
  *
  * Provides endpoints for managing LLM provider API keys used in evaluations.
  *
- * All routes require authentication.
+ * Access Control:
+ * - GET (list masked keys): All authenticated users
+ * - POST/DELETE (add/remove/verify keys): Admin only
+ * - GET (decrypted keys): Internal services only
  */
 
 import express from 'express';
 import { getAllKeys, addKey, deleteKey, getDecryptedKeys, verifyKey } from '../controllers/evaluationLlmApiKey.ctrl';
 import authenticateJWT from '../middleware/auth.middleware';
+import authorize from '../middleware/accessControl.middleware';
 
 /**
  * Middleware to restrict access to internal services only (localhost)
@@ -42,16 +46,18 @@ router.get('/', authenticateJWT, getAllKeys);
 /**
  * POST /api/evaluation-llm-keys
  * Add a new LLM API key
+ * @access Admin only
  *
  * Body:
  * - provider: string (openai, anthropic, google, xai, mistral, huggingface)
  * - apiKey: string (will be encrypted before storage)
  */
-router.post('/', authenticateJWT, addKey);
+router.post('/', authenticateJWT, authorize(['Admin']), addKey);
 
 /**
  * POST /api/evaluation-llm-keys/verify
  * Verify an LLM API key by making a test call to the provider
+ * @access Admin only
  *
  * Body:
  * - provider: string (openai, anthropic, google, xai, mistral, huggingface, openrouter)
@@ -61,16 +67,17 @@ router.post('/', authenticateJWT, addKey);
  * - valid: boolean (whether the key is valid)
  * - message: string (verification result message)
  */
-router.post('/verify', authenticateJWT, verifyKey);
+router.post('/verify', authenticateJWT, authorize(['Admin']), verifyKey);
 
 /**
  * DELETE /api/evaluation-llm-keys/:provider
  * Delete an LLM API key
+ * @access Admin only
  *
  * Params:
  * - provider: string (openai, anthropic, google, xai, mistral, huggingface)
  */
-router.delete('/:provider', authenticateJWT, deleteKey);
+router.delete('/:provider', authenticateJWT, authorize(['Admin']), deleteKey);
 
 /**
  * GET /api/evaluation-llm-keys/internal/decrypted


### PR DESCRIPTION
The backend had no role restriction on LLM API key management endpoints. Any authenticated user (Editor, Reviewer, Auditor) could add, verify, or delete organization-wide LLM provider keys via direct API calls, bypassing the frontend-only UI restriction at `permissions.ts:68`. This aligns backend enforcement with the existing frontend permission.

List of actions: 

- Add `authorize(['Admin'])` middleware to POST, POST /verify, and DELETE routes for evaluation LLM API keys
- Add admin redirect guard to standalone OrgSettings page (`/evals/settings`)
- GET (list masked keys) remains available to all authenticated users

