### PR TITLE
fix: run agent discovery tenant migrations on server startup

### DIFF
--- a/Servers/index.ts
+++ b/Servers/index.ts
@@ -80,6 +80,7 @@ import featureSettingsRoutes from "./routes/featureSettings.route";
 import agentDiscoveryRoutes from "./routes/agentDiscovery.route";
 import invitationRoutes from "./routes/invitation.route";
 import { setupNotificationSubscriber } from "./services/notificationSubscriber.service";
+import { addAgentDiscoveryTables } from "./scripts/addAgentDiscoveryTables";
 
 const swaggerDoc = YAML.load("./swagger.yaml");
 
@@ -245,6 +246,15 @@ try {
       await setupNotificationSubscriber();
     } catch (error) {
       console.error("Failed to setup notification subscriber:", error);
+    }
+  })();
+
+  // Run agent discovery tenant migrations (idempotent, safe on every boot)
+  (async () => {
+    try {
+      await addAgentDiscoveryTables();
+    } catch (error) {
+      console.error("Agent discovery table migration failed:", error);
     }
   })();
 


### PR DESCRIPTION
## Summary
- Calls `addAgentDiscoveryTables()` during server startup so that tenant schemas created before the agent discovery feature get the missing `agent_primitives`, `agent_discovery_sync_log`, and `agent_audit_log` tables automatically
- Uses `CREATE TABLE IF NOT EXISTS`, making it idempotent and safe on every boot
- Wrapped in try/catch so a migration failure doesn't block server startup

## Problem
When upgrading a server that predates the agent discovery feature, existing tenant schemas lack the three agent discovery tables. This causes 500 errors on `/agent-primitives` endpoints. The migration script existed but had to be run manually.

## Test plan
- [ ] Restart backend server, confirm migration log messages appear
- [ ] Navigate to agent discovery — verify no 500 errors
- [ ] Confirm `npx tsc --noEmit` passes
- [ ] Verify new tenant creation still works (tables already included in `createNewTenant`)