### PR TITLE
Enhance AI advisor UI and improve responsive layout

### DIFF
--- a/Clients/src/presentation/components/AdvisorChat/CustomComposer.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/CustomComposer.tsx
@@ -18,14 +18,13 @@ const CustomTextField = forwardRef<
       {...props}
       data-composer-input
       aria-label="Type your message"
-      rows={2}
+      rows={3}
       style={{
         width: '100%',
-        minHeight: '40px',
         resize: 'none',
         border: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
         borderRadius: Number(theme.shape.borderRadius) * 1.25,
-        padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+        padding: '8px',
         fontFamily: theme.typography.fontFamily,
         fontSize: theme.typography.body2.fontSize as string,
         lineHeight: 1.5,
@@ -51,7 +50,7 @@ export const CustomComposer: FC<CustomComposerProps> = ({ pageContext }) => {
       style={{
         borderTop: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
         backgroundColor: theme.palette.background.main ?? theme.palette.background.default,
-        padding: theme.spacing(1.5),
+        padding: '8px',
       }}
     >
       <Stack direction="row" gap="8px" alignItems="flex-end">
@@ -107,6 +106,19 @@ export const CustomComposer: FC<CustomComposerProps> = ({ pageContext }) => {
         }}
       >
         Press Enter to send • Shift+Enter for new line
+      </Stack>
+      <Stack
+        direction="row"
+        justifyContent="center"
+        sx={{
+          paddingTop: '8px',
+          paddingBottom: '0px',
+          fontSize: 10,
+          color: theme.palette.text.accent ?? theme.palette.text.disabled,
+          textAlign: 'center',
+        }}
+      >
+        AI advisor can make mistakes. Please double-check responses.
       </Stack>
     </ComposerPrimitive.Root>
   );

--- a/Clients/src/presentation/components/AdvisorChat/CustomMessage.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/CustomMessage.tsx
@@ -1,9 +1,9 @@
-import { FC, useContext, useEffect, useState, memo } from 'react';
+import { FC, useContext, useEffect, useState, useRef, useCallback, memo } from 'react';
 import { Stack, Box, useTheme, Avatar, Typography, Theme } from '@mui/material';
 import { MessagePrimitive, useMessagePartText, useAssistantState } from '@assistant-ui/react';
 import Markdown from 'react-markdown';
 
-import { Bot } from 'lucide-react';
+import { Bot, Copy, Check } from 'lucide-react';
 import { ChartRenderer } from './ChartRenderer';
 import VWAvatar from '../Avatar/VWAvatar';
 import { VerifyWiseContext } from '../../../application/contexts/VerifyWise.context';
@@ -123,6 +123,175 @@ const MessageTimestamp: FC = () => {
   );
 };
 
+const CopyButton: FC<{ bubbleRef: React.RefObject<HTMLDivElement | null> }> = ({ bubbleRef }) => {
+  const theme = useTheme();
+  const [copied, setCopied] = useState(false);
+  const message = useAssistantState(({ message }) => message);
+
+  // Don't show while message is still generating or for welcome message
+  if (message.status?.type === 'running' || message.id === 'welcome') {
+    return null;
+  }
+
+  const handleCopy = async () => {
+    const el = bubbleRef.current;
+    if (!el) return;
+
+    try {
+      const html = el.innerHTML;
+      const text = el.innerText;
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'text/html': new Blob([html], { type: 'text/html' }),
+          'text/plain': new Blob([text], { type: 'text/plain' }),
+        }),
+      ]);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback to plain text
+      const text = el.innerText;
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <Box
+      onClick={handleCopy}
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '4px',
+        cursor: 'pointer',
+        color: copied
+          ? (theme.palette.success?.main ?? '#4CAF50')
+          : (theme.palette.text.tertiary ?? theme.palette.text.disabled),
+        ml: 0.5,
+        '&:hover': {
+          color: copied
+            ? (theme.palette.success?.main ?? '#4CAF50')
+            : theme.palette.text.primary,
+        },
+      }}
+      aria-label="Copy response"
+      title={copied ? 'Copied!' : 'Copy'}
+    >
+      {copied ? <Check size={12} strokeWidth={1.5} /> : <Copy size={12} strokeWidth={1.5} />}
+      <Typography
+        component="span"
+        sx={{
+          fontSize: 11,
+          lineHeight: 1,
+        }}
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </Typography>
+    </Box>
+  );
+};
+
+const THINKING_MESSAGES = [
+  'Thinking wisely',
+  'Verifying assumptions',
+  'Consulting the knowledge base',
+  'Reasoning through options',
+  'Checking the fine print',
+  'Connecting the dots',
+  'Reading between the lines',
+  'Crunching the context',
+  'Doing the due diligence',
+  'Sifting through the details',
+  'Asking the right questions',
+  'Double-checking everything',
+  'Looking at the big picture',
+  'Weighing the evidence',
+  'Putting it all together',
+  'Going through the checklist',
+  'Making sense of it all',
+  'Almost there',
+  'One more thing to check',
+  'Brewing an answer',
+];
+
+const ThinkingIndicator: FC = () => {
+  const theme = useTheme();
+  const [messageIndex, setMessageIndex] = useState(() =>
+    Math.floor(Math.random() * THINKING_MESSAGES.length)
+  );
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+
+  const rotate = useCallback(() => {
+    setMessageIndex((prev) => {
+      let next: number;
+      do {
+        next = Math.floor(Math.random() * THINKING_MESSAGES.length);
+      } while (next === prev && THINKING_MESSAGES.length > 1);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(rotate, 2500);
+    return () => clearInterval(intervalRef.current);
+  }, [rotate]);
+
+  return (
+    <Stack
+      direction="row"
+      gap={1.5}
+      sx={{
+        alignSelf: 'flex-start',
+        maxWidth: '75%',
+      }}
+    >
+      <Box
+        sx={{
+          backgroundColor: theme.palette.background.fill ?? theme.palette.grey[100],
+          padding: '12px 16px',
+          borderRadius: 3,
+          borderTopLeftRadius: 1,
+        }}
+      >
+        <Stack direction="row" gap={1} alignItems="center">
+          <Stack direction="row" gap={0.75}>
+            {[0, 0.2, 0.4].map((delay, index) => (
+              <Box
+                key={index}
+                sx={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  backgroundColor: theme.palette.text.accent ?? theme.palette.text.secondary,
+                  animation: 'pulse 1.4s infinite',
+                  animationDelay: `${delay}s`,
+                  '@keyframes pulse': {
+                    '0%, 60%, 100%': { opacity: 0.3 },
+                    '30%': { opacity: 1 },
+                  },
+                }}
+              />
+            ))}
+          </Stack>
+          <Typography
+            variant="caption"
+            sx={{
+              color: theme.palette.text.tertiary ?? theme.palette.text.disabled,
+              fontSize: 11,
+              fontStyle: 'italic',
+              ml: 0.5,
+              transition: 'opacity 200ms ease',
+            }}
+          >
+            {THINKING_MESSAGES[messageIndex]}
+          </Typography>
+        </Stack>
+      </Box>
+    </Stack>
+  );
+};
+
 const DEFAULT_USER: User = {
   id: 1,
   name: "",
@@ -136,6 +305,7 @@ const CustomMessageComponent: FC = () => {
   const { userId, users, photoRefreshFlag } = useContext(VerifyWiseContext);
   const { fetchProfilePhotoAsBlobUrl } = useProfilePhotoFetch();
   const [avatarUrl, setAvatarUrl] = useState<string>("");
+  const bubbleRef = useRef<HTMLDivElement>(null);
 
   const user: User = users
     ? users.find((u: User) => u.id === userId) || DEFAULT_USER
@@ -181,6 +351,8 @@ const CustomMessageComponent: FC = () => {
               xs: '100%',
             },
             justifyContent: 'flex-end',
+            paddingLeft: '8px',
+            paddingRight: '8px',
           }}
         >
           <Box
@@ -191,7 +363,7 @@ const CustomMessageComponent: FC = () => {
               borderRadius: 3,
               borderTopRightRadius: 1,
               fontSize: theme.typography.body2.fontSize,
-              lineHeight: 1.5,
+              lineHeight: 1.7,
               wordBreak: 'break-word',
               whiteSpace: 'pre-wrap',
             }}
@@ -214,6 +386,8 @@ const CustomMessageComponent: FC = () => {
           sx={{
             alignSelf: 'flex-start',
             width: '100%',
+            paddingLeft: '8px',
+            paddingRight: '16px',
           }}
         >
           <Avatar
@@ -228,63 +402,32 @@ const CustomMessageComponent: FC = () => {
           </Avatar>
 
           <MessagePrimitive.If hasContent={false}>
-            <Stack
-                direction="row"
-                gap={1.5}
-                sx={{
-                  alignSelf: 'flex-start',
-                  maxWidth: '75%',
-                }}
-              >
-                <Box
-                  sx={{
-                    backgroundColor: theme.palette.background.fill ?? theme.palette.grey[100],
-                    padding: '12px 16px',
-                    borderRadius: 3,
-                    borderTopLeftRadius: 1,
-                  }}
-                >
-                  <Stack direction="row" gap={0.75}>
-                    {[0, 0.2, 0.4].map((delay, index) => (
-                      <Box
-                        key={index}
-                        sx={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: '50%',
-                          backgroundColor: theme.palette.text.accent ?? theme.palette.text.secondary,
-                          animation: 'pulse 1.4s infinite',
-                          animationDelay: `${delay}s`,
-                          '@keyframes pulse': {
-                            '0%, 60%, 100%': { opacity: 0.3 },
-                            '30%': { opacity: 1 },
-                          },
-                        }}
-                      />
-                    ))}
-                  </Stack>
-                </Box>
-              </Stack>
+            <ThinkingIndicator />
           </MessagePrimitive.If>
 
           <MessagePrimitive.If hasContent>
             <Stack gap={0.75} sx={{ flex: 1, minWidth: 0 }}>
               <Box
+                ref={bubbleRef}
                 sx={{
                   backgroundColor: theme.palette.background.fill ?? theme.palette.grey[100],
+                  border: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
                   color: theme.palette.text.primary,
                   padding: '10px 14px',
                   borderRadius: 3,
                   borderTopLeftRadius: 1,
                   fontSize: theme.typography.body2.fontSize,
-                  lineHeight: 1.5,
+                  lineHeight: 1.7,
                   wordBreak: 'break-word',
                 }}
               >
                 <MessagePrimitive.Content components={{ Text: MessageText }} />
               </Box>
               <MessageChart />
-              <MessageTimestamp />
+              <Stack direction="row" alignItems="center" justifyContent="space-between">
+                <MessageTimestamp />
+                <CopyButton bubbleRef={bubbleRef} />
+              </Stack>
             </Stack>
           </MessagePrimitive.If>
         </Stack>

--- a/Clients/src/presentation/components/AdvisorChat/CustomThread.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/CustomThread.tsx
@@ -38,7 +38,7 @@ const SuggestionChipsComponent = ({ suggestions }: SuggestionChipsProps) => {
         sx={{
           display: 'flex',
           flexWrap: 'wrap',
-          gap: theme.spacing(1),
+          gap: '8px',
           justifyContent: 'center',
           maxWidth: 400,
         }}
@@ -126,7 +126,7 @@ const CustomThreadComponent = ({ pageContext }: CustomThreadProps) => {
             padding: theme.spacing(2),
           }}
         >
-          <Stack gap={1.5}>
+          <Stack gap="16px">
             <ThreadPrimitive.Messages
               components={{
                 UserMessage: CustomMessage,

--- a/Clients/src/presentation/components/AdvisorChat/advisorConfig.ts
+++ b/Clients/src/presentation/components/AdvisorChat/advisorConfig.ts
@@ -27,7 +27,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/risk-management',
     displayName: 'Risks',
     welcomeMessage: "Hello! I'm your AI Risk Management Advisor. I can help you analyze risk distributions, track mitigation progress, identify high-priority risks, and understand trends over time. What would you like to know about your risks?",
-    placeholder: 'Ask me about your risks...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our risk landscape', label: 'Summarize all risks' },
       { prompt: 'Show me the risk distribution by severity and likelihood', label: 'Show risk matrix' },
@@ -42,7 +42,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/model-inventory',
     displayName: 'Models',
     welcomeMessage: "Hello! I'm your AI Model Inventory Advisor. I can help you understand your model landscape, check approval statuses, review security assessments, and analyze provider distributions. What would you like to know about your models?",
-    placeholder: 'Ask me about your models...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our AI model inventory', label: 'Summarize all models' },
       { prompt: 'Which models are pending approval or blocked?', label: 'Find pending approvals' },
@@ -57,7 +57,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/model-inventory/model-risks',
     displayName: 'Model Risks',
     welcomeMessage: "Hello! I'm your AI Model Risk Advisor. I can help you analyze model-specific risks, track risk categories and severity levels, monitor mitigation progress, and identify risks needing attention. What would you like to know about your model risks?",
-    placeholder: 'Ask me about your model risks...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our model risk landscape', label: 'Summarize all model risks' },
       { prompt: 'Show me the distribution of risks by severity level', label: 'Show severity breakdown' },
@@ -72,7 +72,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/vendors',
     displayName: 'Vendors',
     welcomeMessage: "Hello! I'm your Vendor Management Advisor. I can help you analyze vendor risks, track review statuses, monitor compliance requirements, and identify vendors needing attention. What would you like to know about your vendors?",
-    placeholder: 'Ask me about your vendors...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our vendor landscape', label: 'Summarize all vendors' },
       { prompt: 'Show me vendor distribution by review status', label: 'Show review status' },
@@ -87,7 +87,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/ai-incident-managements',
     displayName: 'AI Incidents',
     welcomeMessage: "Hello! I'm your AI Incident Management Advisor. I can help you analyze incident trends, track severity levels, monitor resolution progress, and identify incidents needing attention. What would you like to know about your AI incidents?",
-    placeholder: 'Ask me about your AI incidents...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our incident landscape', label: 'Summarize all incidents' },
       { prompt: 'Show me incident distribution by severity', label: 'Show severity breakdown' },
@@ -102,7 +102,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/tasks',
     displayName: 'Tasks',
     welcomeMessage: "Hello! I'm your Task Management Advisor. I can help you analyze task distributions, track progress, identify overdue items, and understand workload across your team. What would you like to know about your tasks?",
-    placeholder: 'Ask me about your tasks...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our task landscape', label: 'Summarize all tasks' },
       { prompt: 'Show me task distribution by status', label: 'Show status breakdown' },
@@ -117,7 +117,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/policies',
     displayName: 'Policies',
     welcomeMessage: "Hello! I'm your Policy Management Advisor. I can help you analyze policy coverage, track review schedules, find policy templates, and identify gaps in your governance framework. What would you like to know about your policies?",
-    placeholder: 'Ask me about your policies...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our policy landscape', label: 'Summarize all policies' },
       { prompt: 'Show me policy distribution by status', label: 'Show status breakdown' },
@@ -132,7 +132,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/overview',
     displayName: 'Use Cases',
     welcomeMessage: "Hello! I'm your Use Case Advisor. I can help you understand your AI use case portfolio, track status and risk classifications, and identify high-risk projects. What would you like to know about your use cases?",
-    placeholder: 'Ask me about your use cases...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our use case portfolio', label: 'Summarize use cases' },
       { prompt: 'Show me the distribution of use cases by risk classification', label: 'Show risk classifications' },
@@ -146,7 +146,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/datasets',
     displayName: 'Datasets',
     welcomeMessage: "Hello! I'm your Dataset Advisor. I can help you analyze your dataset inventory, track PII exposure, review data classifications, and identify datasets with known biases. What would you like to know about your datasets?",
-    placeholder: 'Ask me about your datasets...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our dataset landscape', label: 'Summarize datasets' },
       { prompt: 'Which datasets contain PII?', label: 'Find PII datasets' },
@@ -160,7 +160,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/framework',
     displayName: 'Frameworks',
     welcomeMessage: "Hello! I'm your Framework Advisor. I can help you understand your compliance framework adoption, project coverage, and compare frameworks. What would you like to know about your frameworks?",
-    placeholder: 'Ask me about your frameworks...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'List all frameworks and their project adoption counts', label: 'List all frameworks' },
       { prompt: 'Which frameworks have the most project adoption?', label: 'Show adoption ranking' },
@@ -172,7 +172,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/training',
     displayName: 'Training',
     welcomeMessage: "Hello! I'm your Training Registry Advisor. I can help you track training completion rates, department coverage, provider statistics, and identify training gaps. What would you like to know about your training programs?",
-    placeholder: 'Ask me about your training programs...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our training programs', label: 'Summarize training' },
       { prompt: 'What is our overall training completion rate?', label: 'Check completion rate' },
@@ -186,7 +186,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/file-manager',
     displayName: 'Evidence',
     welcomeMessage: "Hello! I'm your Evidence Hub Advisor. I can help you track evidence items, monitor expiry dates, check model coverage, and identify compliance gaps. What would you like to know about your evidence?",
-    placeholder: 'Ask me about your evidence...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of our evidence', label: 'Summarize evidence' },
       { prompt: 'Which evidence items have expired?', label: 'Find expired evidence' },
@@ -199,7 +199,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/reporting',
     displayName: 'Reporting',
     welcomeMessage: "Hello! I'm your Reporting Advisor. I can help you understand your report generation history, find reports by type, and analyze reporting patterns. What would you like to know about your reports?",
-    placeholder: 'Ask me about your reports...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Show me all generated reports', label: 'List all reports' },
       { prompt: 'Show me the breakdown of reports by type', label: 'Reports by type' },
@@ -211,7 +211,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/ai-trust-center',
     displayName: 'AI Trust Center',
     welcomeMessage: "Hello! I'm your AI Trust Center Advisor. I can help you understand your trust center configuration, check section visibility, review resources and subprocessors. What would you like to know about your AI Trust Center?",
-    placeholder: 'Ask me about your AI Trust Center...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Show me the current trust center configuration', label: 'Show trust center overview' },
       { prompt: 'Which sections are publicly visible?', label: 'Check section visibility' },
@@ -224,7 +224,7 @@ export const ADVISOR_DOMAINS: Record<string, AdvisorDomainConfig> = {
     path: '/agent-discovery',
     displayName: 'Agent Discovery',
     welcomeMessage: "Hello! I'm your Agent Discovery Advisor. I can help you understand your discovered agent landscape, track review statuses, identify stale agents, and analyze source system distributions. What would you like to know about your agents?",
-    placeholder: 'Ask me about your discovered agents...',
+    placeholder: 'Ask any question about your data...',
     suggestions: [
       { prompt: 'Give me an executive summary of agent discovery', label: 'Summarize agents' },
       { prompt: 'How many agents are unreviewed?', label: 'Find unreviewed agents' },
@@ -267,7 +267,7 @@ export const getSuggestions = (domain?: AdvisorDomain): AdvisorSuggestion[] => {
   return ADVISOR_DOMAINS[domain]?.suggestions ?? [];
 };
 
-export const DEFAULT_PLACEHOLDER = 'Ask me anything...';
+export const DEFAULT_PLACEHOLDER = 'Ask any question about your data...';
 
 /**
  * Get placeholder text for a domain

--- a/Clients/src/presentation/components/Cards/RisksCard/style.ts
+++ b/Clients/src/presentation/components/Cards/RisksCard/style.ts
@@ -1,22 +1,21 @@
 export const projectRisksCard = {
-  minWidth: "fit-content",
-  width: { xs: "100%", sm: "fit-content" },
+  width: "100%",
   height: "100%",
   display: "flex",
   flexDirection: { xs: "column", sm: "row" },
+  flexWrap: "wrap",
   gap: "16px",
-  overflow: "auto",
 };
 
 export const projectRisksTileCard = {
   paddingY: { xs: "10px", sm: "15px" },
-  paddingX: { xs: "15px", sm: "30px" },
+  paddingX: { xs: "15px", sm: "20px" },
   textAlign: "center" as const,
   fontWeight: 600,
   gap: 5,
   position: "relative" as const,
-  minWidth: { xs: "120px", sm: "140px" },
-  width: { xs: "120px", sm: "140px" },
+  flex: { xs: "1 1 120px", sm: "1 1 100px" },
+  minWidth: { xs: "100px", sm: "100px" },
   background: "linear-gradient(135deg, #ffffff 0%, #f8fafc 100%)",
   border: "1px solid #E5E7EB",
   borderRadius: 2,

--- a/Clients/src/presentation/components/UserGuide/AdvisorHeader.tsx
+++ b/Clients/src/presentation/components/UserGuide/AdvisorHeader.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useState } from "react";
-import { X } from "lucide-react";
+import { Maximize2, Minimize2, X } from "lucide-react";
 import { colors, typography, spacing, border } from "./styles/theme";
 import { getLLMKeys } from "../../../application/repository/llmKeys.repository";
 import { LLMKeysModel } from "../../../domain/models/Common/llmKeys/llmKeys.model";
@@ -9,6 +9,8 @@ interface AdvisorHeaderProps {
   selectedLLMKeyId?: number;
   onLLMKeyChange?: (keyId: number) => void;
   onLLMKeysLoaded?: (hasKeys: boolean, isLoading: boolean) => void;
+  isEnlarged?: boolean;
+  onToggleEnlarge?: () => void;
 }
 
 const AdvisorHeader: FC<AdvisorHeaderProps> = ({
@@ -16,6 +18,8 @@ const AdvisorHeader: FC<AdvisorHeaderProps> = ({
   selectedLLMKeyId,
   onLLMKeyChange,
   onLLMKeysLoaded,
+  isEnlarged = false,
+  onToggleEnlarge,
 }) => {
   const [llmKeys, setLLMKeys] = useState<LLMKeysModel[]>([]);
   const [loading, setLoading] = useState(true);
@@ -85,7 +89,7 @@ const AdvisorHeader: FC<AdvisorHeaderProps> = ({
             textOverflow: "ellipsis",
           }}
         >
-          Advisor
+          AI advisor
         </span>
 
         {/* Right side: LLM Key Selector and Actions */}
@@ -121,6 +125,33 @@ const AdvisorHeader: FC<AdvisorHeaderProps> = ({
                 </option>
               ))}
             </select>
+          )}
+
+          {/* Enlarge/Shrink button */}
+          {onToggleEnlarge && (
+            <button
+              onClick={onToggleEnlarge}
+              className="header-icon-button"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 28,
+                height: 28,
+                backgroundColor: "transparent",
+                border: "none",
+                borderRadius: border.radius,
+                cursor: "pointer",
+                color: colors.text.secondary,
+              }}
+              title={isEnlarged ? "Shrink" : "Enlarge"}
+            >
+              {isEnlarged ? (
+                <Minimize2 size={14} strokeWidth={1.5} />
+              ) : (
+                <Maximize2 size={14} strokeWidth={1.5} />
+              )}
+            </button>
           )}
 
           {/* Close button */}

--- a/Clients/src/presentation/components/UserGuide/SidebarWrapper.tsx
+++ b/Clients/src/presentation/components/UserGuide/SidebarWrapper.tsx
@@ -47,6 +47,7 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [contentWidth, setContentWidthLocal] = useState(DEFAULT_CONTENT_WIDTH);
+  const [isAdvisorEnlarged, setIsAdvisorEnlarged] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [isHoveringHandle, setIsHoveringHandle] = useState(false);
   const [mouseY, setMouseY] = useState(0);
@@ -363,6 +364,18 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
     }
   }
 
+  // Handle advisor enlarge toggle
+  const handleToggleAdvisorEnlarge = useCallback(() => {
+    setIsAdvisorEnlarged((prev) => {
+      const next = !prev;
+      const newWidth = next
+        ? Math.round(DEFAULT_CONTENT_WIDTH * 1.4)
+        : DEFAULT_CONTENT_WIDTH;
+      setContentWidth(newWidth);
+      return next;
+    });
+  }, [setContentWidth]);
+
   // Handle tab click - open sidebar if closed, close if clicking active tab, or switch tab
   const handleTabClick = (tab: Tab) => {
     if (!isOpen) {
@@ -374,6 +387,11 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
     } else {
       // Clicking a different tab switches to it
       setActiveTab(tab);
+      // Reset enlarge when switching away from advisor
+      if (isAdvisorEnlarged) {
+        setIsAdvisorEnlarged(false);
+        setContentWidth(DEFAULT_CONTENT_WIDTH);
+      }
     }
   };
 
@@ -442,7 +460,7 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
           position: 'absolute',
           left: 0,
           top: 0,
-          width: 8,
+          width: 4,
           height: '100%',
           cursor: 'ew-resize',
           zIndex: 20,
@@ -508,6 +526,8 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
                 selectedLLMKeyId={selectedLLMKeyId}
                 onLLMKeyChange={handleLLMKeyChange}
                 onLLMKeysLoaded={handleLLMKeysLoaded}
+                isEnlarged={isAdvisorEnlarged}
+                onToggleEnlarge={handleToggleAdvisorEnlarge}
               />
             ): (
               <SidebarHeader

--- a/Clients/src/presentation/containers/Dashboard/index.css
+++ b/Clients/src/presentation/containers/Dashboard/index.css
@@ -36,7 +36,7 @@
   min-height: 0; /* Critical for flex scroll containers */
   overflow-y: auto !important;
   overflow-x: hidden !important;
-  padding: 24px;
+  padding: 24px 8px 24px 24px;
 }
 .home-layout > div:has(> [class*="fallback__"]) .background-pattern-svg {
   position: absolute;


### PR DESCRIPTION
## Summary
- Add rotating playful thinking messages to AI advisor loading indicator
- Add enlarge/shrink toggle (40% wider) to AI advisor header
- Rename "Advisor" to "AI advisor" throughout the sidebar
- Add disclaimer text and copy button (rich text) to assistant responses
- Improve chat bubble spacing: 1.7 line height, 16px gaps, 8px avatar padding
- Unify all advisor placeholder text to "Ask any question about your data..."
- Make status tile cards (policies, tasks, models) flex-responsive instead of fixed-width
- Reduce main content right padding from 24px to 8px near sidebar
- Reduce sidebar resize handle from 8px to 4px

## Test plan
- [ ] Open AI advisor on any page — verify "Ask any question about your data..." placeholder
- [ ] Send a message — verify rotating thinking messages appear while loading
- [ ] Receive a response — verify copy button appears below the answer, copies rich text
- [ ] Click enlarge button — verify advisor widens by ~40%, click again to shrink
- [ ] Navigate to /policies — verify 7 status cards resize when sidebar is resized
- [ ] Check spacing: 16px between bubbles, 8px around avatars, disclaimer text below composer
- [ ] Switch tabs and back — verify enlarge state resets on tab switch