### PR TITLE
feat: add Custom LLM provider with user-defined endpoint and headers

### DIFF
--- a/Clients/src/domain/models/Common/llmKeys/llmKeys.model.ts
+++ b/Clients/src/domain/models/Common/llmKeys/llmKeys.model.ts
@@ -1,7 +1,7 @@
-export type LLMProviderId = "anthropic" | "openai" | "openrouter";
+export type LLMProviderId = "anthropic" | "openai" | "openrouter" | "custom";
 
 // Display names for providers (used in forms and UI)
-export type LLMProviderName = "Anthropic" | "OpenAI" | "OpenRouter";
+export type LLMProviderName = "Anthropic" | "OpenAI" | "OpenRouter" | "Custom";
 
 interface LLMKeysData {
   id: number;
@@ -9,6 +9,7 @@ interface LLMKeysData {
   key: string;
   url?: string | null;
   model: string;
+  custom_headers?: Record<string, string> | null;
   created_at?: string;
 }
 
@@ -16,6 +17,8 @@ export interface LLMKeysFormData {
   name: LLMProviderName;
   key: string;
   model: string;
+  url?: string | null;
+  custom_headers?: Record<string, string> | null;
 }
 
 export interface LLMProviderConfig {
@@ -32,6 +35,7 @@ export class LLMKeysModel {
   key!: string;
   url?: string | null;
   model!: string;
+  custom_headers?: Record<string, string> | null;
   created_at?: string;
 
   constructor(data: LLMKeysData) {
@@ -40,6 +44,7 @@ export class LLMKeysModel {
     this.key = data.key;
     this.url = data.url;
     this.model = data.model;
+    this.custom_headers = data.custom_headers;
     this.created_at = data.created_at;
   }
 
@@ -79,6 +84,13 @@ export class LLMKeysModel {
       keyPrefix: "sk-or-",
       keyPlaceholder: "sk-or-v1-...",
       apiKeyUrl: "https://openrouter.ai/keys",
+    },
+    {
+      id: "custom",
+      name: "Custom",
+      keyPrefix: "",
+      keyPlaceholder: "Enter your API key",
+      apiKeyUrl: "",
     },
   ];
 

--- a/Clients/src/presentation/pages/SettingsPage/LLMKeys/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/LLMKeys/index.tsx
@@ -15,6 +15,8 @@ import {
   Trash2 as DeleteIcon,
   Edit as EditIcon,
   ExternalLink,
+  Server as ServerIcon,
+  X as XIcon,
 } from "lucide-react";
 import Alert from "../../../components/Alert";
 import StandardModal from "../../../components/Modals/StandardModal";
@@ -54,6 +56,11 @@ interface AlertState {
   isToast?: boolean;
 }
 
+interface HeaderRow {
+  key: string;
+  value: string;
+}
+
 const LLMKeys = () => {
   const initialFormData: LLMKeysFormData = {
     name: "Anthropic",
@@ -75,6 +82,9 @@ const LLMKeys = () => {
   const [hoveredKeyId, setHoveredKeyId] = useState<number | null>(null);
   const [deletingKeyId, setDeletingKeyId] = useState<number | null>(null);
   const [formData, setFormData] = useState<LLMKeysFormData>(initialFormData);
+
+  // Custom headers state
+  const [headerRows, setHeaderRows] = useState<HeaderRow[]>([]);
 
   const showAlert = useCallback(
     (variant: AlertState["variant"], title: string, body: string) => {
@@ -108,15 +118,21 @@ const LLMKeys = () => {
     if (alert) {
       const timeoutId = setTimeout(() => {
         setAlert(null);
-      }, 3000); // 3 seconds
+      }, 3000);
 
       return () => clearTimeout(timeoutId);
     }
     return undefined;
   }, [alert]);
 
+  const isCustomProvider = formData.name === "Custom";
+
   const isCreateButtonDisabled =
-    !formData.key || !formData.model || !formData.name || isLoading;
+    !formData.key ||
+    !formData.model ||
+    !formData.name ||
+    (isCustomProvider && !formData.url) ||
+    isLoading;
 
   // Get provider config for current selection
   const currentProviderConfig = useMemo(
@@ -136,6 +152,7 @@ const LLMKeys = () => {
 
   // Get models for selected provider with "Other" option
   const modelOptions = useMemo(() => {
+    if (isCustomProvider) return [];
     if (!currentProviderId) return [];
     const models = getModelsForProvider(currentProviderId);
     const options = models.map((model) => ({
@@ -145,19 +162,42 @@ const LLMKeys = () => {
     // Add "Other" option at the end
     options.push({ _id: "__custom__", name: "Other (enter manually)" });
     return options;
-  }, [currentProviderId]);
+  }, [currentProviderId, isCustomProvider]);
+
+  // Convert headerRows to Record for API
+  const getCustomHeadersFromRows = useCallback((): Record<string, string> | null => {
+    const filtered = headerRows.filter((r) => r.key.trim() && r.value.trim());
+    if (filtered.length === 0) return null;
+    const result: Record<string, string> = {};
+    for (const row of filtered) {
+      result[row.key.trim()] = row.value.trim();
+    }
+    return result;
+  }, [headerRows]);
+
+  // Convert Record to headerRows for editing
+  const headersToRows = (headers: Record<string, string> | null | undefined): HeaderRow[] => {
+    if (!headers || Object.keys(headers).length === 0) return [];
+    return Object.entries(headers).map(([key, value]) => ({ key, value }));
+  };
 
   // Reset model when provider changes, auto-selecting the recommended model
   const handleProviderChange = useCallback((providerName: string) => {
+    const isCustom = providerName === "Custom";
     const providerId = LLMKeysModel.getProviderIdByName(providerName as LLMProviderName);
-    const recommended = providerId ? getRecommendedModel(providerId) : undefined;
+    const recommended = !isCustom && providerId ? getRecommendedModel(providerId) : undefined;
     setFormData(prev => ({
       ...prev,
       name: providerName as LLMProviderName,
       model: recommended?.id || "",
+      url: isCustom ? (prev.name === "Custom" ? prev.url : "") : undefined,
+      custom_headers: isCustom ? prev.custom_headers : undefined,
     }));
-    setIsCustomModel(false);
-    setCustomModelName("");
+    setIsCustomModel(isCustom);
+    setCustomModelName(isCustom ? "" : "");
+    if (!isCustom) {
+      setHeaderRows([]);
+    }
   }, []);
 
   // Handle model selection including custom option
@@ -178,10 +218,37 @@ const LLMKeys = () => {
     setFormData(prev => ({ ...prev, model: value }));
   }, []);
 
+  // Header row management
+  const handleAddHeaderRow = useCallback(() => {
+    setHeaderRows(prev => [...prev, { key: "", value: "" }]);
+  }, []);
+
+  const handleRemoveHeaderRow = useCallback((index: number) => {
+    setHeaderRows(prev => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleHeaderRowChange = useCallback(
+    (index: number, field: "key" | "value", value: string) => {
+      setHeaderRows(prev =>
+        prev.map((row, i) => (i === index ? { ...row, [field]: value } : row))
+      );
+    },
+    []
+  );
+
   const handleCreateKey = useCallback(async () => {
     setIsLoading(true);
     try {
-      const response = await createLLMKey({ body: formData });
+      const body: any = {
+        name: formData.name,
+        key: formData.key,
+        model: formData.model,
+      };
+      if (isCustomProvider) {
+        body.url = formData.url;
+        body.custom_headers = getCustomHeadersFromRows();
+      }
+      const response = await createLLMKey({ body });
       if (response && response.data) {
         showAlert("success", "Success", "API key added successfully");
         fetchLLMKeys();
@@ -196,13 +263,23 @@ const LLMKeys = () => {
       setFormData(initialFormData);
       setIsCustomModel(false);
       setCustomModelName("");
+      setHeaderRows([]);
     }
-  }, [fetchLLMKeys, formData, showAlert, initialFormData]);
+  }, [fetchLLMKeys, formData, showAlert, initialFormData, isCustomProvider, getCustomHeadersFromRows]);
 
   const handleEditKey = useCallback(async () => {
     setIsLoading(true);
     try {
-      const response = await editLLMKey({ id: keyToEdit, body: formData });
+      const body: any = {
+        name: formData.name,
+        key: formData.key,
+        model: formData.model,
+      };
+      if (isCustomProvider) {
+        body.url = formData.url;
+        body.custom_headers = getCustomHeadersFromRows();
+      }
+      const response = await editLLMKey({ id: keyToEdit, body });
       if (response && response.data) {
         showAlert("success", "Success", "API key updated successfully");
         fetchLLMKeys();
@@ -217,8 +294,9 @@ const LLMKeys = () => {
       setFormData(initialFormData);
       setIsCustomModel(false);
       setCustomModelName("");
+      setHeaderRows([]);
     }
-  }, [fetchLLMKeys, formData, showAlert, keyToEdit, initialFormData]);
+  }, [fetchLLMKeys, formData, showAlert, keyToEdit, initialFormData, isCustomProvider, getCustomHeadersFromRows]);
 
   const handleDeleteKey = useCallback(async () => {
     if (!keyToDelete) return;
@@ -246,27 +324,39 @@ const LLMKeys = () => {
     setFormData(initialFormData);
     setIsCustomModel(false);
     setCustomModelName("");
+    setHeaderRows([]);
   }, []);
 
   const handleEditButtonClick = useCallback((data: LLMKeysModel) => {
     setKeyToEdit(data.id.toString());
+    const isCustom = data.name === "Custom";
     setFormData({
       name: data.name,
       key: data.key,
       model: data.model,
+      url: isCustom ? data.url : undefined,
+      custom_headers: isCustom ? data.custom_headers : undefined,
     });
-    // Check if the model is a custom one (not in the predefined list)
-    const providerId = LLMKeysModel.getProviderIdByName(data.name);
-    if (providerId) {
-      const models = getModelsForProvider(providerId);
-      const isPresetModel = models.some(m => m.id === data.model);
-      if (!isPresetModel) {
-        setIsCustomModel(true);
-        setCustomModelName(data.model);
-      } else {
-        setIsCustomModel(false);
-        setCustomModelName("");
+
+    if (isCustom) {
+      setIsCustomModel(true);
+      setCustomModelName(data.model);
+      setHeaderRows(headersToRows(data.custom_headers));
+    } else {
+      // Check if the model is a custom one (not in the predefined list)
+      const providerId = LLMKeysModel.getProviderIdByName(data.name);
+      if (providerId) {
+        const models = getModelsForProvider(providerId);
+        const isPresetModel = models.some(m => m.id === data.model);
+        if (!isPresetModel) {
+          setIsCustomModel(true);
+          setCustomModelName(data.model);
+        } else {
+          setIsCustomModel(false);
+          setCustomModelName("");
+        }
       }
+      setHeaderRows([]);
     }
     setIsEditModalOpen(true);
   }, []);
@@ -407,11 +497,15 @@ const LLMKeys = () => {
                 >
                   <Box sx={{ flex: 1 }}>
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1 }}>
-                      <img
-                        src={PROVIDER_LOGOS[key.name]}
-                        alt={key.name}
-                        style={{ width: 20, height: 20 }}
-                      />
+                      {key.name === "Custom" ? (
+                        <ServerIcon size={20} color="#475467" strokeWidth={1.5} />
+                      ) : (
+                        <img
+                          src={PROVIDER_LOGOS[key.name]}
+                          alt={key.name}
+                          style={{ width: 20, height: 20 }}
+                        />
+                      )}
                       <Typography
                         sx={{
                           fontSize: 14,
@@ -420,13 +514,32 @@ const LLMKeys = () => {
                           letterSpacing: "0.01em",
                         }}
                       >
-                        {key.name}
+                        {key.name === "Custom" ? "Custom endpoint" : key.name}
                       </Typography>
                     </Box>
                     <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
                       <Typography sx={{ fontSize: 12, color: "#666666" }}>
                         {key.model}
                       </Typography>
+                      {key.name === "Custom" && key.url && (
+                        <>
+                          <Typography sx={{ fontSize: 12, color: "#999999" }}>
+                            •
+                          </Typography>
+                          <Typography
+                            sx={{
+                              fontSize: 12,
+                              color: "#999999",
+                              maxWidth: 300,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {key.url}
+                          </Typography>
+                        </>
+                      )}
                       <Typography sx={{ fontSize: 12, color: "#999999" }}>
                         •
                       </Typography>
@@ -546,11 +659,15 @@ const LLMKeys = () => {
                     },
                   }}
                 >
-                  <img
-                    src={PROVIDER_LOGOS[provider.name]}
-                    alt={provider.name}
-                    style={{ width: 24, height: 24 }}
-                  />
+                  {provider.id === "custom" ? (
+                    <ServerIcon size={24} color="#475467" strokeWidth={1.5} />
+                  ) : (
+                    <img
+                      src={PROVIDER_LOGOS[provider.name]}
+                      alt={provider.name}
+                      style={{ width: 24, height: 24 }}
+                    />
+                  )}
                   <Typography sx={{ fontSize: 12, fontWeight: 500, color: "#344054" }}>
                     {provider.name}
                   </Typography>
@@ -559,26 +676,59 @@ const LLMKeys = () => {
             </Box>
           </Box>
 
-          {/* Model Selection Dropdown */}
-          <Box>
-            <Select
-              id="llm-form-model"
-              label="Model"
-              value={isCustomModel ? "__custom__" : formData.model}
-              items={modelOptions}
-              onChange={(e) => handleModelChange(e.target.value as string)}
-              placeholder="Select a model"
-              isRequired
-            />
-            {modelOptions.length === 0 && (
+          {/* Endpoint URL (Custom provider only) */}
+          {isCustomProvider && (
+            <Box>
+              <Field
+                id="llm-form-url"
+                label="Endpoint URL"
+                value={formData.url || ""}
+                onChange={(e) => handleFormChange("url", e.target.value)}
+                placeholder="https://your-llm-proxy.example.com/v1"
+                isRequired
+              />
               <Typography sx={{ fontSize: 11, color: "#666666", mt: 0.5 }}>
-                Select a provider first to see available models
+                OpenAI-compatible endpoint (LiteLLM, vLLM, Ollama, Azure OpenAI, etc.)
               </Typography>
-            )}
-          </Box>
+            </Box>
+          )}
 
-          {/* Custom Model Input (shown when "Other" is selected) */}
-          {isCustomModel && (
+          {/* Model Selection - Dropdown for standard providers, free text for Custom */}
+          {isCustomProvider ? (
+            <Box>
+              <Field
+                id="llm-form-model"
+                label="Model name"
+                value={formData.model}
+                onChange={(e) => handleFormChange("model", e.target.value)}
+                placeholder="e.g., gpt-4, llama-3, claude-3-5-sonnet"
+                isRequired
+              />
+              <Typography sx={{ fontSize: 11, color: "#666666", mt: 0.5 }}>
+                Enter the exact model ID supported by your endpoint
+              </Typography>
+            </Box>
+          ) : (
+            <Box>
+              <Select
+                id="llm-form-model"
+                label="Model"
+                value={isCustomModel ? "__custom__" : formData.model}
+                items={modelOptions}
+                onChange={(e) => handleModelChange(e.target.value as string)}
+                placeholder="Select a model"
+                isRequired
+              />
+              {modelOptions.length === 0 && (
+                <Typography sx={{ fontSize: 11, color: "#666666", mt: 0.5 }}>
+                  Select a provider first to see available models
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {/* Custom Model Input (shown when "Other" is selected for standard providers) */}
+          {!isCustomProvider && isCustomModel && (
             <Box>
               <Field
                 id="llm-form-custom-model"
@@ -604,7 +754,7 @@ const LLMKeys = () => {
               placeholder={currentProviderConfig?.keyPlaceholder || "Enter your API key"}
               isRequired
             />
-            {currentProviderConfig && (
+            {!isCustomProvider && currentProviderConfig && (
               <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.5 }}>
                 <Typography sx={{ fontSize: 11, color: "#666666" }}>
                   Get your API key from
@@ -629,6 +779,77 @@ const LLMKeys = () => {
               </Box>
             )}
           </Box>
+
+          {/* Custom Headers (Custom provider only) */}
+          {isCustomProvider && (
+            <Box>
+              <Typography
+                component="label"
+                sx={{ fontSize: 13, fontWeight: 500, color: "#344054", mb: 1, display: "block" }}
+              >
+                Custom headers
+              </Typography>
+              <Typography sx={{ fontSize: 11, color: "#666666", mb: 1.5 }}>
+                Optional HTTP headers sent with every request (e.g., HTTP-Referer, X-Title, Helicone-Auth)
+              </Typography>
+              <Stack spacing={1.5}>
+                {headerRows.map((row, index) => (
+                  <Box
+                    key={index}
+                    sx={{ display: "flex", gap: 1, alignItems: "center" }}
+                  >
+                    <Box sx={{ flex: 1 }}>
+                      <Field
+                        id={`header-key-${index}`}
+                        value={row.key}
+                        onChange={(e) =>
+                          handleHeaderRowChange(index, "key", e.target.value)
+                        }
+                        placeholder="Header name"
+                      />
+                    </Box>
+                    <Box sx={{ flex: 1 }}>
+                      <Field
+                        id={`header-value-${index}`}
+                        value={row.value}
+                        onChange={(e) =>
+                          handleHeaderRowChange(index, "value", e.target.value)
+                        }
+                        placeholder="Value"
+                      />
+                    </Box>
+                    <IconButton
+                      onClick={() => handleRemoveHeaderRow(index)}
+                      size="small"
+                      sx={{
+                        color: "#999999",
+                        "&:hover": { color: "#DC2626", backgroundColor: "#FEF2F2" },
+                      }}
+                    >
+                      <XIcon size={16} />
+                    </IconButton>
+                  </Box>
+                ))}
+                <Box>
+                  <Typography
+                    onClick={handleAddHeaderRow}
+                    sx={{
+                      fontSize: 12,
+                      color: "#13715B",
+                      cursor: "pointer",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                      "&:hover": { textDecoration: "underline" },
+                    }}
+                  >
+                    <PlusIcon size={14} />
+                    Add header
+                  </Typography>
+                </Box>
+              </Stack>
+            </Box>
+          )}
         </Stack>
       </StandardModal>
 
@@ -638,7 +859,7 @@ const LLMKeys = () => {
           title="Delete API key"
           body={
             <Typography fontSize={13}>
-              Are you sure you want to delete the API key "{keyToDelete.name}"?
+              Are you sure you want to delete the API key "{keyToDelete.name === "Custom" ? "Custom endpoint" : keyToDelete.name}"?
               This action cannot be undone and any advisor using this key will
               lose access.
             </Typography>

--- a/Clients/src/presentation/pages/SettingsPage/LLMKeys/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/LLMKeys/index.tsx
@@ -628,7 +628,7 @@ const LLMKeys = () => {
             <Box
               sx={{
                 display: "flex",
-                gap: 1.5,
+                gap: "8px",
                 mt: 1,
               }}
             >
@@ -644,10 +644,10 @@ const LLMKeys = () => {
                     gap: 1,
                     padding: "12px 8px",
                     borderRadius: "4px",
-                    border: "1px solid",
+                    border: "0.5px solid",
                     borderColor: formData.name === provider.name
                       ? "#13715B"
-                      : "#d0d5dd",
+                      : "#eaecf0",
                     backgroundColor: formData.name === provider.name
                       ? "#f0fdf4"
                       : "#ffffff",
@@ -792,11 +792,11 @@ const LLMKeys = () => {
               <Typography sx={{ fontSize: 11, color: "#666666", mb: 1.5 }}>
                 Optional HTTP headers sent with every request (e.g., HTTP-Referer, X-Title, Helicone-Auth)
               </Typography>
-              <Stack spacing={1.5}>
+              <Stack spacing="8px">
                 {headerRows.map((row, index) => (
                   <Box
                     key={index}
-                    sx={{ display: "flex", gap: 1, alignItems: "center" }}
+                    sx={{ display: "flex", gap: "8px", alignItems: "center" }}
                   >
                     <Box sx={{ flex: 1 }}>
                       <Field

--- a/Servers/advisor/aiSdkAgent.ts
+++ b/Servers/advisor/aiSdkAgent.ts
@@ -27,25 +27,28 @@ interface AiSdkAdvisorParams {
       parameters: Record<string, unknown>;
     };
   }>;
-  provider: "Anthropic" | "OpenAI" | "OpenRouter";
+  provider: "Anthropic" | "OpenAI" | "OpenRouter" | "Custom";
+  headers?: Record<string, string>;
 }
 
 /**
  * Create the appropriate AI SDK model instance based on provider.
  */
-function createModel(params: Pick<AiSdkAdvisorParams, "provider" | "apiKey" | "baseURL" | "model">) {
+function createModel(params: Pick<AiSdkAdvisorParams, "provider" | "apiKey" | "baseURL" | "model" | "headers">) {
   if (params.provider === "Anthropic") {
     const anthropic = createAnthropic({
       apiKey: params.apiKey,
       baseURL: params.baseURL || undefined,
+      headers: params.headers,
     });
     return anthropic(params.model);
   }
 
-  // OpenAI and OpenRouter both use the OpenAI-compatible interface
+  // OpenAI, OpenRouter, and Custom all use the OpenAI-compatible interface
   const openai = createOpenAI({
     apiKey: params.apiKey,
     baseURL: params.baseURL,
+    headers: params.headers,
   });
   return openai(params.model);
 }

--- a/Servers/controllers/advisor.ctrl.ts
+++ b/Servers/controllers/advisor.ctrl.ts
@@ -143,7 +143,8 @@ export async function runAdvisor(req: Request, res: Response) {
       tenant: tenantId,
       availableTools,
       toolsDefinition,
-      provider: apiKey.name as "Anthropic" | "OpenAI" | "OpenRouter",
+      provider: apiKey.name as "Anthropic" | "OpenAI" | "OpenRouter" | "Custom",
+      headers: apiKey.custom_headers || undefined,
     };
 
     const response = await runAdvisorAiSdk(agentParams);
@@ -345,7 +346,8 @@ export async function streamAdvisor(req: Request, res: Response) {
       tenant: tenantId,
       availableTools,
       toolsDefinition,
-      provider: apiKey.name as "Anthropic" | "OpenAI" | "OpenRouter",
+      provider: apiKey.name as "Anthropic" | "OpenAI" | "OpenRouter" | "Custom",
+      headers: apiKey.custom_headers || undefined,
     };
 
     // Send an immediate status event so the client knows the connection is open
@@ -464,7 +466,8 @@ export async function streamAdvisorV2(req: Request, res: Response) {
       tenant: tenantId,
       availableTools,
       toolsDefinition,
-      provider: apiKey.name as "Anthropic" | "OpenAI" | "OpenRouter",
+      provider: apiKey.name as "Anthropic" | "OpenAI" | "OpenRouter" | "Custom",
+      headers: apiKey.custom_headers || undefined,
     });
 
     // Use the streamText result's built-in method to pipe the AI SDK protocol.

--- a/Servers/controllers/llmKey.ctrl.ts
+++ b/Servers/controllers/llmKey.ctrl.ts
@@ -18,10 +18,23 @@ import { ILLMKey, LLMProvider } from "../domain.layer/interfaces/i.llmKey";
 
 const fileName = "llmKey.ctrl.ts";
 
+/**
+ * Validate that custom_headers is a plain object with string keys and string values.
+ */
+function isValidCustomHeaders(
+  headers: unknown
+): headers is Record<string, string> {
+  if (typeof headers !== "object" || headers === null || Array.isArray(headers))
+    return false;
+  return Object.entries(headers).every(
+    ([k, v]) => typeof k === "string" && typeof v === "string"
+  );
+}
+
 export const getLLMKeys = async (req: Request, res: Response) => {
   const functionName = "getLLMKeys";
 
-  logger.debug(`🛠️ Fetching LLM Keys`);
+  logger.debug(`Fetching LLM Keys`);
   logStructured(
     "processing",
     `starting LLM Keys fetch`,
@@ -36,7 +49,7 @@ export const getLLMKeys = async (req: Request, res: Response) => {
       functionName,
       fileName,
     );
-    logger.debug(`✅ Fetched ${llmKeys.length} LLM Keys`);
+    logger.debug(`Fetched ${llmKeys.length} LLM Keys`);
     return res.status(200).json(STATUS_CODE[200](llmKeys));
   } catch (error) {
     logStructured(
@@ -51,7 +64,7 @@ export const getLLMKeys = async (req: Request, res: Response) => {
       req.userId!,
       req.tenantId!
     );
-    logger.error("❌ Error in getLLMKeys:", error);
+    logger.error("Error in getLLMKeys:", error);
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }
 };
@@ -59,13 +72,13 @@ export const getLLMKeys = async (req: Request, res: Response) => {
 export const getLLMKey = async (req: Request, res: Response) => {
   const functionName = "getLLMKey";
 
-  logger.debug(`🛠️ Fetching LLM Keys`);
+  logger.debug(`Fetching LLM Keys`);
   logStructured("processing", `starting LLM Key fetch`, functionName, fileName);
   try {
     const name = req.params.name as string;
     const llmKey = await getLLMKeyQuery(req.tenantId!, name);
     logStructured("successful", `fetched LLM Key`, functionName, fileName);
-    logger.debug(`✅ Fetched LLM Key with name: ${name}`);
+    logger.debug(`Fetched LLM Key with name: ${name}`);
     return res.status(200).json(STATUS_CODE[200](llmKey));
   } catch (error) {
     logStructured(
@@ -80,7 +93,7 @@ export const getLLMKey = async (req: Request, res: Response) => {
       req.userId!,
       req.tenantId!
     );
-    logger.error("❌ Error in getLLMKey:", error);
+    logger.error("Error in getLLMKey:", error);
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }
 };
@@ -89,7 +102,7 @@ export const createLLMKey = async (req: Request, res: Response) => {
   const functionName = "createLLMKey";
 
   const transaction = await sequelize.transaction();
-  const { name, key, model } = req.body;
+  const { name, key, model, url: userUrl, custom_headers } = req.body;
 
   if (!name || typeof name !== "string" || !key || typeof key !== "string") {
     await transaction.rollback();
@@ -103,9 +116,33 @@ export const createLLMKey = async (req: Request, res: Response) => {
       .status(400)
       .json(
         STATUS_CODE[400](
-          "Invalid provider name. Must be one of: Anthropic, OpenAI, OpenRouter",
+          "Invalid provider name. Must be one of: Anthropic, OpenAI, OpenRouter, Custom",
         ),
       );
+  }
+
+  // For Custom provider, URL is required
+  if (name === "Custom") {
+    if (!userUrl || typeof userUrl !== "string") {
+      await transaction.rollback();
+      return res
+        .status(400)
+        .json(STATUS_CODE[400]("Endpoint URL is required for Custom provider"));
+    }
+  }
+
+  // Validate custom_headers if provided
+  if (custom_headers !== undefined && custom_headers !== null) {
+    if (!isValidCustomHeaders(custom_headers)) {
+      await transaction.rollback();
+      return res
+        .status(400)
+        .json(
+          STATUS_CODE[400](
+            "custom_headers must be an object with string keys and string values"
+          )
+        );
+    }
   }
 
   logStructured(
@@ -114,16 +151,18 @@ export const createLLMKey = async (req: Request, res: Response) => {
     functionName,
     fileName,
   );
-  logger.debug(`🛠️ Creating LLM Key: ${name}`);
+  logger.debug(`Creating LLM Key: ${name}`);
   try {
-    // Auto-populate URL based on provider name
-    const url = getLLMProviderUrl(name as LLMProvider);
+    // For Custom provider, use user-provided URL; otherwise auto-populate
+    const url =
+      name === "Custom" ? userUrl : getLLMProviderUrl(name as LLMProvider);
 
     const data: ILLMKey = {
       name: name as LLMProvider,
       key,
       url,
       model,
+      custom_headers: custom_headers || null,
     };
     const llmKey = await createLLMKeyQuery(data, req.tenantId!, transaction);
     logStructured(
@@ -132,7 +171,7 @@ export const createLLMKey = async (req: Request, res: Response) => {
       functionName,
       fileName,
     );
-    logger.debug(`✅ Created LLM Key: ${llmKey.id}`);
+    logger.debug(`Created LLM Key: ${llmKey.id}`);
 
     await transaction.commit();
     return res.status(201).json(STATUS_CODE[201](llmKey));
@@ -175,7 +214,7 @@ export const createLLMKey = async (req: Request, res: Response) => {
       req.userId!,
       req.tenantId!
     );
-    logger.error("❌ Error in createLLMKey:", error);
+    logger.error("Error in createLLMKey:", error);
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }
 };
@@ -184,7 +223,7 @@ export const updateLLMKey = async (req: Request, res: Response) => {
   const functionName = "updateLLMKey";
 
   const transaction = await sequelize.transaction();
-  const { name, key, model } = req.body;
+  const { name, key, model, url: userUrl, custom_headers } = req.body;
   const id = parseInt(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id);
 
   // Validate that name is a valid LLM provider if provided
@@ -194,9 +233,33 @@ export const updateLLMKey = async (req: Request, res: Response) => {
       .status(400)
       .json(
         STATUS_CODE[400](
-          "Invalid provider name. Must be one of: Anthropic, OpenAI, OpenRouter",
+          "Invalid provider name. Must be one of: Anthropic, OpenAI, OpenRouter, Custom",
         ),
       );
+  }
+
+  // For Custom provider, URL is required
+  if (name === "Custom" && userUrl !== undefined) {
+    if (typeof userUrl !== "string" || !userUrl) {
+      await transaction.rollback();
+      return res
+        .status(400)
+        .json(STATUS_CODE[400]("Endpoint URL is required for Custom provider"));
+    }
+  }
+
+  // Validate custom_headers if provided
+  if (custom_headers !== undefined && custom_headers !== null) {
+    if (!isValidCustomHeaders(custom_headers)) {
+      await transaction.rollback();
+      return res
+        .status(400)
+        .json(
+          STATUS_CODE[400](
+            "custom_headers must be an object with string keys and string values"
+          )
+        );
+    }
   }
 
   logStructured(
@@ -205,16 +268,22 @@ export const updateLLMKey = async (req: Request, res: Response) => {
     functionName,
     fileName,
   );
-  logger.debug(`🛠️ Updating LLM Key: ${name}`);
+  logger.debug(`Updating LLM Key: ${name}`);
   try {
-    // Auto-populate URL based on provider name if name is being updated
-    const url = name ? getLLMProviderUrl(name as LLMProvider) : undefined;
+    // For Custom provider, use user-provided URL; otherwise auto-populate
+    let url: string | undefined;
+    if (name === "Custom") {
+      url = userUrl;
+    } else if (name) {
+      url = getLLMProviderUrl(name as LLMProvider);
+    }
 
     const data: Partial<ILLMKey> = {
       ...(name && { name: name as LLMProvider }),
       ...(key && { key }),
-      ...(url && { url }),
+      ...(url !== undefined && { url }),
       ...(model && { model }),
+      ...(custom_headers !== undefined && { custom_headers: custom_headers || null }),
     };
     const llmKey = await updateLLMKeyByIdQuery(
       id,
@@ -230,7 +299,7 @@ export const updateLLMKey = async (req: Request, res: Response) => {
         functionName,
         fileName,
       );
-      logger.debug(`✅ updated LLM Key: ${id}`);
+      logger.debug(`updated LLM Key: ${id}`);
 
       await transaction.commit();
       return res.status(200).json(STATUS_CODE[200](llmKey));
@@ -284,7 +353,7 @@ export const updateLLMKey = async (req: Request, res: Response) => {
       req.userId!,
       req.tenantId!
     );
-    logger.error("❌ Error in updateLLMKey:", error);
+    logger.error("Error in updateLLMKey:", error);
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }
 };
@@ -293,7 +362,7 @@ export const deleteLLMKey = async (req: Request, res: Response) => {
   const functionName = "deleteLLMKey";
 
   const { id } = req.params;
-  logger.debug(`🛠️ Deleting LLM Key: ${id}`);
+  logger.debug(`Deleting LLM Key: ${id}`);
   logStructured(
     "processing",
     `starting LLM Key deletion for ${id}`,
@@ -321,7 +390,7 @@ export const deleteLLMKey = async (req: Request, res: Response) => {
       functionName,
       fileName,
     );
-    logger.debug(`✅ Deleted LLM Key: ${id}`);
+    logger.debug(`Deleted LLM Key: ${id}`);
     return res
       .status(200)
       .json(STATUS_CODE[200]({ message: "LLM Key deleted successfully" }));
@@ -333,7 +402,7 @@ export const deleteLLMKey = async (req: Request, res: Response) => {
       req.userId!,
       req.tenantId!
     );
-    logger.error("❌ Error in deleteLLMKey:", error);
+    logger.error("Error in deleteLLMKey:", error);
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }
 };

--- a/Servers/database/migrations/20260223192558-add-custom-llm-provider-and-headers.js
+++ b/Servers/database/migrations/20260223192558-add-custom-llm-provider-and-headers.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/**
+ * Migration: Add 'Custom' provider to enum_llm_keys_provider and custom_headers column.
+ *
+ * ALTER TYPE ... ADD VALUE cannot run inside a transaction in PostgreSQL,
+ * so the ENUM change is done first outside any transaction, then the column
+ * addition loops all tenants inside its own transaction.
+ */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Step 1: Add 'Custom' to the ENUM (must be outside a transaction)
+    await queryInterface.sequelize.query(
+      `ALTER TYPE enum_llm_keys_provider ADD VALUE IF NOT EXISTS 'Custom';`
+    );
+
+    // Step 2: Add custom_headers JSONB column to all tenant schemas
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const [organizations] = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+      for (const organization of organizations) {
+        const tenantHash = getTenantHash(organization.id);
+
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${tenantHash}".llm_keys
+           ADD COLUMN IF NOT EXISTS custom_headers JSONB DEFAULT NULL;`,
+          { transaction }
+        );
+
+        console.log(`Added custom_headers column to ${tenantHash}.llm_keys`);
+      }
+
+      await transaction.commit();
+      console.log('Migration completed successfully');
+    } catch (error) {
+      await transaction.rollback();
+      console.error('Migration failed:', error);
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Note: PostgreSQL does not support removing values from an ENUM type.
+    // The 'Custom' value will remain in the ENUM but can be ignored.
+
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const [organizations] = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+      for (const organization of organizations) {
+        const tenantHash = getTenantHash(organization.id);
+
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${tenantHash}".llm_keys
+           DROP COLUMN IF EXISTS custom_headers;`,
+          { transaction }
+        );
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};

--- a/Servers/database/migrations/20260223192558-add-custom-llm-provider-and-headers.js
+++ b/Servers/database/migrations/20260223192558-add-custom-llm-provider-and-headers.js
@@ -9,10 +9,22 @@
  */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    // Step 1: Add 'Custom' to the ENUM (must be outside a transaction)
-    await queryInterface.sequelize.query(
-      `ALTER TYPE enum_llm_keys_provider ADD VALUE IF NOT EXISTS 'Custom';`
+    // Step 1: Ensure the ENUM type exists (it may not if the original
+    // migration was skipped or this is a fresh DB set up via createNewTenant)
+    const [enumCheck] = await queryInterface.sequelize.query(
+      `SELECT 1 FROM pg_type WHERE typname = 'enum_llm_keys_provider';`
     );
+    if (enumCheck.length === 0) {
+      // Create the full ENUM including Custom from scratch
+      await queryInterface.sequelize.query(
+        `CREATE TYPE enum_llm_keys_provider AS ENUM ('Anthropic', 'OpenAI', 'OpenRouter', 'Custom');`
+      );
+    } else {
+      // ENUM exists — add 'Custom' value (must be outside a transaction)
+      await queryInterface.sequelize.query(
+        `ALTER TYPE enum_llm_keys_provider ADD VALUE IF NOT EXISTS 'Custom';`
+      );
+    }
 
     // Step 2: Add custom_headers JSONB column to all tenant schemas
     const transaction = await queryInterface.sequelize.transaction();

--- a/Servers/domain.layer/interfaces/i.llmKey.ts
+++ b/Servers/domain.layer/interfaces/i.llmKey.ts
@@ -1,9 +1,10 @@
-export type LLMProvider = "Anthropic" | "OpenAI" | "OpenRouter";
+export type LLMProvider = "Anthropic" | "OpenAI" | "OpenRouter" | "Custom";
 export interface ILLMKey {
   id?: number;
   key: string;
   name: LLMProvider;
   url?: string | null;
   model: string;
+  custom_headers?: Record<string, string> | null;
   created_at?: Date;
 }

--- a/Servers/domain.layer/models/llmKey/llmKey.model.ts
+++ b/Servers/domain.layer/models/llmKey/llmKey.model.ts
@@ -19,7 +19,7 @@ export class LLMKeyModel extends Model<LLMKeyModel> implements ILLMKey {
   key!: string;
 
   @Column({
-    type: DataType.ENUM("Anthropic", "OpenAI", "OpenRouter"),
+    type: DataType.ENUM("Anthropic", "OpenAI", "OpenRouter", "Custom"),
     allowNull: false,
   })
   name!: LLMProvider;
@@ -35,6 +35,13 @@ export class LLMKeyModel extends Model<LLMKeyModel> implements ILLMKey {
     allowNull: false,
   })
   model!: string;
+
+  @Column({
+    type: DataType.JSONB,
+    allowNull: true,
+    defaultValue: null,
+  })
+  custom_headers!: Record<string, string> | null;
 
   @Column({
     type: DataType.DATE,

--- a/Servers/scripts/createNewTenant.ts
+++ b/Servers/scripts/createNewTenant.ts
@@ -2450,8 +2450,15 @@ export const createNewTenant = async (
     ].map((query) => sequelize.query(query, { transaction })));
 
     // Create llm_keys table for LLM API key management
-    // Note: Requires global ENUM type enum_llm_keys_provider to exist
-    // This is created by migration 20251126220719-create-llm-keys-table.js
+    // Ensure the global ENUM type exists (includes 'Custom' provider)
+    await sequelize.query(
+      `DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'enum_llm_keys_provider') THEN
+          CREATE TYPE enum_llm_keys_provider AS ENUM ('Anthropic', 'OpenAI', 'OpenRouter', 'Custom');
+        END IF;
+      END $$;`,
+      { transaction }
+    );
     await sequelize.query(
       `CREATE TABLE IF NOT EXISTS "${tenantHash}".llm_keys (
         id SERIAL PRIMARY KEY,
@@ -2459,6 +2466,7 @@ export const createNewTenant = async (
         name enum_llm_keys_provider NOT NULL,
         url TEXT,
         model TEXT NOT NULL,
+        custom_headers JSONB DEFAULT NULL,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );`,
       { transaction }

--- a/Servers/utils/llmKey.utils.ts
+++ b/Servers/utils/llmKey.utils.ts
@@ -15,7 +15,7 @@ export const maskApiKey = (key: string): string => {
 
 export const getLLMKeysQuery = async (tenant: string) => {
   const result = (await sequelize.query(
-    `SELECT id, name, url, model, created_at FROM "${tenant}".llm_keys ORDER BY created_at DESC;`,
+    `SELECT id, name, url, model, custom_headers, created_at FROM "${tenant}".llm_keys ORDER BY created_at DESC;`,
   )) as [LLMKeyModel[], number];
   return result[0];
 };
@@ -26,14 +26,14 @@ export const getLLMKeysQuery = async (tenant: string) => {
  */
 export const getLLMKeysWithKeyQuery = async (tenant: string) => {
   const result = (await sequelize.query(
-    `SELECT id, name, url, model, key, created_at FROM "${tenant}".llm_keys ORDER BY created_at DESC;`,
+    `SELECT id, name, url, model, key, custom_headers, created_at FROM "${tenant}".llm_keys ORDER BY created_at DESC;`,
   )) as [LLMKeyModel[], number];
   return result[0];
 };
 
 export const getLLMKeyQuery = async (tenant: string, name: string) => {
   const result = (await sequelize.query(
-    `SELECT id, name, url, model, created_at FROM "${tenant}".llm_keys WHERE name = :name;`,
+    `SELECT id, name, url, model, custom_headers, created_at FROM "${tenant}".llm_keys WHERE name = :name;`,
     {
       replacements: { name },
     },
@@ -48,13 +48,14 @@ export const createLLMKeyQuery = async (
 ) => {
   // Exclude 'key' from RETURNING to prevent exposing API key in response
   const result = (await sequelize.query(
-    `INSERT INTO "${tenant}".llm_keys (key, name, url, model) VALUES (:key, :name, :url, :model) RETURNING id, name, url, model, created_at;`,
+    `INSERT INTO "${tenant}".llm_keys (key, name, url, model, custom_headers) VALUES (:key, :name, :url, :model, :custom_headers) RETURNING id, name, url, model, custom_headers, created_at;`,
     {
       replacements: {
         key: data.key,
         name: data.name,
         url: data.url,
         model: data.model,
+        custom_headers: data.custom_headers ? JSON.stringify(data.custom_headers) : null,
       },
       transaction,
     },
@@ -68,11 +69,18 @@ export const updateLLMKeyByIdQuery = async (
   tenant: string,
   transaction: Transaction,
 ): Promise<LLMKeyModel | null> => {
-  const updateData: Partial<Record<keyof ILLMKey, any>> = {};
-  const setClause = ["name", "key", "url", "model"]
+  const updateData: Record<string, any> = {};
+  const fields = ["name", "key", "url", "model", "custom_headers"];
+  const setClause = fields
     .filter((f) => {
-      if (data[f as keyof ILLMKey] !== undefined && data[f as keyof ILLMKey]) {
-        updateData[f as keyof ILLMKey] = data[f as keyof ILLMKey];
+      const value = data[f as keyof typeof data];
+      // Allow null for custom_headers (to clear it) and url (to clear it)
+      if (value !== undefined) {
+        if (f === "custom_headers") {
+          updateData[f] = value ? JSON.stringify(value) : null;
+        } else {
+          updateData[f] = value;
+        }
         return true;
       }
       return false;
@@ -80,8 +88,10 @@ export const updateLLMKeyByIdQuery = async (
     .map((f) => `${f} = :${f}`)
     .join(", ");
 
+  if (!setClause) return null;
+
   // Exclude 'key' from RETURNING to prevent exposing API key in response
-  const query = `UPDATE "${tenant}".llm_keys SET ${setClause} WHERE id = :id RETURNING id, name, url, model, created_at;`;
+  const query = `UPDATE "${tenant}".llm_keys SET ${setClause} WHERE id = :id RETURNING id, name, url, model, custom_headers, created_at;`;
 
   updateData.id = id;
 
@@ -108,18 +118,18 @@ export const deleteLLMKeyQuery = async (id: number, tenant: string) => {
   return result.length > 0;
 };
 
-export const getLLMProviderUrl = (provider: LLMProvider): string => {
-  const urls: Record<LLMProvider, string> = {
-    Anthropic: "https://api.anthropic.com/v1",
-    OpenAI: "https://api.openai.com/v1/",
-    OpenRouter: "https://openrouter.ai/api/v1/",
-  };
+const standardProviderUrls: Record<string, string> = {
+  Anthropic: "https://api.anthropic.com/v1",
+  OpenAI: "https://api.openai.com/v1/",
+  OpenRouter: "https://openrouter.ai/api/v1/",
+};
 
-  return urls[provider];
+export const getLLMProviderUrl = (provider: LLMProvider): string => {
+  return standardProviderUrls[provider] || "";
 };
 
 export const isValidLLMProvider = (
   provider: string,
 ): provider is LLMProvider => {
-  return ["Anthropic", "OpenAI", "OpenRouter"].includes(provider);
+  return ["Anthropic", "OpenAI", "OpenRouter", "Custom"].includes(provider);
 };


### PR DESCRIPTION
## Summary
- Adds a **Custom** provider option to LLM Keys, allowing connection to self-hosted or OpenAI-compatible endpoints (LiteLLM, vLLM, Ollama, Azure OpenAI, Portkey, etc.)
- Supports user-defined endpoint URL, free-text model name, and optional custom HTTP headers (e.g., HTTP-Referer, Helicone-Auth, routing headers)
- Custom headers are passed through the AI SDK agent to `createOpenAI()` / `createAnthropic()` provider constructors for full proxy compatibility

## Changes

### Database
- Migration adds `'Custom'` to `enum_llm_keys_provider` ENUM and `custom_headers JSONB` column across all tenant schemas
- `createNewTenant.ts` updated for new tenants

### Backend (6 files)
- `i.llmKey.ts` / `llmKey.model.ts`: `"Custom"` in provider type, `custom_headers` field
- `llmKey.utils.ts`: CRUD queries include `custom_headers`
- `llmKey.ctrl.ts`: validates Custom requires URL, validates headers shape
- `aiSdkAgent.ts`: accepts and passes `headers` to SDK clients
- `advisor.ctrl.ts`: reads `custom_headers` from selected key, passes to all agent endpoints

### Frontend (2 files)
- `llmKeys.model.ts`: new `"custom"` provider config, `url` + `custom_headers` in form data
- `LLMKeys/index.tsx`: 4th provider card (Server icon), endpoint URL field, free-text model input, key-value header editor with add/remove

## Test plan
- [ ] Standard providers (Anthropic, OpenAI, OpenRouter) behave unchanged
- [ ] Create a Custom key: endpoint URL required, model is free text, headers can be added/removed
- [ ] Edit a Custom key: all fields (URL, model, headers) persist correctly
- [ ] Key list shows server icon and endpoint URL for Custom keys
- [ ] Advisor works with a Custom key pointing to an OpenAI-compatible endpoint
- [ ] Migration runs cleanly on existing databases