### PR TITLE
fix: resolve null timestamps across all Sequelize models

### DIFF
--- a/Clients/src/application/hooks/useDashboardMetrics.ts
+++ b/Clients/src/application/hooks/useDashboardMetrics.ts
@@ -412,7 +412,7 @@ export const useDashboardMetrics = () => {
             (risk.current_risk_level || risk.risk_level_autocalculated || "medium")
               .toLowerCase()
               .includes("low") ? "low" as const : "medium" as const,
-          created_at: risk.created_at || risk.date_of_assessment || new Date().toISOString(),
+          created_at: risk.created_at || risk.createdAt || risk.date_of_assessment,
           project_name: risk.project_name || "General",
         })),
       };
@@ -449,8 +449,7 @@ export const useDashboardMetrics = () => {
           uploaded_at:
             file.uploaded_time ||
             file.created_at ||
-            file.updated_at ||
-            new Date().toISOString(),
+            file.updated_at,
           project_name: file.project_title || file.project_name || "General",
           user_name:
             `${file.uploader_name || ""} ${
@@ -507,7 +506,7 @@ export const useDashboardMetrics = () => {
           severity:
             risk.risk_level?.toLowerCase().replace(" risk", "") || "medium",
           created_at:
-            risk.review_date || risk.created_at || new Date().toISOString(),
+            risk.review_date || risk.created_at || risk.createdAt,
           vendor_name: risk.vendor_name || "Unknown Vendor",
         })),
       };
@@ -538,7 +537,7 @@ export const useDashboardMetrics = () => {
             vendor.company_name ||
             "Unknown Vendor",
           created_at:
-            vendor.created_at || vendor.createdAt || new Date().toISOString(),
+            vendor.created_at || vendor.createdAt,
           status: vendor.status || vendor.vendor_status || "Active",
         })),
       };
@@ -572,7 +571,7 @@ export const useDashboardMetrics = () => {
           id: policy.id || "unknown",
           title: policy.title || "Untitled Policy",
           status: policy.status || "unknown",
-          last_updated_at: policy.last_updated_at || new Date().toISOString(),
+          last_updated_at: policy.last_updated_at || policy.updated_at || policy.updatedAt,
           author_id: policy.author_id || 0,
         })),
       };
@@ -645,7 +644,8 @@ export const useDashboardMetrics = () => {
           description: incident.description || incident.title || "Incident",
           severity: incident.severity || "Unknown",
           status: incident.status || "Unknown",
-          created_at: incident.created_at || incident.createdAt || new Date().toISOString(),
+          created_at: incident.created_at || incident.createdAt,
+          updated_at: incident.updated_at || incident.updatedAt,
         })),
       };
 
@@ -719,7 +719,7 @@ export const useDashboardMetrics = () => {
           id: risk.id || index + 1,
           title: risk.risk_name || "Untitled Risk",
           severity: (risk.risk_level || "medium").toLowerCase() as "critical" | "high" | "medium" | "low",
-          created_at: risk.created_at || new Date().toISOString(),
+          created_at: risk.created_at || risk.createdAt,
           model_name: risk.model_name || undefined,
         })),
       };

--- a/Servers/domain.layer/interfaces/i.vendor.ts
+++ b/Servers/domain.layer/interfaces/i.vendor.ts
@@ -16,6 +16,7 @@ export interface IVendor {
   reviewer?: number | null; // optional field, can be filled by user
   review_date?: Date; // optional field, can be filled by user
   created_at?: Date;
+  updated_at?: Date;
   // Vendor scorecard fields - optional, will be filled by user
   data_sensitivity?:
     | "None"

--- a/Servers/domain.layer/models/assessment/assessment.model.ts
+++ b/Servers/domain.layer/models/assessment/assessment.model.ts
@@ -218,7 +218,7 @@ export class AssessmentModel
       id: this.id,
       project_id: this.project_id,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
     };
   }
 
@@ -237,7 +237,7 @@ export class AssessmentModel
       id: this.id,
       project_id: this.project_id,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/automation/automation.model.ts
+++ b/Servers/domain.layer/models/automation/automation.model.ts
@@ -225,8 +225,8 @@ export class AutomationModel extends Model<AutomationModel> implements IAutomati
       is_active: this.is_active,
       created_by: this.created_by,
       creator: this.creator?.toSafeJSON(),
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 }

--- a/Servers/domain.layer/models/automationAction/automationAction.model.ts
+++ b/Servers/domain.layer/models/automationAction/automationAction.model.ts
@@ -158,8 +158,8 @@ export class AutomationActionModel extends Model<AutomationActionModel> implemen
       label: this.label,
       description: this.description,
       default_params: this.default_params,
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 }

--- a/Servers/domain.layer/models/automationExecutionLog/automationExecutionLog.model.ts
+++ b/Servers/domain.layer/models/automationExecutionLog/automationExecutionLog.model.ts
@@ -179,8 +179,8 @@ export class AutomationExecutionLogModel extends Model<AutomationExecutionLogMod
       status: this.status,
       error_message: this.error_message,
       execution_time_ms: this.execution_time_ms,
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 }

--- a/Servers/domain.layer/models/automationTrigger/automationTrigger.model.ts
+++ b/Servers/domain.layer/models/automationTrigger/automationTrigger.model.ts
@@ -154,8 +154,8 @@ export class AutomationTriggerModel extends Model<AutomationTriggerModel> implem
       label: this.label,
       event_name: this.event_name,
       description: this.description,
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 }

--- a/Servers/domain.layer/models/automationTriggerAction/automationTriggerAction.model.ts
+++ b/Servers/domain.layer/models/automationTriggerAction/automationTriggerAction.model.ts
@@ -206,8 +206,8 @@ export class AutomationTriggerActionModel extends Model<AutomationTriggerActionM
       action_id: this.action_id,
       trigger: this.trigger?.toJSON(),
       action: this.action?.toJSON(),
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 }

--- a/Servers/domain.layer/models/control/control.model.ts
+++ b/Servers/domain.layer/models/control/control.model.ts
@@ -624,7 +624,7 @@ export class ControlModel extends Model<ControlModel> implements IControl {
       implementation_details: this.implementation_details,
       control_category_id: this.control_category_id,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       isOverdue: this.isOverdue(),
       isCompleted: this.isCompleted(),
       progressPercentage: this.getProgressPercentage(),

--- a/Servers/domain.layer/models/controlCategory/controlCategory.model.ts
+++ b/Servers/domain.layer/models/controlCategory/controlCategory.model.ts
@@ -245,7 +245,7 @@ export class ControlCategoryModel
       project_id: this.project_id,
       title: this.title,
       order_no: this.order_no,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       is_demo: this.is_demo,
     };
   }
@@ -284,7 +284,7 @@ export class ControlCategoryModel
       project_id: this.project_id,
       title: this.title,
       order_no: this.order_no,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       is_demo: this.is_demo,
       // Include dynamically added properties from queries
       controls: dataValues?.controls,

--- a/Servers/domain.layer/models/dataset/dataset.model.ts
+++ b/Servers/domain.layer/models/dataset/dataset.model.ts
@@ -302,8 +302,8 @@ export class DatasetModel extends Model<DatasetModel> implements IDataset {
       preprocessing_steps: this.preprocessing_steps,
       documentation_data: this.documentation_data || [],
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString?.() || this.created_at,
-      updated_at: this.updated_at?.toISOString?.() || this.updated_at,
+      created_at: (this.createdAt ?? this.created_at)?.toISOString?.() || this.createdAt || this.created_at,
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString?.() || this.updatedAt || this.updated_at,
       models: dataValues.models || [],
       projects: dataValues.projects || [],
     };

--- a/Servers/domain.layer/models/dataset/datasetModelInventory.model.ts
+++ b/Servers/domain.layer/models/dataset/datasetModelInventory.model.ts
@@ -92,7 +92,7 @@ export class DatasetModelInventoryModel
       dataset_id: this.dataset_id,
       model_inventory_id: this.model_inventory_id,
       relationship_type: this.relationship_type,
-      created_at: this.created_at?.toISOString?.() || this.created_at,
+      created_at: (this.createdAt ?? this.created_at)?.toISOString?.() || this.createdAt || this.created_at,
     };
   }
 

--- a/Servers/domain.layer/models/dataset/datasetProject.model.ts
+++ b/Servers/domain.layer/models/dataset/datasetProject.model.ts
@@ -51,7 +51,7 @@ export class DatasetProjectModel
       id: this.id,
       dataset_id: this.dataset_id,
       project_id: this.project_id,
-      created_at: this.created_at?.toISOString?.() || this.created_at,
+      created_at: (this.createdAt ?? this.created_at)?.toISOString?.() || this.createdAt || this.created_at,
     };
   }
 

--- a/Servers/domain.layer/models/entityGraphAnnotations/entityGraphAnnotations.model.ts
+++ b/Servers/domain.layer/models/entityGraphAnnotations/entityGraphAnnotations.model.ts
@@ -228,8 +228,8 @@ export class EntityGraphAnnotationsModel extends Model<EntityGraphAnnotationsMod
       entity_type: this.entity_type,
       entity_id: this.entity_id,
       organization_id: this.organization_id,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/entityGraphGapRules/entityGraphGapRules.model.ts
+++ b/Servers/domain.layer/models/entityGraphGapRules/entityGraphGapRules.model.ts
@@ -195,8 +195,8 @@ export class EntityGraphGapRulesModel extends Model<EntityGraphGapRulesModel> {
       user_id: this.user_id,
       organization_id: this.organization_id,
       rules: this.rules,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/entityGraphViews/entityGraphViews.model.ts
+++ b/Servers/domain.layer/models/entityGraphViews/entityGraphViews.model.ts
@@ -226,8 +226,8 @@ export class EntityGraphViewsModel extends Model<EntityGraphViewsModel> {
       user_id: this.user_id,
       organization_id: this.organization_id,
       config: this.config,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/evidenceHub/evidenceHub.model.ts
+++ b/Servers/domain.layer/models/evidenceHub/evidenceHub.model.ts
@@ -82,8 +82,8 @@ export class EvidenceHubModel extends Model<EvidenceHubModel> {
       evidence_files: this.evidence_files,
       expiry_date: this.expiry_date?.toISOString() || null,
       mapped_model_ids: this.mapped_model_ids,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 
@@ -100,8 +100,8 @@ export class EvidenceHubModel extends Model<EvidenceHubModel> {
       evidence_files: this.evidence_files,
       expiry_date: this.expiry_date?.toISOString() || null,
       mapped_model_ids: this.mapped_model_ids,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/frameworks/frameworks.model.ts
+++ b/Servers/domain.layer/models/frameworks/frameworks.model.ts
@@ -290,7 +290,7 @@ export class FrameworkModel
       id: this.id,
       name: this.name,
       description: this.description,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
     };
   }
 
@@ -302,7 +302,7 @@ export class FrameworkModel
       id: this.id,
       name: this.name,
       description: this.description,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       is_organizational: this.is_organizational,
       ageInDays: this.getAgeInDays(),
       isActive: this.isActive(),
@@ -456,7 +456,7 @@ export class FrameworkModel
       id: this.id,
       name: this.name,
       description: this.description,
-      created_at: this.created_at,
+      created_at: (this.createdAt ?? this.created_at),
       ageInDays: this.getAgeInDays(),
       isActive: this.isActive(),
       isRecent: this.isRecent(),

--- a/Servers/domain.layer/models/incidentManagement/incidemtManagement.model.ts
+++ b/Servers/domain.layer/models/incidentManagement/incidemtManagement.model.ts
@@ -248,8 +248,8 @@ export class AIIncidentManagementModel
             approved_by: this.approved_by,
             approval_date: this.approval_date?.toISOString() || null,
             approval_notes: this.approval_notes,
-            created_at: this.created_at?.toISOString(),
-            updated_at: this.updated_at?.toISOString(),
+            created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+            updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
         };
     }
 
@@ -288,8 +288,8 @@ export class AIIncidentManagementModel
             approved_by: this.approved_by,
             approval_date: this.approval_date?.toISOString() || null,
             approval_notes: this.approval_notes,
-            created_at: this.created_at?.toISOString(),
-            updated_at: this.updated_at?.toISOString(),
+            created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+            updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
         };
     }
 

--- a/Servers/domain.layer/models/modelInventory/modelInventory.model.ts
+++ b/Servers/domain.layer/models/modelInventory/modelInventory.model.ts
@@ -306,8 +306,8 @@ export class ModelInventoryModel
       hosting_provider: this.hosting_provider,
       security_assessment_data: this.security_assessment_data!= undefined ? this.security_assessment_data : [],
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
       projects: dataValues.projects || [],
       frameworks: dataValues.frameworks || [],
     };
@@ -344,8 +344,8 @@ export class ModelInventoryModel
       hosting_provider: this.hosting_provider,
       security_assessment_data: this.security_assessment_data!= undefined ? this.security_assessment_data : [],
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
       projects: dataValues.projects || [],
       frameworks: dataValues.frameworks || [],
     };

--- a/Servers/domain.layer/models/modelRisk/modelRisk.model.ts
+++ b/Servers/domain.layer/models/modelRisk/modelRisk.model.ts
@@ -230,8 +230,8 @@ export class ModelRiskModel
       current_values: this.current_values,
       threshold: this.threshold,
       model_id: this.model_id,
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 

--- a/Servers/domain.layer/models/notes/notes.model.ts
+++ b/Servers/domain.layer/models/notes/notes.model.ts
@@ -411,8 +411,8 @@ export class NotesModel extends Model<NotesModel> {
       attached_to_id: this.attached_to_id,
       organization_id: this.organization_id,
       is_edited: this.is_edited,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/organization/organization.model.ts
+++ b/Servers/domain.layer/models/organization/organization.model.ts
@@ -364,7 +364,7 @@ export class OrganizationModel
       id: this.id,
       name: this.name,
       logo: this.logo,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       onboarding_status: this.onboarding_status,
     };
   }
@@ -377,7 +377,7 @@ export class OrganizationModel
       id: this.id,
       name: this.name,
       logo: this.logo,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       onboarding_status: this.onboarding_status,
       ageInDays: this.getAgeInDays(),
     };

--- a/Servers/domain.layer/models/policy/policy.model.ts
+++ b/Servers/domain.layer/models/policy/policy.model.ts
@@ -123,7 +123,7 @@ export class PolicyManagerModel extends Model<PolicyManagerModel> implements IPo
       review_comment: this.review_comment,
       reviewed_by: this.reviewed_by,
       reviewed_at: this.reviewed_at,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/policy/policy_linked_objects.model.ts
+++ b/Servers/domain.layer/models/policy/policy_linked_objects.model.ts
@@ -60,8 +60,8 @@ import { LinkedObjectType } from "../../enums/policy-manager.enum";
         policy_id: this.policy_id,
         object_id: this.object_id,
         object_type: this.object_type,
-        created_at: this.created_at,
-        updated_at: this.updated_at,
+        created_at: (this.createdAt ?? this.created_at),
+        updated_at: (this.updatedAt ?? this.updated_at),
       };
     }
   

--- a/Servers/domain.layer/models/project/project.model.ts
+++ b/Servers/domain.layer/models/project/project.model.ts
@@ -185,7 +185,7 @@ export class ProjectModel
       last_updated: this.last_updated?.toISOString(),
       last_updated_by: this.last_updated_by,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       is_organizational: this.is_organizational,
       status: this.status,
       _source: (this as any)._source,

--- a/Servers/domain.layer/models/projectScope/projectScope.model.ts
+++ b/Servers/domain.layer/models/projectScope/projectScope.model.ts
@@ -504,7 +504,7 @@ export class ProjectScopeModel
       usesPersonalData: this.usesPersonalData,
       hasOngoingMonitoring: this.hasOngoingMonitoring,
       isNewAiTechnology: this.isNewAiTechnology,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       is_demo: this.is_demo,
     };
   }
@@ -524,7 +524,7 @@ export class ProjectScopeModel
       hasOngoingMonitoring: this.hasOngoingMonitoring,
       unintendedOutcomes: this.unintendedOutcomes,
       technologyDocumentation: this.technologyDocumentation,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       is_demo: this.is_demo,
       riskLevel: this.getRiskLevel(),
     };

--- a/Servers/domain.layer/models/question/question.model.ts
+++ b/Servers/domain.layer/models/question/question.model.ts
@@ -515,8 +515,8 @@ export class QuestionModel extends Model<QuestionModel> implements IQuestion {
       answer: this.answer,
       subtopic_id: this.subtopic_id,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
       status: this.status,
       progressPercentage: this.getProgressPercentage(),
     };

--- a/Servers/domain.layer/models/risks/risk.model.ts
+++ b/Servers/domain.layer/models/risks/risk.model.ts
@@ -498,8 +498,8 @@ export class RiskModel extends Model<RiskModel> implements IRisk {
       approval_status: this.approval_status,
       date_of_assessment: this.date_of_assessment,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/shareLink/shareLink.model.ts
+++ b/Servers/domain.layer/models/shareLink/shareLink.model.ts
@@ -128,8 +128,8 @@ export class ShareLinkModel extends Model<ShareLinkModel> implements IShareLink 
       settings: this.settings,
       is_enabled: this.is_enabled,
       expires_at: this.expires_at,
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 }

--- a/Servers/domain.layer/models/subcontrol/subcontrol.model.ts
+++ b/Servers/domain.layer/models/subcontrol/subcontrol.model.ts
@@ -567,8 +567,8 @@ export class SubcontrolModel
       feedback_files: this.feedback_files,
       control_id: this.control_id,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
       progressPercentage: this.getProgressPercentage(),
       isOverdue: this.isOverdue(),
     };

--- a/Servers/domain.layer/models/subtopic/subtopic.model.ts
+++ b/Servers/domain.layer/models/subtopic/subtopic.model.ts
@@ -221,8 +221,8 @@ export class SubtopicModel extends Model<SubtopicModel> implements ISubtopic {
       order_no: this.order_no,
       topic_id: this.topic_id,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
       // Include dynamically added properties from queries
       questions: dataValues?.questions,
     };

--- a/Servers/domain.layer/models/tasks/tasks.model.ts
+++ b/Servers/domain.layer/models/tasks/tasks.model.ts
@@ -277,8 +277,8 @@ export class TasksModel extends Model<TasksModel> implements ITask {
       priority: this.priority,
       status: this.status,
       categories: this.categories,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 
@@ -297,8 +297,8 @@ export class TasksModel extends Model<TasksModel> implements ITask {
       priority: this.priority,
       status: this.status,
       categories: this.categories,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
       isOverdue: this.isOverdue(),
       // Include dynamically added properties from queries
       assignees: dataValues?.assignees,

--- a/Servers/domain.layer/models/tenantAutomationAction/tenantAutomationAction.model.ts
+++ b/Servers/domain.layer/models/tenantAutomationAction/tenantAutomationAction.model.ts
@@ -214,8 +214,8 @@ export class TenantAutomationActionModel extends Model<TenantAutomationActionMod
       action_type: this.action_type?.toJSON(),
       params: this.params,
       order: this.order,
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 }

--- a/Servers/domain.layer/models/topic/topic.model.ts
+++ b/Servers/domain.layer/models/topic/topic.model.ts
@@ -216,8 +216,8 @@ export class TopicModel extends Model<TopicModel> implements ITopic {
       order_no: this.order_no,
       assessment_id: this.assessment_id,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/user/user.model.ts
+++ b/Servers/domain.layer/models/user/user.model.ts
@@ -675,7 +675,7 @@ export class UserModel extends Model<UserModel> {
       surname: this.surname,
       email: this.email,
       role_id: this.role_id,
-      created_at: this.created_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
       last_login: this.last_login?.toISOString(),
       is_demo: this.is_demo,
     };

--- a/Servers/domain.layer/models/vendor/vendor.model.ts
+++ b/Servers/domain.layer/models/vendor/vendor.model.ts
@@ -591,8 +591,8 @@ export class VendorModel extends Model<VendorModel> implements IVendor {
       reviewer: this.reviewer,
       review_date: this.review_date?.toISOString(),
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 

--- a/Servers/domain.layer/models/vendorRisk/vendorRisk.model.ts
+++ b/Servers/domain.layer/models/vendorRisk/vendorRisk.model.ts
@@ -198,8 +198,8 @@ export class VendorRiskModel
       action_owner: this.action_owner,
       risk_level: this.risk_level,
       is_demo: this.is_demo,
-      created_at: this.created_at?.toISOString(),
-      updated_at: this.updated_at?.toISOString(),
+      created_at: (this.createdAt ?? this.created_at)?.toISOString(),
+      updated_at: (this.updatedAt ?? this.updated_at)?.toISOString(),
     };
   }
 }

--- a/Servers/domain.layer/models/virtualFolder/virtualFolder.model.ts
+++ b/Servers/domain.layer/models/virtualFolder/virtualFolder.model.ts
@@ -111,8 +111,8 @@ export class VirtualFolderModel extends Model<VirtualFolderModel> implements IVi
       icon: this.icon,
       is_system: this.is_system,
       created_by: this.created_by,
-      created_at: this.created_at,
-      updated_at: this.updated_at,
+      created_at: (this.createdAt ?? this.created_at),
+      updated_at: (this.updatedAt ?? this.updated_at),
     };
   }
 }

--- a/Servers/utils/vendor.utils.ts
+++ b/Servers/utils/vendor.utils.ts
@@ -47,6 +47,8 @@ export const getAllVendorsQuery = async (
     // Extract dataValues to include all database columns including scorecard fields
     vendorsWithDetails.push({
       ...vendor.dataValues,
+      created_at: (vendor.createdAt ?? vendor.created_at)?.toISOString(),
+      updated_at: (vendor.updatedAt ?? vendor.updated_at)?.toISOString(),
       projects: projects.map((p) => p.project_id),
       reviewer_name:
         reviewer_name[0].length > 0 ? reviewer_name[0][0].full_name : "",
@@ -76,8 +78,11 @@ export const getVendorByIdQuery = async (
       model: VendorsProjectsModel,
     }
   );
+  const vendor = result[0] as VendorModel;
   return {
-    ...result[0].dataValues,
+    ...vendor.dataValues,
+    created_at: (vendor.createdAt ?? vendor.created_at)?.toISOString(),
+    updated_at: (vendor.updatedAt ?? vendor.updated_at)?.toISOString(),
     projects: (projects || []).map((p) => p.project_id),
   };
 };
@@ -114,7 +119,13 @@ export const getVendorByProjectIdQuery = async (
     // commenting as, for the current functionality, project and vendor have 1:1 mapping
     // const projects = await sequelize.query("SELECT project_id FROM vendors_projects WHERE vendor_id = $1", [vendors_project.vendor_id])
     // vendors.push({ ...vendor[0], projects: projects.map(p => p.project_id) })
-    vendors.push({ ...vendor[0].dataValues, projects: [project_id] });
+    const v = vendor[0] as VendorModel;
+    vendors.push({
+      ...v.dataValues,
+      created_at: (v.createdAt ?? v.created_at)?.toISOString(),
+      updated_at: (v.updatedAt ?? v.updated_at)?.toISOString(),
+      projects: [project_id],
+    });
   }
   return vendors;
 };


### PR DESCRIPTION
## Summary

- Fix systemic bug where all 37 Sequelize models returned `null` for `created_at` / `updated_at` fields due to `timestamps: true` + `underscored: true` causing Sequelize to map DB column `created_at` to `this.createdAt` (camelCase), while all serialization methods accessed `this.created_at` (snake_case)
- Fix vendor.utils.ts `dataValues` spreads that bypassed model serialization entirely
- Remove `new Date().toISOString()` fallbacks in dashboard metrics hook that masked null timestamps as "just now"

## Test plan

- [ ] Verify dashboard "Recent Activity" shows correct timestamps for all entity types
- [ ] Verify automations execution history shows correct timestamps
- [ ] Verify model risk tables display correct dates
- [ ] Verify vendor list shows correct creation dates
- [ ] Verify incidents, policies, tasks, and evidence pages show correct timestamps