### PR TITLE
fix: resolve FK violation when deleting demo data

### DIFF
--- a/Servers/utils/eu.utils.ts
+++ b/Servers/utils/eu.utils.ts
@@ -1531,6 +1531,14 @@ export const deleteAssessmentEUByProjectIdQuery = async (
   if (assessmentId[0].length === 0) {
     return false;
   }
+  // Delete answers_eu__risks first (FK: answer_id -> answers_eu.id)
+  await sequelize.query(
+    `DELETE FROM "${tenant}".answers_eu__risks WHERE answer_id IN (SELECT id FROM "${tenant}".answers_eu WHERE assessment_id = :assessment_id)`,
+    {
+      replacements: { assessment_id: assessmentId[0][0].id },
+      transaction,
+    }
+  );
   await sequelize.query(
     `DELETE FROM "${tenant}".answers_eu WHERE assessment_id = :assessment_id`,
     {
@@ -1567,6 +1575,11 @@ export const deleteComplianeEUByProjectIdQuery = async (
     return false;
   }
   for (let control of controlIds[0]) {
+    // Delete controls_eu__risks first (FK: control_id -> controls_eu.id)
+    await sequelize.query(
+      `DELETE FROM "${tenant}".controls_eu__risks WHERE control_id = :control_id`,
+      { replacements: { control_id: control.id }, transaction }
+    );
     await sequelize.query(
       `DELETE FROM "${tenant}".subcontrols_eu WHERE control_id = :control_id`,
       { replacements: { control_id: control.id }, transaction }


### PR DESCRIPTION
## Summary
- Fixes 500 Internal Server Error when deleting demo data via settings
- Root cause: `deleteAssessmentEUByProjectIdQuery` and `deleteComplianeEUByProjectIdQuery` in `eu.utils.ts` did not delete from FK child tables (`answers_eu__risks`, `controls_eu__risks`) before deleting parent rows (`answers_eu`, `controls_eu`)
- Added FK-safe deletion of `answers_eu__risks` before `answers_eu` and `controls_eu__risks` before `controls_eu`

## Test plan
- [ ] Create demo data via onboarding flow
- [ ] Go to Settings > Management > Delete demo data
- [ ] Confirm deletion completes without error
- [ ] Verify no demo projects, vendors, policies, or users remain