### PR TITLE
fix: display experiment name instead of ID across UI

### DIFF
--- a/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
@@ -100,7 +100,7 @@ const EvaluationTableBody: React.FC<IEvaluationTableBodyProps> = ({
               },
             }}
           >
-            {/* EXPERIMENT ID */}
+            {/* EXPERIMENT NAME */}
             <TableCell
               sx={{
                 ...singleTheme.tableStyles.primary.body.cell,
@@ -134,7 +134,7 @@ const EvaluationTableBody: React.FC<IEvaluationTableBodyProps> = ({
               ) : row.status === "Failed" ? (
                 <Typography sx={{ fontSize: 13, color: "#c62828", fontWeight: 500 }}>Failed</Typography>
               ) : (
-                row.id
+                row.name || row.id
               )}
             </TableCell>
 

--- a/Clients/src/presentation/components/Table/EvaluationTable/TableHead/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/TableHead/index.tsx
@@ -4,7 +4,7 @@ import singleTheme from "../../../../themes/v1SingleTheme";
 
 // Column width definitions for consistent spacing
 const columnWidths: Record<string, string> = {
-  "EXPERIMENT ID": "20%",
+  "EXPERIMENT NAME": "20%",
   "MODEL": "12%",
   "JUDGE/SCORER": "16%",
   "# PROMPTS": "8%",
@@ -15,7 +15,7 @@ const columnWidths: Record<string, string> = {
 
 // Map column labels to sortable field keys
 const columnSortKeys: Record<string, string> = {
-  "EXPERIMENT ID": "id",
+  "EXPERIMENT NAME": "name",
   "MODEL": "model",
   "JUDGE/SCORER": "judge",
   "# PROMPTS": "prompts",

--- a/Clients/src/presentation/pages/EvalsDashboard/ExperimentDetailContent.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ExperimentDetailContent.tsx
@@ -470,7 +470,7 @@ export default function ExperimentDetailContent({ experimentId, projectId, onBac
           ) : (
             <>
               <Typography sx={{ fontSize: 18, fontWeight: 700, color: "#111827" }}>
-                {experiment.id}
+                {experiment.name || experiment.id}
               </Typography>
               <IconButton
                 size="small"

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -666,6 +666,7 @@ export default function NewExperimentModal({
       if (onStarted && response?.experiment?.id) {
         onStarted({
           id: response.experiment.id,
+          name: experimentConfig.name,
           config: experimentConfig.config,
           status: "running",
           created_at: new Date().toISOString(),

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx
@@ -255,6 +255,7 @@ export default function ProjectExperiments({ projectId, orgId, onViewExperiment,
         // Add the new experiment to the list optimistically
         handleStarted({
           id: response.experiment.id,
+          name: nextName,
           config: payload.config as Record<string, unknown>,
           status: "running",
           created_at: new Date().toISOString(),
@@ -360,7 +361,7 @@ export default function ProjectExperiments({ projectId, orgId, onViewExperiment,
     }
   };
 
-  const handleStarted = (exp: { id: string; config: Record<string, unknown>; status: string; created_at?: string }) => {
+  const handleStarted = (exp: { id: string; name?: string; config: Record<string, unknown>; status: string; created_at?: string }) => {
     const cfg = exp.config as { 
       model?: { name?: string }; 
       judgeLlm?: { model?: string; provider?: string };
@@ -378,7 +379,7 @@ export default function ProjectExperiments({ projectId, orgId, onViewExperiment,
       ({
         id: exp.id,
         project_id: projectId,
-        name: cfg.model?.name || exp.id,
+        name: exp.name || exp.id,
         description: `Pending eval for ${cfg.model?.name || "model"}`,
         config: cfgForState,
         baseline_experiment_id: undefined,
@@ -479,7 +480,7 @@ export default function ProjectExperiments({ projectId, orgId, onViewExperiment,
   }, [experiments, filterData, searchTerm]);
 
   // Transform to table format
-  const tableColumns = ["EXPERIMENT ID", "MODEL", "JUDGE/SCORER", "# PROMPTS", "DATASET", "DATE", "ACTION"];
+  const tableColumns = ["EXPERIMENT NAME", "MODEL", "JUDGE/SCORER", "# PROMPTS", "DATASET", "DATE", "ACTION"];
 
   const tableRows: IEvaluationRow[] = filteredExperiments.map((exp) => {
     // Get dataset name from config - try multiple sources

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectOverview.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectOverview.tsx
@@ -509,7 +509,7 @@ export default function ProjectOverview({
           </Box>
         ) : (
           <EvaluationTable
-            columns={["EXPERIMENT ID", "MODEL", "JUDGE/SCORER", "# PROMPTS", "DATASET", "DATE"]}
+            columns={["EXPERIMENT NAME", "MODEL", "JUDGE/SCORER", "# PROMPTS", "DATASET", "DATE"]}
             rows={recentExperimentsRows}
             page={0}
             setCurrentPagingation={() => {}}


### PR DESCRIPTION
## Describe your changes

- Fixed experiment detail page showing the raw auto-generated ID (exp_20260213_...) instead of the user-friendly name
- Renamed table column from "EXPERIMENT ID" to "EXPERIMENT NAME" across both the Experiments tab and Project Overview
- Table now displays experiment.name with a fallback to experiment.id for older experiments
- Fixed optimistic updates so newly created experiments and reruns immediately show the correct name without requiring a page refresh

Test plan
- Open an existing experiment detail page — verify the title shows the name (e.g., magistral-small-2509 - 2026-02-13
  01:29:02) instead of the ID
- Edit the experiment name via the pencil icon — verify the displayed title updates after saving
- Check the experiments table — verify column header reads "EXPERIMENT NAME"
- Create a new experiment — verify the table row immediately shows the name, not the ID
- Rerun an existing experiment — verify the rerun row shows the correct name
- Verify sorting by the name column works correctly

## Write your issue number after "Fixes "

This PR does not intend to fix a specified issue. 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
