### PR TITLE
Fix "Invalid Date" in evidence upload date column

### DIFF
--- a/Servers/repositories/file.repository.ts
+++ b/Servers/repositories/file.repository.ts
@@ -373,7 +373,7 @@ export async function uploadOrganizationFile(
       (filename, size, type, file_path, content, uploaded_by, uploaded_time, model_id, org_id, is_demo, source, project_id, file_group_id, review_status, version, approval_workflow_id)
     VALUES
       (:filename, :size, :mimetype, :file_path, :content, :uploaded_by, NOW(), :model_id, :org_id, false, :source, NULL, gen_random_uuid(), :review_status, '1.0', :approval_workflow_id)
-    RETURNING *`;
+    RETURNING id, filename, size, type AS mimetype, file_path, uploaded_by, uploaded_time AS upload_date, model_id, org_id, is_demo, source, project_id, file_group_id, review_status, version, approval_workflow_id`;
 
   const result = await sequelize.query(query, {
     replacements: {


### PR DESCRIPTION
## Summary
- Fixed the "Invalid Date" display in the Upload Date column of the Evidence & Documents page after uploading a file
- Root cause: the `uploadOrganizationFile` INSERT query used `RETURNING *`, which returns the raw column name `uploaded_time` — but the controller accesses `upload_date`, resulting in `undefined` being sent to the frontend
- Changed `RETURNING *` to an explicit column list with `uploaded_time AS upload_date`, matching the alias used in all other SELECT queries in the same file

## Test plan
- [ ] Upload a file in Evidence & Documents page and verify the Upload Date column shows a valid date (e.g., `2026-02-23`) instead of "Invalid Date"
- [ ] Verify existing file listings still display correct upload dates
- [ ] Verify file upload via model inventory evidence hub still works correctly