### PR TITLE
feat: add release notes tab to right sidebar and user menu

### DIFF
--- a/Clients/src/presentation/components/Sidebar/SidebarFooter.tsx
+++ b/Clients/src/presentation/components/Sidebar/SidebarFooter.tsx
@@ -29,6 +29,7 @@ import {
   FolderCog,
   LogOut,
   MessageCircle,
+  Sparkles,
   Telescope,
   X,
 } from "lucide-react";
@@ -57,6 +58,7 @@ interface SidebarFooterProps {
   showDemoDataButton?: boolean;
   showReadyToSubscribe?: boolean;
   openUserGuide?: () => void;
+  openReleaseNotes?: () => void;
   /** Only show demo data options to admins */
   isAdmin?: boolean;
 }
@@ -99,6 +101,7 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
   showDemoDataButton = true,
   showReadyToSubscribe = false,
   openUserGuide,
+  openReleaseNotes,
   isAdmin = false,
 }) => {
   const theme = useTheme();
@@ -824,6 +827,39 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
                   >
                     <HelpCircle size={16} strokeWidth={1.5} />
                     <Typography sx={{ fontSize: "13px" }}>Help center</Typography>
+                  </ListItemButton>
+
+                  {/* Release notes */}
+                  <ListItemButton
+                    onClick={() => {
+                      if (openReleaseNotes) {
+                        openReleaseNotes();
+                      }
+                      closePopup();
+                    }}
+                    sx={{
+                      height: "32px",
+                      gap: theme.spacing(4),
+                      borderRadius: theme.shape.borderRadius,
+                      px: theme.spacing(4),
+                      "& svg": {
+                        color: theme.palette.text.tertiary,
+                        stroke: theme.palette.text.tertiary,
+                      },
+                      "&:hover": {
+                        backgroundColor: "#F9FAFB",
+                      },
+                      "&:hover svg": {
+                        color: "#13715B !important",
+                        stroke: "#13715B !important",
+                      },
+                      "&:hover svg path": {
+                        stroke: "#13715B !important",
+                      },
+                    }}
+                  >
+                    <Sparkles size={16} strokeWidth={1.5} />
+                    <Typography sx={{ fontSize: "13px" }}>Release notes</Typography>
                   </ListItemButton>
 
                   {/* What's New */}

--- a/Clients/src/presentation/components/Sidebar/SidebarShell.tsx
+++ b/Clients/src/presentation/components/Sidebar/SidebarShell.tsx
@@ -91,6 +91,7 @@ export interface SidebarShellProps {
   showDemoDataButton?: boolean;
   showReadyToSubscribe?: boolean;
   openUserGuide?: () => void;
+  openReleaseNotes?: () => void;
   /** Only show demo data options to admins */
   isAdmin?: boolean;
 
@@ -114,6 +115,7 @@ const SidebarShell: FC<SidebarShellProps> = ({
   showDemoDataButton = true,
   showReadyToSubscribe = false,
   openUserGuide,
+  openReleaseNotes,
   isAdmin = false,
   enableFlyingHearts = false,
 }) => {
@@ -1013,6 +1015,7 @@ const SidebarShell: FC<SidebarShellProps> = ({
           showDemoDataButton={showDemoDataButton}
           showReadyToSubscribe={showReadyToSubscribe}
           openUserGuide={openUserGuide}
+          openReleaseNotes={openReleaseNotes}
           isAdmin={isAdmin}
         />
 

--- a/Clients/src/presentation/components/Sidebar/index.tsx
+++ b/Clients/src/presentation/components/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useCallback, useEffect, useState, useContext } from "react";
 import { useLocation, useNavigate } from "react-router";
 import {
   Home,
@@ -45,7 +45,8 @@ const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { open: openUserGuide } = useUserGuideSidebarContext();
+  const { open: openUserGuide, openTab } = useUserGuideSidebarContext();
+  const openReleaseNotes = useCallback(() => openTab('whats-new'), [openTab]);
   const { changeComponentVisibility } = useContext(VerifyWiseContext);
 
   const { refs: _refs, allVisible } = useMultipleOnScreen<HTMLElement>({
@@ -241,6 +242,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       showDemoDataButton={showDemoDataButton}
       showReadyToSubscribe={true}
       openUserGuide={openUserGuide}
+      openReleaseNotes={openReleaseNotes}
       isAdmin={isAdmin}
       enableFlyingHearts={true}
     />

--- a/Clients/src/presentation/components/UserGuide/SidebarWrapper.tsx
+++ b/Clients/src/presentation/components/UserGuide/SidebarWrapper.tsx
@@ -7,6 +7,7 @@ import CollectionPage from './CollectionPage';
 import ArticlePage from './ArticlePage';
 import ContentRenderer from './ContentRenderer';
 import HelpSection from './HelpSection';
+import WhatsNewSection from './WhatsNewSection';
 import SearchResults from './SearchResults';
 import { getCollection, getArticle } from '@user-guide-content/userGuideConfig';
 import { getArticleContent } from '@user-guide-content/content';
@@ -17,7 +18,7 @@ import { AdvisorDomain, isAdvisorEligiblePath, getDomainByPath } from '../Adviso
 import AdvisorHeader from './AdvisorHeader';
 import './SidebarWrapper.css';
 
-type Tab = 'user-guide' | 'advisor' | 'help';
+type Tab = 'user-guide' | 'advisor' | 'help' | 'whats-new';
 
 interface SidebarWrapperProps {
   isOpen: boolean;
@@ -39,7 +40,7 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
   initialPath,
   onOpenInNewTab,
 }) => {
-  const { setContentWidth: setContextContentWidth } = useUserGuideSidebarContext();
+  const { setContentWidth: setContextContentWidth, requestedTab, clearRequestedTab } = useUserGuideSidebarContext();
   const [activeTab, setActiveTab] = useState<Tab>('user-guide');
   const [collectionId, setCollectionId] = useState<string | undefined>();
   const [articleId, setArticleId] = useState<string | undefined>();
@@ -117,6 +118,14 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
       setActiveTab('user-guide');
     }
   }, [activeTab, displayAdvisor]);
+
+  // React to external tab open requests (e.g. from SidebarFooter menu)
+  useEffect(() => {
+    if (requestedTab) {
+      setActiveTab(requestedTab as Tab);
+      clearRequestedTab();
+    }
+  }, [requestedTab, clearRequestedTab]);
 
   // Persist sidebar state to localStorage
   useEffect(() => {
@@ -243,7 +252,9 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
         }
         return items;
       case 'advisor':
-        return [{ label: 'Advisor', onClick: () => {} }];
+        return [{ label: 'AI advisor', onClick: () => {} }];
+      case 'whats-new':
+        return [{ label: "What's new", onClick: () => {} }];
       default:
         return [{ label: 'Help', onClick: () => {} }];
     }
@@ -345,7 +356,9 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
         return renderUserGuideContent();
       case 'advisor':
         return renderAdvisorContent();
-      default: 
+      case 'whats-new':
+        return <WhatsNewSection />;
+      default:
         return <HelpSection />;
     }
   }

--- a/Clients/src/presentation/components/UserGuide/TabBar.tsx
+++ b/Clients/src/presentation/components/UserGuide/TabBar.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { BookOpen, HelpCircle, MessageSquare } from 'lucide-react';
+import { BookOpen, HelpCircle, MessageSquare, Sparkles } from 'lucide-react';
 import { colors, typography } from './styles/theme';
 import './TabBar.css';
 
-type Tab = 'user-guide' | 'advisor' | 'help';
+type Tab = 'user-guide' | 'advisor' | 'help' | 'whats-new';
 
 interface TabBarProps {
   activeTab: Tab | undefined;
@@ -84,12 +84,19 @@ const TabBar: React.FC<TabBarProps> = ({ activeTab, onTabChange, displayAdvisor 
       {displayAdvisor && (
         <TabItem
           id="advisor"
-          label="Advisor"
+          label="AI advisor"
           icon={<MessageSquare size={18} strokeWidth={1.5} />}
           isActive={activeTab === 'advisor'}
           onClick={() => onTabChange('advisor')}
         />
       )}
+      <TabItem
+        id="whats-new"
+        label="What's new"
+        icon={<Sparkles size={18} strokeWidth={1.5} />}
+        isActive={activeTab === 'whats-new'}
+        onClick={() => onTabChange('whats-new')}
+      />
       <TabItem
         id="help"
         label="Help"

--- a/Clients/src/presentation/components/UserGuide/UserGuideSidebarContext.tsx
+++ b/Clients/src/presentation/components/UserGuide/UserGuideSidebarContext.tsx
@@ -20,6 +20,11 @@ interface UserGuideSidebarContextValue {
   totalSidebarWidth: number;
   /** Required padding-right for main content to maintain minimum gap */
   requiredPaddingRight: number;
+  /** Open sidebar to a specific tab */
+  openTab: (tab: string) => void;
+  /** Tab requested by external code — consumed and cleared by SidebarWrapper */
+  requestedTab: string | undefined;
+  clearRequestedTab: () => void;
 }
 
 const UserGuideSidebarContext = createContext<UserGuideSidebarContextValue | null>(null);
@@ -33,6 +38,7 @@ export const UserGuideSidebarProvider: React.FC<{ children: React.ReactNode }> =
 
   const [currentPath, setCurrentPath] = useState<string | undefined>();
   const [contentWidth, setContentWidth] = useState(DEFAULT_CONTENT_WIDTH);
+  const [requestedTab, setRequestedTab] = useState<string | undefined>();
 
   // Calculate total sidebar width and required padding
   const totalSidebarWidth = isOpen ? TAB_BAR_WIDTH + contentWidth : TAB_BAR_WIDTH;
@@ -81,6 +87,15 @@ export const UserGuideSidebarProvider: React.FC<{ children: React.ReactNode }> =
     setIsOpen((prev) => !prev);
   }, []);
 
+  const openTab = useCallback((tab: string) => {
+    setRequestedTab(tab);
+    setIsOpen(true);
+  }, []);
+
+  const clearRequestedTab = useCallback(() => {
+    setRequestedTab(undefined);
+  }, []);
+
   return (
     <UserGuideSidebarContext.Provider value={{
       isOpen,
@@ -92,6 +107,9 @@ export const UserGuideSidebarProvider: React.FC<{ children: React.ReactNode }> =
       setContentWidth,
       totalSidebarWidth,
       requiredPaddingRight,
+      openTab,
+      requestedTab,
+      clearRequestedTab,
     }}>
       {children}
     </UserGuideSidebarContext.Provider>

--- a/Clients/src/presentation/components/UserGuide/WhatsNewSection.tsx
+++ b/Clients/src/presentation/components/UserGuide/WhatsNewSection.tsx
@@ -1,0 +1,366 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import { colors, typography, spacing, border } from './styles/theme';
+
+interface ChangelogEntry {
+  version: string;
+  date: string;
+  title: string;
+  summary: string;
+  items: string[];
+}
+
+const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: 'v2.0',
+    date: 'February 6, 2026',
+    title: 'Plugin marketplace and notifications',
+    summary:
+      'Major release introducing a plugin marketplace for extensibility, a virtual file manager with tag-like folder behavior, real-time notifications via SSE, and dataset inventory for EU AI Act Article 10 compliance.',
+    items: [
+      'Plugin marketplace with install/uninstall and generic execute endpoint',
+      'Virtual file manager — hierarchical folders, multi-folder tagging, "All files" and "Uncategorized" views',
+      'Real-time notification system with SSE, email integration, mark-as-read, and load-more pagination',
+      'Dataset inventory — training, validation, testing, and production datasets with PII tracking and bias documentation',
+      'Post-market monitoring module for EU AI Act compliance',
+      'Governance score widget on dashboard',
+      'Task deadline view with priority-colored flags and inline editing',
+      'Unified upload component across modules',
+      'Selectable cards to filter vendor risk tables',
+    ],
+  },
+  {
+    version: 'v1.9',
+    date: 'January 15, 2026',
+    title: 'Entity graph and AI detection',
+    summary:
+      'Introduces an interactive entity graph for visualizing relationships between models, risks, vendors, and controls. Adds a code-scanning AI detection module, an AI-powered governance advisor, and an LLM evaluation arena for model comparison.',
+    items: [
+      'Entity graph — interactive visualization of model, risk, vendor, and control relationships',
+      'AI detection module — scans repositories to identify AI-generated content',
+      'Governance advisor — AI chat providing contextual compliance and risk guidance',
+      'LLM evaluation arena — run experiments, compare models, and measure performance metrics',
+      'Multi-tenancy with schema-per-tenant isolation',
+      'Redesigned dashboard with executive and operations views',
+      'Policy export to PDF and Word formats',
+    ],
+  },
+  {
+    version: 'v1.8',
+    date: 'December 19, 2025',
+    title: 'LLM evals module and docs sidebar',
+    summary:
+      'Adds a dedicated LLM evaluation module with project dashboards and dataset management. Introduces the in-app documentation sidebar, activity history tracking across all modules, and a rich text policy editor with image and table support.',
+    items: [
+      'LLM evals module with project overview stats, grouping, and tenant-aware datasets',
+      'In-app user guide sidebar with search, breadcrumbs, and navigation history',
+      'Activity history tracking for vendor risks, vendors, policies, incidents, use cases, and project risks',
+      'Rich text policy editor with image and table support (PlateJS)',
+      'Reporting system with native DOCX generation and PDF export',
+      'App switcher sidebar for multi-module navigation',
+      'Modern tabular structure for ISO 42001, ISO 27001, and EU AI Act frameworks',
+      'Stricter TypeScript compiler options enabled',
+    ],
+  },
+  {
+    version: 'v1.7',
+    date: 'December 3, 2025',
+    title: 'Model versioning and compliance frameworks',
+    summary:
+      'Adds model versioning to track description changes over time, NIST AI RMF framework support with risk linking, and CE marking for EU AI Act compliance. Introduces Wise Search for app-wide search and a user onboarding wizard.',
+    items: [
+      'Model versioning — view historical changes to model descriptions',
+      'NIST AI RMF framework with function breakdown dashboard and risk linking',
+      'CE marking workflow for EU AI Act compliance',
+      'Wise Search — app-wide search across all modules',
+      'User onboarding wizard for first-time setup',
+      'Kubernetes deployment support',
+      'Table export, print, and advanced GroupBy and Filter functionality',
+      'Vendor icons auto-fetched from BrandFetch',
+      'Geist font with Inter fallback adopted app-wide',
+    ],
+  },
+  {
+    version: 'v1.6.4',
+    date: 'November 17, 2025',
+    title: 'IBM AI Risk database and organization projects',
+    summary:
+      'Integrates the IBM AI Risk database, adds organization-level project creation, and includes report interface improvements and demo data fixes.',
+    items: [
+      'IBM AI Risk database integration for enriched risk intelligence',
+      'Organization-level project creation workflow',
+      'Report interfaces and data type improvements',
+      'Use case and demo data bug fixes',
+    ],
+  },
+  {
+    version: 'v1.6.1',
+    date: 'November 4, 2025',
+    title: 'MLflow integration and file uploads',
+    summary:
+      'Brings MLflow integration for experiment tracking, Ollama support for local LLM inference in the bias and fairness module, and a mega dropdown menu for quick entity creation across modules.',
+    items: [
+      'MLflow integration for experiment tracking',
+      'File manager with upload support in evidence modules',
+      'Ollama support for local model inference (bias and fairness)',
+      'Reporting automations for scheduled and on-demand reports',
+      'Mega dropdown menu for quick entity creation',
+      'Standardized form modals with consistent design system',
+      'Model-project and model-framework linking',
+      'Count badges on tab labels',
+      'Geography field for use cases',
+    ],
+  },
+  {
+    version: 'v1.6',
+    date: 'October 28, 2025',
+    title: 'Automations and integrations hub',
+    summary:
+      'Introduces a full automations module with drawer-based creation, update, and delete workflows. Adds a dedicated integrations hub with Slack connectivity and a new AI incident management module built for EU AI Act compliance.',
+    items: [
+      'Automations module — drawer UI for creating, updating, and deleting workflow rules',
+      'Integrations hub with dashboard buttons for Slack and third-party tools',
+      'AI incident management — structured incident tracking with evidence linkage for EU AI Act',
+      'Bias and fairness module backend logic and redesigned UI',
+      'Improved report selection component with module-level filtering',
+      'Revamped dashboard layout with better spacing and navigation links',
+      'Unified sidebar behavior — no more shrink on browser resize',
+    ],
+  },
+  {
+    version: 'v1.5',
+    date: 'October 14, 2025',
+    title: 'UI overhaul and enterprise auth',
+    summary:
+      'A major UI refresh with ~40 merged PRs — complete icon migration to Lucide React, reusable EmptyState component, command palette with keyboard navigation, and enterprise SSO via Microsoft Azure AD (EntraID).',
+    items: [
+      'Microsoft Azure AD (EntraID) single sign-on integration',
+      'API keys management interface',
+      'Framework dashboard with analytics and tabbed navigation',
+      'Slack connectivity for notifications',
+      'PlateJS rich text editor for policy management',
+      'Command palette with keyboard navigation',
+      'Complete SVG icon migration to Lucide React — removed @mui/icons-material',
+      'Reusable EmptyState component and standardized table backgrounds',
+      'Terminology update: "Project" renamed to "Use case" throughout the app',
+      'Bundle size optimized through icon migration',
+    ],
+  },
+  {
+    version: 'v1.4',
+    date: 'September 24, 2025',
+    title: 'Task management and model risk',
+    summary:
+      'Adds a full task management page for project and compliance tracking, completes model risk management with Swagger API documentation, and introduces fairness metric visualizations for bias assessments.',
+    items: [
+      'Task management page with assignment workflow and compliance tracking',
+      'Model risk management completed with full API documentation in Swagger',
+      'Fairness metric visualizations for bias assessments',
+      'Deployment and session management system',
+      'Event tracker enabled for OSS builds',
+      'Training API endpoints added to Swagger',
+      'Redesigned sidebar and helper drawer for clarity',
+      'Search and pagination improvements across modules',
+    ],
+  },
+  {
+    version: 'v1.2.2',
+    date: 'August 26, 2025',
+    title: 'Vendor risk refactor and Redux migration',
+    summary:
+      'Restructures and expands vendor risk management, migrates state management to Redux for a single source of truth, and adds project dashboard improvements including search and card/table toggle with persistence.',
+    items: [
+      'Vendor risk repository refactored and expanded',
+      'Redux state management migration — single source of truth',
+      'Bias and fairness module unit tests',
+      'Project dashboard — search, card/table toggle with localStorage persistence',
+      'Risk visualization enhancements for project risks',
+      'Model inventory — separated provider and model fields with migration',
+      'Organization logo support in settings',
+      'TanStack Query adopted on AI Trust Center page',
+    ],
+  },
+];
+
+const WhatsNewSection: React.FC = () => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [currentVersion, setCurrentVersion] = useState(CHANGELOG[0].version);
+  const [showStickyBar, setShowStickyBar] = useState(false);
+
+  const handleScroll = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const scrollTop = container.scrollTop;
+    setShowStickyBar(scrollTop > 40);
+
+    // Find which card is currently most visible at the top
+    for (let i = 0; i < cardRefs.current.length; i++) {
+      const card = cardRefs.current[i];
+      if (!card) continue;
+      const rect = card.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      const relativeTop = rect.top - containerRect.top;
+      if (relativeTop > -rect.height / 2) {
+        setCurrentVersion(CHANGELOG[i].version);
+        break;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  const currentEntry = CHANGELOG.find((e) => e.version === currentVersion);
+
+  return (
+    <div
+      ref={scrollContainerRef}
+      style={{
+        height: '100%',
+        overflowY: 'auto',
+        position: 'relative',
+      }}
+    >
+      {/* Sticky version bar */}
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 10,
+          backgroundColor: colors.background.white,
+          borderBottom: border.default,
+          padding: '8px 24px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          opacity: showStickyBar ? 1 : 0,
+          transform: showStickyBar ? 'translateY(0)' : 'translateY(-4px)',
+          transition: 'opacity 150ms ease, transform 150ms ease',
+          pointerEvents: showStickyBar ? 'auto' : 'none',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <span
+            style={{
+              fontFamily: typography.fontFamily.sans,
+              fontSize: typography.fontSize.base,
+              fontWeight: typography.fontWeight.semibold,
+              color: colors.text.primary,
+            }}
+          >
+            {currentVersion}
+          </span>
+          <span
+            style={{
+              fontFamily: typography.fontFamily.sans,
+              fontSize: typography.fontSize.xs,
+              color: colors.text.muted,
+            }}
+          >
+            {currentEntry?.date}
+          </span>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div style={{ padding: spacing.xl }}>
+        <h2
+          style={{
+            fontFamily: typography.fontFamily.sans,
+            fontSize: typography.fontSize.lg,
+            fontWeight: typography.fontWeight.semibold,
+            color: colors.text.primary,
+            marginBottom: spacing.sm,
+            marginTop: 0,
+          }}
+        >
+          What's new
+        </h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: spacing.lg }}>
+          {CHANGELOG.map((entry, index) => (
+            <div
+              key={entry.version}
+              ref={(el) => { cardRefs.current[index] = el; }}
+              style={{
+                backgroundColor: colors.background.white,
+                border: border.default,
+                borderRadius: border.radius,
+                padding: spacing.lg,
+              }}
+            >
+              {/* Date and version */}
+              <div
+                style={{
+                  fontFamily: typography.fontFamily.sans,
+                  fontSize: typography.fontSize.xs,
+                  color: colors.text.muted,
+                  marginBottom: spacing.sm,
+                }}
+              >
+                {entry.date} &middot; {entry.version}
+              </div>
+
+              {/* Title */}
+              <div
+                style={{
+                  fontFamily: typography.fontFamily.sans,
+                  fontSize: typography.fontSize.md,
+                  fontWeight: typography.fontWeight.semibold,
+                  color: colors.text.primary,
+                  marginBottom: spacing.sm,
+                }}
+              >
+                {entry.title}
+              </div>
+
+              {/* Summary */}
+              <p
+                style={{
+                  fontFamily: typography.fontFamily.sans,
+                  fontSize: typography.fontSize.xs,
+                  color: colors.text.secondary,
+                  lineHeight: typography.lineHeight.relaxed,
+                  margin: 0,
+                  marginBottom: spacing.md,
+                }}
+              >
+                {entry.summary}
+              </p>
+
+              {/* Items */}
+              <ul
+                style={{
+                  margin: 0,
+                  paddingLeft: spacing.lg,
+                  listStyle: 'disc',
+                }}
+              >
+                {entry.items.map((item, i) => (
+                  <li
+                    key={i}
+                    style={{
+                      fontFamily: typography.fontFamily.sans,
+                      fontSize: typography.fontSize.xs,
+                      color: colors.text.secondary,
+                      lineHeight: typography.lineHeight.relaxed,
+                      paddingBottom: '2px',
+                    }}
+                  >
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WhatsNewSection;


### PR DESCRIPTION
## Summary
- Adds a "What's new" release notes tab to the right sidebar (positioned above Help) with a sparkles icon, showing 10 changelog entries (v1.2.2–v2.0) sourced from actual GitHub releases
- Each entry includes date, version, summary paragraph, and detailed feature bullet points
- Sticky version bar appears while scrolling to show current version context
- Adds "Release notes" item to the bottom-left user context menu that opens the sidebar to the release notes tab
- Renames "Advisor" to "AI advisor" in the right sidebar tab bar and breadcrumbs

## Test plan
- [ ] Navigate to any page — verify sparkles icon tab appears in right sidebar between AI advisor and Help
- [ ] Click the tab — verify changelog entries render with dates, versions, summaries, and feature lists
- [ ] Scroll through entries — verify sticky version bar appears and updates as you scroll
- [ ] Click bottom-left user menu — verify "Release notes" item appears above "What's new?"
- [ ] Click "Release notes" in user menu — verify right sidebar opens to release notes tab
- [ ] Switch between tabs and refresh — verify tab state persists via localStorage
- [ ] Run `npx tsc --noEmit` — zero errors