### PR TITLE
fix: remove duplicate autoFocus parameter in Field component

### DIFF
--- a/Clients/src/presentation/components/Inputs/Field/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Field/index.tsx
@@ -77,7 +77,6 @@ const Field = forwardRef(
       formHelperTextProps,
       min,
       max,
-      autoFocus,
     }: FieldProps,
     ref: ForwardedRef<HTMLInputElement>
   ) => {


### PR DESCRIPTION
## Summary
- Removes duplicate `autoFocus` destructured prop in the `Field` component that was causing a white screen crash
- The prop was added twice across two commits in PR #3352: once at line 62 (`55ce5d73`) and again at line 80 (`00631804`)
- This caused `SyntaxError: Duplicate parameter name not allowed in this context` on page load

## Test plan
- [ ] Verify the app loads without a white screen on localhost:5173
- [ ] Verify `autoFocus` prop still works correctly on Field inputs