### PR TITLE
feat: add law-aware bias audit module to LLM Evals

### DIFF
--- a/Clients/src/application/repository/deepEval.repository.ts
+++ b/Clients/src/application/repository/deepEval.repository.ts
@@ -58,6 +58,17 @@ import {
   type ArenaComparison,
   type ArenaComparisonSummary,
 } from "../../infrastructure/api/deepEvalArenaService";
+import {
+  biasAuditService,
+  type BiasAuditPresetSummary,
+  type BiasAuditPreset,
+  type BiasAuditSummary,
+  type BiasAuditDetailResponse,
+  type GroupResultRow,
+  type CategoryTableResult,
+  type BiasAuditResultFull,
+  type CreateBiasAuditConfig,
+} from "../../infrastructure/api/biasAuditService";
 
 // Re-export types for presentation layer
 export type {
@@ -90,6 +101,15 @@ export type {
   ArenaComparisonResult,
   ArenaComparison,
   ArenaComparisonSummary,
+  // Bias audit types
+  BiasAuditPresetSummary,
+  BiasAuditPreset,
+  BiasAuditSummary,
+  BiasAuditDetailResponse,
+  GroupResultRow,
+  CategoryTableResult,
+  BiasAuditResultFull,
+  CreateBiasAuditConfig,
 };
 
 // Re-export utility functions for presentation layer
@@ -290,3 +310,29 @@ export const getArenaComparisonResults = (comparisonId: string) =>
 
 export const deleteArenaComparison = (comparisonId: string) =>
   deepEvalArenaService.deleteComparison(comparisonId);
+
+// ==================== BIAS AUDITS ====================
+
+export const listBiasAuditPresets = () =>
+  biasAuditService.listPresets();
+
+export const getBiasAuditPreset = (presetId: string) =>
+  biasAuditService.getPreset(presetId);
+
+export const runBiasAudit = (dataset: File, config: CreateBiasAuditConfig) =>
+  biasAuditService.runAudit(dataset, config);
+
+export const getBiasAuditStatus = (auditId: string) =>
+  biasAuditService.getStatus(auditId);
+
+export const getBiasAuditResults = (auditId: string) =>
+  biasAuditService.getResults(auditId);
+
+export const listBiasAudits = (params?: { org_id?: string; project_id?: string }) =>
+  biasAuditService.listAudits(params);
+
+export const deleteBiasAudit = (auditId: string) =>
+  biasAuditService.deleteAudit(auditId);
+
+export const parseBiasAuditCsvHeaders = (dataset: File) =>
+  biasAuditService.parseHeaders(dataset);

--- a/Clients/src/infrastructure/api/biasAuditService.ts
+++ b/Clients/src/infrastructure/api/biasAuditService.ts
@@ -1,0 +1,219 @@
+import CustomAxios from "./customAxios";
+
+// ==================== TYPES ====================
+
+export interface BiasAuditPresetSummary {
+  id: string;
+  name: string;
+  jurisdiction: string;
+  effective_date: string;
+  mode: string;
+  description: string;
+}
+
+export interface CategoryConfig {
+  label: string;
+  groups: string[];
+}
+
+export interface IntersectionalConfig {
+  required: boolean;
+  cross: string[];
+}
+
+export interface ResultsTableConfig {
+  type: string;
+  category_key?: string;
+  title: string;
+}
+
+export interface BiasAuditPreset {
+  id: string;
+  name: string;
+  jurisdiction: string;
+  effective_date: string;
+  mode: string;
+  description: string;
+  categories: Record<string, CategoryConfig>;
+  intersectional?: IntersectionalConfig;
+  metrics: string[];
+  threshold: number | null;
+  small_sample_exclusion: number | null;
+  required_metadata: string[];
+  results_format?: {
+    tables: ResultsTableConfig[];
+  };
+  checklist_items?: string[];
+  recommended_threshold?: number | null;
+  sections?: string[];
+}
+
+export interface BiasAuditSummary {
+  id: string;
+  orgId: string;
+  projectId: string | null;
+  presetId: string;
+  presetName: string;
+  mode: string;
+  status: "pending" | "running" | "completed" | "failed";
+  config: Record<string, any>;
+  results: BiasAuditResultFull | null;
+  error: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+  createdBy: string | null;
+}
+
+export interface GroupResultRow {
+  id: number;
+  auditId: string;
+  categoryType: string;
+  categoryName: string;
+  applicantCount: number;
+  selectedCount: number;
+  selectionRate: number;
+  impactRatio: number | null;
+  excluded: boolean;
+  flagged: boolean;
+  createdAt: string;
+}
+
+export interface CategoryTableResult {
+  title: string;
+  category_key: string;
+  rows: {
+    category_type: string;
+    category_name: string;
+    applicant_count: number;
+    selected_count: number;
+    selection_rate: number;
+    impact_ratio: number | null;
+    excluded: boolean;
+    flagged: boolean;
+  }[];
+  highest_group: string | null;
+  highest_rate: number | null;
+}
+
+export interface BiasAuditResultFull {
+  tables: CategoryTableResult[];
+  overall_selection_rate: number;
+  total_applicants: number;
+  total_selected: number;
+  unknown_count: number;
+  flags_count: number;
+  excluded_count: number;
+  summary: string;
+}
+
+export interface BiasAuditDetailResponse {
+  auditId: string;
+  status: string;
+  presetId: string;
+  presetName: string;
+  mode: string;
+  config: Record<string, any>;
+  results: BiasAuditResultFull;
+  resultRows: GroupResultRow[];
+  createdAt: string;
+  completedAt: string;
+  createdBy: string | null;
+}
+
+export interface CreateBiasAuditConfig {
+  presetId: string;
+  presetName?: string;
+  mode?: string;
+  orgId: string;
+  projectId?: string;
+  categories?: Record<string, CategoryConfig>;
+  intersectional?: IntersectionalConfig;
+  metrics?: string[];
+  threshold?: number | null;
+  smallSampleExclusion?: number | null;
+  outcomeColumn: string;
+  columnMapping: Record<string, string>;
+  metadata?: Record<string, string>;
+}
+
+// ==================== SERVICE ====================
+
+class BiasAuditService {
+  // Presets
+  async listPresets(): Promise<BiasAuditPresetSummary[]> {
+    const res = await CustomAxios.get("/deepeval/bias-audits/presets");
+    return (res.data as { presets: BiasAuditPresetSummary[] }).presets;
+  }
+
+  async getPreset(presetId: string): Promise<BiasAuditPreset> {
+    const res = await CustomAxios.get(
+      `/deepeval/bias-audits/presets/${presetId}`
+    );
+    return (res.data as { preset: BiasAuditPreset }).preset;
+  }
+
+  // Audits
+  async runAudit(
+    dataset: File,
+    config: CreateBiasAuditConfig
+  ): Promise<{ auditId: string; status: string }> {
+    const formData = new FormData();
+    formData.append("dataset", dataset);
+    formData.append("config_json", JSON.stringify(config));
+    formData.append("org_id", config.orgId);
+
+    const res = await CustomAxios.post(
+      "/deepeval/bias-audits/run",
+      formData,
+      { headers: { "Content-Type": "multipart/form-data" } }
+    );
+    return res.data as { auditId: string; status: string };
+  }
+
+  async getStatus(
+    auditId: string
+  ): Promise<{ auditId: string; status: string; error?: string }> {
+    const res = await CustomAxios.get(
+      `/deepeval/bias-audits/${auditId}/status`
+    );
+    return res.data as { auditId: string; status: string; error?: string };
+  }
+
+  async getResults(auditId: string): Promise<BiasAuditDetailResponse> {
+    const res = await CustomAxios.get(
+      `/deepeval/bias-audits/${auditId}/results`
+    );
+    return res.data as BiasAuditDetailResponse;
+  }
+
+  async listAudits(params?: {
+    org_id?: string;
+    project_id?: string;
+  }): Promise<BiasAuditSummary[]> {
+    const res = await CustomAxios.get("/deepeval/bias-audits", { params });
+    return (res.data as { audits: BiasAuditSummary[] }).audits;
+  }
+
+  async deleteAudit(
+    auditId: string
+  ): Promise<{ message: string; auditId: string }> {
+    const res = await CustomAxios.delete(
+      `/deepeval/bias-audits/${auditId}`
+    );
+    return res.data as { message: string; auditId: string };
+  }
+
+  async parseHeaders(dataset: File): Promise<string[]> {
+    const formData = new FormData();
+    formData.append("dataset", dataset);
+    const res = await CustomAxios.post(
+      "/deepeval/bias-audits/parse-headers",
+      formData,
+      { headers: { "Content-Type": "multipart/form-data" } }
+    );
+    return (res.data as { headers: string[] }).headers;
+  }
+}
+
+export const biasAuditService = new BiasAuditService();

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, XCircle, Users, UserCheck, Percent, AlertTriangle, HelpCircl
 import { cardStyles } from "../../themes";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { getStatusChip, getModeChip } from "./biasAuditHelpers";
+import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
 import {
   getBiasAuditResults,
   getBiasAuditStatus,
@@ -185,6 +186,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchResults = useCallback(async () => {
@@ -305,7 +307,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
           <CustomizableButton
             variant="outlined"
             text={isDeleting ? "Deleting..." : "Delete"}
-            onClick={handleDelete}
+            onClick={() => setShowDeleteConfirm(true)}
             disabled={isDeleting}
             sx={{ height: 34, fontSize: 13, border: `1px solid ${theme.palette.border.dark}`, color: "#B42318", "&:hover": { backgroundColor: "#FEF3F2", border: "1px solid #FCA5A5" } }}
           />
@@ -359,6 +361,20 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
             <ResultsTable key={index} table={table} threshold={audit.config?.threshold ?? 0.80} />
           ))}
         </>
+      )}
+
+      {showDeleteConfirm && (
+        <ConfirmationModal
+          isOpen={showDeleteConfirm}
+          title="Delete bias audit"
+          body="Are you sure you want to delete this bias audit? This action cannot be undone."
+          proceedText="Delete"
+          cancelText="Cancel"
+          onProceed={handleDelete}
+          onCancel={() => setShowDeleteConfirm(false)}
+          proceedButtonVariant="contained"
+          proceedButtonColor="error"
+        />
       )}
     </Box>
   );

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
@@ -1,0 +1,267 @@
+import { useState, useEffect, useCallback } from "react";
+import { Box, Stack, Typography, Chip, CircularProgress } from "@mui/material";
+import { ArrowLeft, CheckCircle, XCircle, RefreshCw, Clock } from "lucide-react";
+import { CustomizableButton } from "../../components/button/customizable-button";
+import {
+  getBiasAuditResults,
+  getBiasAuditStatus,
+  deleteBiasAudit,
+  type BiasAuditDetailResponse,
+  type CategoryTableResult,
+} from "../../../application/repository/deepEval.repository";
+
+interface BiasAuditDetailProps {
+  auditId: string;
+  onBack: () => void;
+}
+
+// Helper: SummaryCard component
+function SummaryCard({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <Box sx={{ border: "1px solid #d0d5dd", borderRadius: "4px", p: 2, flex: 1, backgroundColor: "#fff" }}>
+      <Typography sx={{ fontSize: 11, color: "#667085", mb: 0.5 }}>{label}</Typography>
+      <Typography sx={{ fontSize: 18, fontWeight: 600, color: highlight ? "#B42318" : "#111827" }}>{value}</Typography>
+    </Box>
+  );
+}
+
+// Helper: ResultsTable component
+function ResultsTable({ table, threshold }: { table: CategoryTableResult; threshold: number }) {
+  return (
+    <Box sx={{ border: "1px solid #d0d5dd", borderRadius: "4px", mb: 3, overflow: "hidden" }}>
+      <Box sx={{ px: 2, py: 1.5, backgroundColor: "#F9FAFB", borderBottom: "1px solid #d0d5dd" }}>
+        <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#344054" }}>{table.title}</Typography>
+        {table.highest_group && (
+          <Typography sx={{ fontSize: 11, color: "#667085" }}>
+            Highest rate: {table.highest_group} ({((table.highest_rate || 0) * 100).toFixed(1)}%)
+          </Typography>
+        )}
+      </Box>
+
+      {/* Table header */}
+      <Stack direction="row" sx={{ borderBottom: "1px solid #e5e7eb", py: 1, px: 2, backgroundColor: "#fff" }}>
+        <Typography sx={{ width: "25%", fontSize: 12, fontWeight: 600, color: "#475467" }}>Group</Typography>
+        <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467", textAlign: "right" }}>Applicants</Typography>
+        <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467", textAlign: "right" }}>Selected</Typography>
+        <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467", textAlign: "right" }}>Selection rate</Typography>
+        <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467", textAlign: "right" }}>Impact ratio</Typography>
+        <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467", textAlign: "right" }}>Status</Typography>
+      </Stack>
+
+      {/* Table rows */}
+      {table.rows.map((row, idx) => (
+        <Stack
+          key={idx}
+          direction="row"
+          alignItems="center"
+          sx={{
+            borderBottom: idx < table.rows.length - 1 ? "1px solid #f2f4f7" : "none",
+            py: 1.25,
+            px: 2,
+            backgroundColor: row.flagged ? "#FEF2F2" : "#fff",
+          }}
+        >
+          <Typography sx={{ width: "25%", fontSize: 13, color: "#111827" }}>{row.category_name}</Typography>
+          <Typography sx={{ width: "15%", fontSize: 13, color: "#475467", textAlign: "right" }}>{row.applicant_count.toLocaleString()}</Typography>
+          <Typography sx={{ width: "15%", fontSize: 13, color: "#475467", textAlign: "right" }}>{row.selected_count.toLocaleString()}</Typography>
+          <Typography sx={{ width: "15%", fontSize: 13, color: "#475467", textAlign: "right" }}>{(row.selection_rate * 100).toFixed(1)}%</Typography>
+          <Typography sx={{ width: "15%", fontSize: 13, textAlign: "right", color: row.excluded ? "#98a2b3" : row.flagged ? "#B42318" : "#475467", fontWeight: row.flagged ? 600 : 400 }}>
+            {row.excluded ? "Excluded (<2%)" : row.impact_ratio != null ? row.impact_ratio.toFixed(3) : "—"}
+          </Typography>
+          <Box sx={{ width: "15%", display: "flex", justifyContent: "flex-end" }}>
+            {row.excluded ? (
+              <Chip label="N/A" size="small" sx={{ fontSize: 10, height: 20, backgroundColor: "#F3F4F6", color: "#6B7280" }} />
+            ) : row.flagged ? (
+              <Chip label="Flag" size="small" sx={{ fontSize: 10, height: 20, backgroundColor: "#FEE2E2", color: "#991B1B" }} />
+            ) : (
+              <Chip label="Pass" size="small" sx={{ fontSize: 10, height: 20, backgroundColor: "#ECFDF5", color: "#065F46" }} />
+            )}
+          </Box>
+        </Stack>
+      ))}
+    </Box>
+  );
+}
+
+// Helper: getModeChip
+function getModeChip(mode: string) {
+  const labels: Record<string, string> = {
+    quantitative_audit: "Quantitative",
+    impact_assessment: "Assessment",
+    compliance_checklist: "Checklist",
+    framework_assessment: "Framework",
+    custom: "Custom",
+  };
+  return <Chip label={labels[mode] || mode} size="small" variant="outlined" sx={{ fontSize: 11, height: 22, borderColor: "#d0d5dd" }} />;
+}
+
+// Helper: getStatusChip
+function getStatusChip(status: string) {
+  switch (status) {
+    case "completed":
+      return <Chip label="Completed" size="small" icon={<CheckCircle size={12} />} sx={{ backgroundColor: "#ECFDF5", color: "#065F46", fontSize: 11, height: 22 }} />;
+    case "running":
+      return <Chip label="Running" size="small" icon={<RefreshCw size={12} />} sx={{ backgroundColor: "#EFF6FF", color: "#1E40AF", fontSize: 11, height: 22 }} />;
+    case "pending":
+      return <Chip label="Pending" size="small" icon={<Clock size={12} />} sx={{ backgroundColor: "#F9FAFB", color: "#374151", fontSize: 11, height: 22 }} />;
+    case "failed":
+      return <Chip label="Failed" size="small" icon={<XCircle size={12} />} sx={{ backgroundColor: "#FEF2F2", color: "#991B1B", fontSize: 11, height: 22 }} />;
+    default:
+      return <Chip label={status} size="small" sx={{ fontSize: 11, height: 22 }} />;
+  }
+}
+
+export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProps) {
+  const [audit, setAudit] = useState<BiasAuditDetailResponse | null>(null);
+  const [status, setStatus] = useState<string>("pending");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchResults = useCallback(async () => {
+    try {
+      const data = await getBiasAuditResults(auditId);
+      setAudit(data);
+      setStatus(data.status);
+      setLoading(false);
+    } catch (err: any) {
+      if (err?.response?.status === 202) {
+        // Still running
+        const statusData = await getBiasAuditStatus(auditId);
+        setStatus(statusData.status);
+        setLoading(false);
+      } else if (err?.response?.status === 500) {
+        setError(err.response?.data?.detail || "Audit failed");
+        setStatus("failed");
+        setLoading(false);
+      } else {
+        setError("Failed to load audit results");
+        setLoading(false);
+      }
+    }
+  }, [auditId]);
+
+  useEffect(() => {
+    fetchResults();
+  }, [fetchResults]);
+
+  // Polling while pending/running
+  useEffect(() => {
+    if (status !== "pending" && status !== "running") return;
+    const interval = setInterval(fetchResults, 3000);
+    return () => clearInterval(interval);
+  }, [status, fetchResults]);
+
+  const handleDownload = () => {
+    if (!audit?.results) return;
+    const json = JSON.stringify(audit.results, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `bias-audit-${auditId}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteBiasAudit(auditId);
+      onBack();
+    } catch (err) {
+      console.error("Failed to delete audit:", err);
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      {/* Header */}
+      <Stack direction="row" alignItems="center" spacing={2} mb={3}>
+        <Box
+          onClick={onBack}
+          sx={{ cursor: "pointer", display: "flex", alignItems: "center", p: 0.5, borderRadius: "4px", "&:hover": { backgroundColor: "#f2f4f7" } }}
+        >
+          <ArrowLeft size={18} color="#475467" strokeWidth={1.5} />
+        </Box>
+        <Stack spacing={0.5} flex={1}>
+          <Stack direction="row" alignItems="center" spacing={1.5}>
+            <Typography sx={{ fontSize: 15, fontWeight: 600, color: "#111827" }}>
+              {audit?.presetName || "Bias audit"}
+            </Typography>
+            {audit?.mode && getModeChip(audit.mode)}
+            {getStatusChip(status)}
+          </Stack>
+          {audit?.createdAt && (
+            <Typography sx={{ fontSize: 12, color: "#667085" }}>
+              Created {new Date(audit.createdAt).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
+            </Typography>
+          )}
+        </Stack>
+        <Stack direction="row" spacing={1}>
+          {audit?.results && (
+            <CustomizableButton
+              variant="outlined"
+              text="Download JSON"
+              onClick={handleDownload}
+              sx={{ height: 34, fontSize: 13, border: "1px solid #d0d5dd", color: "#344054" }}
+            />
+          )}
+          <CustomizableButton
+            variant="outlined"
+            text="Delete"
+            onClick={handleDelete}
+            sx={{ height: 34, fontSize: 13, border: "1px solid #d0d5dd", color: "#B42318", "&:hover": { backgroundColor: "#FEF3F2", border: "1px solid #FCA5A5" } }}
+          />
+        </Stack>
+      </Stack>
+
+      {/* Loading/pending/running state */}
+      {(loading || status === "pending" || status === "running") && (
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", py: 10, gap: 2 }}>
+          <CircularProgress size={32} sx={{ color: "#13715B" }} />
+          <Typography sx={{ fontSize: 14, color: "#475467" }}>
+            {status === "running" ? "Audit is running..." : "Waiting to start..."}
+          </Typography>
+        </Box>
+      )}
+
+      {/* Failed state */}
+      {status === "failed" && (
+        <Box sx={{ border: "1px solid #FCA5A5", borderRadius: "4px", p: 3, backgroundColor: "#FEF2F2" }}>
+          <Stack direction="row" spacing={1.5} alignItems="flex-start">
+            <XCircle size={18} color="#991B1B" strokeWidth={1.5} />
+            <Stack spacing={0.5}>
+              <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#991B1B" }}>Audit failed</Typography>
+              <Typography sx={{ fontSize: 13, color: "#7F1D1D" }}>{error || "An unknown error occurred"}</Typography>
+            </Stack>
+          </Stack>
+        </Box>
+      )}
+
+      {/* Completed state */}
+      {status === "completed" && audit?.results && (
+        <>
+          {/* Summary cards */}
+          <Stack direction="row" spacing={2} mb={3}>
+            <SummaryCard label="Total applicants" value={audit.results.total_applicants.toLocaleString()} />
+            <SummaryCard label="Total selected" value={audit.results.total_selected.toLocaleString()} />
+            <SummaryCard label="Selection rate" value={`${(audit.results.overall_selection_rate * 100).toFixed(1)}%`} />
+            <SummaryCard label="Flags" value={audit.results.flags_count.toString()} highlight={audit.results.flags_count > 0} />
+            {audit.results.unknown_count > 0 && (
+              <SummaryCard label="Unknown" value={audit.results.unknown_count.toLocaleString()} />
+            )}
+          </Stack>
+
+          {/* Summary text */}
+          <Box sx={{ border: "1px solid #d0d5dd", borderRadius: "4px", p: 2, mb: 3, backgroundColor: "#F9FAFB" }}>
+            <Typography sx={{ fontSize: 13, color: "#475467", lineHeight: 1.6 }}>{audit.results.summary}</Typography>
+          </Box>
+
+          {/* Results tables */}
+          {audit.results.tables.map((table, index) => (
+            <ResultsTable key={index} table={table} threshold={audit.config?.threshold ?? 0.80} />
+          ))}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -18,6 +18,7 @@ import { Trash2, Eye, ChevronsUpDown, ChevronUp, ChevronDown } from "lucide-reac
 import { CustomizableButton } from "../../components/button/customizable-button";
 import SearchBox from "../../components/Search/SearchBox";
 import { EmptyState } from "../../components/EmptyState";
+import HelperIcon from "../../components/HelperIcon";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
 import NewBiasAuditModal from "./NewBiasAuditModal";
 import { getStatusChip, getModeChip, formatDate } from "./biasAuditHelpers";
@@ -190,7 +191,10 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
       {/* Header */}
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
         <Stack spacing={0.5}>
-          <Typography sx={{ fontSize: 15, fontWeight: 600, color: theme.palette.text.primary }}>Bias audits</Typography>
+          <Box display="flex" alignItems="center" gap={1}>
+            <Typography sx={{ fontSize: 15, fontWeight: 600, color: theme.palette.text.primary }}>Bias audits</Typography>
+            <HelperIcon articlePath="llm-evals/bias-audits" />
+          </Box>
           <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
             Run compliance-aware bias audits against demographic datasets
           </Typography>

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -85,6 +85,7 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
   const [modalOpen, setModalOpen] = useState(false);
   const [auditToDelete, setAuditToDelete] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const deletingRef = useRef(false);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const [sortConfig, setSortConfig] = useState<SortConfig>(() => {
@@ -149,7 +150,8 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
   }, [audits, fetchAudits]);
 
   const handleDelete = async () => {
-    if (!auditToDelete || deleting) return;
+    if (!auditToDelete || deletingRef.current) return;
+    deletingRef.current = true;
     setDeleting(true);
     try {
       await deleteBiasAudit(auditToDelete);
@@ -160,6 +162,7 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
     } finally {
       setAuditToDelete(null);
       setDeleting(false);
+      deletingRef.current = false;
     }
   };
 

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Box, Stack, Typography, Chip, IconButton, CircularProgress, Alert } from "@mui/material";
-import { Plus, Trash2, Eye, RefreshCw, AlertTriangle, CheckCircle, Clock, XCircle } from "lucide-react";
+import { Trash2, Eye, RefreshCw, AlertTriangle, CheckCircle, Clock, XCircle } from "lucide-react";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import SearchBox from "../../components/Search/SearchBox";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
@@ -120,6 +120,16 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
     fetchAudits();
   }, [fetchAudits]);
 
+  // Cleanup polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, []);
+
   // Polling for running/pending audits (ref-based to avoid interval churn)
   useEffect(() => {
     const hasRunning = audits.some((a) => a.status === "running" || a.status === "pending");
@@ -130,13 +140,6 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
       clearInterval(pollingRef.current);
       pollingRef.current = null;
     }
-
-    return () => {
-      if (pollingRef.current) {
-        clearInterval(pollingRef.current);
-        pollingRef.current = null;
-      }
-    };
   }, [audits, fetchAudits]);
 
   const handleDelete = async () => {

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -1,0 +1,285 @@
+import { useState, useEffect, useCallback } from "react";
+import { Box, Stack, Typography, Chip, IconButton, CircularProgress } from "@mui/material";
+import { Plus, Trash2, Eye, RefreshCw, AlertTriangle, CheckCircle, Clock, XCircle } from "lucide-react";
+import { CustomizableButton } from "../../components/button/customizable-button";
+import SearchBox from "../../components/Search/SearchBox";
+import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
+import NewBiasAuditModal from "./NewBiasAuditModal";
+import {
+  listBiasAudits,
+  deleteBiasAudit,
+  type BiasAuditSummary,
+} from "../../../application/repository/deepEval.repository";
+
+interface BiasAuditsListProps {
+  orgId: string;
+  onViewAudit: (auditId: string) => void;
+}
+
+function getStatusChip(status: string) {
+  switch (status) {
+    case "completed":
+      return (
+        <Chip
+          label="Completed"
+          size="small"
+          icon={<CheckCircle size={12} />}
+          sx={{ backgroundColor: "#ECFDF5", color: "#065F46", fontSize: 11, height: 22 }}
+        />
+      );
+    case "running":
+      return (
+        <Chip
+          label="Running"
+          size="small"
+          icon={<RefreshCw size={12} />}
+          sx={{ backgroundColor: "#EFF6FF", color: "#1E40AF", fontSize: 11, height: 22 }}
+        />
+      );
+    case "pending":
+      return (
+        <Chip
+          label="Pending"
+          size="small"
+          icon={<Clock size={12} />}
+          sx={{ backgroundColor: "#F9FAFB", color: "#374151", fontSize: 11, height: 22 }}
+        />
+      );
+    case "failed":
+      return (
+        <Chip
+          label="Failed"
+          size="small"
+          icon={<XCircle size={12} />}
+          sx={{ backgroundColor: "#FEF2F2", color: "#991B1B", fontSize: 11, height: 22 }}
+        />
+      );
+    default:
+      return <Chip label={status} size="small" sx={{ fontSize: 11, height: 22 }} />;
+  }
+}
+
+function getModeChip(mode: string) {
+  const labels: Record<string, string> = {
+    quantitative_audit: "Quantitative",
+    impact_assessment: "Assessment",
+    compliance_checklist: "Checklist",
+    framework_assessment: "Framework",
+    custom: "Custom",
+  };
+  return (
+    <Chip
+      label={labels[mode] || mode}
+      size="small"
+      variant="outlined"
+      sx={{ fontSize: 11, height: 22, borderColor: "#d0d5dd" }}
+    />
+  );
+}
+
+function getResultSummary(audit: BiasAuditSummary) {
+  if (audit.status !== "completed" || !audit.results) return "—";
+  const flags = audit.results.flags_count;
+  if (flags === 0) return <Typography sx={{ fontSize: 13, color: "#065F46" }}>No flags</Typography>;
+  return (
+    <Typography sx={{ fontSize: 13, color: "#991B1B", fontWeight: 500 }}>
+      {flags} flag{flags !== 1 ? "s" : ""}
+    </Typography>
+  );
+}
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return "—";
+  return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListProps) {
+  const [audits, setAudits] = useState<BiasAuditSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [auditToDelete, setAuditToDelete] = useState<string | null>(null);
+
+  const fetchAudits = useCallback(async () => {
+    try {
+      const data = await listBiasAudits({ org_id: orgId });
+      setAudits(data);
+    } catch (err) {
+      console.error("Failed to load bias audits:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    fetchAudits();
+  }, [fetchAudits]);
+
+  // Polling for running/pending audits
+  useEffect(() => {
+    const hasRunning = audits.some((a) => a.status === "running" || a.status === "pending");
+    if (!hasRunning) return;
+    const interval = setInterval(fetchAudits, 5000);
+    return () => clearInterval(interval);
+  }, [audits, fetchAudits]);
+
+  const handleDelete = async () => {
+    if (!auditToDelete) return;
+    try {
+      await deleteBiasAudit(auditToDelete);
+      setAudits((prev) => prev.filter((a) => a.id !== auditToDelete));
+    } catch (err) {
+      console.error("Failed to delete audit:", err);
+    } finally {
+      setAuditToDelete(null);
+    }
+  };
+
+  const filteredAudits = audits.filter((a) =>
+    a.presetName.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      {/* Header */}
+      <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
+        <Stack spacing={0.5}>
+          <Typography sx={{ fontSize: 15, fontWeight: 600, color: "#111827" }}>Bias audits</Typography>
+          <Typography sx={{ fontSize: 13, color: "#667085" }}>
+            Run compliance-aware bias audits against demographic datasets
+          </Typography>
+        </Stack>
+        <CustomizableButton
+          variant="contained"
+          text="New bias audit"
+          onClick={() => setModalOpen(true)}
+          sx={{ height: 34, fontSize: 13, backgroundColor: "#13715B", "&:hover": { backgroundColor: "#0F5A47" } }}
+        />
+      </Stack>
+
+      {/* Search */}
+      <Box sx={{ mb: 2, maxWidth: 320 }}>
+        <SearchBox value={searchQuery} onChange={setSearchQuery} placeholder="Search audits..." />
+      </Box>
+
+      {/* Content */}
+      <Box sx={{ border: "1px solid #d0d5dd", borderRadius: "4px", backgroundColor: "#fff" }}>
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+            <CircularProgress size={24} sx={{ color: "#13715B" }} />
+          </Box>
+        ) : filteredAudits.length === 0 ? (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              py: 8,
+              gap: 2,
+            }}
+          >
+            <AlertTriangle size={40} color="#d0d5dd" strokeWidth={1} />
+            <Typography sx={{ fontSize: 14, color: "#667085" }}>No bias audits yet</Typography>
+            <Typography sx={{ fontSize: 13, color: "#98a2b3" }}>
+              Create your first bias audit to get started
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            {/* Table Header */}
+            <Stack direction="row" sx={{ borderBottom: "1px solid #d0d5dd", py: 1, px: 2 }}>
+              <Typography sx={{ width: "25%", fontSize: 12, fontWeight: 600, color: "#475467" }}>
+                Framework
+              </Typography>
+              <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467" }}>Mode</Typography>
+              <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467" }}>
+                Status
+              </Typography>
+              <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467" }}>
+                Result
+              </Typography>
+              <Typography sx={{ width: "20%", fontSize: 12, fontWeight: 600, color: "#475467" }}>Date</Typography>
+              <Typography sx={{ width: "10%", fontSize: 12, fontWeight: 600, color: "#475467" }}>
+                Actions
+              </Typography>
+            </Stack>
+
+            {/* Table Rows */}
+            {filteredAudits.map((audit) => (
+              <Stack
+                key={audit.id}
+                direction="row"
+                alignItems="center"
+                sx={{
+                  borderBottom: "1px solid #f2f4f7",
+                  py: 1.5,
+                  px: 2,
+                  cursor: "pointer",
+                  "&:hover": { backgroundColor: "#f9fafb" },
+                }}
+                onClick={() => onViewAudit(audit.id)}
+              >
+                <Typography sx={{ width: "25%", fontSize: 13, color: "#111827" }}>{audit.presetName}</Typography>
+                <Box sx={{ width: "15%" }}>{getModeChip(audit.mode)}</Box>
+                <Box sx={{ width: "15%" }}>{getStatusChip(audit.status)}</Box>
+                <Box sx={{ width: "15%" }}>{getResultSummary(audit)}</Box>
+                <Typography sx={{ width: "20%", fontSize: 13, color: "#667085" }}>
+                  {formatDate(audit.createdAt)}
+                </Typography>
+                <Stack direction="row" spacing={0.5} sx={{ width: "10%" }}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onViewAudit(audit.id);
+                    }}
+                    sx={{ padding: 0.5 }}
+                  >
+                    <Eye size={16} strokeWidth={1.5} color="#667085" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setAuditToDelete(audit.id);
+                    }}
+                    sx={{ padding: 0.5 }}
+                  >
+                    <Trash2 size={16} strokeWidth={1.5} color="#667085" />
+                  </IconButton>
+                </Stack>
+              </Stack>
+            ))}
+          </>
+        )}
+      </Box>
+
+      {/* New Bias Audit Modal */}
+      <NewBiasAuditModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        orgId={orgId}
+        onAuditCreated={(auditId) => {
+          setModalOpen(false);
+          fetchAudits();
+        }}
+      />
+
+      {/* Delete Confirmation Modal */}
+      {!!auditToDelete && (
+        <ConfirmationModal
+          isOpen={!!auditToDelete}
+          title="Delete bias audit"
+          body="Are you sure you want to delete this bias audit? This action cannot be undone."
+          proceedText="Delete"
+          cancelText="Cancel"
+          onProceed={handleDelete}
+          onCancel={() => setAuditToDelete(null)}
+          proceedButtonVariant="contained"
+          proceedButtonColor="error"
+        />
+      )}
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -1,5 +1,19 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { Box, Stack, Typography, IconButton, CircularProgress, Alert, useTheme } from "@mui/material";
+import {
+  Stack,
+  Typography,
+  IconButton,
+  CircularProgress,
+  Alert,
+  useTheme,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableContainer,
+  Box,
+} from "@mui/material";
 import { Trash2, Eye } from "lucide-react";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import SearchBox from "../../components/Search/SearchBox";
@@ -105,6 +119,16 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
     fontSize: 12,
     fontWeight: 600,
     color: theme.palette.text.secondary,
+    py: 1,
+    px: 2,
+    borderBottom: `1px solid ${theme.palette.border.dark}`,
+  };
+
+  const bodyCellSx = {
+    fontSize: 13,
+    py: 1.5,
+    px: 2,
+    borderBottom: `1px solid ${theme.palette.border.light}`,
   };
 
   return (
@@ -147,81 +171,71 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
           showBorder
         />
       ) : (
-        <Box
-          component="table"
+        <TableContainer
           sx={{
-            width: "100%",
-            borderCollapse: "collapse",
             border: `1px solid ${theme.palette.border.dark}`,
             borderRadius: "4px",
-            overflow: "hidden",
             backgroundColor: theme.palette.background.paper,
           }}
         >
-          <Box component="thead">
-            <Box
-              component="tr"
-              sx={{ borderBottom: `1px solid ${theme.palette.border.dark}` }}
-            >
-              <Box component="th" sx={{ ...headerCellSx, width: "25%", textAlign: "left", py: 1, px: 2 }}>Framework</Box>
-              <Box component="th" sx={{ ...headerCellSx, width: "15%", textAlign: "left", py: 1, px: 2 }}>Mode</Box>
-              <Box component="th" sx={{ ...headerCellSx, width: "15%", textAlign: "left", py: 1, px: 2 }}>Status</Box>
-              <Box component="th" sx={{ ...headerCellSx, width: "15%", textAlign: "left", py: 1, px: 2 }}>Result</Box>
-              <Box component="th" sx={{ ...headerCellSx, width: "20%", textAlign: "left", py: 1, px: 2 }}>Date</Box>
-              <Box component="th" sx={{ ...headerCellSx, width: "10%", textAlign: "left", py: 1, px: 2 }}>Actions</Box>
-            </Box>
-          </Box>
-          <Box component="tbody">
-            {filteredAudits.map((audit) => (
-              <Box
-                component="tr"
-                key={audit.id}
-                onClick={() => onViewAudit(audit.id)}
-                sx={{
-                  borderBottom: `1px solid ${theme.palette.border.light}`,
-                  cursor: "pointer",
-                  "&:hover": { backgroundColor: theme.palette.action.hover },
-                }}
-              >
-                <Box component="td" sx={{ py: 1.5, px: 2 }}>
-                  <Typography sx={{ fontSize: 13, color: theme.palette.text.primary }}>{audit.presetName}</Typography>
-                </Box>
-                <Box component="td" sx={{ py: 1.5, px: 2 }}>{getModeChip(audit.mode)}</Box>
-                <Box component="td" sx={{ py: 1.5, px: 2 }}>{getStatusChip(audit.status)}</Box>
-                <Box component="td" sx={{ py: 1.5, px: 2 }}>{getResultSummary(audit)}</Box>
-                <Box component="td" sx={{ py: 1.5, px: 2 }}>
-                  <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
-                    {formatDate(audit.createdAt)}
-                  </Typography>
-                </Box>
-                <Box component="td" sx={{ py: 1.5, px: 2 }}>
-                  <Stack direction="row" spacing={0.5}>
-                    <IconButton
-                      size="small"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onViewAudit(audit.id);
-                      }}
-                      sx={{ padding: 0.5 }}
-                    >
-                      <Eye size={16} strokeWidth={1.5} color={theme.palette.text.secondary} />
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setAuditToDelete(audit.id);
-                      }}
-                      sx={{ padding: 0.5 }}
-                    >
-                      <Trash2 size={16} strokeWidth={1.5} color={theme.palette.text.secondary} />
-                    </IconButton>
-                  </Stack>
-                </Box>
-              </Box>
-            ))}
-          </Box>
-        </Box>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ ...headerCellSx, width: "25%" }}>Framework</TableCell>
+                <TableCell sx={{ ...headerCellSx, width: "15%" }}>Mode</TableCell>
+                <TableCell sx={{ ...headerCellSx, width: "15%" }}>Status</TableCell>
+                <TableCell sx={{ ...headerCellSx, width: "15%" }}>Result</TableCell>
+                <TableCell sx={{ ...headerCellSx, width: "20%" }}>Date</TableCell>
+                <TableCell sx={{ ...headerCellSx, width: "10%" }}>Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filteredAudits.map((audit) => (
+                <TableRow
+                  key={audit.id}
+                  onClick={() => onViewAudit(audit.id)}
+                  sx={{
+                    cursor: "pointer",
+                    "&:hover": { backgroundColor: theme.palette.action.hover },
+                    "&:last-child td": { borderBottom: 0 },
+                  }}
+                >
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: 13, color: theme.palette.text.primary }}>
+                      {audit.presetName}
+                    </Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>{getModeChip(audit.mode)}</TableCell>
+                  <TableCell sx={bodyCellSx}>{getStatusChip(audit.status)}</TableCell>
+                  <TableCell sx={bodyCellSx}>{getResultSummary(audit)}</TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
+                      {formatDate(audit.createdAt)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx} onClick={(e) => e.stopPropagation()}>
+                    <Stack direction="row" spacing={0.5}>
+                      <IconButton
+                        size="small"
+                        onClick={() => onViewAudit(audit.id)}
+                        sx={{ padding: 0.5 }}
+                      >
+                        <Eye size={16} strokeWidth={1.5} color={theme.palette.text.secondary} />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        onClick={() => setAuditToDelete(audit.id)}
+                        sx={{ padding: 0.5 }}
+                      >
+                        <Trash2 size={16} strokeWidth={1.5} color={theme.palette.text.secondary} />
+                      </IconButton>
+                    </Stack>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
       )}
 
       {/* New Bias Audit Modal */}

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { Box, Stack, Typography, Chip, IconButton, CircularProgress, Alert } from "@mui/material";
-import { Trash2, Eye, RefreshCw, AlertTriangle, CheckCircle, Clock, XCircle } from "lucide-react";
+import { Box, Stack, Typography, IconButton, CircularProgress, Alert, useTheme } from "@mui/material";
+import { Trash2, Eye } from "lucide-react";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import SearchBox from "../../components/Search/SearchBox";
+import { EmptyState } from "../../components/EmptyState";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
 import NewBiasAuditModal from "./NewBiasAuditModal";
+import { getStatusChip, getModeChip, formatDate } from "./biasAuditHelpers";
 import {
   listBiasAudits,
   deleteBiasAudit,
@@ -14,67 +16,6 @@ import {
 interface BiasAuditsListProps {
   orgId: string;
   onViewAudit: (auditId: string) => void;
-}
-
-function getStatusChip(status: string) {
-  switch (status) {
-    case "completed":
-      return (
-        <Chip
-          label="Completed"
-          size="small"
-          icon={<CheckCircle size={12} />}
-          sx={{ backgroundColor: "#ECFDF5", color: "#065F46", fontSize: 11, height: 22 }}
-        />
-      );
-    case "running":
-      return (
-        <Chip
-          label="Running"
-          size="small"
-          icon={<RefreshCw size={12} />}
-          sx={{ backgroundColor: "#EFF6FF", color: "#1E40AF", fontSize: 11, height: 22 }}
-        />
-      );
-    case "pending":
-      return (
-        <Chip
-          label="Pending"
-          size="small"
-          icon={<Clock size={12} />}
-          sx={{ backgroundColor: "#F9FAFB", color: "#374151", fontSize: 11, height: 22 }}
-        />
-      );
-    case "failed":
-      return (
-        <Chip
-          label="Failed"
-          size="small"
-          icon={<XCircle size={12} />}
-          sx={{ backgroundColor: "#FEF2F2", color: "#991B1B", fontSize: 11, height: 22 }}
-        />
-      );
-    default:
-      return <Chip label={status} size="small" sx={{ fontSize: 11, height: 22 }} />;
-  }
-}
-
-function getModeChip(mode: string) {
-  const labels: Record<string, string> = {
-    quantitative_audit: "Quantitative",
-    impact_assessment: "Assessment",
-    compliance_checklist: "Checklist",
-    framework_assessment: "Framework",
-    custom: "Custom",
-  };
-  return (
-    <Chip
-      label={labels[mode] || mode}
-      size="small"
-      variant="outlined"
-      sx={{ fontSize: 11, height: 22, borderColor: "#d0d5dd" }}
-    />
-  );
 }
 
 function getResultSummary(audit: BiasAuditSummary) {
@@ -88,12 +29,8 @@ function getResultSummary(audit: BiasAuditSummary) {
   );
 }
 
-function formatDate(dateStr: string | null) {
-  if (!dateStr) return "—";
-  return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-}
-
 export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListProps) {
+  const theme = useTheme();
   const [audits, setAudits] = useState<BiasAuditSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -164,13 +101,19 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
     [audits, searchQuery]
   );
 
+  const headerCellSx = {
+    fontSize: 12,
+    fontWeight: 600,
+    color: theme.palette.text.secondary,
+  };
+
   return (
     <Box sx={{ width: "100%" }}>
       {/* Header */}
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
         <Stack spacing={0.5}>
-          <Typography sx={{ fontSize: 15, fontWeight: 600, color: "#111827" }}>Bias audits</Typography>
-          <Typography sx={{ fontSize: 13, color: "#667085" }}>
+          <Typography sx={{ fontSize: 15, fontWeight: 600, color: theme.palette.text.primary }}>Bias audits</Typography>
+          <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
             Run compliance-aware bias audits against demographic datasets
           </Typography>
         </Stack>
@@ -178,7 +121,7 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
           variant="contained"
           text="New bias audit"
           onClick={() => setModalOpen(true)}
-          sx={{ height: 34, fontSize: 13, backgroundColor: "#13715B", "&:hover": { backgroundColor: "#0F5A47" } }}
+          sx={{ height: 34, fontSize: 13 }}
         />
       </Stack>
 
@@ -194,97 +137,92 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
       )}
 
       {/* Content */}
-      <Box sx={{ border: "1px solid #d0d5dd", borderRadius: "4px", backgroundColor: "#fff" }}>
-        {loading ? (
-          <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
-            <CircularProgress size={24} sx={{ color: "#13715B" }} />
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <CircularProgress size={24} sx={{ color: theme.palette.primary.main }} />
+        </Box>
+      ) : filteredAudits.length === 0 ? (
+        <EmptyState
+          message="No bias audits yet. Create your first bias audit to get started."
+          showBorder
+        />
+      ) : (
+        <Box
+          component="table"
+          sx={{
+            width: "100%",
+            borderCollapse: "collapse",
+            border: `1px solid ${theme.palette.border.dark}`,
+            borderRadius: "4px",
+            overflow: "hidden",
+            backgroundColor: theme.palette.background.paper,
+          }}
+        >
+          <Box component="thead">
+            <Box
+              component="tr"
+              sx={{ borderBottom: `1px solid ${theme.palette.border.dark}` }}
+            >
+              <Box component="th" sx={{ ...headerCellSx, width: "25%", textAlign: "left", py: 1, px: 2 }}>Framework</Box>
+              <Box component="th" sx={{ ...headerCellSx, width: "15%", textAlign: "left", py: 1, px: 2 }}>Mode</Box>
+              <Box component="th" sx={{ ...headerCellSx, width: "15%", textAlign: "left", py: 1, px: 2 }}>Status</Box>
+              <Box component="th" sx={{ ...headerCellSx, width: "15%", textAlign: "left", py: 1, px: 2 }}>Result</Box>
+              <Box component="th" sx={{ ...headerCellSx, width: "20%", textAlign: "left", py: 1, px: 2 }}>Date</Box>
+              <Box component="th" sx={{ ...headerCellSx, width: "10%", textAlign: "left", py: 1, px: 2 }}>Actions</Box>
+            </Box>
           </Box>
-        ) : filteredAudits.length === 0 ? (
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              py: 8,
-              gap: 2,
-            }}
-          >
-            <AlertTriangle size={40} color="#d0d5dd" strokeWidth={1} />
-            <Typography sx={{ fontSize: 14, color: "#667085" }}>No bias audits yet</Typography>
-            <Typography sx={{ fontSize: 13, color: "#98a2b3" }}>
-              Create your first bias audit to get started
-            </Typography>
-          </Box>
-        ) : (
-          <>
-            {/* Table Header */}
-            <Stack direction="row" sx={{ borderBottom: "1px solid #d0d5dd", py: 1, px: 2 }}>
-              <Typography sx={{ width: "25%", fontSize: 12, fontWeight: 600, color: "#475467" }}>
-                Framework
-              </Typography>
-              <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467" }}>Mode</Typography>
-              <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467" }}>
-                Status
-              </Typography>
-              <Typography sx={{ width: "15%", fontSize: 12, fontWeight: 600, color: "#475467" }}>
-                Result
-              </Typography>
-              <Typography sx={{ width: "20%", fontSize: 12, fontWeight: 600, color: "#475467" }}>Date</Typography>
-              <Typography sx={{ width: "10%", fontSize: 12, fontWeight: 600, color: "#475467" }}>
-                Actions
-              </Typography>
-            </Stack>
-
-            {/* Table Rows */}
+          <Box component="tbody">
             {filteredAudits.map((audit) => (
-              <Stack
+              <Box
+                component="tr"
                 key={audit.id}
-                direction="row"
-                alignItems="center"
-                sx={{
-                  borderBottom: "1px solid #f2f4f7",
-                  py: 1.5,
-                  px: 2,
-                  cursor: "pointer",
-                  "&:hover": { backgroundColor: "#f9fafb" },
-                }}
                 onClick={() => onViewAudit(audit.id)}
+                sx={{
+                  borderBottom: `1px solid ${theme.palette.border.light}`,
+                  cursor: "pointer",
+                  "&:hover": { backgroundColor: theme.palette.action.hover },
+                }}
               >
-                <Typography sx={{ width: "25%", fontSize: 13, color: "#111827" }}>{audit.presetName}</Typography>
-                <Box sx={{ width: "15%" }}>{getModeChip(audit.mode)}</Box>
-                <Box sx={{ width: "15%" }}>{getStatusChip(audit.status)}</Box>
-                <Box sx={{ width: "15%" }}>{getResultSummary(audit)}</Box>
-                <Typography sx={{ width: "20%", fontSize: 13, color: "#667085" }}>
-                  {formatDate(audit.createdAt)}
-                </Typography>
-                <Stack direction="row" spacing={0.5} sx={{ width: "10%" }}>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onViewAudit(audit.id);
-                    }}
-                    sx={{ padding: 0.5 }}
-                  >
-                    <Eye size={16} strokeWidth={1.5} color="#667085" />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setAuditToDelete(audit.id);
-                    }}
-                    sx={{ padding: 0.5 }}
-                  >
-                    <Trash2 size={16} strokeWidth={1.5} color="#667085" />
-                  </IconButton>
-                </Stack>
-              </Stack>
+                <Box component="td" sx={{ py: 1.5, px: 2 }}>
+                  <Typography sx={{ fontSize: 13, color: theme.palette.text.primary }}>{audit.presetName}</Typography>
+                </Box>
+                <Box component="td" sx={{ py: 1.5, px: 2 }}>{getModeChip(audit.mode)}</Box>
+                <Box component="td" sx={{ py: 1.5, px: 2 }}>{getStatusChip(audit.status)}</Box>
+                <Box component="td" sx={{ py: 1.5, px: 2 }}>{getResultSummary(audit)}</Box>
+                <Box component="td" sx={{ py: 1.5, px: 2 }}>
+                  <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
+                    {formatDate(audit.createdAt)}
+                  </Typography>
+                </Box>
+                <Box component="td" sx={{ py: 1.5, px: 2 }}>
+                  <Stack direction="row" spacing={0.5}>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onViewAudit(audit.id);
+                      }}
+                      sx={{ padding: 0.5 }}
+                    >
+                      <Eye size={16} strokeWidth={1.5} color={theme.palette.text.secondary} />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setAuditToDelete(audit.id);
+                      }}
+                      sx={{ padding: 0.5 }}
+                    >
+                      <Trash2 size={16} strokeWidth={1.5} color={theme.palette.text.secondary} />
+                    </IconButton>
+                  </Stack>
+                </Box>
+              </Box>
             ))}
-          </>
-        )}
-      </Box>
+          </Box>
+        </Box>
+      )}
 
       {/* New Bias Audit Modal */}
       <NewBiasAuditModal

--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsDashboard.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsDashboard.tsx
@@ -63,6 +63,8 @@ import ProjectScorers from "./ProjectScorers";
 import ModelsPage from "./ModelsPage";
 import ExperimentDetailContent from "./ExperimentDetailContent";
 import ArenaPage from "./ArenaPage";
+import BiasAuditsList from "./BiasAuditsList";
+import BiasAuditDetail from "./BiasAuditDetail";
 import type { DeepEvalProject } from "./types";
 
 // Track if Evals dashboard has been loaded before (persists across module switches)
@@ -218,6 +220,7 @@ export default function EvalsDashboard() {
   const shouldSkipLoading = hasLoadedEvalsBefore && !!projectId;
   const [initialLoading, setInitialLoading] = useState(!shouldSkipLoading);
   const [selectedExperimentId, setSelectedExperimentId] = useState<string | null>(null);
+  const [selectedBiasAuditId, setSelectedBiasAuditId] = useState<string | null>(null);
   const [recentExperiments, setRecentExperiments] = useState<RecentExperiment[]>(() => {
     try {
       const stored = localStorage.getItem(RECENT_EXPERIMENTS_KEY);
@@ -1639,6 +1642,14 @@ export default function EvalsDashboard() {
 
               {tab === "arena" && (
                 <ArenaPage orgId={orgId || currentProject?.orgId || ""} />
+              )}
+
+              {tab === "bias-audits" && (
+                selectedBiasAuditId ? (
+                  <BiasAuditDetail auditId={selectedBiasAuditId} onBack={() => setSelectedBiasAuditId(null)} />
+                ) : (
+                  <BiasAuditsList orgId={orgId || currentProject?.orgId || ""} onViewAudit={(id) => setSelectedBiasAuditId(id)} />
+                )
               )}
 
               {tab === "configuration" && (

--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
@@ -7,6 +7,7 @@ import {
   KeyRound,
   Swords,
   Cpu,
+  Scale,
 } from "lucide-react";
 import SidebarShell, {
   SidebarMenuItem,
@@ -116,12 +117,19 @@ export default function EvalsSidebar({
       disabled: false, // Always enabled - org-scoped
     },
     {
+      id: "bias-audits",
+      label: "Bias audits",
+      value: "bias-audits",
+      icon: <Scale size={16} strokeWidth={1.5} />,
+      disabled: false, // Always enabled - org-scoped
+      dividerAfter: true,
+    },
+    {
       id: "configuration",
       label: "Configuration",
       value: "configuration",
       icon: <Settings size={16} strokeWidth={1.5} />,
       disabled: disabled,
-      dividerAfter: true,
     },
     {
       id: "settings",

--- a/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
@@ -1,0 +1,696 @@
+/**
+ * NewBiasAuditModal - Multi-step modal for creating a new bias audit
+ *
+ * Uses StepperModal to guide users through:
+ * 1. Selecting a compliance framework preset
+ * 2. Entering AEDT (Automated Employment Decision Tool) information
+ * 3. Uploading demographic data and mapping columns
+ * 4. Reviewing configuration and running the audit
+ *
+ * @component
+ */
+
+import { useState, useEffect, useCallback, ChangeEvent } from "react";
+import { Box, Stack, Typography, Grid, Chip, CircularProgress } from "@mui/material";
+import { Upload, FileSpreadsheet, CheckCircle } from "lucide-react";
+import StepperModal from "../../components/Modals/StepperModal";
+import Field from "../../components/Inputs/Field";
+import Select from "../../components/Inputs/Select";
+import {
+  listBiasAuditPresets,
+  getBiasAuditPreset,
+  runBiasAudit,
+  type BiasAuditPresetSummary,
+  type BiasAuditPreset,
+  type CreateBiasAuditConfig,
+} from "../../../application/repository/deepEval.repository";
+
+interface NewBiasAuditModalProps {
+  /** Controls modal visibility */
+  isOpen: boolean;
+  /** Callback when modal closes */
+  onClose: () => void;
+  /** Organization ID for the audit */
+  orgId: string;
+  /** Callback when audit is successfully created */
+  onAuditCreated: (auditId: string) => void;
+}
+
+/**
+ * PresetCard - Card component for displaying a bias audit preset
+ */
+function PresetCard({
+  preset,
+  selected,
+  onClick,
+}: {
+  preset: BiasAuditPresetSummary;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const modeColors: Record<string, { bg: string; color: string }> = {
+    quantitative_audit: { bg: "#ECFDF5", color: "#065F46" },
+    impact_assessment: { bg: "#EFF6FF", color: "#1E40AF" },
+    compliance_checklist: { bg: "#FFF7ED", color: "#9A3412" },
+    framework_assessment: { bg: "#F5F3FF", color: "#5B21B6" },
+    custom: { bg: "#F9FAFB", color: "#374151" },
+  };
+
+  const modeLabels: Record<string, string> = {
+    quantitative_audit: "Quantitative",
+    impact_assessment: "Assessment",
+    compliance_checklist: "Checklist",
+    framework_assessment: "Framework",
+    custom: "Custom",
+  };
+
+  const mc = modeColors[preset.mode] || modeColors.custom;
+
+  return (
+    <Box
+      onClick={onClick}
+      sx={{
+        border: selected ? "2px solid #13715B" : "1px solid #d0d5dd",
+        borderRadius: "4px",
+        p: 2,
+        cursor: "pointer",
+        backgroundColor: selected ? "#F0FDF9" : "#fff",
+        "&:hover": { borderColor: "#13715B" },
+        transition: "border-color 0.15s",
+      }}
+    >
+      <Stack spacing={1}>
+        <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+          <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#111827" }}>
+            {preset.name}
+          </Typography>
+          <Chip
+            label={modeLabels[preset.mode] || preset.mode}
+            size="small"
+            sx={{
+              fontSize: 10,
+              height: 20,
+              backgroundColor: mc.bg,
+              color: mc.color,
+            }}
+          />
+        </Stack>
+        <Typography sx={{ fontSize: 11, color: "#667085" }}>
+          {preset.jurisdiction}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: 12,
+            color: "#475467",
+            lineHeight: 1.4,
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {preset.description}
+        </Typography>
+      </Stack>
+    </Box>
+  );
+}
+
+const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
+  isOpen,
+  onClose,
+  orgId,
+  onAuditCreated,
+}) => {
+  // Step control
+  const [activeStep, setActiveStep] = useState(0);
+
+  // Step 1: Preset selection
+  const [presets, setPresets] = useState<BiasAuditPresetSummary[]>([]);
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+  const [fullPreset, setFullPreset] = useState<BiasAuditPreset | null>(null);
+  const [loadingPresets, setLoadingPresets] = useState(true);
+  const [loadingPreset, setLoadingPreset] = useState(false);
+
+  // Step 2: AEDT metadata
+  const [aedtName, setAedtName] = useState("");
+  const [aedtDescription, setAedtDescription] = useState("");
+  const [distributionDate, setDistributionDate] = useState("");
+  const [dataSourceDescription, setDataSourceDescription] = useState("");
+
+  // Step 3: Demographic data
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [csvHeaders, setCsvHeaders] = useState<string[]>([]);
+  const [csvPreview, setCsvPreview] = useState<string[][]>([]);
+  const [columnMapping, setColumnMapping] = useState<Record<string, string>>({});
+  const [outcomeColumn, setOutcomeColumn] = useState("");
+
+  // Step 4: Review & run
+  const [threshold, setThreshold] = useState<number | null>(0.8);
+  const [smallSampleExclusion, setSmallSampleExclusion] = useState<number | null>(null);
+  const [intersectionalEnabled, setIntersectionalEnabled] = useState(false);
+
+  // Submission state
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Load presets on modal open
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoadingPresets(true);
+    listBiasAuditPresets()
+      .then(setPresets)
+      .catch((err) => {
+        console.error("Failed to load presets:", err);
+      })
+      .finally(() => setLoadingPresets(false));
+  }, [isOpen]);
+
+  // Handle preset selection
+  const handlePresetSelect = async (presetId: string) => {
+    setSelectedPresetId(presetId);
+    setLoadingPreset(true);
+    try {
+      const preset = await getBiasAuditPreset(presetId);
+      setFullPreset(preset);
+      // Auto-fill from preset
+      setThreshold(preset.threshold ?? 0.8);
+      setSmallSampleExclusion(preset.small_sample_exclusion ?? null);
+      setIntersectionalEnabled(preset.intersectional?.required ?? false);
+    } catch (err) {
+      console.error("Failed to load preset:", err);
+    } finally {
+      setLoadingPreset(false);
+    }
+  };
+
+  // Handle CSV file upload and parsing
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setCsvFile(file);
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const text = event.target?.result as string;
+      const lines = text.split("\n").filter((l) => l.trim());
+      if (lines.length === 0) return;
+
+      const headers = lines[0]
+        .split(",")
+        .map((h) => h.trim().replace(/^"|"$/g, ""));
+      setCsvHeaders(headers);
+
+      const preview: string[][] = [];
+      for (let i = 1; i < Math.min(lines.length, 6); i++) {
+        preview.push(
+          lines[i].split(",").map((c) => c.trim().replace(/^"|"$/g, ""))
+        );
+      }
+      setCsvPreview(preview);
+    };
+    reader.readAsText(file);
+  };
+
+  // Handle column mapping change
+  const handleColumnMappingChange = (categoryKey: string, columnName: string) => {
+    setColumnMapping((prev) => ({ ...prev, [categoryKey]: columnName }));
+  };
+
+  // Handle final submission
+  const handleSubmit = async () => {
+    if (!csvFile || !fullPreset) return;
+    setIsSubmitting(true);
+    try {
+      const config: CreateBiasAuditConfig = {
+        presetId: fullPreset.id,
+        presetName: fullPreset.name,
+        mode: fullPreset.mode,
+        orgId,
+        categories: fullPreset.categories,
+        intersectional: {
+          required: intersectionalEnabled,
+          cross: fullPreset.intersectional?.cross || [],
+        },
+        metrics: fullPreset.metrics,
+        threshold,
+        smallSampleExclusion: smallSampleExclusion,
+        outcomeColumn,
+        columnMapping,
+        metadata: {
+          aedt_name: aedtName,
+          description: aedtDescription,
+          distribution_date: distributionDate,
+          data_source_description: dataSourceDescription,
+        },
+      };
+      const result = await runBiasAudit(csvFile, config);
+      onAuditCreated(result.auditId);
+      handleClose();
+    } catch (err) {
+      console.error("Failed to create bias audit:", err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Reset all state on close
+  const handleClose = () => {
+    setActiveStep(0);
+    setSelectedPresetId(null);
+    setFullPreset(null);
+    setAedtName("");
+    setAedtDescription("");
+    setDistributionDate("");
+    setDataSourceDescription("");
+    setCsvFile(null);
+    setCsvHeaders([]);
+    setCsvPreview([]);
+    setColumnMapping({});
+    setOutcomeColumn("");
+    setThreshold(0.8);
+    setSmallSampleExclusion(null);
+    setIntersectionalEnabled(false);
+    onClose();
+  };
+
+  // Determine if current step is valid
+  const canProceed = (() => {
+    switch (activeStep) {
+      case 0:
+        return !!selectedPresetId && !loadingPreset;
+      case 1:
+        return aedtName.trim().length > 0;
+      case 2: {
+        if (!csvFile || !outcomeColumn) return false;
+        const categoryKeys = Object.keys(fullPreset?.categories || {});
+        return categoryKeys.every((key) => !!columnMapping[key]);
+      }
+      case 3:
+        return true;
+      default:
+        return false;
+    }
+  })();
+
+  // Render step content
+  const renderStepContent = () => {
+    switch (activeStep) {
+      case 0:
+        return renderStep1();
+      case 1:
+        return renderStep2();
+      case 2:
+        return renderStep3();
+      case 3:
+        return renderStep4();
+      default:
+        return null;
+    }
+  };
+
+  // Step 1: Compliance framework selection
+  const renderStep1 = () => (
+    <Stack spacing={3}>
+      <Box>
+        <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#344054", mb: 1 }}>
+          Select a compliance framework
+        </Typography>
+        <Typography sx={{ fontSize: 13, color: "#667085", mb: 3 }}>
+          Choose the regulatory framework that applies to your bias audit
+        </Typography>
+      </Box>
+
+      {loadingPresets ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress size={32} sx={{ color: "#13715B" }} />
+        </Box>
+      ) : (
+        <Grid container spacing={2}>
+          {presets.map((preset) => (
+            <Grid item xs={12} sm={6} md={4} key={preset.id}>
+              <PresetCard
+                preset={preset}
+                selected={selectedPresetId === preset.id}
+                onClick={() => handlePresetSelect(preset.id)}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      {loadingPreset && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+          <CircularProgress size={24} sx={{ color: "#13715B" }} />
+        </Box>
+      )}
+    </Stack>
+  );
+
+  // Step 2: AEDT metadata
+  const renderStep2 = () => (
+    <Stack spacing={3}>
+      <Box>
+        <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#344054", mb: 1 }}>
+          Model / AEDT information
+        </Typography>
+        <Typography sx={{ fontSize: 13, color: "#667085", mb: 3 }}>
+          Provide details about the Automated Employment Decision Tool being audited
+        </Typography>
+      </Box>
+
+      <Field
+        id="aedt-name"
+        label="AEDT name"
+        placeholder="Enter the name of your decision tool"
+        value={aedtName}
+        onChange={(e) => setAedtName(e.target.value)}
+        isRequired
+      />
+
+      <Field
+        id="aedt-description"
+        label="Description"
+        placeholder="Describe the purpose and function of this tool"
+        value={aedtDescription}
+        onChange={(e) => setAedtDescription(e.target.value)}
+        type="description"
+        rows={3}
+        isOptional
+      />
+
+      <Field
+        id="distribution-date"
+        label="Distribution date"
+        placeholder="YYYY-MM-DD"
+        value={distributionDate}
+        onChange={(e) => setDistributionDate(e.target.value)}
+        isOptional
+      />
+
+      <Field
+        id="data-source-description"
+        label="Data source description"
+        placeholder="Describe where this data comes from"
+        value={dataSourceDescription}
+        onChange={(e) => setDataSourceDescription(e.target.value)}
+        type="description"
+        rows={3}
+        isOptional
+      />
+    </Stack>
+  );
+
+  // Step 3: Demographic data upload and mapping
+  const renderStep3 = () => (
+    <Stack spacing={3}>
+      <Box>
+        <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#344054", mb: 1 }}>
+          Upload demographic data
+        </Typography>
+        <Typography sx={{ fontSize: 13, color: "#667085", mb: 3 }}>
+          Upload a CSV file containing demographic information and outcomes
+        </Typography>
+      </Box>
+
+      {/* File upload area */}
+      <Box
+        sx={{
+          border: "2px dashed #d0d5dd",
+          borderRadius: "4px",
+          p: 4,
+          textAlign: "center",
+          cursor: "pointer",
+          "&:hover": { borderColor: "#13715B", backgroundColor: "#F9FAFB" },
+          position: "relative",
+        }}
+        onClick={() => document.getElementById("csv-upload-input")?.click()}
+      >
+        <input
+          id="csv-upload-input"
+          type="file"
+          accept=".csv"
+          onChange={handleFileChange}
+          style={{ display: "none" }}
+        />
+        {csvFile ? (
+          <Stack alignItems="center" spacing={1}>
+            <FileSpreadsheet size={32} color="#13715B" strokeWidth={1.5} />
+            <Typography sx={{ fontSize: 13, fontWeight: 500, color: "#111827" }}>
+              {csvFile.name}
+            </Typography>
+            <Typography sx={{ fontSize: 12, color: "#667085" }}>
+              {csvHeaders.length} columns detected
+            </Typography>
+          </Stack>
+        ) : (
+          <Stack alignItems="center" spacing={1}>
+            <Upload size={32} color="#98a2b3" strokeWidth={1.5} />
+            <Typography sx={{ fontSize: 13, color: "#475467" }}>
+              Click to upload CSV file
+            </Typography>
+            <Typography sx={{ fontSize: 12, color: "#98a2b3" }}>
+              Comma-separated values with demographic columns
+            </Typography>
+          </Stack>
+        )}
+      </Box>
+
+      {/* Column mapping */}
+      {csvFile && csvHeaders.length > 0 && (
+        <Stack spacing={2} mt={3}>
+          <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#344054" }}>
+            Column mapping
+          </Typography>
+
+          {Object.entries(fullPreset?.categories || {}).map(([key, cat]) => (
+            <Stack key={key} direction="row" alignItems="center" spacing={2}>
+              <Typography sx={{ fontSize: 13, color: "#475467", minWidth: 140 }}>
+                {cat.label}
+              </Typography>
+              <Select
+                id={`mapping-${key}`}
+                value={columnMapping[key] || ""}
+                onChange={(e) =>
+                  handleColumnMappingChange(key, String(e.target.value))
+                }
+                items={csvHeaders.map((h) => ({ _id: h, name: h }))}
+                placeholder={`Select column for ${cat.label}`}
+                sx={{ flex: 1 }}
+              />
+            </Stack>
+          ))}
+
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <Typography sx={{ fontSize: 13, color: "#475467", minWidth: 140 }}>
+              Outcome column
+            </Typography>
+            <Select
+              id="outcome-column"
+              value={outcomeColumn}
+              onChange={(e) => setOutcomeColumn(String(e.target.value))}
+              items={csvHeaders.map((h) => ({ _id: h, name: h }))}
+              placeholder="Select outcome column"
+              sx={{ flex: 1 }}
+            />
+          </Stack>
+        </Stack>
+      )}
+
+      {/* CSV preview */}
+      {csvPreview.length > 0 && (
+        <Box mt={3}>
+          <Typography
+            sx={{ fontSize: 13, fontWeight: 600, color: "#344054", mb: 2 }}
+          >
+            Data preview
+          </Typography>
+          <Box
+            sx={{
+              border: "1px solid #d0d5dd",
+              borderRadius: "4px",
+              overflow: "auto",
+            }}
+          >
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                fontSize: "12px",
+              }}
+            >
+              <thead>
+                <tr style={{ backgroundColor: "#F9FAFB" }}>
+                  {csvHeaders.map((header, idx) => (
+                    <th
+                      key={idx}
+                      style={{
+                        padding: "8px 12px",
+                        textAlign: "left",
+                        fontWeight: 600,
+                        color: "#344054",
+                        borderBottom: "1px solid #d0d5dd",
+                      }}
+                    >
+                      {header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {csvPreview.map((row, rowIdx) => (
+                  <tr
+                    key={rowIdx}
+                    style={{
+                      borderBottom:
+                        rowIdx < csvPreview.length - 1
+                          ? "1px solid #EAECF0"
+                          : "none",
+                    }}
+                  >
+                    {row.map((cell, cellIdx) => (
+                      <td
+                        key={cellIdx}
+                        style={{
+                          padding: "8px 12px",
+                          color: "#475467",
+                        }}
+                      >
+                        {cell}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Box>
+        </Box>
+      )}
+    </Stack>
+  );
+
+  // Step 4: Review & run
+  const renderStep4 = () => (
+    <Stack spacing={3}>
+      <Box>
+        <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#344054", mb: 1 }}>
+          Review & run
+        </Typography>
+        <Typography sx={{ fontSize: 13, color: "#667085", mb: 3 }}>
+          Review your configuration and adjust audit settings before running
+        </Typography>
+      </Box>
+
+      {/* Summary */}
+      <Box sx={{ border: "1px solid #d0d5dd", borderRadius: "4px", p: 2 }}>
+        <Typography
+          sx={{ fontSize: 13, fontWeight: 600, color: "#344054", mb: 1.5 }}
+        >
+          Summary
+        </Typography>
+        <Stack spacing={1}>
+          <Stack direction="row" justifyContent="space-between">
+            <Typography sx={{ fontSize: 13, color: "#667085" }}>
+              Framework
+            </Typography>
+            <Typography sx={{ fontSize: 13, color: "#111827", fontWeight: 500 }}>
+              {fullPreset?.name}
+            </Typography>
+          </Stack>
+          <Stack direction="row" justifyContent="space-between">
+            <Typography sx={{ fontSize: 13, color: "#667085" }}>
+              AEDT name
+            </Typography>
+            <Typography sx={{ fontSize: 13, color: "#111827" }}>
+              {aedtName}
+            </Typography>
+          </Stack>
+          <Stack direction="row" justifyContent="space-between">
+            <Typography sx={{ fontSize: 13, color: "#667085" }}>Dataset</Typography>
+            <Typography sx={{ fontSize: 13, color: "#111827" }}>
+              {csvFile?.name}
+            </Typography>
+          </Stack>
+          <Stack direction="row" justifyContent="space-between">
+            <Typography sx={{ fontSize: 13, color: "#667085" }}>
+              Categories
+            </Typography>
+            <Typography sx={{ fontSize: 13, color: "#111827" }}>
+              {Object.keys(fullPreset?.categories || {}).length}
+            </Typography>
+          </Stack>
+        </Stack>
+      </Box>
+
+      {/* Audit settings */}
+      <Stack spacing={2}>
+        <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#344054" }}>
+          Audit settings
+        </Typography>
+        <Stack direction="row" spacing={2}>
+          <Field
+            id="threshold"
+            label="Threshold (4/5ths rule)"
+            type="number"
+            value={threshold?.toString() || ""}
+            onChange={(e) =>
+              setThreshold(e.target.value ? parseFloat(e.target.value) : null)
+            }
+            sx={{ flex: 1 }}
+          />
+          <Field
+            id="small-sample-exclusion"
+            label="Small sample exclusion %"
+            type="number"
+            value={smallSampleExclusion?.toString() || ""}
+            onChange={(e) =>
+              setSmallSampleExclusion(
+                e.target.value ? parseFloat(e.target.value) : null
+              )
+            }
+            sx={{ flex: 1 }}
+          />
+        </Stack>
+        {fullPreset?.intersectional && (
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <input
+              type="checkbox"
+              checked={intersectionalEnabled}
+              onChange={(e) => setIntersectionalEnabled(e.target.checked)}
+              style={{ cursor: "pointer" }}
+            />
+            <Typography sx={{ fontSize: 13, color: "#475467" }}>
+              Enable intersectional analysis (
+              {fullPreset.intersectional.cross.join(" × ")})
+            </Typography>
+          </Stack>
+        )}
+      </Stack>
+    </Stack>
+  );
+
+  return (
+    <StepperModal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="New bias audit"
+      steps={[
+        "Compliance framework",
+        "Model / AEDT",
+        "Demographic data",
+        "Review & run",
+      ]}
+      activeStep={activeStep}
+      onNext={() => setActiveStep((prev) => prev + 1)}
+      onBack={() => setActiveStep((prev) => prev - 1)}
+      onSubmit={handleSubmit}
+      canProceed={canProceed}
+      isSubmitting={isSubmitting}
+      submitButtonText="Run audit"
+      maxWidth="900px"
+    >
+      {renderStepContent()}
+    </StepperModal>
+  );
+};
+
+export default NewBiasAuditModal;

--- a/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
@@ -10,12 +10,13 @@
  * @component
  */
 
-import { useState, useEffect, useCallback, useRef, ChangeEvent } from "react";
-import { Box, Stack, Typography, Grid, Chip, CircularProgress, Alert } from "@mui/material";
-import { Upload, FileSpreadsheet, CheckCircle } from "lucide-react";
+import { useState, useEffect, useRef, ChangeEvent } from "react";
+import { Box, Stack, Typography, Grid, Chip, CircularProgress, Alert, useTheme } from "@mui/material";
+import { Upload, FileSpreadsheet } from "lucide-react";
 import StepperModal from "../../components/Modals/StepperModal";
 import Field from "../../components/Inputs/Field";
 import Select from "../../components/Inputs/Select";
+import Checkbox from "../../components/Inputs/Checkbox";
 import {
   listBiasAuditPresets,
   getBiasAuditPreset,
@@ -48,6 +49,7 @@ function PresetCard({
   selected: boolean;
   onClick: () => void;
 }) {
+  const theme = useTheme();
   const modeColors: Record<string, { bg: string; color: string }> = {
     quantitative_audit: { bg: "#ECFDF5", color: "#065F46" },
     impact_assessment: { bg: "#EFF6FF", color: "#1E40AF" },
@@ -70,18 +72,18 @@ function PresetCard({
     <Box
       onClick={onClick}
       sx={{
-        border: selected ? "2px solid #13715B" : "1px solid #d0d5dd",
+        border: selected ? `2px solid ${theme.palette.primary.main}` : `1px solid ${theme.palette.border.dark}`,
         borderRadius: "4px",
         p: 2,
         cursor: "pointer",
-        backgroundColor: selected ? "#F0FDF9" : "#fff",
-        "&:hover": { borderColor: "#13715B" },
+        backgroundColor: selected ? "#F0FDF9" : theme.palette.background.paper,
+        "&:hover": { borderColor: theme.palette.primary.main },
         transition: "border-color 0.15s",
       }}
     >
       <Stack spacing={1}>
         <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-          <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#111827" }}>
+          <Typography sx={{ fontSize: 13, fontWeight: 600, color: theme.palette.text.primary }}>
             {preset.name}
           </Typography>
           <Chip
@@ -95,13 +97,13 @@ function PresetCard({
             }}
           />
         </Stack>
-        <Typography sx={{ fontSize: 11, color: "#667085" }}>
+        <Typography sx={{ fontSize: 11, color: theme.palette.text.secondary }}>
           {preset.jurisdiction}
         </Typography>
         <Typography
           sx={{
             fontSize: 12,
-            color: "#475467",
+            color: theme.palette.text.secondary,
             lineHeight: 1.4,
             display: "-webkit-box",
             WebkitLineClamp: 2,
@@ -367,7 +369,7 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
 
       {loadingPresets ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-          <CircularProgress size={32} sx={{ color: "#13715B" }} />
+          <CircularProgress size={32} sx={{ color: "primary.main" }} />
         </Box>
       ) : (
         <Grid container spacing={2}>
@@ -385,7 +387,7 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
 
       {loadingPreset && (
         <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-          <CircularProgress size={24} sx={{ color: "#13715B" }} />
+          <CircularProgress size={24} sx={{ color: "primary.main" }} />
         </Box>
       )}
     </Stack>
@@ -556,20 +558,16 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
               overflow: "auto",
             }}
           >
-            <table
-              style={{
-                width: "100%",
-                borderCollapse: "collapse",
-                fontSize: "12px",
-              }}
-            >
-              <thead>
-                <tr style={{ backgroundColor: "#F9FAFB" }}>
+            <Box component="table" sx={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+              <Box component="thead">
+                <Box component="tr" sx={{ backgroundColor: "#F9FAFB" }}>
                   {csvHeaders.map((header, idx) => (
-                    <th
+                    <Box
+                      component="th"
                       key={idx}
-                      style={{
-                        padding: "8px 12px",
+                      sx={{
+                        py: 1,
+                        px: 1.5,
                         textAlign: "left",
                         fontWeight: 600,
                         color: "#344054",
@@ -577,36 +575,32 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
                       }}
                     >
                       {header}
-                    </th>
+                    </Box>
                   ))}
-                </tr>
-              </thead>
-              <tbody>
+                </Box>
+              </Box>
+              <Box component="tbody">
                 {csvPreview.map((row, rowIdx) => (
-                  <tr
+                  <Box
+                    component="tr"
                     key={rowIdx}
-                    style={{
-                      borderBottom:
-                        rowIdx < csvPreview.length - 1
-                          ? "1px solid #EAECF0"
-                          : "none",
+                    sx={{
+                      borderBottom: rowIdx < csvPreview.length - 1 ? "1px solid #EAECF0" : "none",
                     }}
                   >
                     {row.map((cell, cellIdx) => (
-                      <td
+                      <Box
+                        component="td"
                         key={cellIdx}
-                        style={{
-                          padding: "8px 12px",
-                          color: "#475467",
-                        }}
+                        sx={{ py: 1, px: 1.5, color: "#475467" }}
                       >
                         {cell}
-                      </td>
+                      </Box>
                     ))}
-                  </tr>
+                  </Box>
                 ))}
-              </tbody>
-            </table>
+              </Box>
+            </Box>
           </Box>
         </Box>
       )}
@@ -702,18 +696,14 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
           />
         </Stack>
         {fullPreset?.intersectional && (
-          <Stack direction="row" alignItems="center" spacing={1}>
-            <input
-              type="checkbox"
-              checked={intersectionalEnabled}
-              onChange={(e) => setIntersectionalEnabled(e.target.checked)}
-              style={{ cursor: "pointer" }}
-            />
-            <Typography sx={{ fontSize: 13, color: "#475467" }}>
-              Enable intersectional analysis (
-              {fullPreset.intersectional.cross.join(" × ")})
-            </Typography>
-          </Stack>
+          <Checkbox
+            id="intersectional-analysis"
+            label={`Enable intersectional analysis (${fullPreset.intersectional.cross.join(" × ")})`}
+            isChecked={intersectionalEnabled}
+            value="intersectional"
+            onChange={(e) => setIntersectionalEnabled(e.target.checked)}
+            size="small"
+          />
         )}
       </Stack>
     </Stack>

--- a/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
@@ -11,7 +11,8 @@
  */
 
 import { useState, useEffect, useRef, ChangeEvent } from "react";
-import { Box, Stack, Typography, Grid, Chip, CircularProgress, Alert, useTheme } from "@mui/material";
+import { Box, Stack, Typography, CircularProgress, Alert, useTheme } from "@mui/material";
+import Chip from "../../components/Chip";
 import { Upload, FileSpreadsheet } from "lucide-react";
 import StepperModal from "../../components/Modals/StepperModal";
 import Field from "../../components/Inputs/Field";
@@ -72,9 +73,9 @@ function PresetCard({
     <Box
       onClick={onClick}
       sx={{
-        border: selected ? `2px solid ${theme.palette.primary.main}` : `1px solid ${theme.palette.border.dark}`,
+        border: `1px solid ${selected ? theme.palette.primary.main : theme.palette.border.dark}`,
         borderRadius: "4px",
-        p: 2,
+        p: "8px",
         cursor: "pointer",
         backgroundColor: selected ? "#F0FDF9" : theme.palette.background.paper,
         "&:hover": { borderColor: theme.palette.primary.main },
@@ -89,17 +90,11 @@ function PresetCard({
           <Chip
             label={modeLabels[preset.mode] || preset.mode}
             size="small"
-            sx={{
-              fontSize: 10,
-              height: 20,
-              backgroundColor: mc.bg,
-              color: mc.color,
-            }}
+            uppercase={false}
+            backgroundColor={mc.bg}
+            textColor={mc.color}
           />
         </Stack>
-        <Typography sx={{ fontSize: 11, color: theme.palette.text.secondary }}>
-          {preset.jurisdiction}
-        </Typography>
         <Typography
           sx={{
             fontSize: 12,
@@ -372,24 +367,24 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
           <CircularProgress size={32} sx={{ color: "primary.main" }} />
         </Box>
       ) : (
-        <Grid container spacing={2}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, 1fr)",
+            gap: "8px",
+          }}
+        >
           {presets.map((preset) => (
-            <Grid item xs={12} sm={6} md={4} key={preset.id}>
-              <PresetCard
-                preset={preset}
-                selected={selectedPresetId === preset.id}
-                onClick={() => handlePresetSelect(preset.id)}
-              />
-            </Grid>
+            <PresetCard
+              key={preset.id}
+              preset={preset}
+              selected={selectedPresetId === preset.id}
+              onClick={() => handlePresetSelect(preset.id)}
+            />
           ))}
-        </Grid>
-      )}
-
-      {loadingPreset && (
-        <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-          <CircularProgress size={24} sx={{ color: "primary.main" }} />
         </Box>
       )}
+
     </Stack>
   );
 

--- a/Clients/src/presentation/pages/EvalsDashboard/biasAuditHelpers.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/biasAuditHelpers.tsx
@@ -1,5 +1,4 @@
-import { Chip } from "@mui/material";
-import { CheckCircle, RefreshCw, Clock, XCircle } from "lucide-react";
+import Chip from "../../components/Chip";
 
 export function getStatusChip(status: string) {
   switch (status) {
@@ -8,8 +7,9 @@ export function getStatusChip(status: string) {
         <Chip
           label="Completed"
           size="small"
-          icon={<CheckCircle size={12} />}
-          sx={{ backgroundColor: "#ECFDF5", color: "#065F46", fontSize: 11, height: 22 }}
+          uppercase={false}
+          backgroundColor="#ECFDF5"
+          textColor="#065F46"
         />
       );
     case "running":
@@ -17,8 +17,9 @@ export function getStatusChip(status: string) {
         <Chip
           label="Running"
           size="small"
-          icon={<RefreshCw size={12} />}
-          sx={{ backgroundColor: "#EFF6FF", color: "#1E40AF", fontSize: 11, height: 22 }}
+          uppercase={false}
+          backgroundColor="#EFF6FF"
+          textColor="#1E40AF"
         />
       );
     case "pending":
@@ -26,8 +27,9 @@ export function getStatusChip(status: string) {
         <Chip
           label="Pending"
           size="small"
-          icon={<Clock size={12} />}
-          sx={{ backgroundColor: "#F9FAFB", color: "#374151", fontSize: 11, height: 22 }}
+          uppercase={false}
+          backgroundColor="#F9FAFB"
+          textColor="#374151"
         />
       );
     case "failed":
@@ -35,12 +37,13 @@ export function getStatusChip(status: string) {
         <Chip
           label="Failed"
           size="small"
-          icon={<XCircle size={12} />}
-          sx={{ backgroundColor: "#FEF2F2", color: "#991B1B", fontSize: 11, height: 22 }}
+          uppercase={false}
+          backgroundColor="#FEF2F2"
+          textColor="#991B1B"
         />
       );
     default:
-      return <Chip label={status} size="small" sx={{ fontSize: 11, height: 22 }} />;
+      return <Chip label={status} size="small" uppercase={false} />;
   }
 }
 
@@ -56,8 +59,8 @@ export function getModeChip(mode: string) {
     <Chip
       label={labels[mode] || mode}
       size="small"
-      variant="outlined"
-      sx={{ fontSize: 11, height: 22, borderColor: "#d0d5dd" }}
+      uppercase={false}
+      variant="default"
     />
   );
 }

--- a/Clients/src/presentation/pages/EvalsDashboard/biasAuditHelpers.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/biasAuditHelpers.tsx
@@ -1,0 +1,68 @@
+import { Chip } from "@mui/material";
+import { CheckCircle, RefreshCw, Clock, XCircle } from "lucide-react";
+
+export function getStatusChip(status: string) {
+  switch (status) {
+    case "completed":
+      return (
+        <Chip
+          label="Completed"
+          size="small"
+          icon={<CheckCircle size={12} />}
+          sx={{ backgroundColor: "#ECFDF5", color: "#065F46", fontSize: 11, height: 22 }}
+        />
+      );
+    case "running":
+      return (
+        <Chip
+          label="Running"
+          size="small"
+          icon={<RefreshCw size={12} />}
+          sx={{ backgroundColor: "#EFF6FF", color: "#1E40AF", fontSize: 11, height: 22 }}
+        />
+      );
+    case "pending":
+      return (
+        <Chip
+          label="Pending"
+          size="small"
+          icon={<Clock size={12} />}
+          sx={{ backgroundColor: "#F9FAFB", color: "#374151", fontSize: 11, height: 22 }}
+        />
+      );
+    case "failed":
+      return (
+        <Chip
+          label="Failed"
+          size="small"
+          icon={<XCircle size={12} />}
+          sx={{ backgroundColor: "#FEF2F2", color: "#991B1B", fontSize: 11, height: 22 }}
+        />
+      );
+    default:
+      return <Chip label={status} size="small" sx={{ fontSize: 11, height: 22 }} />;
+  }
+}
+
+export function getModeChip(mode: string) {
+  const labels: Record<string, string> = {
+    quantitative_audit: "Quantitative",
+    impact_assessment: "Assessment",
+    compliance_checklist: "Checklist",
+    framework_assessment: "Framework",
+    custom: "Custom",
+  };
+  return (
+    <Chip
+      label={labels[mode] || mode}
+      size="small"
+      variant="outlined"
+      sx={{ fontSize: 11, height: 22, borderColor: "#d0d5dd" }}
+    />
+  );
+}
+
+export function formatDate(dateStr: string | null) {
+  if (!dateStr) return "—";
+  return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}

--- a/EvalServer/src/app.py
+++ b/EvalServer/src/app.py
@@ -9,6 +9,7 @@ from routers.deepeval_projects import router as deepeval_projects
 from routers.evaluation_logs import router as evaluation_logs
 from routers.deepeval_orgs import router as deepeval_orgs
 from routers.deepeval_arena import router as deepeval_arena
+from routers.bias_audits import router as bias_audits
 from middlewares.middleware import TenantMiddleware
 from database.redis import close_redis
 from alembic.config import Config
@@ -66,6 +67,7 @@ app.include_router(deepeval, prefix="/deepeval", tags=["DeepEval"])
 app.include_router(deepeval_projects, prefix="/deepeval", tags=["DeepEval Projects"])
 app.include_router(deepeval_orgs, prefix="/deepeval", tags=["DeepEval Orgs"])
 app.include_router(deepeval_arena, prefix="/deepeval", tags=["DeepEval Arena"])
+app.include_router(bias_audits, prefix="/deepeval", tags=["Bias Audits"])
 app.include_router(evaluation_logs, tags=["Evaluation Logs & Monitoring"])
 
 if __name__ == "__main__":

--- a/EvalServer/src/controllers/bias_audits.py
+++ b/EvalServer/src/controllers/bias_audits.py
@@ -1,0 +1,359 @@
+"""
+Bias Audits Controller
+
+Handles bias audit creation, background task execution,
+status polling, and result retrieval.
+"""
+
+import json
+import traceback
+from datetime import datetime
+from typing import Dict, Any, Optional
+from fastapi import HTTPException, BackgroundTasks, UploadFile
+from fastapi.responses import JSONResponse
+
+from database.db import get_db
+from crud.bias_audits import (
+    create_bias_audit,
+    get_bias_audit,
+    update_bias_audit_status,
+    list_bias_audits,
+    delete_bias_audit,
+    create_bias_audit_result_rows,
+    get_bias_audit_result_rows,
+)
+
+import sys
+from pathlib import Path
+
+# Add engines to path
+engines_path = str(Path(__file__).parent.parent / "engines")
+if engines_path not in sys.path:
+    sys.path.insert(0, engines_path)
+
+
+async def list_presets_controller() -> JSONResponse:
+    """List all available bias audit presets (summaries only)."""
+    from presets.bias_audits.loader import list_presets
+    summaries = list_presets()
+    return JSONResponse(status_code=200, content={"presets": summaries})
+
+
+async def get_preset_controller(preset_id: str) -> JSONResponse:
+    """Get full details of a single preset."""
+    from presets.bias_audits.loader import get_preset
+    preset = get_preset(preset_id)
+    if not preset:
+        raise HTTPException(status_code=404, detail=f"Preset '{preset_id}' not found")
+    return JSONResponse(status_code=200, content={"preset": preset})
+
+
+async def create_bias_audit_controller(
+    background_tasks: BackgroundTasks,
+    dataset: UploadFile,
+    config_json: str,
+    tenant: str,
+    user_id: Optional[str] = None,
+    org_id: Optional[str] = None,
+) -> JSONResponse:
+    """
+    Create and execute a bias audit.
+
+    1. Parse config, load preset, merge overrides
+    2. Save audit record with status=pending
+    3. Launch background task
+    4. Return 202 with audit ID
+    """
+    try:
+        config_data = json.loads(config_json)
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid config JSON: {e}")
+
+    preset_id = config_data.get("presetId", "custom")
+    from presets.bias_audits.loader import get_preset
+    preset = get_preset(preset_id)
+    preset_name = preset["name"] if preset else config_data.get("presetName", "Custom")
+    mode = preset["mode"] if preset else config_data.get("mode", "quantitative_audit")
+
+    # Generate audit ID
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    audit_id = f"bias_audit_{tenant}_{timestamp}"
+
+    # Read CSV bytes
+    csv_bytes = await dataset.read()
+    if not csv_bytes:
+        raise HTTPException(status_code=400, detail="Empty dataset file")
+
+    # Resolve org_id
+    effective_org_id = org_id or config_data.get("orgId", "")
+    if not effective_org_id:
+        raise HTTPException(status_code=400, detail="org_id is required")
+
+    # Save to DB
+    try:
+        async with get_db() as db:
+            created = await create_bias_audit(
+                tenant=tenant,
+                db=db,
+                audit_id=audit_id,
+                org_id=effective_org_id,
+                project_id=config_data.get("projectId"),
+                preset_id=preset_id,
+                preset_name=preset_name,
+                mode=mode,
+                config=config_data,
+                created_by=user_id,
+            )
+            await db.commit()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to create audit: {e}")
+
+    # Launch background task
+    background_tasks.add_task(
+        run_bias_audit_task,
+        audit_id=audit_id,
+        csv_bytes=csv_bytes,
+        config_data=config_data,
+        preset=preset,
+        tenant=tenant,
+    )
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            "auditId": audit_id,
+            "status": "pending",
+            "message": "Bias audit started",
+        },
+    )
+
+
+async def run_bias_audit_task(
+    audit_id: str,
+    csv_bytes: bytes,
+    config_data: Dict[str, Any],
+    preset: Optional[Dict[str, Any]],
+    tenant: str,
+) -> None:
+    """Background task: parse CSV, run computation, store results."""
+    try:
+        # Update status to running
+        async with get_db() as db:
+            await update_bias_audit_status(tenant, db, audit_id, status="running")
+            await db.commit()
+
+        print(f"[BiasAudit] Starting audit {audit_id}")
+
+        from engines.bias_audit.models import BiasAuditConfig, CategoryConfig, IntersectionalConfig
+        from engines.bias_audit.dataset_parser import parse_csv_dataset
+        from engines.bias_audit.engine import compute_bias_audit
+
+        # Build config from preset + overrides
+        categories_raw = config_data.get("categories") or (preset.get("categories") if preset else {})
+        categories = {}
+        for key, val in categories_raw.items():
+            if isinstance(val, dict):
+                categories[key] = CategoryConfig(
+                    label=val.get("label", key),
+                    groups=val.get("groups", []),
+                )
+            else:
+                categories[key] = CategoryConfig(label=key, groups=[])
+
+        intersectional_raw = config_data.get("intersectional") or (preset.get("intersectional") if preset else {})
+        intersectional = IntersectionalConfig(
+            required=intersectional_raw.get("required", False),
+            cross=intersectional_raw.get("cross", []),
+        )
+
+        audit_config = BiasAuditConfig(
+            preset_id=config_data.get("presetId", "custom"),
+            preset_name=preset["name"] if preset else "Custom",
+            mode=preset["mode"] if preset else config_data.get("mode", "quantitative_audit"),
+            categories=categories,
+            intersectional=intersectional,
+            metrics=config_data.get("metrics") or (preset.get("metrics") if preset else ["selection_rate", "impact_ratio"]),
+            threshold=config_data.get("threshold") if "threshold" in config_data else (preset.get("threshold") if preset else 0.80),
+            small_sample_exclusion=config_data.get("smallSampleExclusion") if "smallSampleExclusion" in config_data else (preset.get("small_sample_exclusion") if preset else None),
+            outcome_column=config_data.get("outcomeColumn", "selected"),
+            column_mapping=config_data.get("columnMapping", {}),
+            metadata=config_data.get("metadata", {}),
+        )
+
+        # Parse CSV
+        records, unknown_count = parse_csv_dataset(
+            csv_bytes=csv_bytes,
+            column_mapping=audit_config.column_mapping,
+            outcome_column=audit_config.outcome_column,
+        )
+
+        if not records:
+            raise ValueError("No valid records found in dataset after parsing. Check column mapping and data.")
+
+        print(f"[BiasAudit] Parsed {len(records)} records, {unknown_count} unknown")
+
+        # Run computation
+        result = compute_bias_audit(
+            records=records,
+            config=audit_config,
+            unknown_count=unknown_count,
+        )
+
+        print(f"[BiasAudit] Computation complete: {result.flags_count} flags")
+
+        # Store results
+        results_dict = result.model_dump()
+
+        # Flatten all group results for the per-row table
+        all_rows = []
+        for table in result.tables:
+            for group_result in table.rows:
+                all_rows.append(group_result.model_dump())
+
+        async with get_db() as db:
+            # Store per-group result rows
+            await create_bias_audit_result_rows(tenant, db, audit_id, all_rows)
+
+            # Store aggregate results as JSONB
+            await update_bias_audit_status(
+                tenant, db, audit_id,
+                status="completed",
+                results=results_dict,
+            )
+            await db.commit()
+
+        print(f"[BiasAudit] Audit {audit_id} completed successfully")
+
+    except Exception as e:
+        print(f"[BiasAudit] Audit {audit_id} failed: {e}")
+        traceback.print_exc()
+
+        try:
+            async with get_db() as db:
+                await update_bias_audit_status(
+                    tenant, db, audit_id,
+                    status="failed",
+                    error=str(e),
+                )
+                await db.commit()
+        except Exception:
+            pass
+
+
+async def get_bias_audit_status_controller(
+    audit_id: str,
+    tenant: str,
+) -> JSONResponse:
+    """Get the status of a bias audit."""
+    async with get_db() as db:
+        audit = await get_bias_audit(tenant, db, audit_id)
+
+    if not audit:
+        raise HTTPException(status_code=404, detail=f"Audit {audit_id} not found")
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "auditId": audit["id"],
+            "status": audit["status"],
+            "presetName": audit["presetName"],
+            "mode": audit["mode"],
+            "error": audit["error"],
+            "createdAt": audit["createdAt"],
+            "updatedAt": audit["updatedAt"],
+            "completedAt": audit["completedAt"],
+        },
+    )
+
+
+async def get_bias_audit_results_controller(
+    audit_id: str,
+    tenant: str,
+) -> JSONResponse:
+    """Get full results of a completed bias audit."""
+    async with get_db() as db:
+        audit = await get_bias_audit(tenant, db, audit_id)
+        if not audit:
+            raise HTTPException(status_code=404, detail=f"Audit {audit_id} not found")
+
+        if audit["status"] in ("pending", "running"):
+            return JSONResponse(
+                status_code=202,
+                content={"auditId": audit_id, "status": audit["status"], "message": f"Audit is still {audit['status']}"},
+            )
+
+        if audit["status"] == "failed":
+            raise HTTPException(status_code=500, detail=f"Audit failed: {audit['error']}")
+
+        result_rows = await get_bias_audit_result_rows(tenant, db, audit_id)
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "auditId": audit["id"],
+            "status": audit["status"],
+            "presetId": audit["presetId"],
+            "presetName": audit["presetName"],
+            "mode": audit["mode"],
+            "config": audit["config"],
+            "results": audit["results"],
+            "resultRows": result_rows,
+            "createdAt": audit["createdAt"],
+            "completedAt": audit["completedAt"],
+            "createdBy": audit["createdBy"],
+        },
+    )
+
+
+async def list_bias_audits_controller(
+    tenant: str,
+    org_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+) -> JSONResponse:
+    """List all bias audits for the tenant."""
+    try:
+        async with get_db() as db:
+            audits = await list_bias_audits(tenant, db, org_id=org_id, project_id=project_id)
+        return JSONResponse(status_code=200, content={"audits": audits})
+    except Exception as e:
+        error_str = str(e).lower()
+        if "does not exist" in error_str or "relation" in error_str:
+            return JSONResponse(status_code=200, content={"audits": []})
+        raise HTTPException(status_code=500, detail=f"Failed to list audits: {e}")
+
+
+async def delete_bias_audit_controller(
+    audit_id: str,
+    tenant: str,
+) -> JSONResponse:
+    """Delete a bias audit and its results."""
+    try:
+        async with get_db() as db:
+            deleted = await delete_bias_audit(tenant, db, audit_id)
+            await db.commit()
+
+        if not deleted:
+            raise HTTPException(status_code=404, detail=f"Audit {audit_id} not found")
+
+        return JSONResponse(
+            status_code=200,
+            content={"message": "Bias audit deleted successfully", "auditId": audit_id},
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to delete audit: {e}")
+
+
+async def get_csv_headers_controller(
+    dataset: UploadFile,
+) -> JSONResponse:
+    """Parse CSV headers for column mapping UI."""
+    from engines.bias_audit.dataset_parser import parse_csv_headers
+
+    csv_bytes = await dataset.read()
+    if not csv_bytes:
+        raise HTTPException(status_code=400, detail="Empty dataset file")
+
+    headers = parse_csv_headers(csv_bytes)
+    return JSONResponse(status_code=200, content={"headers": headers})

--- a/EvalServer/src/controllers/bias_audits.py
+++ b/EvalServer/src/controllers/bias_audits.py
@@ -125,7 +125,8 @@ async def create_bias_audit_controller(
             )
             await db.commit()
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to create audit: {e}")
+        logger.error(f"[BiasAudit] Failed to create audit for tenant {tenant}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to create audit. Please try again.")
 
     # Launch background task
     background_tasks.add_task(
@@ -357,7 +358,8 @@ async def list_bias_audits_controller(
         error_str = str(e).lower()
         if "does not exist" in error_str or "relation" in error_str:
             return JSONResponse(status_code=200, content={"audits": []})
-        raise HTTPException(status_code=500, detail=f"Failed to list audits: {e}")
+        logger.error(f"[BiasAudit] Failed to list audits for tenant {tenant}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to list audits. Please try again.")
 
 
 async def delete_bias_audit_controller(
@@ -380,7 +382,8 @@ async def delete_bias_audit_controller(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to delete audit: {e}")
+        logger.error(f"[BiasAudit] Failed to delete audit {audit_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to delete audit. Please try again.")
 
 
 async def get_csv_headers_controller(

--- a/EvalServer/src/crud/bias_audits.py
+++ b/EvalServer/src/crud/bias_audits.py
@@ -1,0 +1,266 @@
+"""
+CRUD operations for bias audits.
+
+Tenant-isolated raw SQL with text() following the pattern from deepeval_scorers.py.
+"""
+
+from typing import List, Dict, Any, Optional
+import json
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import datetime
+
+
+async def create_bias_audit(
+    tenant: str,
+    db: AsyncSession,
+    *,
+    audit_id: str,
+    org_id: str,
+    project_id: Optional[str],
+    preset_id: str,
+    preset_name: str,
+    mode: str,
+    config: Dict[str, Any],
+    created_by: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Create a new bias audit record."""
+    result = await db.execute(
+        text(
+            f'''
+            INSERT INTO "{tenant}".llm_evals_bias_audits
+            (id, org_id, project_id, preset_id, preset_name, mode, status, config, created_by)
+            VALUES
+            (:id, :org_id, :project_id, :preset_id, :preset_name, :mode, 'pending', :config, :created_by)
+            RETURNING id, org_id, project_id, preset_id, preset_name, mode, status,
+                      config, results, error, created_at, updated_at, completed_at, created_by
+            '''
+        ),
+        {
+            "id": audit_id,
+            "org_id": org_id,
+            "project_id": project_id,
+            "preset_id": preset_id,
+            "preset_name": preset_name,
+            "mode": mode,
+            "config": json.dumps(config),
+            "created_by": created_by,
+        },
+    )
+    row = result.mappings().first()
+    if not row:
+        return None
+    return _row_to_dict(row)
+
+
+async def get_bias_audit(
+    tenant: str,
+    db: AsyncSession,
+    audit_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Get a single bias audit by ID."""
+    result = await db.execute(
+        text(
+            f'''
+            SELECT id, org_id, project_id, preset_id, preset_name, mode, status,
+                   config, results, error, created_at, updated_at, completed_at, created_by
+            FROM "{tenant}".llm_evals_bias_audits
+            WHERE id = :id
+            '''
+        ),
+        {"id": audit_id},
+    )
+    row = result.mappings().first()
+    if not row:
+        return None
+    return _row_to_dict(row)
+
+
+async def update_bias_audit_status(
+    tenant: str,
+    db: AsyncSession,
+    audit_id: str,
+    *,
+    status: str,
+    results: Optional[Dict[str, Any]] = None,
+    error: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Update audit status, results, and/or error."""
+    updates = ["status = :status", "updated_at = CURRENT_TIMESTAMP"]
+    params: Dict[str, Any] = {"id": audit_id, "status": status}
+
+    if results is not None:
+        updates.append("results = :results")
+        params["results"] = json.dumps(results)
+
+    if error is not None:
+        updates.append("error = :error")
+        params["error"] = error
+
+    if status in ("completed", "failed"):
+        updates.append("completed_at = CURRENT_TIMESTAMP")
+
+    result = await db.execute(
+        text(
+            f'''
+            UPDATE "{tenant}".llm_evals_bias_audits
+            SET {", ".join(updates)}
+            WHERE id = :id
+            RETURNING id, org_id, project_id, preset_id, preset_name, mode, status,
+                      config, results, error, created_at, updated_at, completed_at, created_by
+            '''
+        ),
+        params,
+    )
+    row = result.mappings().first()
+    if not row:
+        return None
+    return _row_to_dict(row)
+
+
+async def list_bias_audits(
+    tenant: str,
+    db: AsyncSession,
+    org_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """List bias audits with optional filtering."""
+    where_clauses = []
+    params: Dict[str, Any] = {}
+
+    if org_id:
+        where_clauses.append("org_id = :org_id")
+        params["org_id"] = org_id
+    if project_id:
+        where_clauses.append("project_id = :project_id")
+        params["project_id"] = project_id
+
+    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+
+    result = await db.execute(
+        text(
+            f'''
+            SELECT id, org_id, project_id, preset_id, preset_name, mode, status,
+                   config, results, error, created_at, updated_at, completed_at, created_by
+            FROM "{tenant}".llm_evals_bias_audits
+            {where_sql}
+            ORDER BY created_at DESC
+            '''
+        ),
+        params if params else {},
+    )
+    rows = result.mappings().all()
+    return [_row_to_dict(row) for row in rows]
+
+
+async def delete_bias_audit(
+    tenant: str,
+    db: AsyncSession,
+    audit_id: str,
+) -> bool:
+    """Delete a bias audit and its result rows (CASCADE)."""
+    result = await db.execute(
+        text(
+            f'''
+            DELETE FROM "{tenant}".llm_evals_bias_audits
+            WHERE id = :id
+            RETURNING id
+            '''
+        ),
+        {"id": audit_id},
+    )
+    row = result.fetchone()
+    return row is not None
+
+
+async def create_bias_audit_result_rows(
+    tenant: str,
+    db: AsyncSession,
+    audit_id: str,
+    rows: List[Dict[str, Any]],
+) -> int:
+    """Bulk insert per-group result rows for an audit."""
+    inserted = 0
+    for row_data in rows:
+        await db.execute(
+            text(
+                f'''
+                INSERT INTO "{tenant}".llm_evals_bias_audit_results
+                (audit_id, category_type, category_name, applicant_count,
+                 selected_count, selection_rate, impact_ratio, excluded, flagged)
+                VALUES
+                (:audit_id, :category_type, :category_name, :applicant_count,
+                 :selected_count, :selection_rate, :impact_ratio, :excluded, :flagged)
+                '''
+            ),
+            {
+                "audit_id": audit_id,
+                "category_type": row_data["category_type"],
+                "category_name": row_data["category_name"],
+                "applicant_count": row_data["applicant_count"],
+                "selected_count": row_data["selected_count"],
+                "selection_rate": row_data["selection_rate"],
+                "impact_ratio": row_data.get("impact_ratio"),
+                "excluded": row_data.get("excluded", False),
+                "flagged": row_data.get("flagged", False),
+            },
+        )
+        inserted += 1
+    return inserted
+
+
+async def get_bias_audit_result_rows(
+    tenant: str,
+    db: AsyncSession,
+    audit_id: str,
+) -> List[Dict[str, Any]]:
+    """Get all per-group result rows for an audit."""
+    result = await db.execute(
+        text(
+            f'''
+            SELECT id, audit_id, category_type, category_name, applicant_count,
+                   selected_count, selection_rate, impact_ratio, excluded, flagged, created_at
+            FROM "{tenant}".llm_evals_bias_audit_results
+            WHERE audit_id = :audit_id
+            ORDER BY id
+            '''
+        ),
+        {"audit_id": audit_id},
+    )
+    rows = result.mappings().all()
+    return [
+        {
+            "id": row["id"],
+            "auditId": row["audit_id"],
+            "categoryType": row["category_type"],
+            "categoryName": row["category_name"],
+            "applicantCount": row["applicant_count"],
+            "selectedCount": row["selected_count"],
+            "selectionRate": float(row["selection_rate"]),
+            "impactRatio": float(row["impact_ratio"]) if row["impact_ratio"] is not None else None,
+            "excluded": row["excluded"],
+            "flagged": row["flagged"],
+            "createdAt": row["created_at"].isoformat() if row["created_at"] else None,
+        }
+        for row in rows
+    ]
+
+
+def _row_to_dict(row) -> Dict[str, Any]:
+    """Convert a database row to a camelCase dict for API responses."""
+    return {
+        "id": row["id"],
+        "orgId": row["org_id"],
+        "projectId": row["project_id"],
+        "presetId": row["preset_id"],
+        "presetName": row["preset_name"],
+        "mode": row["mode"],
+        "status": row["status"],
+        "config": row["config"] if isinstance(row["config"], dict) else (json.loads(row["config"]) if row["config"] else {}),
+        "results": row["results"] if isinstance(row["results"], dict) else (json.loads(row["results"]) if row["results"] else None),
+        "error": row["error"],
+        "createdAt": row["created_at"].isoformat() if row["created_at"] else None,
+        "updatedAt": row["updated_at"].isoformat() if row["updated_at"] else None,
+        "completedAt": row["completed_at"].isoformat() if row["completed_at"] else None,
+        "createdBy": row["created_by"],
+    }

--- a/EvalServer/src/database/migrations/versions/b1a2s3a4u5d6_create_bias_audit_tables.py
+++ b/EvalServer/src/database/migrations/versions/b1a2s3a4u5d6_create_bias_audit_tables.py
@@ -1,0 +1,95 @@
+"""create-bias-audit-tables
+
+Revision ID: b1a2s3a4u5d6
+Revises: f7a8b9c0d1e2
+Create Date: 2026-02-13
+
+Creates llm_evals_bias_audits and llm_evals_bias_audit_results tables
+in each tenant schema for the bias audit module.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from database.migrations.util import _discover_tenant_schemas
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1a2s3a4u5d6'
+down_revision: Union[str, None] = 'f7a8b9c0d1e2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create bias audit tables in all tenant schemas."""
+    schemas = _discover_tenant_schemas(op, sa)
+    for schema_name in schemas:
+        print(f"Creating bias audit tables in schema: {schema_name}")
+
+        # ============================================================
+        # 1. BIAS AUDITS TABLE
+        # ============================================================
+        op.execute(sa.text(f'''
+            CREATE TABLE IF NOT EXISTS "{schema_name}".llm_evals_bias_audits (
+                id VARCHAR(255) PRIMARY KEY,
+                org_id VARCHAR(255) NOT NULL,
+                project_id VARCHAR(255),
+                preset_id VARCHAR(100) NOT NULL,
+                preset_name VARCHAR(255) NOT NULL,
+                mode VARCHAR(50) NOT NULL,
+                status VARCHAR(50) NOT NULL DEFAULT 'pending',
+                config JSONB NOT NULL,
+                results JSONB,
+                error TEXT,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                completed_at TIMESTAMP WITH TIME ZONE,
+                created_by VARCHAR(255)
+            );
+        '''))
+        op.execute(sa.text(f'''
+            CREATE INDEX IF NOT EXISTS idx_llm_evals_bias_audits_org_id
+            ON "{schema_name}".llm_evals_bias_audits(org_id);
+        '''))
+        op.execute(sa.text(f'''
+            CREATE INDEX IF NOT EXISTS idx_llm_evals_bias_audits_status
+            ON "{schema_name}".llm_evals_bias_audits(status);
+        '''))
+        op.execute(sa.text(f'''
+            CREATE INDEX IF NOT EXISTS idx_llm_evals_bias_audits_created_at
+            ON "{schema_name}".llm_evals_bias_audits(created_at DESC);
+        '''))
+
+        # ============================================================
+        # 2. BIAS AUDIT RESULTS TABLE (per-group breakdown)
+        # ============================================================
+        op.execute(sa.text(f'''
+            CREATE TABLE IF NOT EXISTS "{schema_name}".llm_evals_bias_audit_results (
+                id SERIAL PRIMARY KEY,
+                audit_id VARCHAR(255) NOT NULL REFERENCES "{schema_name}".llm_evals_bias_audits(id) ON DELETE CASCADE,
+                category_type VARCHAR(100) NOT NULL,
+                category_name VARCHAR(255) NOT NULL,
+                applicant_count INTEGER NOT NULL,
+                selected_count INTEGER NOT NULL,
+                selection_rate DOUBLE PRECISION NOT NULL,
+                impact_ratio DOUBLE PRECISION,
+                excluded BOOLEAN DEFAULT FALSE,
+                flagged BOOLEAN DEFAULT FALSE,
+                created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+            );
+        '''))
+        op.execute(sa.text(f'''
+            CREATE INDEX IF NOT EXISTS idx_llm_evals_bias_audit_results_audit_id
+            ON "{schema_name}".llm_evals_bias_audit_results(audit_id);
+        '''))
+
+        print(f"  ✓ Created bias audit tables in {schema_name}")
+
+
+def downgrade() -> None:
+    """Drop bias audit tables from all tenant schemas."""
+    schemas = _discover_tenant_schemas(op, sa)
+    for schema_name in schemas:
+        op.execute(sa.text(f'DROP TABLE IF EXISTS "{schema_name}".llm_evals_bias_audit_results CASCADE;'))
+        op.execute(sa.text(f'DROP TABLE IF EXISTS "{schema_name}".llm_evals_bias_audits CASCADE;'))

--- a/EvalServer/src/database/migrations/versions/b1a2s3a4u5d6_create_bias_audit_tables.py
+++ b/EvalServer/src/database/migrations/versions/b1a2s3a4u5d6_create_bias_audit_tables.py
@@ -57,6 +57,10 @@ def upgrade() -> None:
             ON "{schema_name}".llm_evals_bias_audits(status);
         '''))
         op.execute(sa.text(f'''
+            CREATE INDEX IF NOT EXISTS idx_llm_evals_bias_audits_project_id
+            ON "{schema_name}".llm_evals_bias_audits(project_id);
+        '''))
+        op.execute(sa.text(f'''
             CREATE INDEX IF NOT EXISTS idx_llm_evals_bias_audits_created_at
             ON "{schema_name}".llm_evals_bias_audits(created_at DESC);
         '''))

--- a/EvalServer/src/engines/bias_audit/dataset_parser.py
+++ b/EvalServer/src/engines/bias_audit/dataset_parser.py
@@ -1,0 +1,95 @@
+"""
+Parse CSV demographic data for bias audits.
+
+Reads a CSV file with demographic columns and a binary outcome column,
+then produces structured records for the computation engine.
+"""
+
+import csv
+import io
+from typing import Dict, List, Tuple
+
+
+def parse_csv_dataset(
+    csv_bytes: bytes,
+    column_mapping: Dict[str, str],
+    outcome_column: str,
+) -> Tuple[List[Dict[str, str]], int]:
+    """
+    Parse CSV bytes into a list of record dicts.
+
+    Args:
+        csv_bytes: Raw CSV file content.
+        column_mapping: Maps preset category keys to CSV column names.
+            e.g. {"sex": "Gender", "race_ethnicity": "Race"}
+        outcome_column: Name of the CSV column containing the binary outcome
+            (1/true/yes/selected = selected, 0/false/no = not selected).
+
+    Returns:
+        Tuple of (records, unknown_count):
+        - records: List of dicts with keys for each category + "selected" (bool).
+        - unknown_count: Number of rows with missing demographic data in any
+          mapped category.
+    """
+    text = csv_bytes.decode("utf-8-sig")  # handle BOM
+    reader = csv.DictReader(io.StringIO(text))
+
+    records: List[Dict[str, str]] = []
+    unknown_count = 0
+
+    # Normalize header names for case-insensitive matching
+    if reader.fieldnames is None:
+        return [], 0
+
+    header_map: Dict[str, str] = {h.strip().lower(): h.strip() for h in reader.fieldnames}
+
+    # Resolve column mapping to actual CSV header names
+    resolved_mapping: Dict[str, str] = {}
+    for category_key, csv_col in column_mapping.items():
+        csv_col_lower = csv_col.strip().lower()
+        if csv_col_lower in header_map:
+            resolved_mapping[category_key] = header_map[csv_col_lower]
+        else:
+            resolved_mapping[category_key] = csv_col.strip()
+
+    outcome_col_lower = outcome_column.strip().lower()
+    resolved_outcome = header_map.get(outcome_col_lower, outcome_column.strip())
+
+    for row in reader:
+        record: Dict[str, str] = {}
+        has_missing = False
+
+        for category_key, csv_col in resolved_mapping.items():
+            value = (row.get(csv_col) or "").strip()
+            if not value:
+                has_missing = True
+            record[category_key] = value
+
+        # Parse outcome
+        outcome_raw = (row.get(resolved_outcome) or "").strip().lower()
+        record["selected"] = outcome_raw in ("1", "true", "yes", "selected", "hired", "promoted")
+
+        if has_missing:
+            unknown_count += 1
+        else:
+            records.append(record)
+
+    return records, unknown_count
+
+
+def parse_csv_headers(csv_bytes: bytes) -> List[str]:
+    """
+    Parse just the headers from a CSV file.
+    Used client-side (or server-side) for column mapping UI.
+
+    Args:
+        csv_bytes: Raw CSV file content.
+
+    Returns:
+        List of column header names.
+    """
+    text = csv_bytes.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        return []
+    return [h.strip() for h in reader.fieldnames]

--- a/EvalServer/src/engines/bias_audit/dataset_parser.py
+++ b/EvalServer/src/engines/bias_audit/dataset_parser.py
@@ -53,9 +53,11 @@ def parse_csv_dataset(
 
     header_map: Dict[str, str] = {h.strip().lower(): h.strip() for h in reader.fieldnames}
 
-    # Resolve column mapping to actual CSV header names
+    # Resolve column mapping to actual CSV header names (skip empty mappings)
     resolved_mapping: Dict[str, str] = {}
     for category_key, csv_col in column_mapping.items():
+        if not csv_col or not csv_col.strip():
+            continue
         csv_col_lower = csv_col.strip().lower()
         if csv_col_lower in header_map:
             resolved_mapping[category_key] = header_map[csv_col_lower]

--- a/EvalServer/src/engines/bias_audit/dataset_parser.py
+++ b/EvalServer/src/engines/bias_audit/dataset_parser.py
@@ -98,7 +98,7 @@ def parse_csv_headers(csv_bytes: bytes) -> List[str]:
     Returns:
         List of column header names.
     """
-    text = csv_bytes.decode("utf-8-sig")
+    text = _decode_csv(csv_bytes)
     reader = csv.DictReader(io.StringIO(text))
     if reader.fieldnames is None:
         return []

--- a/EvalServer/src/engines/bias_audit/dataset_parser.py
+++ b/EvalServer/src/engines/bias_audit/dataset_parser.py
@@ -10,6 +10,16 @@ import io
 from typing import Dict, List, Tuple
 
 
+def _decode_csv(csv_bytes: bytes) -> str:
+    """Decode CSV bytes with fallback encodings."""
+    for encoding in ("utf-8-sig", "utf-8", "latin-1", "cp1252"):
+        try:
+            return csv_bytes.decode(encoding)
+        except (UnicodeDecodeError, ValueError):
+            continue
+    raise ValueError("Unable to decode CSV file. Please ensure it is UTF-8 encoded.")
+
+
 def parse_csv_dataset(
     csv_bytes: bytes,
     column_mapping: Dict[str, str],
@@ -31,7 +41,7 @@ def parse_csv_dataset(
         - unknown_count: Number of rows with missing demographic data in any
           mapped category.
     """
-    text = csv_bytes.decode("utf-8-sig")  # handle BOM
+    text = _decode_csv(csv_bytes)
     reader = csv.DictReader(io.StringIO(text))
 
     records: List[Dict[str, str]] = []

--- a/EvalServer/src/engines/bias_audit/engine.py
+++ b/EvalServer/src/engines/bias_audit/engine.py
@@ -1,0 +1,258 @@
+"""
+Bias audit computation engine.
+
+Computes selection rates, impact ratios, and intersectional analyses
+for demographic bias audits. Operates on structured record data
+(not ML tensors or fairlearn MetricFrames).
+"""
+
+from typing import Dict, List, Optional
+from collections import defaultdict
+
+from .models import (
+    BiasAuditConfig,
+    BiasAuditResult,
+    CategoryTable,
+    GroupResult,
+)
+
+
+def compute_bias_audit(
+    records: List[Dict],
+    config: BiasAuditConfig,
+    unknown_count: int = 0,
+) -> BiasAuditResult:
+    """
+    Run the full bias audit computation.
+
+    Args:
+        records: List of record dicts. Each has category keys + "selected" (bool).
+        config: Audit configuration with categories, thresholds, etc.
+        unknown_count: Count of rows excluded due to missing demographic data.
+
+    Returns:
+        BiasAuditResult with per-category tables and aggregate statistics.
+    """
+    total_applicants = len(records)
+    total_selected = sum(1 for r in records if r.get("selected"))
+    overall_rate = total_selected / total_applicants if total_applicants > 0 else 0.0
+
+    tables: List[CategoryTable] = []
+    total_flags = 0
+    total_excluded = 0
+
+    # Compute per-category tables
+    for category_key, category_config in config.categories.items():
+        table = _compute_category_table(
+            records=records,
+            category_key=category_key,
+            category_label=category_config.label,
+            total_applicants=total_applicants,
+            threshold=config.threshold,
+            small_sample_exclusion=config.small_sample_exclusion,
+        )
+        tables.append(table)
+        total_flags += sum(1 for r in table.rows if r.flagged)
+        total_excluded += sum(1 for r in table.rows if r.excluded)
+
+    # Compute intersectional table if required
+    if config.intersectional.required and len(config.intersectional.cross) >= 2:
+        intersectional_table = _compute_intersectional_table(
+            records=records,
+            cross_keys=config.intersectional.cross,
+            categories=config.categories,
+            total_applicants=total_applicants,
+            threshold=config.threshold,
+            small_sample_exclusion=config.small_sample_exclusion,
+        )
+        tables.append(intersectional_table)
+        total_flags += sum(1 for r in intersectional_table.rows if r.flagged)
+        total_excluded += sum(1 for r in intersectional_table.rows if r.excluded)
+
+    # Build summary
+    summary_parts = [
+        f"Audit analyzed {total_applicants:,} applicants with {total_selected:,} selections "
+        f"(overall rate: {overall_rate:.1%}).",
+    ]
+    if unknown_count > 0:
+        summary_parts.append(f"{unknown_count:,} rows excluded due to missing demographic data.")
+    if total_flags > 0:
+        summary_parts.append(
+            f"{total_flags} group(s) flagged with impact ratio below "
+            f"{config.threshold or 0.80:.2f} threshold."
+        )
+    else:
+        summary_parts.append("No adverse impact flags detected.")
+    if total_excluded > 0:
+        summary_parts.append(
+            f"{total_excluded} group(s) excluded from impact ratio calculations "
+            f"due to small sample size."
+        )
+
+    return BiasAuditResult(
+        tables=tables,
+        overall_selection_rate=round(overall_rate, 6),
+        total_applicants=total_applicants,
+        total_selected=total_selected,
+        unknown_count=unknown_count,
+        flags_count=total_flags,
+        excluded_count=total_excluded,
+        summary=" ".join(summary_parts),
+    )
+
+
+def _compute_category_table(
+    records: List[Dict],
+    category_key: str,
+    category_label: str,
+    total_applicants: int,
+    threshold: Optional[float],
+    small_sample_exclusion: Optional[float],
+) -> CategoryTable:
+    """
+    Compute selection rates and impact ratios for a single category.
+
+    Groups records by category value, calculates per-group stats,
+    then computes impact ratios relative to the highest selection rate.
+    """
+    # Group records
+    groups: Dict[str, Dict] = defaultdict(lambda: {"applicants": 0, "selected": 0})
+    for record in records:
+        group_name = record.get(category_key, "")
+        if not group_name:
+            continue
+        groups[group_name]["applicants"] += 1
+        if record.get("selected"):
+            groups[group_name]["selected"] += 1
+
+    # Compute selection rates
+    group_results: List[GroupResult] = []
+    highest_rate = 0.0
+    highest_group = ""
+
+    for group_name, counts in sorted(groups.items()):
+        applicants = counts["applicants"]
+        selected = counts["selected"]
+        rate = selected / applicants if applicants > 0 else 0.0
+
+        if rate > highest_rate:
+            highest_rate = rate
+            highest_group = group_name
+
+        group_results.append(GroupResult(
+            category_type=category_key,
+            category_name=group_name,
+            applicant_count=applicants,
+            selected_count=selected,
+            selection_rate=round(rate, 6),
+        ))
+
+    # Compute impact ratios
+    for result in group_results:
+        # Check small sample exclusion
+        if small_sample_exclusion and total_applicants > 0:
+            proportion = result.applicant_count / total_applicants
+            if proportion < small_sample_exclusion:
+                result.excluded = True
+                result.impact_ratio = None
+                continue
+
+        if highest_rate > 0:
+            ratio = result.selection_rate / highest_rate
+            result.impact_ratio = round(ratio, 6)
+
+            # Flag if below threshold
+            if threshold is not None and ratio < threshold:
+                result.flagged = True
+        else:
+            result.impact_ratio = None
+
+    return CategoryTable(
+        title=f"Impact ratios by {category_label.lower()}",
+        category_key=category_key,
+        rows=group_results,
+        highest_group=highest_group,
+        highest_rate=round(highest_rate, 6) if highest_rate > 0 else None,
+    )
+
+
+def _compute_intersectional_table(
+    records: List[Dict],
+    cross_keys: List[str],
+    categories: Dict,
+    total_applicants: int,
+    threshold: Optional[float],
+    small_sample_exclusion: Optional[float],
+) -> CategoryTable:
+    """
+    Compute intersectional cross-tabulation.
+
+    Creates compound group names (e.g. "Male - Hispanic or Latino")
+    and computes selection rates and impact ratios across all combinations.
+    """
+    # Group records by compound key
+    groups: Dict[str, Dict] = defaultdict(lambda: {"applicants": 0, "selected": 0})
+
+    for record in records:
+        parts = []
+        skip = False
+        for key in cross_keys:
+            value = record.get(key, "")
+            if not value:
+                skip = True
+                break
+            parts.append(value)
+        if skip:
+            continue
+
+        compound_name = " - ".join(parts)
+        groups[compound_name]["applicants"] += 1
+        if record.get("selected"):
+            groups[compound_name]["selected"] += 1
+
+    # Compute selection rates
+    group_results: List[GroupResult] = []
+    highest_rate = 0.0
+    highest_group = ""
+
+    for group_name, counts in sorted(groups.items()):
+        applicants = counts["applicants"]
+        selected = counts["selected"]
+        rate = selected / applicants if applicants > 0 else 0.0
+
+        if rate > highest_rate:
+            highest_rate = rate
+            highest_group = group_name
+
+        group_results.append(GroupResult(
+            category_type="intersectional",
+            category_name=group_name,
+            applicant_count=applicants,
+            selected_count=selected,
+            selection_rate=round(rate, 6),
+        ))
+
+    # Compute impact ratios
+    for result in group_results:
+        if small_sample_exclusion and total_applicants > 0:
+            proportion = result.applicant_count / total_applicants
+            if proportion < small_sample_exclusion:
+                result.excluded = True
+                result.impact_ratio = None
+                continue
+
+        if highest_rate > 0:
+            ratio = result.selection_rate / highest_rate
+            result.impact_ratio = round(ratio, 6)
+            if threshold is not None and ratio < threshold:
+                result.flagged = True
+        else:
+            result.impact_ratio = None
+
+    return CategoryTable(
+        title="Impact ratios by intersectional category",
+        category_key="intersectional",
+        rows=group_results,
+        highest_group=highest_group,
+        highest_rate=round(highest_rate, 6) if highest_rate > 0 else None,
+    )

--- a/EvalServer/src/engines/bias_audit/models.py
+++ b/EvalServer/src/engines/bias_audit/models.py
@@ -1,0 +1,80 @@
+"""
+Pydantic models for bias audit configuration and results.
+"""
+
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class CategoryConfig(BaseModel):
+    """Configuration for a single protected category."""
+    label: str
+    groups: List[str] = Field(default_factory=list)
+
+
+class IntersectionalConfig(BaseModel):
+    """Configuration for intersectional analysis."""
+    required: bool = False
+    cross: List[str] = Field(default_factory=list)
+
+
+class ResultsTableConfig(BaseModel):
+    """Configuration for a single results table."""
+    type: str  # "category" or "intersectional"
+    category_key: Optional[str] = None
+    title: str
+
+
+class ResultsFormatConfig(BaseModel):
+    """Configuration for results format."""
+    tables: List[ResultsTableConfig] = Field(default_factory=list)
+
+
+class BiasAuditConfig(BaseModel):
+    """Full configuration for running a bias audit."""
+    preset_id: str
+    preset_name: str = ""
+    mode: str = "quantitative_audit"
+    categories: Dict[str, CategoryConfig] = Field(default_factory=dict)
+    intersectional: IntersectionalConfig = Field(default_factory=IntersectionalConfig)
+    metrics: List[str] = Field(default_factory=lambda: ["selection_rate", "impact_ratio"])
+    threshold: Optional[float] = 0.80
+    small_sample_exclusion: Optional[float] = None
+    required_metadata: List[str] = Field(default_factory=list)
+    metadata: Dict[str, str] = Field(default_factory=dict)
+    results_format: ResultsFormatConfig = Field(default_factory=ResultsFormatConfig)
+    outcome_column: str = "selected"
+    column_mapping: Dict[str, str] = Field(default_factory=dict)
+
+
+class GroupResult(BaseModel):
+    """Result for a single demographic group."""
+    category_type: str  # "sex", "race_ethnicity", "intersectional"
+    category_name: str  # e.g. "Male", "Hispanic or Latino Female"
+    applicant_count: int
+    selected_count: int
+    selection_rate: float
+    impact_ratio: Optional[float] = None
+    excluded: bool = False
+    flagged: bool = False
+
+
+class CategoryTable(BaseModel):
+    """A table of results for one category or intersectional analysis."""
+    title: str
+    category_key: str  # e.g. "sex", "race_ethnicity", "intersectional"
+    rows: List[GroupResult] = Field(default_factory=list)
+    highest_group: Optional[str] = None
+    highest_rate: Optional[float] = None
+
+
+class BiasAuditResult(BaseModel):
+    """Complete results from a bias audit computation."""
+    tables: List[CategoryTable] = Field(default_factory=list)
+    overall_selection_rate: float = 0.0
+    total_applicants: int = 0
+    total_selected: int = 0
+    unknown_count: int = 0
+    flags_count: int = 0
+    excluded_count: int = 0
+    summary: str = ""

--- a/EvalServer/src/presets/bias_audits/brazil_bill2338.json
+++ b/EvalServer/src/presets/bias_audits/brazil_bill2338.json
@@ -4,7 +4,7 @@
   "jurisdiction": "Brazil",
   "effective_date": "2024-12-10",
   "mode": "compliance_checklist",
-  "description": "Brazil AI regulatory framework requiring algorithmic impact assessments, bias detection in training data, inclusive development practices, and comprehensive impact assessment records for high-risk AI systems.",
+  "description": "Brazil AI regulatory framework requiring algorithmic impact assessments, bias detection in training data, inclusive development practices, and impact records for high-risk AI systems.",
   "categories": {
     "race": {
       "label": "Race",
@@ -74,8 +74,14 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "checklist", "title": "Compliance checklist" },
-      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+      {
+        "type": "checklist",
+        "title": "Compliance checklist"
+      },
+      {
+        "type": "assessment",
+        "title": "Recommended EEOC-style adverse impact analysis"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/brazil_bill2338.json
+++ b/EvalServer/src/presets/bias_audits/brazil_bill2338.json
@@ -1,0 +1,81 @@
+{
+  "id": "brazil_bill2338",
+  "name": "Brazil Bill 2338",
+  "jurisdiction": "Brazil",
+  "effective_date": "2024-12-10",
+  "mode": "compliance_checklist",
+  "description": "Brazil AI regulatory framework requiring algorithmic impact assessments, bias detection in training data, inclusive development practices, and comprehensive impact assessment records for high-risk AI systems.",
+  "categories": {
+    "race": {
+      "label": "Race",
+      "groups": []
+    },
+    "color": {
+      "label": "Color",
+      "groups": []
+    },
+    "ethnicity": {
+      "label": "Ethnicity",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": []
+    },
+    "gender": {
+      "label": "Gender",
+      "groups": []
+    },
+    "sexual_orientation": {
+      "label": "Sexual Orientation",
+      "groups": []
+    },
+    "age": {
+      "label": "Age",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "religion": {
+      "label": "Religion",
+      "groups": []
+    },
+    "political_opinion": {
+      "label": "Political Opinion",
+      "groups": []
+    },
+    "national_origin": {
+      "label": "National Origin",
+      "groups": []
+    },
+    "social_origin": {
+      "label": "Social Origin",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "recommended_threshold": null,
+  "checklist_items": [
+    "Conduct algorithmic impact assessment",
+    "Document bias detection in training data",
+    "Document inclusive development team practices",
+    "Maintain impact assessment records"
+  ],
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "compliance_officer"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "checklist", "title": "Compliance checklist" },
+      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/california_feha.json
+++ b/EvalServer/src/presets/bias_audits/california_feha.json
@@ -4,7 +4,7 @@
   "jurisdiction": "California",
   "effective_date": "1959-09-18",
   "mode": "quantitative_audit",
-  "description": "California Fair Employment and Housing Act. Prohibits employment discrimination across 14+ protected categories. Requires adverse impact analysis using the four-fifths rule with extended record retention requirements.",
+  "description": "California Fair Employment and Housing Act. Prohibits employment discrimination across 14+ protected categories with adverse impact analysis using the four-fifths rule.",
   "categories": {
     "race": {
       "label": "Race",
@@ -28,7 +28,10 @@
     },
     "sex": {
       "label": "Sex",
-      "groups": ["Male", "Female"]
+      "groups": [
+        "Male",
+        "Female"
+      ]
     },
     "gender_identity": {
       "label": "Gender Identity",
@@ -75,8 +78,11 @@
     "required": false,
     "cross": []
   },
-  "metrics": ["selection_rate", "impact_ratio"],
-  "threshold": 0.80,
+  "metrics": [
+    "selection_rate",
+    "impact_ratio"
+  ],
+  "threshold": 0.8,
   "required_metadata": [
     "audit_date",
     "selection_procedure_description",
@@ -87,8 +93,16 @@
   "retention_period": "4 years",
   "results_format": {
     "tables": [
-      { "type": "category", "category_key": "race", "title": "Impact ratios by race" },
-      { "type": "category", "category_key": "sex", "title": "Impact ratios by sex" }
+      {
+        "type": "category",
+        "category_key": "race",
+        "title": "Impact ratios by race"
+      },
+      {
+        "type": "category",
+        "category_key": "sex",
+        "title": "Impact ratios by sex"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/california_feha.json
+++ b/EvalServer/src/presets/bias_audits/california_feha.json
@@ -1,0 +1,94 @@
+{
+  "id": "california_feha",
+  "name": "California FEHA",
+  "jurisdiction": "California",
+  "effective_date": "1959-09-18",
+  "mode": "quantitative_audit",
+  "description": "California Fair Employment and Housing Act. Prohibits employment discrimination across 14+ protected categories. Requires adverse impact analysis using the four-fifths rule with extended record retention requirements.",
+  "categories": {
+    "race": {
+      "label": "Race",
+      "groups": [
+        "White",
+        "Black or African American",
+        "Hispanic or Latino",
+        "Asian",
+        "Native Hawaiian or Pacific Islander",
+        "American Indian or Alaska Native",
+        "Two or more races"
+      ]
+    },
+    "color": {
+      "label": "Color",
+      "groups": []
+    },
+    "religion": {
+      "label": "Religion",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": ["Male", "Female"]
+    },
+    "gender_identity": {
+      "label": "Gender Identity",
+      "groups": []
+    },
+    "sexual_orientation": {
+      "label": "Sexual Orientation",
+      "groups": []
+    },
+    "marital_status": {
+      "label": "Marital Status",
+      "groups": []
+    },
+    "national_origin": {
+      "label": "National Origin",
+      "groups": []
+    },
+    "ancestry": {
+      "label": "Ancestry",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "medical_condition": {
+      "label": "Medical Condition",
+      "groups": []
+    },
+    "age_40_plus": {
+      "label": "Age (40+)",
+      "groups": []
+    },
+    "genetic_information": {
+      "label": "Genetic Information",
+      "groups": []
+    },
+    "military_veteran_status": {
+      "label": "Military/Veteran Status",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": ["selection_rate", "impact_ratio"],
+  "threshold": 0.80,
+  "required_metadata": [
+    "audit_date",
+    "selection_procedure_description",
+    "job_title",
+    "data_source_description",
+    "retention_period"
+  ],
+  "retention_period": "4 years",
+  "results_format": {
+    "tables": [
+      { "type": "category", "category_key": "race", "title": "Impact ratios by race" },
+      { "type": "category", "category_key": "sex", "title": "Impact ratios by sex" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/colorado_sb205.json
+++ b/EvalServer/src/presets/bias_audits/colorado_sb205.json
@@ -4,7 +4,7 @@
   "jurisdiction": "Colorado",
   "effective_date": "2026-02-01",
   "mode": "impact_assessment",
-  "description": "Colorado AI Act requiring developers and deployers of high-risk AI systems to complete impact assessments addressing algorithmic discrimination across protected classes, with alignment to the NIST AI Risk Management Framework.",
+  "description": "Colorado AI Act requiring developers and deployers of high-risk AI systems to complete impact assessments addressing algorithmic discrimination, aligned with NIST AI RMF.",
   "categories": {
     "race": {
       "label": "Race",
@@ -76,11 +76,26 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "assessment", "title": "Risk analysis" },
-      { "type": "assessment", "title": "Data categories and sources" },
-      { "type": "assessment", "title": "Performance metrics by protected class" },
-      { "type": "assessment", "title": "Mitigation measures" },
-      { "type": "assessment", "title": "NIST AI RMF alignment" }
+      {
+        "type": "assessment",
+        "title": "Risk analysis"
+      },
+      {
+        "type": "assessment",
+        "title": "Data categories and sources"
+      },
+      {
+        "type": "assessment",
+        "title": "Performance metrics by protected class"
+      },
+      {
+        "type": "assessment",
+        "title": "Mitigation measures"
+      },
+      {
+        "type": "assessment",
+        "title": "NIST AI RMF alignment"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/colorado_sb205.json
+++ b/EvalServer/src/presets/bias_audits/colorado_sb205.json
@@ -1,0 +1,86 @@
+{
+  "id": "colorado_sb205",
+  "name": "Colorado SB 24-205",
+  "jurisdiction": "Colorado",
+  "effective_date": "2026-02-01",
+  "mode": "impact_assessment",
+  "description": "Colorado AI Act requiring developers and deployers of high-risk AI systems to complete impact assessments addressing algorithmic discrimination across protected classes, with alignment to the NIST AI Risk Management Framework.",
+  "categories": {
+    "race": {
+      "label": "Race",
+      "groups": []
+    },
+    "color": {
+      "label": "Color",
+      "groups": []
+    },
+    "religion": {
+      "label": "Religion",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": []
+    },
+    "sexual_orientation": {
+      "label": "Sexual Orientation",
+      "groups": []
+    },
+    "gender_identity": {
+      "label": "Gender Identity",
+      "groups": []
+    },
+    "national_origin": {
+      "label": "National Origin",
+      "groups": []
+    },
+    "ancestry": {
+      "label": "Ancestry",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "age": {
+      "label": "Age",
+      "groups": []
+    },
+    "creed": {
+      "label": "Creed",
+      "groups": []
+    },
+    "marital_status": {
+      "label": "Marital Status",
+      "groups": []
+    },
+    "pregnancy": {
+      "label": "Pregnancy",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "threshold": null,
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "risk_analysis",
+    "data_categories",
+    "performance_metrics",
+    "mitigation_measures",
+    "nist_ai_rmf_alignment"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "assessment", "title": "Risk analysis" },
+      { "type": "assessment", "title": "Data categories and sources" },
+      { "type": "assessment", "title": "Performance metrics by protected class" },
+      { "type": "assessment", "title": "Mitigation measures" },
+      { "type": "assessment", "title": "NIST AI RMF alignment" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/custom.json
+++ b/EvalServer/src/presets/bias_audits/custom.json
@@ -1,0 +1,19 @@
+{
+  "id": "custom",
+  "name": "Custom",
+  "jurisdiction": "",
+  "effective_date": "",
+  "mode": "custom",
+  "description": "User-defined custom bias audit configuration. All categories, metrics, thresholds, and metadata fields are defined by the user.",
+  "categories": {},
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "threshold": null,
+  "required_metadata": [],
+  "results_format": {
+    "sections": []
+  }
+}

--- a/EvalServer/src/presets/bias_audits/eeoc_guidelines.json
+++ b/EvalServer/src/presets/bias_audits/eeoc_guidelines.json
@@ -1,0 +1,42 @@
+{
+  "id": "eeoc_guidelines",
+  "name": "EEOC Uniform Guidelines",
+  "jurisdiction": "United States (Federal)",
+  "effective_date": "1978-09-25",
+  "mode": "quantitative_audit",
+  "description": "Uniform Guidelines on Employee Selection Procedures. Requires adverse impact analysis using the four-fifths (80%) rule across race, sex, and ethnic groups for any selection procedure.",
+  "categories": {
+    "race": {
+      "label": "Race",
+      "groups": [
+        "White",
+        "Black",
+        "Hispanic",
+        "Asian/Pacific Islander",
+        "American Indian/Alaska Native"
+      ]
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": ["Male", "Female"]
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": ["selection_rate", "impact_ratio"],
+  "threshold": 0.80,
+  "required_metadata": [
+    "audit_date",
+    "selection_procedure_description",
+    "job_title",
+    "data_source_description"
+  ],
+  "results_format": {
+    "tables": [
+      { "type": "category", "category_key": "race", "title": "Impact ratios by race" },
+      { "type": "category", "category_key": "sex", "title": "Impact ratios by sex" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/eu_ai_act.json
+++ b/EvalServer/src/presets/bias_audits/eu_ai_act.json
@@ -1,0 +1,58 @@
+{
+  "id": "eu_ai_act",
+  "name": "EU AI Act Article 9",
+  "jurisdiction": "European Union",
+  "effective_date": "2024-08-01",
+  "mode": "impact_assessment",
+  "description": "EU Artificial Intelligence Act risk management requirements for high-risk AI systems. Mandates bias testing, residual risk assessment, human oversight measures, and continuous monitoring across protected characteristics.",
+  "categories": {
+    "racial_ethnic_origin": {
+      "label": "Racial/Ethnic Origin",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": []
+    },
+    "religion_belief": {
+      "label": "Religion/Belief",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "age": {
+      "label": "Age",
+      "groups": []
+    },
+    "sexual_orientation": {
+      "label": "Sexual Orientation",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "threshold": null,
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "risk_management_measures",
+    "bias_testing_results",
+    "residual_risk_assessment",
+    "human_oversight_measures",
+    "continuous_monitoring_plan"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "assessment", "title": "Risk management measures" },
+      { "type": "assessment", "title": "Bias testing results" },
+      { "type": "assessment", "title": "Residual risk assessment" },
+      { "type": "assessment", "title": "Human oversight measures" },
+      { "type": "assessment", "title": "Continuous monitoring plan" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/eu_ai_act.json
+++ b/EvalServer/src/presets/bias_audits/eu_ai_act.json
@@ -4,7 +4,7 @@
   "jurisdiction": "European Union",
   "effective_date": "2024-08-01",
   "mode": "impact_assessment",
-  "description": "EU Artificial Intelligence Act risk management requirements for high-risk AI systems. Mandates bias testing, residual risk assessment, human oversight measures, and continuous monitoring across protected characteristics.",
+  "description": "EU AI Act risk management requirements for high-risk AI systems. Mandates bias testing, residual risk assessment, human oversight, and monitoring across protected characteristics.",
   "categories": {
     "racial_ethnic_origin": {
       "label": "Racial/Ethnic Origin",
@@ -48,11 +48,26 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "assessment", "title": "Risk management measures" },
-      { "type": "assessment", "title": "Bias testing results" },
-      { "type": "assessment", "title": "Residual risk assessment" },
-      { "type": "assessment", "title": "Human oversight measures" },
-      { "type": "assessment", "title": "Continuous monitoring plan" }
+      {
+        "type": "assessment",
+        "title": "Risk management measures"
+      },
+      {
+        "type": "assessment",
+        "title": "Bias testing results"
+      },
+      {
+        "type": "assessment",
+        "title": "Residual risk assessment"
+      },
+      {
+        "type": "assessment",
+        "title": "Human oversight measures"
+      },
+      {
+        "type": "assessment",
+        "title": "Continuous monitoring plan"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/illinois_hb3773.json
+++ b/EvalServer/src/presets/bias_audits/illinois_hb3773.json
@@ -4,7 +4,7 @@
   "jurisdiction": "Illinois",
   "effective_date": "2026-01-01",
   "mode": "compliance_checklist",
-  "description": "Illinois AI Video Interview Act and employment discrimination provisions. Requires applicant notice, consent collection, data retention documentation, and evidence of non-discrimination in AI-assisted hiring.",
+  "description": "Illinois AI Video Interview Act and employment discrimination provisions. Requires applicant notice, consent, data retention, and evidence of non-discrimination in AI hiring.",
   "categories": {
     "race": {
       "label": "Race",
@@ -60,7 +60,7 @@
     "cross": []
   },
   "metrics": [],
-  "recommended_threshold": 0.80,
+  "recommended_threshold": 0.8,
   "checklist_items": [
     "Provide notice to applicants about AI use",
     "Document consent collection process",
@@ -74,8 +74,14 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "checklist", "title": "Compliance checklist" },
-      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+      {
+        "type": "checklist",
+        "title": "Compliance checklist"
+      },
+      {
+        "type": "assessment",
+        "title": "Recommended EEOC-style adverse impact analysis"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/illinois_hb3773.json
+++ b/EvalServer/src/presets/bias_audits/illinois_hb3773.json
@@ -1,0 +1,81 @@
+{
+  "id": "illinois_hb3773",
+  "name": "Illinois HB 3773",
+  "jurisdiction": "Illinois",
+  "effective_date": "2026-01-01",
+  "mode": "compliance_checklist",
+  "description": "Illinois AI Video Interview Act and employment discrimination provisions. Requires applicant notice, consent collection, data retention documentation, and evidence of non-discrimination in AI-assisted hiring.",
+  "categories": {
+    "race": {
+      "label": "Race",
+      "groups": []
+    },
+    "color": {
+      "label": "Color",
+      "groups": []
+    },
+    "religion": {
+      "label": "Religion",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": []
+    },
+    "national_origin": {
+      "label": "National Origin",
+      "groups": []
+    },
+    "ancestry": {
+      "label": "Ancestry",
+      "groups": []
+    },
+    "age": {
+      "label": "Age",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "citizenship": {
+      "label": "Citizenship",
+      "groups": []
+    },
+    "marital_status": {
+      "label": "Marital Status",
+      "groups": []
+    },
+    "sexual_orientation": {
+      "label": "Sexual Orientation",
+      "groups": []
+    },
+    "military_status": {
+      "label": "Military Status",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "recommended_threshold": 0.80,
+  "checklist_items": [
+    "Provide notice to applicants about AI use",
+    "Document consent collection process",
+    "Maintain data retention records",
+    "Document non-discrimination evidence"
+  ],
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "compliance_officer"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "checklist", "title": "Compliance checklist" },
+      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/iso_42001.json
+++ b/EvalServer/src/presets/bias_audits/iso_42001.json
@@ -1,0 +1,47 @@
+{
+  "id": "iso_42001",
+  "name": "ISO/IEC 42001:2023",
+  "jurisdiction": "International",
+  "effective_date": "2023-12-18",
+  "mode": "framework_assessment",
+  "description": "ISO/IEC 42001:2023 AI Management System standard. Provides requirements for establishing, implementing, maintaining, and continually improving an AI management system, including risk assessment, impact analysis, and continuous improvement.",
+  "categories": {},
+  "sections": [
+    {
+      "id": "risk_assessment",
+      "title": "Risk Assessment",
+      "description": "Systematic identification, analysis, and evaluation of AI-related risks including bias and discrimination."
+    },
+    {
+      "id": "impact_analysis",
+      "title": "Impact Analysis",
+      "description": "Assessment of potential adverse impacts of AI systems on individuals, groups, and society."
+    },
+    {
+      "id": "continuous_improvement",
+      "title": "Continuous Improvement",
+      "description": "Ongoing monitoring, measurement, and improvement of the AI management system and its controls."
+    }
+  ],
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "threshold": null,
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "management_system_documentation",
+    "risk_assessment_records",
+    "adverse_impact_analysis",
+    "continuous_monitoring_evidence"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "framework", "section_id": "risk_assessment", "title": "Risk assessment records" },
+      { "type": "framework", "section_id": "impact_analysis", "title": "Adverse impact analysis" },
+      { "type": "framework", "section_id": "continuous_improvement", "title": "Continuous monitoring evidence" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/iso_42001.json
+++ b/EvalServer/src/presets/bias_audits/iso_42001.json
@@ -4,7 +4,7 @@
   "jurisdiction": "International",
   "effective_date": "2023-12-18",
   "mode": "framework_assessment",
-  "description": "ISO/IEC 42001:2023 AI Management System standard. Provides requirements for establishing, implementing, maintaining, and continually improving an AI management system, including risk assessment, impact analysis, and continuous improvement.",
+  "description": "ISO/IEC 42001:2023 AI Management System standard. Provides requirements for establishing and improving an AI management system, including risk assessment and impact analysis.",
   "categories": {},
   "sections": [
     {
@@ -39,9 +39,21 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "framework", "section_id": "risk_assessment", "title": "Risk assessment records" },
-      { "type": "framework", "section_id": "impact_analysis", "title": "Adverse impact analysis" },
-      { "type": "framework", "section_id": "continuous_improvement", "title": "Continuous monitoring evidence" }
+      {
+        "type": "framework",
+        "section_id": "risk_assessment",
+        "title": "Risk assessment records"
+      },
+      {
+        "type": "framework",
+        "section_id": "impact_analysis",
+        "title": "Adverse impact analysis"
+      },
+      {
+        "type": "framework",
+        "section_id": "continuous_improvement",
+        "title": "Continuous monitoring evidence"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/loader.py
+++ b/EvalServer/src/presets/bias_audits/loader.py
@@ -5,8 +5,11 @@ Reads and caches law/framework preset JSON files from the bias_audits directory.
 """
 
 import json
+import logging
 from pathlib import Path
 from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 _PRESETS_DIR = Path(__file__).parent
 _cache: Dict[str, dict] = {}
@@ -23,7 +26,8 @@ def _load_all() -> Dict[str, dict]:
                 preset = json.load(f)
             preset_id = preset.get("id", path.stem)
             _cache[preset_id] = preset
-        except (json.JSONDecodeError, KeyError):
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.error(f"Failed to load preset {path.name}: {e}")
             continue
     return _cache
 

--- a/EvalServer/src/presets/bias_audits/loader.py
+++ b/EvalServer/src/presets/bias_audits/loader.py
@@ -1,0 +1,57 @@
+"""
+Bias audit preset loader.
+
+Reads and caches law/framework preset JSON files from the bias_audits directory.
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_PRESETS_DIR = Path(__file__).parent
+_cache: Dict[str, dict] = {}
+
+
+def _load_all() -> Dict[str, dict]:
+    """Load all preset JSON files into cache."""
+    global _cache
+    if _cache:
+        return _cache
+    for path in sorted(_PRESETS_DIR.glob("*.json")):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                preset = json.load(f)
+            preset_id = preset.get("id", path.stem)
+            _cache[preset_id] = preset
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return _cache
+
+
+def get_preset(preset_id: str) -> Optional[dict]:
+    """Get a single preset by ID. Returns None if not found."""
+    presets = _load_all()
+    return presets.get(preset_id)
+
+
+def list_presets() -> List[dict]:
+    """List all preset summaries (without full category details)."""
+    presets = _load_all()
+    summaries = []
+    for preset in presets.values():
+        summaries.append({
+            "id": preset["id"],
+            "name": preset["name"],
+            "jurisdiction": preset.get("jurisdiction", ""),
+            "effective_date": preset.get("effective_date", ""),
+            "mode": preset["mode"],
+            "description": preset.get("description", ""),
+        })
+    return summaries
+
+
+def reload_presets() -> None:
+    """Force reload of all presets (useful for testing)."""
+    global _cache
+    _cache = {}
+    _load_all()

--- a/EvalServer/src/presets/bias_audits/new_jersey.json
+++ b/EvalServer/src/presets/bias_audits/new_jersey.json
@@ -1,0 +1,81 @@
+{
+  "id": "new_jersey",
+  "name": "New Jersey N.J.A.C. 13:16",
+  "jurisdiction": "New Jersey",
+  "effective_date": "2024-04-01",
+  "mode": "compliance_checklist",
+  "description": "New Jersey regulations on automated decision-making in employment. Requires documentation of AI use, disparate impact assessment, validation records, and consideration of alternative selection procedures.",
+  "categories": {
+    "race": {
+      "label": "Race",
+      "groups": []
+    },
+    "creed": {
+      "label": "Creed",
+      "groups": []
+    },
+    "color": {
+      "label": "Color",
+      "groups": []
+    },
+    "national_origin": {
+      "label": "National Origin",
+      "groups": []
+    },
+    "ancestry": {
+      "label": "Ancestry",
+      "groups": []
+    },
+    "age": {
+      "label": "Age",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "marital_status": {
+      "label": "Marital Status",
+      "groups": []
+    },
+    "sexual_orientation": {
+      "label": "Sexual Orientation",
+      "groups": []
+    },
+    "gender_identity": {
+      "label": "Gender Identity",
+      "groups": []
+    },
+    "pregnancy": {
+      "label": "Pregnancy",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "recommended_threshold": 0.80,
+  "checklist_items": [
+    "Document AI use in employment decisions",
+    "Assess disparate impact liability",
+    "Maintain records of AI tool validation",
+    "Document alternative selection procedures considered"
+  ],
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "compliance_officer"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "checklist", "title": "Compliance checklist" },
+      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/new_jersey.json
+++ b/EvalServer/src/presets/bias_audits/new_jersey.json
@@ -4,7 +4,7 @@
   "jurisdiction": "New Jersey",
   "effective_date": "2024-04-01",
   "mode": "compliance_checklist",
-  "description": "New Jersey regulations on automated decision-making in employment. Requires documentation of AI use, disparate impact assessment, validation records, and consideration of alternative selection procedures.",
+  "description": "New Jersey regulations on automated decision-making in employment. Requires AI use documentation, disparate impact assessment, and validation of selection procedures.",
   "categories": {
     "race": {
       "label": "Race",
@@ -60,7 +60,7 @@
     "cross": []
   },
   "metrics": [],
-  "recommended_threshold": 0.80,
+  "recommended_threshold": 0.8,
   "checklist_items": [
     "Document AI use in employment decisions",
     "Assess disparate impact liability",
@@ -74,8 +74,14 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "checklist", "title": "Compliance checklist" },
-      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+      {
+        "type": "checklist",
+        "title": "Compliance checklist"
+      },
+      {
+        "type": "assessment",
+        "title": "Recommended EEOC-style adverse impact analysis"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/nist_ai_rmf.json
+++ b/EvalServer/src/presets/bias_audits/nist_ai_rmf.json
@@ -4,7 +4,7 @@
   "jurisdiction": "United States (Voluntary Framework)",
   "effective_date": "2023-01-26",
   "mode": "framework_assessment",
-  "description": "NIST AI Risk Management Framework (AI RMF 1.0) providing a structured approach to managing AI risks. Organized into four core functions: Govern, Map, Measure, and Manage, with user-defined categories for bias assessment.",
+  "description": "NIST AI Risk Management Framework (AI RMF 1.0) for managing AI risks. Organized into four core functions: Govern, Map, Measure, and Manage, with bias assessment categories.",
   "categories": {},
   "sections": [
     {
@@ -44,10 +44,26 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "framework", "section_id": "govern", "title": "Govern documentation" },
-      { "type": "framework", "section_id": "map", "title": "Risk identification" },
-      { "type": "framework", "section_id": "measure", "title": "Quantitative metrics" },
-      { "type": "framework", "section_id": "manage", "title": "Mitigation tracking" }
+      {
+        "type": "framework",
+        "section_id": "govern",
+        "title": "Govern documentation"
+      },
+      {
+        "type": "framework",
+        "section_id": "map",
+        "title": "Risk identification"
+      },
+      {
+        "type": "framework",
+        "section_id": "measure",
+        "title": "Quantitative metrics"
+      },
+      {
+        "type": "framework",
+        "section_id": "manage",
+        "title": "Mitigation tracking"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/nist_ai_rmf.json
+++ b/EvalServer/src/presets/bias_audits/nist_ai_rmf.json
@@ -1,0 +1,53 @@
+{
+  "id": "nist_ai_rmf",
+  "name": "NIST AI Risk Management Framework",
+  "jurisdiction": "United States (Voluntary Framework)",
+  "effective_date": "2023-01-26",
+  "mode": "framework_assessment",
+  "description": "NIST AI Risk Management Framework (AI RMF 1.0) providing a structured approach to managing AI risks. Organized into four core functions: Govern, Map, Measure, and Manage, with user-defined categories for bias assessment.",
+  "categories": {},
+  "sections": [
+    {
+      "id": "govern",
+      "title": "Govern",
+      "description": "Policies, processes, procedures, and practices for AI risk management are in place and implemented."
+    },
+    {
+      "id": "map",
+      "title": "Map",
+      "description": "Context is recognized and risks related to the AI system are identified."
+    },
+    {
+      "id": "measure",
+      "title": "Measure",
+      "description": "Identified risks are assessed, analyzed, or tracked using quantitative and qualitative methods."
+    },
+    {
+      "id": "manage",
+      "title": "Manage",
+      "description": "Risks are prioritized and acted upon based on projected impact."
+    }
+  ],
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "threshold": null,
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "govern_documentation",
+    "risk_identification",
+    "quantitative_metrics",
+    "mitigation_tracking"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "framework", "section_id": "govern", "title": "Govern documentation" },
+      { "type": "framework", "section_id": "map", "title": "Risk identification" },
+      { "type": "framework", "section_id": "measure", "title": "Quantitative metrics" },
+      { "type": "framework", "section_id": "manage", "title": "Mitigation tracking" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/nyc_ll144.json
+++ b/EvalServer/src/presets/bias_audits/nyc_ll144.json
@@ -1,0 +1,46 @@
+{
+  "id": "nyc_ll144",
+  "name": "NYC Local Law 144",
+  "jurisdiction": "New York City",
+  "effective_date": "2023-07-05",
+  "mode": "quantitative_audit",
+  "description": "Annual independent bias audit for automated employment decision tools (AEDTs). Requires selection rate and impact ratio calculations across EEO Component 1 categories with intersectional analysis.",
+  "categories": {
+    "sex": {
+      "label": "Sex",
+      "groups": ["Male", "Female"]
+    },
+    "race_ethnicity": {
+      "label": "Race/Ethnicity",
+      "groups": [
+        "Hispanic or Latino",
+        "White",
+        "Black or African American",
+        "Native Hawaiian or Pacific Islander",
+        "Asian",
+        "Native American or Alaska Native",
+        "Two or more races"
+      ]
+    }
+  },
+  "intersectional": {
+    "required": true,
+    "cross": ["sex", "race_ethnicity"]
+  },
+  "metrics": ["selection_rate", "impact_ratio"],
+  "threshold": 0.80,
+  "small_sample_exclusion": 0.02,
+  "required_metadata": [
+    "audit_date",
+    "aedt_name",
+    "aedt_distribution_date",
+    "data_source_description"
+  ],
+  "results_format": {
+    "tables": [
+      { "type": "category", "category_key": "sex", "title": "Impact ratios by sex" },
+      { "type": "category", "category_key": "race_ethnicity", "title": "Impact ratios by race/ethnicity" },
+      { "type": "intersectional", "title": "Impact ratios by intersectional category" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/singapore_wfa.json
+++ b/EvalServer/src/presets/bias_audits/singapore_wfa.json
@@ -1,0 +1,65 @@
+{
+  "id": "singapore_wfa",
+  "name": "Singapore Workplace Fairness Act",
+  "jurisdiction": "Singapore",
+  "effective_date": "2025-01-08",
+  "mode": "compliance_checklist",
+  "description": "Singapore Workplace Fairness Act requirements for AI-assisted employment decisions. Mandates transparency, traceability, outcome monitoring, and regular audits across protected attributes.",
+  "categories": {
+    "race": {
+      "label": "Race",
+      "groups": []
+    },
+    "nationality": {
+      "label": "Nationality",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": []
+    },
+    "age": {
+      "label": "Age",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "religion": {
+      "label": "Religion",
+      "groups": []
+    },
+    "language": {
+      "label": "Language",
+      "groups": []
+    },
+    "marital_pregnancy_status": {
+      "label": "Marital/Pregnancy Status",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "recommended_threshold": null,
+  "checklist_items": [
+    "Document transparency measures",
+    "Maintain traceability records",
+    "Implement outcome monitoring",
+    "Document regular audit schedule"
+  ],
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "compliance_officer"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "checklist", "title": "Compliance checklist" },
+      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/south_korea.json
+++ b/EvalServer/src/presets/bias_audits/south_korea.json
@@ -4,7 +4,7 @@
   "jurisdiction": "South Korea",
   "effective_date": "2025-01-09",
   "mode": "impact_assessment",
-  "description": "South Korea AI Basic Act requirements for high-impact AI systems. Mandates fundamental rights assessments, human-in-the-loop safeguards, and transparency requirements across protected demographic categories.",
+  "description": "South Korea AI Basic Act for high-impact AI systems. Mandates fundamental rights assessments, human-in-the-loop safeguards, and transparency across protected categories.",
   "categories": {
     "gender": {
       "label": "Gender",
@@ -46,9 +46,18 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "assessment", "title": "Fundamental rights assessment" },
-      { "type": "assessment", "title": "Human-in-the-loop safeguards" },
-      { "type": "assessment", "title": "Transparency requirements" }
+      {
+        "type": "assessment",
+        "title": "Fundamental rights assessment"
+      },
+      {
+        "type": "assessment",
+        "title": "Human-in-the-loop safeguards"
+      },
+      {
+        "type": "assessment",
+        "title": "Transparency requirements"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/south_korea.json
+++ b/EvalServer/src/presets/bias_audits/south_korea.json
@@ -1,0 +1,54 @@
+{
+  "id": "south_korea",
+  "name": "South Korea AI Basic Act",
+  "jurisdiction": "South Korea",
+  "effective_date": "2025-01-09",
+  "mode": "impact_assessment",
+  "description": "South Korea AI Basic Act requirements for high-impact AI systems. Mandates fundamental rights assessments, human-in-the-loop safeguards, and transparency requirements across protected demographic categories.",
+  "categories": {
+    "gender": {
+      "label": "Gender",
+      "groups": []
+    },
+    "age": {
+      "label": "Age",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "race": {
+      "label": "Race",
+      "groups": []
+    },
+    "region_of_origin": {
+      "label": "Region of Origin",
+      "groups": []
+    },
+    "religion": {
+      "label": "Religion",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "threshold": null,
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "fundamental_rights_assessment",
+    "human_in_the_loop",
+    "transparency_requirements"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "assessment", "title": "Fundamental rights assessment" },
+      { "type": "assessment", "title": "Human-in-the-loop safeguards" },
+      { "type": "assessment", "title": "Transparency requirements" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/texas_traiga.json
+++ b/EvalServer/src/presets/bias_audits/texas_traiga.json
@@ -1,0 +1,59 @@
+{
+  "id": "texas_traiga",
+  "name": "Texas TRAIGA",
+  "jurisdiction": "Texas",
+  "effective_date": "2025-09-01",
+  "mode": "compliance_checklist",
+  "description": "Texas Responsible AI Governance Act. Focuses on risk management, disclosure, and record retention for AI systems used in employment. Addresses intentional discrimination rather than disparate impact.",
+  "categories": {
+    "race": {
+      "label": "Race",
+      "groups": []
+    },
+    "color": {
+      "label": "Color",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "religion": {
+      "label": "Religion",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": []
+    },
+    "national_origin": {
+      "label": "National Origin",
+      "groups": []
+    },
+    "age": {
+      "label": "Age",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "recommended_threshold": null,
+  "checklist_items": [
+    "Maintain risk management policy",
+    "Document AI disclosure to applicants",
+    "Maintain record retention documentation"
+  ],
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "compliance_officer"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "checklist", "title": "Compliance checklist" }
+    ]
+  }
+}

--- a/EvalServer/src/presets/bias_audits/uk_gdpr_equality.json
+++ b/EvalServer/src/presets/bias_audits/uk_gdpr_equality.json
@@ -4,7 +4,7 @@
   "jurisdiction": "United Kingdom",
   "effective_date": "2018-05-25",
   "mode": "compliance_checklist",
-  "description": "UK General Data Protection Regulation combined with the Equality Act 2010. Requires Data Protection Impact Assessments for automated decision-making and assessment of impact across protected characteristics.",
+  "description": "UK GDPR combined with the Equality Act 2010. Requires Data Protection Impact Assessments for automated decision-making and impact assessment across protected characteristics.",
   "categories": {
     "age": {
       "label": "Age",
@@ -62,8 +62,14 @@
   ],
   "results_format": {
     "sections": [
-      { "type": "checklist", "title": "Compliance checklist" },
-      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+      {
+        "type": "checklist",
+        "title": "Compliance checklist"
+      },
+      {
+        "type": "assessment",
+        "title": "Recommended EEOC-style adverse impact analysis"
+      }
     ]
   }
 }

--- a/EvalServer/src/presets/bias_audits/uk_gdpr_equality.json
+++ b/EvalServer/src/presets/bias_audits/uk_gdpr_equality.json
@@ -1,0 +1,69 @@
+{
+  "id": "uk_gdpr_equality",
+  "name": "UK GDPR + Equality Act",
+  "jurisdiction": "United Kingdom",
+  "effective_date": "2018-05-25",
+  "mode": "compliance_checklist",
+  "description": "UK General Data Protection Regulation combined with the Equality Act 2010. Requires Data Protection Impact Assessments for automated decision-making and assessment of impact across protected characteristics.",
+  "categories": {
+    "age": {
+      "label": "Age",
+      "groups": []
+    },
+    "disability": {
+      "label": "Disability",
+      "groups": []
+    },
+    "gender_reassignment": {
+      "label": "Gender Reassignment",
+      "groups": []
+    },
+    "marriage_civil_partnership": {
+      "label": "Marriage/Civil Partnership",
+      "groups": []
+    },
+    "pregnancy_maternity": {
+      "label": "Pregnancy/Maternity",
+      "groups": []
+    },
+    "race": {
+      "label": "Race",
+      "groups": []
+    },
+    "religion_belief": {
+      "label": "Religion/Belief",
+      "groups": []
+    },
+    "sex": {
+      "label": "Sex",
+      "groups": []
+    },
+    "sexual_orientation": {
+      "label": "Sexual Orientation",
+      "groups": []
+    }
+  },
+  "intersectional": {
+    "required": false,
+    "cross": []
+  },
+  "metrics": [],
+  "recommended_threshold": null,
+  "checklist_items": [
+    "Complete Data Protection Impact Assessment",
+    "Document automated decision-making justification",
+    "Assess impact across Equality Act characteristics",
+    "Document human review procedures"
+  ],
+  "required_metadata": [
+    "audit_date",
+    "system_description",
+    "data_protection_officer"
+  ],
+  "results_format": {
+    "sections": [
+      { "type": "checklist", "title": "Compliance checklist" },
+      { "type": "assessment", "title": "Recommended EEOC-style adverse impact analysis" }
+    ]
+  }
+}

--- a/EvalServer/src/routers/bias_audits.py
+++ b/EvalServer/src/routers/bias_audits.py
@@ -1,0 +1,109 @@
+"""
+Bias Audits Router
+
+Endpoints for managing bias audits with law-aware presets.
+"""
+
+from fastapi import APIRouter, BackgroundTasks, Request, UploadFile, File, Form
+from controllers.bias_audits import (
+    list_presets_controller,
+    get_preset_controller,
+    create_bias_audit_controller,
+    get_bias_audit_status_controller,
+    get_bias_audit_results_controller,
+    list_bias_audits_controller,
+    delete_bias_audit_controller,
+    get_csv_headers_controller,
+)
+
+router = APIRouter()
+
+
+# ==================== PRESETS ====================
+
+@router.get("/bias-audits/presets")
+async def list_presets():
+    """List all available bias audit preset summaries."""
+    return await list_presets_controller()
+
+
+@router.get("/bias-audits/presets/{preset_id}")
+async def get_preset(preset_id: str):
+    """Get full details of a single preset."""
+    return await get_preset_controller(preset_id)
+
+
+# ==================== AUDITS ====================
+
+@router.post("/bias-audits/run")
+async def create_bias_audit(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    dataset: UploadFile = File(...),
+    config_json: str = Form(...),
+    org_id: str = Form(...),
+):
+    """
+    Create and execute a bias audit.
+
+    Multipart form: dataset CSV file + config_json string + org_id.
+    Returns 202 with auditId for polling.
+    """
+    user_id = request.headers.get("x-user-id")
+    return await create_bias_audit_controller(
+        background_tasks=background_tasks,
+        dataset=dataset,
+        config_json=config_json,
+        tenant=request.state.tenant,
+        user_id=user_id,
+        org_id=org_id,
+    )
+
+
+@router.get("/bias-audits/{audit_id}/status")
+async def get_audit_status(audit_id: str, request: Request):
+    """Poll the status of a bias audit."""
+    return await get_bias_audit_status_controller(
+        audit_id,
+        request.state.tenant,
+    )
+
+
+@router.get("/bias-audits/{audit_id}/results")
+async def get_audit_results(audit_id: str, request: Request):
+    """Get full results of a completed bias audit."""
+    return await get_bias_audit_results_controller(
+        audit_id,
+        request.state.tenant,
+    )
+
+
+@router.get("/bias-audits")
+async def list_audits(
+    request: Request,
+    org_id: str | None = None,
+    project_id: str | None = None,
+):
+    """List all bias audits for the tenant."""
+    return await list_bias_audits_controller(
+        tenant=request.state.tenant,
+        org_id=org_id,
+        project_id=project_id,
+    )
+
+
+@router.delete("/bias-audits/{audit_id}")
+async def delete_audit(audit_id: str, request: Request):
+    """Delete a bias audit and its results."""
+    return await delete_bias_audit_controller(
+        audit_id,
+        request.state.tenant,
+    )
+
+
+# ==================== UTILITIES ====================
+
+@router.post("/bias-audits/parse-headers")
+async def parse_csv_headers(dataset: UploadFile = File(...)):
+    """Parse CSV headers for column mapping UI."""
+    return await get_csv_headers_controller(dataset)

--- a/shared/user-guide-content/content/index.ts
+++ b/shared/user-guide-content/content/index.ts
@@ -36,6 +36,7 @@ import { llmEvalsOverviewContent } from './llm-evals/llm-evals-overview';
 import { runningExperimentsContent } from './llm-evals/running-experiments';
 import { managingDatasetsContent } from './llm-evals/managing-datasets';
 import { configuringScorersContent } from './llm-evals/configuring-scorers';
+import { biasAuditsContent } from './llm-evals/bias-audits';
 import { scanningContent } from './ai-detection/scanning';
 import { historyContent } from './ai-detection/history';
 
@@ -89,6 +90,7 @@ export const articleContentMap: Record<string, ArticleContent> = {
   'llm-evals/running-experiments': runningExperimentsContent,
   'llm-evals/managing-datasets': managingDatasetsContent,
   'llm-evals/configuring-scorers': configuringScorersContent,
+  'llm-evals/bias-audits': biasAuditsContent,
   // AI Detection
   'ai-detection/scanning': scanningContent,
   'ai-detection/history': historyContent,

--- a/shared/user-guide-content/content/llm-evals/bias-audits.ts
+++ b/shared/user-guide-content/content/llm-evals/bias-audits.ts
@@ -1,0 +1,311 @@
+import type { ArticleContent } from '../../contentTypes';
+
+export const biasAuditsContent: ArticleContent = {
+  blocks: [
+    {
+      type: 'heading',
+      id: 'overview',
+      level: 2,
+      text: 'What is a bias audit?',
+    },
+    {
+      type: 'paragraph',
+      text: 'A bias audit analyzes whether an AI system treats demographic groups fairly. You upload applicant data with demographic categories and outcomes (selected or not), and the system calculates selection rates and impact ratios for each group. If any group\'s selection rate falls below the threshold compared to the most-selected group, it gets flagged.',
+    },
+    {
+      type: 'paragraph',
+      text: 'This matters for regulatory compliance. NYC Local Law 144, for example, requires annual independent bias audits for any automated employment decision tool. The EU AI Act and EEOC guidelines have similar expectations. VerifyWise supports 15 compliance frameworks out of the box, each with pre-configured categories, thresholds, and reporting requirements.',
+    },
+    {
+      type: 'heading',
+      id: 'accessing',
+      level: 2,
+      text: 'Accessing bias audits',
+    },
+    {
+      type: 'paragraph',
+      text: 'Open the LLM Evals module from the sidebar and click **Bias audits**. You\'ll see a list of all audits for your organization, sortable by date, status, framework, or mode. Running audits update automatically every few seconds.',
+    },
+    {
+      type: 'heading',
+      id: 'creating',
+      level: 2,
+      text: 'Creating a new audit',
+    },
+    {
+      type: 'paragraph',
+      text: 'Click **New bias audit** to open the setup wizard. It walks you through four steps.',
+    },
+    {
+      type: 'heading',
+      id: 'step-1',
+      level: 3,
+      text: 'Step 1: Select a compliance framework',
+    },
+    {
+      type: 'paragraph',
+      text: 'Pick the law or standard that applies to your situation. Each framework card shows the jurisdiction and a short description of what it requires. Frameworks are grouped by audit mode:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Quantitative audit', text: 'Computes selection rates and impact ratios with statistical flagging. Used by NYC LL144, EEOC guidelines, and California FEHA.' },
+        { bold: 'Impact assessment', text: 'Structured assessment with optional quantitative supplement. Used by Colorado SB 205, EU AI Act, and South Korea.' },
+        { bold: 'Compliance checklist', text: 'Checklist-based evaluation with recommended quantitative analysis. Used by Illinois HB 3773, New Jersey, Texas TRAIGA, and others.' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'Selecting a framework auto-fills everything: protected categories, group labels, threshold values, and intersectional analysis settings. You can override any of these in step 4.',
+    },
+    {
+      type: 'callout',
+      variant: 'tip',
+      text: 'Not sure which framework applies? If you\'re hiring in New York City using an AI tool, start with NYC LL144. For general US employment, EEOC guidelines is a safe default. The "Custom" preset lets you configure everything from scratch.',
+    },
+    {
+      type: 'heading',
+      id: 'step-2',
+      level: 3,
+      text: 'Step 2: Enter system information',
+    },
+    {
+      type: 'paragraph',
+      text: 'Provide details about the AI system being audited. The form adapts based on your framework. For NYC LL144, you\'ll see fields specific to AEDTs (automated employment decision tools). For other frameworks, the labels adjust accordingly.',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'System name', text: 'The name of the AI tool or model being audited.' },
+        { bold: 'Description', text: 'What the system does and how it\'s used in decision-making.' },
+        { bold: 'Distribution date', text: 'When the tool was first deployed or made available.' },
+        { bold: 'Data source description', text: 'Where the demographic and outcome data came from.' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'step-3',
+      level: 3,
+      text: 'Step 3: Upload demographic data',
+    },
+    {
+      type: 'paragraph',
+      text: 'Upload a CSV file where each row represents one applicant. The file needs demographic columns and a binary outcome column.',
+    },
+    {
+      type: 'callout',
+      variant: 'info',
+      text: 'The wizard shows required columns based on your selected framework. For NYC LL144, you need sex and race/ethnicity columns plus an outcome column. Categories with empty group definitions are marked as optional.',
+    },
+    {
+      type: 'paragraph',
+      text: 'After uploading, you\'ll see:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Column mapping', text: 'Dropdowns that map each required demographic category to a column in your CSV. For example, map "Sex" to your CSV\'s "Gender" column.' },
+        { bold: 'Outcome column', text: 'Select the column that indicates selection outcomes. Accepted values: 1, true, yes, selected, hired, promoted (and their inverses for non-selection).' },
+        { bold: 'Data preview', text: 'A preview of the first five rows so you can confirm the data looks correct before proceeding.' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'The wizard validates that required categories are mapped, no duplicate mappings exist, and the outcome column isn\'t reused as a demographic column.',
+    },
+    {
+      type: 'heading',
+      id: 'step-4',
+      level: 3,
+      text: 'Step 4: Review and run',
+    },
+    {
+      type: 'paragraph',
+      text: 'Review all settings before running the audit. The framework auto-fills these values, but you can adjust them:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Adverse impact threshold', text: 'Groups with an impact ratio below this value are flagged. NYC LL144 and EEOC use 0.80 (the "four-fifths rule").' },
+        { bold: 'Small sample exclusion', text: 'Groups representing less than this percentage of total applicants are excluded from impact ratio calculations. Prevents unreliable results from very small groups.' },
+        { bold: 'Intersectional analysis', text: 'When enabled, the audit computes cross-tabulated results (e.g., Male + Hispanic, Female + Asian) in addition to per-category results.' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'Click **Run audit** to start. The audit runs in the background and typically completes in a few seconds. You\'ll be redirected to the audit list where the status updates automatically.',
+    },
+    {
+      type: 'heading',
+      id: 'results',
+      level: 2,
+      text: 'Reading audit results',
+    },
+    {
+      type: 'paragraph',
+      text: 'Click into a completed audit to see the results. The detail page has three sections: summary cards, a text summary, and the impact ratio tables.',
+    },
+    {
+      type: 'heading',
+      id: 'summary-cards',
+      level: 3,
+      text: 'Summary cards',
+    },
+    {
+      type: 'paragraph',
+      text: 'At the top you\'ll see cards for total applicants, total selected, overall selection rate, and number of flags. If rows were excluded due to missing demographic data, an "Unknown" card also appears.',
+    },
+    {
+      type: 'heading',
+      id: 'impact-tables',
+      level: 3,
+      text: 'Impact ratio tables',
+    },
+    {
+      type: 'paragraph',
+      text: 'Each demographic category gets its own table. For NYC LL144, you\'ll see separate tables for sex, race/ethnicity, and (if enabled) intersectional categories. Each table shows:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Group', text: 'The demographic group name (e.g., "Female", "Hispanic or Latino").' },
+        { bold: 'Applicants', text: 'Number of applicants in this group.' },
+        { bold: 'Selected', text: 'Number selected/hired from this group.' },
+        { bold: 'Selection rate', text: 'Percentage of the group that was selected.' },
+        { bold: 'Impact ratio', text: 'This group\'s selection rate divided by the highest group\'s selection rate. A value of 1.000 means equal treatment.' },
+        { bold: 'Status', text: 'Pass (above threshold), Flag (below threshold), or N/A (excluded due to small sample size).' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'Flagged rows are highlighted in red. The table header shows which group had the highest selection rate, since all impact ratios are calculated relative to that group.',
+    },
+    {
+      type: 'callout',
+      variant: 'warning',
+      text: 'A flag doesn\'t automatically mean discrimination. It means the data shows a statistical disparity that warrants further investigation. The four-fifths rule is a screening tool, not a legal conclusion.',
+    },
+    {
+      type: 'heading',
+      id: 'intersectional',
+      level: 3,
+      text: 'Intersectional results',
+    },
+    {
+      type: 'paragraph',
+      text: 'When intersectional analysis is enabled, an additional table shows compound groups like "Male - Hispanic or Latino" or "Female - Asian". This reveals disparities that single-category analysis might miss. For example, a system might treat women and men equally overall, but show significant differences for women of a specific racial group.',
+    },
+    {
+      type: 'heading',
+      id: 'actions',
+      level: 2,
+      text: 'Audit actions',
+    },
+    {
+      type: 'paragraph',
+      text: 'From the results page, you can:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Download JSON', text: 'Export the full results as a JSON file for external reporting or record-keeping.' },
+        { bold: 'Delete', text: 'Permanently remove the audit and all its results. This requires confirmation.' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'frameworks',
+      level: 2,
+      text: 'Supported frameworks',
+    },
+    {
+      type: 'table',
+      columns: [
+        { key: 'framework', label: 'Framework', width: '30%' },
+        { key: 'jurisdiction', label: 'Jurisdiction', width: '25%' },
+        { key: 'mode', label: 'Mode', width: '20%' },
+        { key: 'threshold', label: 'Default threshold', width: '25%' },
+      ],
+      rows: [
+        { framework: 'NYC Local Law 144', jurisdiction: 'New York City', mode: 'Quantitative audit', threshold: '0.80' },
+        { framework: 'EEOC guidelines', jurisdiction: 'United States', mode: 'Quantitative audit', threshold: '0.80' },
+        { framework: 'California FEHA', jurisdiction: 'California', mode: 'Quantitative audit', threshold: '0.80' },
+        { framework: 'Colorado SB 205', jurisdiction: 'Colorado', mode: 'Impact assessment', threshold: '0.80' },
+        { framework: 'EU AI Act', jurisdiction: 'European Union', mode: 'Impact assessment', threshold: '0.80' },
+        { framework: 'South Korea AI Act', jurisdiction: 'South Korea', mode: 'Impact assessment', threshold: '0.80' },
+        { framework: 'Illinois HB 3773', jurisdiction: 'Illinois', mode: 'Compliance checklist', threshold: '0.80' },
+        { framework: 'New Jersey AI guidance', jurisdiction: 'New Jersey', mode: 'Compliance checklist', threshold: '—' },
+        { framework: 'Texas TRAIGA', jurisdiction: 'Texas', mode: 'Compliance checklist', threshold: '—' },
+        { framework: 'UK GDPR & Equality Act', jurisdiction: 'United Kingdom', mode: 'Compliance checklist', threshold: '0.80' },
+        { framework: 'Singapore WFA', jurisdiction: 'Singapore', mode: 'Compliance checklist', threshold: '—' },
+        { framework: 'Brazil Bill 2338', jurisdiction: 'Brazil', mode: 'Compliance checklist', threshold: '—' },
+        { framework: 'NIST AI RMF', jurisdiction: 'International', mode: 'Impact assessment', threshold: '0.80' },
+        { framework: 'ISO 42001', jurisdiction: 'International', mode: 'Impact assessment', threshold: '0.80' },
+        { framework: 'Custom', jurisdiction: '—', mode: 'Quantitative audit', threshold: 'User-defined' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'csv-format',
+      level: 2,
+      text: 'Preparing your CSV file',
+    },
+    {
+      type: 'paragraph',
+      text: 'Your CSV needs at minimum a demographic column and an outcome column. Here\'s what a typical file looks like for an NYC LL144 audit:',
+    },
+    {
+      type: 'code',
+      language: 'csv',
+      code: 'Gender,Race,Selected\nMale,White,1\nFemale,Hispanic or Latino,0\nMale,Black or African American,1\nFemale,Asian,1\nMale,White,0',
+    },
+    {
+      type: 'paragraph',
+      text: 'A few things to keep in mind:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Column names are flexible', text: 'You map them in step 3, so they don\'t need to match the framework\'s category names exactly.' },
+        { bold: 'Outcome values', text: 'The outcome column accepts 1/true/yes/selected/hired/promoted as positive outcomes. Everything else (0/false/no/rejected/declined) is treated as not selected.' },
+        { bold: 'Missing data', text: 'Rows with empty values in any mapped demographic column are excluded and counted separately as "unknown".' },
+        { bold: 'File size', text: 'Maximum 50 MB. Quoted fields with commas are supported (RFC 4180).' },
+        { bold: 'Encoding', text: 'UTF-8 is preferred. The parser also handles UTF-8 with BOM, Latin-1, and Windows-1252.' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'understanding-math',
+      level: 2,
+      text: 'How the math works',
+    },
+    {
+      type: 'paragraph',
+      text: 'The core calculation is straightforward. For each demographic group:',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: '**Selection rate** = number selected / total applicants in that group' },
+        { text: '**Impact ratio** = this group\'s selection rate / highest group\'s selection rate' },
+        { text: 'If the impact ratio falls below the threshold (typically 0.80), the group is **flagged**' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'The 0.80 threshold is the "four-fifths rule" from the EEOC Uniform Guidelines on Employee Selection Procedures. It means a group\'s selection rate should be at least 80% of the most-selected group\'s rate. A ratio of 0.75 means that group is selected at 75% the rate of the top group, which falls below the threshold.',
+    },
+    {
+      type: 'paragraph',
+      text: 'Groups that make up less than the small sample exclusion percentage (default 2%) are excluded from the calculation entirely, since small samples produce unreliable ratios.',
+    },
+    {
+      type: 'article-links',
+      title: 'Related articles',
+      items: [
+        { collectionId: 'llm-evals', articleId: 'llm-evals-overview', title: 'LLM Evals overview', description: 'Introduction to the evaluation platform' },
+        { collectionId: 'llm-evals', articleId: 'running-experiments', title: 'Running experiments', description: 'Create evaluation experiments for your models' },
+      ],
+    },
+  ],
+};

--- a/shared/user-guide-content/userGuideConfig.ts
+++ b/shared/user-guide-content/userGuideConfig.ts
@@ -132,7 +132,7 @@ export const collections: Collection[] = [
     title: 'LLM Evals',
     description: 'Evaluate and benchmark your LLM applications for quality, safety, and performance.',
     icon: 'FlaskConical',
-    articleCount: 4,
+    articleCount: 5,
     articles: [
       {
         id: 'llm-evals-overview',
@@ -157,6 +157,12 @@ export const collections: Collection[] = [
         title: 'Configuring scorers',
         description: 'Set up evaluation metrics and scoring thresholds.',
         keywords: ['scorer', 'metric', 'threshold', 'judge', 'llm', 'bias', 'toxicity', 'hallucination', 'conversational', 'turn relevancy', 'knowledge retention', 'coherence', 'task completion'],
+      },
+      {
+        id: 'bias-audits',
+        title: 'Running bias audits',
+        description: 'Run demographic bias audits against compliance frameworks like NYC LL144 and EEOC.',
+        keywords: ['bias', 'audit', 'fairness', 'discrimination', 'impact ratio', 'selection rate', 'demographic', 'compliance', 'nyc', 'll144', 'eeoc', 'four-fifths', 'adverse impact', 'intersectional'],
       },
     ],
   },
@@ -415,6 +421,12 @@ export const fastFinds: FastFind[] = [
     title: 'Conducting a risk assessment',
     collectionId: 'risk-management',
     articleId: 'risk-assessment',
+  },
+  {
+    id: 'ff-7',
+    title: 'Running a bias audit for NYC LL144',
+    collectionId: 'llm-evals',
+    articleId: 'bias-audits',
   },
 ];
 


### PR DESCRIPTION
## Summary

- Adds a complete bias audit system to LLM Evals that lets users run demographic bias audits against 15 compliance frameworks (NYC LL144, EEOC, EU AI Act, California FEHA, etc.)
- Backend computes selection rates, impact ratios, and 4/5ths rule flagging from uploaded CSV demographic data, with intersectional cross-tabulation support
- Frontend provides a 4-step modal (preset selection → system info → CSV upload with column mapping → review & run) and a results detail page with per-category tables

## What's included

**Backend (EvalServer)**
- 15 law preset JSON files with jurisdiction-specific categories, thresholds, and metrics
- Computation engine (`engines/bias_audit/`) — selection rates, impact ratios, small sample exclusion, intersectional analysis
- CSV parser with RFC 4180 support, multi-encoding fallback, and outcome value validation
- CRUD layer with tenant-isolated SQL, background task lifecycle (pending → running → completed/failed)
- FastAPI router with 7 endpoints under `/deepeval/bias-audits/`
- Alembic migration for `llm_evals_bias_audits` and `llm_evals_bias_audit_results` tables

**Frontend (Clients)**
- `NewBiasAuditModal` — StepperModal with preset cards, dynamic column mapping, CSV preview with XSS protection
- `BiasAuditsList` — sortable/searchable table with status polling and delete confirmation
- `BiasAuditDetail` — stat cards, per-category results tables with flag/pass/excluded chips, JSON download
- API service layer with full TypeScript interfaces
- Sidebar integration under LLM Evals

**Security hardening**
- XSS protection in CSV preview (HTML entity escaping)
- Generic error messages in API responses (no DB internals leaked)
- Input validation: threshold clamped 0-1, empty column mappings filtered, outcome values validated
- Race condition guards: ref-based double-delete prevention, network error retry tolerance in polling

## Test plan

- [ ] Run `alembic upgrade head` — verify `llm_evals_bias_audits` and `llm_evals_bias_audit_results` tables created
- [ ] Navigate to LLM Evals → Bias audits tab
- [ ] Create audit with NYC LL144 preset, upload CSV with sex/race columns + outcome column
- [ ] Verify column mapping UI shows required vs optional categories
- [ ] Verify results page shows impact ratio tables with proper flagging
- [ ] Test with CSV containing quoted fields with commas
- [ ] Test delete audit flow
- [ ] Verify EvalServer logs show warnings for unrecognized outcome values