### PR TITLE
Fix release notes and help center buttons across all modules

### DIFF
--- a/Clients/src/presentation/pages/AIDetection/AIDetectionSidebar.tsx
+++ b/Clients/src/presentation/pages/AIDetection/AIDetectionSidebar.tsx
@@ -7,11 +7,13 @@
  * @module pages/AIDetection/AIDetectionSidebar
  */
 
+import { useCallback } from "react";
 import { Search, History, Settings } from "lucide-react";
 import SidebarShell, {
   SidebarMenuItem,
   RecentSection,
 } from "../../components/Sidebar/SidebarShell";
+import { useUserGuideSidebarContext } from "../../components/UserGuide";
 import { Scan } from "../../../domain/ai-detection/types";
 
 interface RecentScan {
@@ -34,6 +36,9 @@ export default function AIDetectionSidebar({
   recentScans = [],
   onScanClick,
 }: AIDetectionSidebarProps) {
+  const { open: openUserGuide, openTab } = useUserGuideSidebarContext();
+  const openReleaseNotes = useCallback(() => openTab('whats-new'), [openTab]);
+
   // Menu items for AI Detection
   const flatItems: SidebarMenuItem[] = [
     {
@@ -93,6 +98,8 @@ export default function AIDetectionSidebar({
       isItemActive={isItemActive}
       onItemClick={handleItemClick}
       showReadyToSubscribe={false}
+      openUserGuide={openUserGuide}
+      openReleaseNotes={openReleaseNotes}
       enableFlyingHearts={false}
     />
   );

--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
@@ -9,11 +9,13 @@ import {
   Cpu,
   Scale,
 } from "lucide-react";
+import { useCallback } from "react";
 import SidebarShell, {
   SidebarMenuItem,
   RecentSection,
   ProjectSelectorConfig,
 } from "../../components/Sidebar/SidebarShell";
+import { useUserGuideSidebarContext } from "../../components/UserGuide";
 
 interface RecentExperiment {
   id: string;
@@ -67,6 +69,9 @@ export default function EvalsSidebar({
   allProjects = [],
   onProjectChange,
 }: EvalsSidebarProps) {
+  const { open: openUserGuide, openTab } = useUserGuideSidebarContext();
+  const openReleaseNotes = useCallback(() => openTab('whats-new'), [openTab]);
+
   // Menu items for Evals
   const flatItems: SidebarMenuItem[] = [
     {
@@ -191,6 +196,8 @@ export default function EvalsSidebar({
       isItemActive={isItemActive}
       onItemClick={handleItemClick}
       showReadyToSubscribe={false}
+      openUserGuide={openUserGuide}
+      openReleaseNotes={openReleaseNotes}
       enableFlyingHearts={false}
     />
   );

--- a/Clients/src/presentation/pages/ShadowAI/ShadowAISidebar.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/ShadowAISidebar.tsx
@@ -5,11 +5,13 @@
  * Follows the SidebarShell pattern established by AIDetectionSidebar.
  */
 
+import { useCallback } from "react";
 import { BarChart3, Users, Bot, ShieldAlert, Settings } from "lucide-react";
 import SidebarShell, {
   SidebarMenuItem,
   RecentSection,
 } from "../../components/Sidebar/SidebarShell";
+import { useUserGuideSidebarContext } from "../../components/UserGuide";
 import { RecentTool } from "../../../application/contexts/ShadowAISidebar.context";
 
 interface ShadowAISidebarProps {


### PR DESCRIPTION
## Summary
- Fixed "Release notes" and "Help center" buttons in the user menu only working in the Governance module
- Added `useUserGuideSidebarContext` hook and `openReleaseNotes`/`openUserGuide` callbacks to AIDetectionSidebar, EvalsSidebar, and ShadowAISidebar
- All three now pass these props to `SidebarShell`, matching the existing pattern in the Governance sidebar

## Test plan
- [ ] Navigate to AI Detection module → click "Release notes" in user menu → "What's new" tab should open
- [ ] Navigate to LLM Evals module → click "Release notes" → "What's new" tab should open
- [ ] Navigate to Shadow AI module → click "Release notes" → "What's new" tab should open
- [ ] Click "Help center" in each module → user guide sidebar should open
- [ ] Verify Governance module still works as before