### PR TITLE
fix: resolve left sidebar toggle closing and reopening instantly

### DIFF
--- a/Clients/src/presentation/components/Chip.tsx
+++ b/Clients/src/presentation/components/Chip.tsx
@@ -72,10 +72,12 @@ const LABEL_TO_VARIANT: Record<string, ChipVariant> = {
   // Status
   approved: "success",
   completed: "success",
+  confirmed: "success",
   resolved: "success",
   active: "success",
   yes: "yes",
   pending: "warning",
+  unreviewed: "warning",
   "in progress": "warning",
   "under review": "warning",
   draft: "default",

--- a/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
+++ b/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
   Drawer,
   Stack,
@@ -6,15 +6,17 @@ import {
   Typography,
   Divider,
   IconButton,
-  Chip,
+  Chip as MuiChip,
   useTheme,
   Tab,
 } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { X, Link as LinkIcon, Unlink } from "lucide-react";
+import VWChip from "../../Chip";
 import { CustomizableButton } from "../../button/customizable-button";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { AgentPrimitiveRow } from "../../../pages/AgentDiscovery/AgentTable";
+import { getAllEntities } from "../../../../application/repository/entity.repository";
 import LinkModelModal from "./LinkModelModal";
 
 interface ReviewAgentModalProps {
@@ -34,8 +36,31 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
   const [permissionsTab, setPermissionsTab] = useState("categories");
+  const [usersMap, setUsersMap] = useState<Record<string, string>>({});
+
+  const fetchUsers = useCallback(async () => {
+    try {
+      const response = await getAllEntities({ routeUrl: "/users" });
+      const usersData = Array.isArray(response?.data) ? response.data : [];
+      const map: Record<string, string> = {};
+      usersData.forEach((u: { id: number; name: string; surname: string }) => {
+        map[String(u.id)] = `${u.name} ${u.surname}`.trim();
+      });
+      setUsersMap(map);
+    } catch (error) {
+      console.error("Failed to fetch users:", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchUsers();
+    }
+  }, [isOpen, fetchUsers]);
 
   if (!agent) return null;
+
+  const ownerName = agent.owner_id ? usersMap[agent.owner_id] || agent.owner_id : "—";
 
   const handleReview = async (status: "confirmed" | "rejected") => {
     setIsSubmitting(true);
@@ -107,21 +132,24 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
           <DetailRow label="Source system" value={agent.source_system} />
           <DetailRow label="Type" value={agent.primitive_type} />
           <DetailRow label="External ID" value={agent.external_id} />
-          <DetailRow label="Owner" value={agent.owner_id || "—"} />
+          <DetailRow label="Owner" value={ownerName} />
           <DetailRow label="Last activity" value={formatDate(agent.last_activity)} />
           <DetailRow label="Created" value={formatDate(agent.created_at)} />
-          <DetailRow
-            label="Review status"
-            value={agent.review_status}
-            isChip
-            chipColor={
-              agent.review_status === "confirmed"
-                ? "#2E7D32"
-                : agent.review_status === "rejected"
-                ? "#D32F2F"
-                : "#F9A825"
-            }
-          />
+          <Box>
+            <Typography fontSize={12} fontWeight={600} color="text.secondary" mb={0.5}>
+              Review status
+            </Typography>
+            <VWChip
+              label={agent.review_status}
+              variant={
+                agent.review_status === "confirmed"
+                  ? "success"
+                  : agent.review_status === "rejected"
+                  ? "error"
+                  : "warning"
+              }
+            />
+          </Box>
           {agent.is_stale && (
             <DetailRow label="Stale" value="This agent has been inactive for 30+ days" />
           )}
@@ -150,7 +178,7 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
                 <Stack direction="row" flexWrap="wrap" gap={0.5}>
                   {(agent.permission_categories || []).length > 0 ? (
                     agent.permission_categories.map((cat) => (
-                      <Chip
+                      <MuiChip
                         key={cat}
                         label={cat}
                         size="small"
@@ -168,7 +196,7 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
                 <Stack direction="row" flexWrap="wrap" gap={0.5}>
                   {(agent.permissions || []).length > 0 ? (
                     agent.permissions.map((perm: any, idx: number) => (
-                      <Chip
+                      <MuiChip
                         key={idx}
                         label={typeof perm === "string" ? perm : JSON.stringify(perm)}
                         size="small"
@@ -283,29 +311,12 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
 const DetailRow: React.FC<{
   label: string;
   value: string;
-  isChip?: boolean;
-  chipColor?: string;
-}> = ({ label, value, isChip, chipColor }) => (
+}> = ({ label, value }) => (
   <Box>
     <Typography fontSize={12} fontWeight={600} color="text.secondary" mb={0.5}>
       {label}
     </Typography>
-    {isChip ? (
-      <Chip
-        label={value}
-        size="small"
-        sx={{
-          fontSize: 11,
-          height: 22,
-          color: chipColor,
-          backgroundColor: chipColor ? `${chipColor}20` : undefined,
-          fontWeight: 500,
-          textTransform: "capitalize",
-        }}
-      />
-    ) : (
-      <Typography fontSize={13}>{value}</Typography>
-    )}
+    <Typography fontSize={13}>{value}</Typography>
   </Box>
 );
 

--- a/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
+++ b/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
@@ -230,12 +230,11 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
             ) : (
               <CustomizableButton
                 variant="outlined"
-                sx={{ border: "1px solid #d0d5dd", gap: "6px" }}
+                sx={{ border: "1px solid #d0d5dd" }}
+                icon={<LinkIcon size={14} strokeWidth={1.5} />}
+                text="Link to model"
                 onClick={() => setIsLinkModalOpen(true)}
-              >
-                <LinkIcon size={14} strokeWidth={1.5} />
-                Link to model
-              </CustomizableButton>
+              />
             )}
           </Box>
 

--- a/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
+++ b/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
@@ -11,7 +11,7 @@ import {
   Tab,
 } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { X, Pencil, Link as LinkIcon, Unlink } from "lucide-react";
+import { X, Link as LinkIcon, Unlink } from "lucide-react";
 import { CustomizableButton } from "../../button/customizable-button";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { AgentPrimitiveRow } from "../../../pages/AgentDiscovery/AgentTable";
@@ -22,7 +22,6 @@ interface ReviewAgentModalProps {
   setIsOpen: (open: boolean) => void;
   agent: AgentPrimitiveRow | null;
   onSuccess: () => void;
-  onEdit?: (agent: AgentPrimitiveRow) => void;
 }
 
 const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
@@ -30,7 +29,6 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
   setIsOpen,
   agent,
   onSuccess,
-  onEdit,
 }) => {
   const theme = useTheme();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -96,20 +94,9 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
           <Typography fontSize={16} fontWeight={600}>
             Agent details
           </Typography>
-          <Stack direction="row" alignItems="center" gap={0.5}>
-            {agent.is_manual && onEdit && (
-              <IconButton
-                onClick={() => onEdit(agent)}
-                size="small"
-                title="Edit agent"
-              >
-                <Pencil size={16} strokeWidth={1.5} />
-              </IconButton>
-            )}
-            <IconButton onClick={() => setIsOpen(false)} size="small">
-              <X size={20} />
-            </IconButton>
-          </Stack>
+          <IconButton onClick={() => setIsOpen(false)} size="small">
+            <X size={20} />
+          </IconButton>
         </Stack>
 
         <Divider />

--- a/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
+++ b/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
@@ -11,7 +11,7 @@ import {
   Tab,
 } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
-import { X, Link as LinkIcon, Unlink } from "lucide-react";
+import { X, Pencil, Link as LinkIcon, Unlink } from "lucide-react";
 import { CustomizableButton } from "../../button/customizable-button";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { AgentPrimitiveRow } from "../../../pages/AgentDiscovery/AgentTable";
@@ -22,6 +22,7 @@ interface ReviewAgentModalProps {
   setIsOpen: (open: boolean) => void;
   agent: AgentPrimitiveRow | null;
   onSuccess: () => void;
+  onEdit?: (agent: AgentPrimitiveRow) => void;
 }
 
 const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
@@ -29,6 +30,7 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
   setIsOpen,
   agent,
   onSuccess,
+  onEdit,
 }) => {
   const theme = useTheme();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -94,9 +96,20 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
           <Typography fontSize={16} fontWeight={600}>
             Agent details
           </Typography>
-          <IconButton onClick={() => setIsOpen(false)} size="small">
-            <X size={20} />
-          </IconButton>
+          <Stack direction="row" alignItems="center" gap={0.5}>
+            {agent.is_manual && onEdit && (
+              <IconButton
+                onClick={() => onEdit(agent)}
+                size="small"
+                title="Edit agent"
+              >
+                <Pencil size={16} strokeWidth={1.5} />
+              </IconButton>
+            )}
+            <IconButton onClick={() => setIsOpen(false)} size="small">
+              <X size={20} />
+            </IconButton>
+          </Stack>
         </Stack>
 
         <Divider />

--- a/Clients/src/presentation/components/Sidebar/SidebarShell.tsx
+++ b/Clients/src/presentation/components/Sidebar/SidebarShell.tsx
@@ -11,7 +11,6 @@ import {
   Typography,
   Chip,
   Popover,
-  Slide,
 } from "@mui/material";
 import { useTheme } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
@@ -32,9 +31,6 @@ import SidebarFooter from "./SidebarFooter";
 import { FlyingHearts } from "../FlyingHearts";
 
 declare const __APP_VERSION__: string;
-
-// Track if sidebar has been shown before (persists across module switches)
-let hasShownSidebarBefore = false;
 
 // Types for menu items
 export interface SidebarMenuItem {
@@ -122,31 +118,11 @@ const SidebarShell: FC<SidebarShellProps> = ({
   const theme = useTheme();
   const dispatch = useDispatch();
 
-  // Sidebar mount state for slide-in animation
-  // Skip animation if sidebar has been shown before (e.g., when switching modules)
-  const [isMounted, setIsMounted] = useState(hasShownSidebarBefore);
-
   // Heart icon state (Easter egg)
   const [showHeartIcon, setShowHeartIcon] = useState(false);
   const [showFlyingHearts, setShowFlyingHearts] = useState(false);
   const [heartReturning, setHeartReturning] = useState(false);
   const heartTimerRef = useRef<NodeJS.Timeout | null>(null);
-
-  // Trigger slide-in after initial render (only on first app load)
-  useEffect(() => {
-    if (hasShownSidebarBefore) {
-      // Skip animation on module switch
-      setIsMounted(true);
-      return;
-    }
-
-    // First time showing sidebar - animate it
-    const timer = setTimeout(() => {
-      setIsMounted(true);
-      hasShownSidebarBefore = true;
-    }, 50);
-    return () => clearTimeout(timer);
-  }, []);
 
   // VerifyWiseContext available for future use
   useContext(VerifyWiseContext);
@@ -526,7 +502,6 @@ const SidebarShell: FC<SidebarShellProps> = ({
   };
 
   return (
-    <Slide direction="right" in={isMounted} timeout={350} mountOnEnter>
       <Stack
         component="aside"
         className={`sidebar-menu ${collapsed ? "collapsed" : "expanded"}`}
@@ -682,7 +657,7 @@ const SidebarShell: FC<SidebarShellProps> = ({
             }}
             onClick={() => dispatch(toggleSidebar())}
           >
-            {delayedCollapsed ? (
+            {collapsed ? (
               <PanelLeftOpen size={16} strokeWidth={1.5} />
             ) : (
               <PanelLeftClose size={16} strokeWidth={1.5} />
@@ -1024,7 +999,6 @@ const SidebarShell: FC<SidebarShellProps> = ({
           <FlyingHearts onComplete={() => setShowFlyingHearts(false)} />
         )}
       </Stack>
-    </Slide>
   );
 };
 

--- a/Clients/src/presentation/components/UserGuide/SidebarWrapper.tsx
+++ b/Clients/src/presentation/components/UserGuide/SidebarWrapper.tsx
@@ -376,8 +376,15 @@ const SidebarWrapper: React.FC<SidebarWrapperProps> = ({
     });
   }, [setContentWidth]);
 
+  // Guard against rapid open/close during CSS transition
+  const tabClickLockRef = useRef(false);
+
   // Handle tab click - open sidebar if closed, close if clicking active tab, or switch tab
   const handleTabClick = (tab: Tab) => {
+    if (tabClickLockRef.current) return;
+    tabClickLockRef.current = true;
+    setTimeout(() => { tabClickLockRef.current = false; }, 350);
+
     if (!isOpen) {
       onOpen();
       setActiveTab(tab);

--- a/Clients/src/presentation/containers/Dashboard/index.tsx
+++ b/Clients/src/presentation/containers/Dashboard/index.tsx
@@ -328,7 +328,7 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
                 minHeight: 0,
                 overflowY: "auto", 
                 overflowX: "hidden",
-                padding: "24px"
+                padding: "24px 8px 24px 24px"
               }}
             >
               <Outlet />

--- a/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
+++ b/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
@@ -14,6 +14,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { ChevronsUpDown, ChevronUp, ChevronDown, AlertTriangle } from "lucide-react";
+import IconButton from "../../components/IconButton";
 import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
 import { EmptyState } from "../../components/EmptyState";
 import Chip from "../../components/Chip";
@@ -53,6 +54,8 @@ interface AgentTableProps {
   agents: AgentPrimitiveRow[];
   isLoading: boolean;
   onRowClick: (agent: AgentPrimitiveRow) => void;
+  onEdit: (agent: AgentPrimitiveRow) => void;
+  onDelete: (agent: AgentPrimitiveRow) => void;
 }
 
 const cellStyle = singleTheme.tableStyles.primary.body.cell;
@@ -65,6 +68,7 @@ const TABLE_COLUMNS = [
   { id: "last_activity", label: "LAST ACTIVITY", sortable: true },
   { id: "review_status", label: "STATUS", sortable: true },
   { id: "stale", label: "", sortable: false },
+  { id: "actions", label: "", sortable: false },
 ];
 
 type SortDirection = "asc" | "desc" | null;
@@ -74,6 +78,8 @@ const AgentTable: React.FC<AgentTableProps> = ({
   agents,
   isLoading,
   onRowClick,
+  onEdit,
+  onDelete,
 }) => {
   const theme = useTheme();
   const [page, setPage] = useState(0);
@@ -296,6 +302,20 @@ const AgentTable: React.FC<AgentTableProps> = ({
                   color="#F9A825"
                 />
               )}
+            </TableCell>
+            <TableCell
+              sx={{ ...cellStyle, width: 40 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <IconButton
+                id={agent.id}
+                onEdit={() => onEdit(agent)}
+                onDelete={() => onDelete(agent)}
+                onMouseEvent={() => {}}
+                warningTitle="Delete this agent?"
+                warningMessage="When you delete this agent, all data related to this agent will be removed. This action is non-recoverable."
+                type="Vendor"
+              />
             </TableCell>
           </TableRow>
         ))}

--- a/Clients/src/presentation/pages/AgentDiscovery/index.tsx
+++ b/Clients/src/presentation/pages/AgentDiscovery/index.tsx
@@ -63,6 +63,7 @@ const AgentDiscovery: React.FC = () => {
   const [selectedAgent, setSelectedAgent] = useState<AgentPrimitiveRow | null>(null);
   const [isReviewModalOpen, setIsReviewModalOpen] = useState(false);
   const [isManualModalOpen, setIsManualModalOpen] = useState(false);
+  const [editAgent, setEditAgent] = useState<AgentPrimitiveRow | null>(null);
 
   // Alert
   const [alert, setAlert] = useState<{
@@ -279,9 +280,16 @@ const AgentDiscovery: React.FC = () => {
 
   const handleManualSuccess = () => {
     setIsManualModalOpen(false);
+    setEditAgent(null);
     fetchAgents();
     fetchStats();
-    showAlertMessage("success", "Agent added successfully.");
+    showAlertMessage("success", editAgent ? "Agent updated successfully." : "Agent added successfully.");
+  };
+
+  const handleEditAgent = (agent: AgentPrimitiveRow) => {
+    setIsReviewModalOpen(false);
+    setEditAgent(agent);
+    setIsManualModalOpen(true);
   };
 
   return (
@@ -396,13 +404,18 @@ const AgentDiscovery: React.FC = () => {
         setIsOpen={setIsReviewModalOpen}
         agent={selectedAgent}
         onSuccess={handleReviewSuccess}
+        onEdit={handleEditAgent}
       />
 
       {/* Manual entry modal */}
       <ManualAgentModal
         isOpen={isManualModalOpen}
-        setIsOpen={setIsManualModalOpen}
+        setIsOpen={(open) => {
+          setIsManualModalOpen(open);
+          if (!open) setEditAgent(null);
+        }}
         onSuccess={handleManualSuccess}
+        agent={editAgent}
       />
     </Stack>
   );

--- a/Clients/src/presentation/pages/AgentDiscovery/index.tsx
+++ b/Clients/src/presentation/pages/AgentDiscovery/index.tsx
@@ -287,9 +287,20 @@ const AgentDiscovery: React.FC = () => {
   };
 
   const handleEditAgent = (agent: AgentPrimitiveRow) => {
-    setIsReviewModalOpen(false);
     setEditAgent(agent);
     setIsManualModalOpen(true);
+  };
+
+  const handleDeleteAgent = async (agent: AgentPrimitiveRow) => {
+    try {
+      await apiServices.delete(`/agent-primitives/${agent.id}`);
+      fetchAgents();
+      fetchStats();
+      showAlertMessage("success", "Agent deleted successfully.");
+    } catch (error) {
+      console.error("Failed to delete agent:", error);
+      showAlertMessage("error", "Failed to delete agent.");
+    }
   };
 
   return (
@@ -394,6 +405,8 @@ const AgentDiscovery: React.FC = () => {
             agents={data}
             isLoading={isLoading}
             onRowClick={handleRowClick}
+            onEdit={handleEditAgent}
+            onDelete={handleDeleteAgent}
           />
         )}
       />
@@ -404,7 +417,6 @@ const AgentDiscovery: React.FC = () => {
         setIsOpen={setIsReviewModalOpen}
         agent={selectedAgent}
         onSuccess={handleReviewSuccess}
-        onEdit={handleEditAgent}
       />
 
       {/* Manual entry modal */}

--- a/Servers/controllers/agentDiscovery.ctrl.ts
+++ b/Servers/controllers/agentDiscovery.ctrl.ts
@@ -3,6 +3,7 @@ import {
   getAllAgentPrimitivesQuery,
   getAgentPrimitiveByIdQuery,
   createAgentPrimitiveQuery,
+  updateAgentPrimitiveQuery,
   deleteAgentPrimitiveByIdQuery,
   updateReviewStatusQuery,
   linkModelQuery,
@@ -154,6 +155,64 @@ export async function createAgentPrimitive(req: Request, res: Response) {
     return res.status(201).json(STATUS_CODE[201](primitive));
   } catch (error) {
     logStructured("error", "failed to create agent primitive", functionName, fileName);
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+}
+
+/**
+ * Update a manually-added agent primitive
+ */
+export async function updateAgentPrimitive(req: Request, res: Response) {
+  const functionName = "updateAgentPrimitive";
+  logStructured("processing", "updating agent primitive", functionName, fileName);
+
+  try {
+    const id = parseInt(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id, 10);
+    if (isNaN(id)) {
+      return res.status(400).json(STATUS_CODE[400]("Invalid agent primitive ID"));
+    }
+
+    const existing = await getAgentPrimitiveByIdQuery(id, req.tenantId!);
+    if (!existing) {
+      return res.status(404).json(STATUS_CODE[404]("Agent primitive not found"));
+    }
+    if (!existing.is_manual) {
+      return res.status(403).json(STATUS_CODE[403]("Only manually-added agents can be edited"));
+    }
+
+    const { display_name, primitive_type, owner_id, metadata } = req.body;
+
+    const updated = await updateAgentPrimitiveQuery(
+      id,
+      { display_name, primitive_type, owner_id, metadata },
+      req.tenantId!
+    );
+
+    // Create audit log entries for each changed field
+    const fieldsToCheck: Array<{ field: string; oldVal: any; newVal: any }> = [
+      { field: "display_name", oldVal: existing.display_name, newVal: display_name },
+      { field: "primitive_type", oldVal: existing.primitive_type, newVal: primitive_type },
+      { field: "owner_id", oldVal: existing.owner_id, newVal: owner_id },
+      { field: "metadata", oldVal: JSON.stringify(existing.metadata), newVal: metadata !== undefined ? JSON.stringify(metadata) : undefined },
+    ];
+
+    for (const { field, oldVal, newVal } of fieldsToCheck) {
+      if (newVal !== undefined && String(oldVal ?? "") !== String(newVal ?? "")) {
+        await createAuditLogQuery({
+          agent_primitive_id: id,
+          action: "field_updated",
+          field_changed: field,
+          old_value: oldVal != null ? String(oldVal) : null,
+          new_value: newVal != null ? String(newVal) : null,
+          performed_by: req.userId!,
+        }, req.tenantId!);
+      }
+    }
+
+    logStructured("successful", "agent primitive updated", functionName, fileName);
+    return res.status(200).json(STATUS_CODE[200](updated));
+  } catch (error) {
+    logStructured("error", "failed to update agent primitive", functionName, fileName);
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }
 }

--- a/Servers/routes/agentDiscovery.route.ts
+++ b/Servers/routes/agentDiscovery.route.ts
@@ -8,6 +8,7 @@ import {
   getSyncStatus,
   getAgentPrimitiveById,
   createAgentPrimitive,
+  updateAgentPrimitive,
   triggerSync,
   reviewAgentPrimitive,
   linkModelToAgent,
@@ -28,6 +29,9 @@ router.get("/:id", authenticateJWT, getAgentPrimitiveById);
 // Create + sync trigger
 router.post("/", authenticateJWT, createAgentPrimitive);
 router.post("/sync", authenticateJWT, triggerSync);
+
+// Update (manual agents only)
+router.patch("/:id", authenticateJWT, updateAgentPrimitive);
 
 // Review + model linking
 router.patch("/:id/review", authenticateJWT, reviewAgentPrimitive);

--- a/Servers/utils/agentDiscovery.utils.ts
+++ b/Servers/utils/agentDiscovery.utils.ts
@@ -136,6 +136,45 @@ export const createAgentPrimitiveQuery = async (
   return (results as AgentPrimitive[])[0];
 };
 
+export const updateAgentPrimitiveQuery = async (
+  id: number,
+  data: {
+    display_name?: string;
+    primitive_type?: string;
+    owner_id?: string | null;
+    metadata?: Record<string, any>;
+  },
+  tenant: string
+): Promise<AgentPrimitive | null> => {
+  const sets: string[] = [];
+  const replacements: Record<string, any> = { id };
+
+  if (data.display_name !== undefined) {
+    sets.push("display_name = :display_name");
+    replacements.display_name = data.display_name;
+  }
+  if (data.primitive_type !== undefined) {
+    sets.push("primitive_type = :primitive_type");
+    replacements.primitive_type = data.primitive_type;
+  }
+  if (data.owner_id !== undefined) {
+    sets.push("owner_id = :owner_id");
+    replacements.owner_id = data.owner_id;
+  }
+  if (data.metadata !== undefined) {
+    sets.push("metadata = :metadata");
+    replacements.metadata = JSON.stringify(data.metadata);
+  }
+
+  sets.push("updated_at = NOW()");
+
+  const [results] = await sequelize.query(
+    `UPDATE "${tenant}".agent_primitives SET ${sets.join(", ")} WHERE id = :id RETURNING *`,
+    { replacements }
+  );
+  return (results as AgentPrimitive[])[0] || null;
+};
+
 export const deleteAgentPrimitiveByIdQuery = async (
   id: number,
   tenant: string


### PR DESCRIPTION
## Summary
- Fixed the left sidebar toggle button that was closing and immediately reopening on click
- Root cause: MUI `<Slide>` animation wrapper was interfering with the sidebar's 650ms CSS width transition
- Also fixed Dashboard inline padding override that was negating the right-padding reduction near the right sidebar

## Changes
- Removed `<Slide>` wrapper and its associated state (`isMounted`, `hasShownSidebarBefore`) from `SidebarShell.tsx`
- Switched toggle icon to use `collapsed` instead of `delayedCollapsed` for immediate visual feedback
- Added 350ms debounce guard on right sidebar tab clicks in `SidebarWrapper.tsx`
- Fixed inline `padding: "24px"` in `Dashboard/index.tsx` to `padding: "24px 8px 24px 24px"`

## Test plan
- [ ] Click left sidebar toggle — should collapse smoothly and stay collapsed
- [ ] Click again — should expand smoothly and stay expanded
- [ ] Rapid-click the toggle — should not glitch or double-toggle
- [ ] Switch between app modules (Governance, LLM Evals, etc.) — sidebar state should persist
- [ ] Verify right sidebar tabs still work correctly
- [ ] Verify content area right padding is reduced near the right sidebar