### PR TITLE
Add self-hosted local LLM scorer support (e.g. Ollama)

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectScorers.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectScorers.tsx
@@ -162,7 +162,9 @@ export default function ProjectScorers({ projectId, orgId }: ProjectScorersProps
         maxTokens: judgeModel.params.max_tokens ?? 256,
         topP: judgeModel.params.top_p ?? 1,
       } : scorerConfig.modelParams || { temperature: 0, maxTokens: 256, topP: 1 };
-      
+      const endpointUrl = typeof judgeModel === 'object' ? judgeModel?.endpointUrl : undefined;
+      const apiKey = typeof judgeModel === 'object' ? judgeModel?.apiKey : undefined;
+
       setEditInitialConfig({
         name: scorer.name || "",
         slug: scorer.metricKey || "",
@@ -173,6 +175,8 @@ export default function ProjectScorers({ projectId, orgId }: ProjectScorersProps
         useChainOfThought: scorerConfig.useChainOfThought ?? true,
         choiceScores: scorerConfig.choiceScores || [{ label: "", score: 0 }],
         passThreshold: scorer.defaultThreshold ?? 0.5,
+        endpointUrl: endpointUrl || "",
+        apiKey: apiKey || "",
         inputSchema: scorerConfig.inputSchema || `{
           "input": "",
           "output": "",
@@ -256,6 +260,10 @@ export default function ProjectScorers({ projectId, orgId }: ProjectScorersProps
               max_tokens: config.modelParams.maxTokens,
               top_p: config.modelParams.topP,
             },
+            ...(config.provider === "self-hosted" && config.endpointUrl
+              ? { endpointUrl: config.endpointUrl } : {}),
+            ...(config.provider === "self-hosted" && config.apiKey
+              ? { apiKey: config.apiKey } : {}),
           },
           messages: config.messages,
           useChainOfThought: config.useChainOfThought,
@@ -305,6 +313,10 @@ export default function ProjectScorers({ projectId, orgId }: ProjectScorersProps
               max_tokens: config.modelParams.maxTokens,
               top_p: config.modelParams.topP,
             },
+            ...(config.provider === "self-hosted" && config.endpointUrl
+              ? { endpointUrl: config.endpointUrl } : {}),
+            ...(config.provider === "self-hosted" && config.apiKey
+              ? { apiKey: config.apiKey } : {}),
           },
           messages: config.messages,
           useChainOfThought: config.useChainOfThought,

--- a/Clients/src/presentation/utils/providers/index.ts
+++ b/Clients/src/presentation/utils/providers/index.ts
@@ -29,6 +29,7 @@ const PROVIDER_META: Record<string, { displayName: string; iconColor: string; lo
   mistral: { displayName: "Mistral", iconColor: "#FF7000", logo: "/src/presentation/assets/icons/mistral_logo.svg" },
   xai: { displayName: "xAI", iconColor: "#000000", logo: "/src/presentation/assets/icons/xai_logo.svg" },
   openrouter: { displayName: "OpenRouter", iconColor: "#6366F1", logo: "/src/presentation/assets/icons/openrouter_logo.svg" },
+  "self-hosted": { displayName: "Self-Hosted", iconColor: "#1A1A2E", logo: "/src/presentation/assets/icons/ollama_logo.svg" },
 };
 
 export const PROVIDERS: Record<string, ProviderConfig> = {
@@ -52,9 +53,15 @@ export const PROVIDERS: Record<string, ProviderConfig> = {
     ...(xaiModels as { provider: string; displayName: string; models: ModelInfo[] }), 
     ...PROVIDER_META.xai 
   },
-  openrouter: { 
-    ...(openrouterModels as { provider: string; displayName: string; models: ModelInfo[] }), 
-    ...PROVIDER_META.openrouter 
+  openrouter: {
+    ...(openrouterModels as { provider: string; displayName: string; models: ModelInfo[] }),
+    ...PROVIDER_META.openrouter
+  },
+  "self-hosted": {
+    provider: "self-hosted",
+    displayName: "Self-Hosted",
+    models: [],
+    ...PROVIDER_META["self-hosted"],
   },
 };
 

--- a/EvalServer/src/utils/run_evaluation.py
+++ b/EvalServer/src/utils/run_evaluation.py
@@ -958,7 +958,7 @@ async def run_evaluation(
                                         "score": result.score,
                                         "label": result.label,
                                         "passed": result.passed,
-                                        "reason": result.raw_response[:200] if result.raw_response else "",
+                                        "reason": result.raw_response if result.raw_response else "",
                                     }
                                 
                             except Exception as scorer_err:


### PR DESCRIPTION
## Describe your changes

Summary

  - Add self-hosted provider option to the scorer UI with endpoint URL, model name, and optional API key fields
  - Auto-append /v1 to self-hosted base URLs for OpenAI-compatible API compatibility (Ollama, vLLM, etc.)
  - Improve label extraction to handle chain-of-thought models (e.g. deepseek-r1) by stripping <think> blocks and searching for
  configured choice labels anywhere in the response
  - Store full model reasoning in experiment results instead of truncating to 200 characters

## Write your issue number after "Fixes "

This PR does not intent to fix any issues.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
