### PR TITLE
fix: extend invitation token expiry from 1 hour to 1 week

### DIFF
--- a/Servers/controllers/vwmailer.ctrl.ts
+++ b/Servers/controllers/vwmailer.ctrl.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import path from "path";
 import fs from "fs/promises";
-import { generateToken } from "../utils/jwt.utils";
+import { generateInviteToken } from "../utils/jwt.utils";
 import { frontEndUrl } from "../config/constants";
 import { sendEmail } from "../services/emailService";
 import {
@@ -43,7 +43,7 @@ export const invite = async (
     );
     const template = await fs.readFile(templatePath, "utf8");
 
-    const token = generateToken({
+    const token = generateInviteToken({
       name,
       surname,
       roleId,

--- a/Servers/routes/vwmailer.route.ts
+++ b/Servers/routes/vwmailer.route.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from "express";
 import { sendEmail } from "../services/emailService";
 import fs from "fs";
 import path from "path";
-import { generateToken } from "../utils/jwt.utils";
+import { generateInviteToken } from "../utils/jwt.utils";
 import { frontEndUrl } from "../config/constants";
 import { invite } from "../controllers/vwmailer.ctrl";
 import { logProcessing, logSuccess, logFailure } from "../utils/logger/logHelper";
@@ -57,7 +57,7 @@ router.post("/reset-password", resetPasswordLimiter, async (req: Request, res: R
       );
       const template = fs.readFileSync(templatePath, "utf8");
 
-      const token = generateToken({
+      const token = generateInviteToken({
         name: name,
         email: to
       }) as string

--- a/Servers/utils/jwt.utils.ts
+++ b/Servers/utils/jwt.utils.ts
@@ -99,6 +99,7 @@ const getRefreshTokenPayload = (token: any): any => {
 
 // Token expiration constants
 const ONE_HOUR_MS = 1 * 3600 * 1000;
+const ONE_WEEK_MS = 7 * 24 * 3600 * 1000;
 const THIRTY_DAYS_MS = 1 * 3600 * 1000 * 24 * 30;
 
 /**
@@ -127,6 +128,13 @@ const generateToken = (payload: Object) => {
 };
 
 /**
+ * Generates a JWT token for invitation and password-reset emails (1 week)
+ */
+const generateInviteToken = (payload: Object) => {
+  return signToken(payload, ONE_WEEK_MS, process.env.JWT_SECRET as string);
+};
+
+/**
  * Generates a long-lived JWT refresh token (30 days)
  * Signed with REFRESH_TOKEN_SECRET for added security
  */
@@ -147,4 +155,4 @@ const generateApiToken = (payload: Object, expiresInDays?: number) => {
   return signToken(payload, expiresInMs, process.env.JWT_SECRET as string);
 };
 
-export { getTokenPayload, generateToken, getRefreshTokenPayload, generateRefreshToken, generateApiToken };
+export { getTokenPayload, generateToken, generateInviteToken, getRefreshTokenPayload, generateRefreshToken, generateApiToken };


### PR DESCRIPTION
## Summary
- Invitation and password-reset email tokens now expire after **1 week** instead of 1 hour
- Added a dedicated `generateInviteToken()` function so auth access tokens remain at 1 hour
- Updated both invitation email and password-reset email to use the new function

## Test plan
- [ ] Send an invitation email → verify the token is valid for 7 days
- [ ] Send a password reset email → verify the link works within 7 days
- [ ] Verify normal login auth tokens still expire after 1 hour
- [ ] Re-invite a user whose previous token expired → verify new link works