### PR TITLE
fix(styleguide): update color values to match current theme

### DIFF
--- a/Clients/src/presentation/pages/StyleGuide/sections/AlertsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/AlertsSection.tsx
@@ -97,7 +97,7 @@ const AlertsSection: React.FC = () => {
                 title="Success"
                 body="Your changes have been saved successfully."
                 icon={<CheckCircle size={20} />}
-                colors={{ text: "#079455", bg: "#ecfdf3" }}
+                colors={{ text: "#138A5E", bg: "#E6F4EA" }}
                 code={alertSnippets.success}
                 onCopy={handleCopy}
               />
@@ -106,7 +106,7 @@ const AlertsSection: React.FC = () => {
                 title="Error"
                 body="Something went wrong. Please try again."
                 icon={<XCircle size={20} />}
-                colors={{ text: "#f04438", bg: "#f9eced" }}
+                colors={{ text: "#D32F2F", bg: "#FFD6D6" }}
                 code={alertSnippets.error}
                 onCopy={handleCopy}
               />
@@ -115,7 +115,7 @@ const AlertsSection: React.FC = () => {
                 title="Warning"
                 body="This action cannot be undone."
                 icon={<AlertTriangle size={20} />}
-                colors={{ text: "#DC6803", bg: "#fffcf5" }}
+                colors={{ text: "#795548", bg: "#FFF8E1" }}
                 code={alertSnippets.warning}
                 onCopy={handleCopy}
               />
@@ -124,7 +124,7 @@ const AlertsSection: React.FC = () => {
                 title="Information"
                 body="New features are available."
                 icon={<Info size={20} />}
-                colors={{ text: "#475467", bg: "#FFFFFF" }}
+                colors={{ text: "#1565C0", bg: "#E3F2FD" }}
                 code={alertSnippets.info}
                 onCopy={handleCopy}
               />
@@ -166,29 +166,29 @@ const AlertsSection: React.FC = () => {
         <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: "16px" }}>
           <AlertColorCard
             variant="Success"
-            textColor="#079455"
-            bgColor="#ecfdf3"
+            textColor="#138A5E"
+            bgColor="#E6F4EA"
             themeKey="theme.palette.status.success"
             onCopy={handleCopy}
           />
           <AlertColorCard
             variant="Error"
-            textColor="#f04438"
-            bgColor="#f9eced"
+            textColor="#D32F2F"
+            bgColor="#FFD6D6"
             themeKey="theme.palette.status.error"
             onCopy={handleCopy}
           />
           <AlertColorCard
             variant="Warning"
-            textColor="#DC6803"
-            bgColor="#fffcf5"
+            textColor="#795548"
+            bgColor="#FFF8E1"
             themeKey="theme.palette.status.warning"
             onCopy={handleCopy}
           />
           <AlertColorCard
             variant="Info"
-            textColor="#475467"
-            bgColor="#FFFFFF"
+            textColor="#1565C0"
+            bgColor="#E3F2FD"
             themeKey="theme.palette.status.info"
             onCopy={handleCopy}
           />
@@ -224,23 +224,23 @@ const AlertsSection: React.FC = () => {
                 alignItems: "center",
                 gap: "16px",
                 p: "16px",
-                backgroundColor: "#ecfdf3",
-                border: "1px solid #079455",
+                backgroundColor: "#E6F4EA",
+                border: "1px solid #138A5E",
                 borderRadius: "4px",
               }}
             >
-              <Box sx={{ color: "#079455" }}>
+              <Box sx={{ color: "#138A5E" }}>
                 <CheckCircle size={20} />
               </Box>
               <Stack spacing="2px" sx={{ flex: 1 }}>
-                <Typography sx={{ fontWeight: 700, color: "#079455", fontSize: 13 }}>
+                <Typography sx={{ fontWeight: 700, color: "#138A5E", fontSize: 13 }}>
                   Success
                 </Typography>
-                <Typography sx={{ color: "#079455", fontSize: 13 }}>
+                <Typography sx={{ color: "#138A5E", fontSize: 13 }}>
                   Your changes have been saved.
                 </Typography>
               </Stack>
-              <Box sx={{ color: "#079455", cursor: "pointer", ml: "16px" }}>
+              <Box sx={{ color: "#138A5E", cursor: "pointer", ml: "16px" }}>
                 <XCircle size={16} />
               </Box>
             </Box>

--- a/Clients/src/presentation/pages/StyleGuide/sections/AvatarsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/AvatarsSection.tsx
@@ -2,90 +2,83 @@ import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Avatar as MuiAvatar, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
 import CodeBlock from "../components/CodeBlock";
+import VWAvatar from "../../../components/Avatar/VWAvatar";
 
 const avatarSnippets = {
-  basic: `import { Avatar as MuiAvatar } from "@mui/material";
+  basic: `import VWAvatar from "@/presentation/components/Avatar/VWAvatar";
 
-<MuiAvatar
-  alt="John Doe"
-  sx={{ width: 40, height: 40 }}
->
-  JD
-</MuiAvatar>`,
-  withImage: `<MuiAvatar
-  alt="John Doe"
-  src="/path/to/image.jpg"
-  sx={{ width: 40, height: 40 }}
+// Display initials avatar for a user
+<VWAvatar
+  user={{ firstname: "John", lastname: "Doe" }}
+  size="small"
 />`,
-  sizes: `// Small (32px)
-<MuiAvatar sx={{ width: 32, height: 32, fontSize: 14 }}>JD</MuiAvatar>
+  withImage: `import VWAvatar from "@/presentation/components/Avatar/VWAvatar";
 
-// Medium (40px) - Default
-<MuiAvatar sx={{ width: 40, height: 40, fontSize: 16 }}>JD</MuiAvatar>
-
-// Large (64px)
-<MuiAvatar sx={{ width: 64, height: 64, fontSize: 22 }}>JD</MuiAvatar>`,
-  colorGeneration: `// Generate consistent color from string
-const stringToColor = (string: string) => {
-  let hash = 0;
-  for (let i = 0; i < string.length; i++) {
-    hash = string.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  let color = "#";
-  for (let i = 0; i < 3; i++) {
-    const value = (hash >> (i * 8)) & 0xff;
-    color += \`00\${value.toString(16)}\`.slice(-2);
-  }
-  return color;
-};
-
-<MuiAvatar
-  sx={{ backgroundColor: stringToColor("John Doe") }}
->
-  JD
-</MuiAvatar>`,
-  withBorder: `<MuiAvatar
-  sx={{
-    width: 40,
-    height: 40,
-    "&::before": {
-      content: '""',
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-      border: "2px solid rgba(255,255,255,0.2)",
-      borderRadius: "50%",
-    },
+// Display avatar with profile image and initials fallback
+<VWAvatar
+  user={{
+    firstname: "John",
+    lastname: "Doe",
+    pathToImage: "/path/to/image.jpg",
   }}
->
-  JD
-</MuiAvatar>`,
-  group: `import { AvatarGroup } from "@mui/material";
+  size="small"
+/>`,
+  sizes: `import VWAvatar from "@/presentation/components/Avatar/VWAvatar";
 
-<AvatarGroup max={4} sx={{ "& .MuiAvatar-root": { width: 32, height: 32, fontSize: 14 } }}>
-  <MuiAvatar>JD</MuiAvatar>
-  <MuiAvatar>AB</MuiAvatar>
-  <MuiAvatar>CD</MuiAvatar>
-  <MuiAvatar>EF</MuiAvatar>
-  <MuiAvatar>GH</MuiAvatar>
+// Small — 32px
+<VWAvatar user={{ firstname: "John", lastname: "Doe" }} size="small" />
+
+// Medium — 64px
+<VWAvatar user={{ firstname: "Alice", lastname: "Brown" }} size="medium" />
+
+// Large — 128px
+<VWAvatar user={{ firstname: "Carlos", lastname: "Davis" }} size="large" />`,
+  colorGeneration: `import VWAvatar from "@/presentation/components/Avatar/VWAvatar";
+
+// VWAvatar uses the theme primary color automatically.
+// No manual color calculation needed.
+<VWAvatar user={{ firstname: "John", lastname: "Doe" }} size="small" />
+<VWAvatar user={{ firstname: "Alice", lastname: "Brown" }} size="small" />
+<VWAvatar user={{ firstname: "Carlos", lastname: "Davis" }} size="small" />`,
+  withBorder: `import VWAvatar from "@/presentation/components/Avatar/VWAvatar";
+
+// showBorder prop (default: true) adds a 2px primary-color border
+// when an image is loaded, or no border when showing initials.
+<VWAvatar
+  user={{ firstname: "John", lastname: "Doe" }}
+  size="small"
+  showBorder
+/>
+
+// Disable border
+<VWAvatar
+  user={{ firstname: "Alice", lastname: "Brown" }}
+  size="small"
+  showBorder={false}
+/>`,
+  group: `import { AvatarGroup } from "@mui/material";
+import VWAvatar from "@/presentation/components/Avatar/VWAvatar";
+
+// Wrap multiple VWAvatars inside MUI AvatarGroup for overlap + overflow
+<AvatarGroup
+  max={4}
+  sx={{ "& .MuiAvatar-root": { width: 32, height: 32, fontSize: 14 } }}
+>
+  <VWAvatar user={{ firstname: "John", lastname: "Doe" }} size="small" />
+  <VWAvatar user={{ firstname: "Alice", lastname: "Brown" }} size="small" />
+  <VWAvatar user={{ firstname: "Carlos", lastname: "Davis" }} size="small" />
+  <VWAvatar user={{ firstname: "Emma", lastname: "Foster" }} size="small" />
+  <VWAvatar user={{ firstname: "George", lastname: "Hill" }} size="small" />
 </AvatarGroup>`,
 };
 
-// Color generation function (same as in Avatar component)
-const stringToColor = (string: string) => {
-  let hash = 0;
-  for (let i = 0; i < string.length; i++) {
-    hash = string.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  let color = "#";
-  for (let i = 0; i < 3; i++) {
-    const value = (hash >> (i * 8)) & 0xff;
-    color += `00${value.toString(16)}`.slice(-2);
-  }
-  return color;
-};
+const sampleUsers = [
+  { firstname: "John", lastname: "Doe" },
+  { firstname: "Alice", lastname: "Brown" },
+  { firstname: "Carlos", lastname: "Davis" },
+  { firstname: "Emma", lastname: "Foster" },
+  { firstname: "George", lastname: "Hill" },
+];
 
 const AvatarsSection: React.FC = () => {
   const theme = useTheme();
@@ -96,14 +89,6 @@ const AvatarsSection: React.FC = () => {
     setCopiedText(text);
     setTimeout(() => setCopiedText(null), 2000);
   };
-
-  const sampleUsers = [
-    { name: "John Doe", initials: "JD" },
-    { name: "Alice Brown", initials: "AB" },
-    { name: "Carlos Davis", initials: "CD" },
-    { name: "Emma Foster", initials: "EF" },
-    { name: "George Hill", initials: "GH" },
-  ];
 
   return (
     <Box sx={{ p: "32px 40px" }}>
@@ -134,16 +119,18 @@ const AvatarsSection: React.FC = () => {
             maxWidth: 600,
           }}
         >
-          User avatars with automatic color generation and fallback initials.
-          Uses MUI Avatar with VerifyWise styling conventions.
+          User avatars with automatic initials fallback and size support.
+          Uses VWAvatar, the VerifyWise avatar component with built-in color generation and size support.
         </Typography>
       </Box>
 
       {/* Basic Avatars */}
       <SpecSection title="Basic avatars">
         <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
-          Avatars display user initials when no image is provided. Colors are
-          automatically generated based on the user's name for consistency.
+          VWAvatar displays user initials when no image is provided. Pass a{" "}
+          <code>user</code> object with <code>firstname</code> and{" "}
+          <code>lastname</code>. The component derives initials and applies
+          theme-based colors automatically.
         </Typography>
 
         <Box sx={{ display: "flex", gap: "40px", flexWrap: "wrap" }}>
@@ -165,18 +152,7 @@ const AvatarsSection: React.FC = () => {
                   }}
                 >
                   {sampleUsers.slice(0, 4).map((user) => (
-                    <MuiAvatar
-                      key={user.name}
-                      sx={{
-                        width: 40,
-                        height: 40,
-                        fontSize: 16,
-                        backgroundColor: stringToColor(user.name),
-                        color: "white",
-                      }}
-                    >
-                      {user.initials}
-                    </MuiAvatar>
+                    <VWAvatar key={`${user.firstname}-${user.lastname}`} user={user} size="small" />
                   ))}
                 </Box>
               </ExampleWithCode>
@@ -197,98 +173,63 @@ const AvatarsSection: React.FC = () => {
                   }}
                 >
                   <Box sx={{ textAlign: "center" }}>
-                    <MuiAvatar
-                      sx={{
-                        width: 32,
-                        height: 32,
-                        fontSize: 14,
-                        backgroundColor: stringToColor("John Doe"),
-                        color: "white",
-                        mb: "8px",
-                      }}
-                    >
-                      JD
-                    </MuiAvatar>
+                    <Box sx={{ display: "flex", justifyContent: "center", mb: "8px" }}>
+                      <VWAvatar user={sampleUsers[0]} size="small" />
+                    </Box>
                     <Typography sx={{ fontSize: 11, color: theme.palette.text.tertiary }}>
-                      32px
+                      small (32px)
                     </Typography>
                   </Box>
                   <Box sx={{ textAlign: "center" }}>
-                    <MuiAvatar
-                      sx={{
-                        width: 40,
-                        height: 40,
-                        fontSize: 16,
-                        backgroundColor: stringToColor("Alice Brown"),
-                        color: "white",
-                        mb: "8px",
-                      }}
-                    >
-                      AB
-                    </MuiAvatar>
+                    <Box sx={{ display: "flex", justifyContent: "center", mb: "8px" }}>
+                      <VWAvatar user={sampleUsers[1]} size="medium" />
+                    </Box>
                     <Typography sx={{ fontSize: 11, color: theme.palette.text.tertiary }}>
-                      40px
+                      medium (64px)
                     </Typography>
                   </Box>
                   <Box sx={{ textAlign: "center" }}>
-                    <MuiAvatar
-                      sx={{
-                        width: 64,
-                        height: 64,
-                        fontSize: 22,
-                        backgroundColor: stringToColor("Carlos Davis"),
-                        color: "white",
-                        mb: "8px",
-                      }}
-                    >
-                      CD
-                    </MuiAvatar>
+                    <Box sx={{ display: "flex", justifyContent: "center", mb: "8px" }}>
+                      <VWAvatar user={sampleUsers[2]} size="large" />
+                    </Box>
                     <Typography sx={{ fontSize: 11, color: theme.palette.text.tertiary }}>
-                      64px
+                      large (128px)
                     </Typography>
                   </Box>
                 </Box>
               </ExampleWithCode>
 
               <ExampleWithCode
-                label="With inner border"
+                label="With and without border"
                 code={avatarSnippets.withBorder}
                 onCopy={handleCopy}
               >
                 <Box
                   sx={{
                     display: "flex",
-                    gap: "16px",
+                    gap: "24px",
                     alignItems: "center",
                     p: "24px",
                     backgroundColor: theme.palette.background.fill,
                     borderRadius: "4px",
                   }}
                 >
-                  {sampleUsers.slice(0, 3).map((user, index) => (
-                    <MuiAvatar
-                      key={user.name}
-                      sx={{
-                        width: index === 1 ? 64 : 40,
-                        height: index === 1 ? 64 : 40,
-                        fontSize: index === 1 ? 22 : 16,
-                        backgroundColor: stringToColor(user.name),
-                        color: "white",
-                        "&::before": {
-                          content: '""',
-                          position: "absolute",
-                          top: 0,
-                          left: 0,
-                          width: "100%",
-                          height: "100%",
-                          border: `${index === 1 ? 3 : 2}px solid rgba(255,255,255,0.2)`,
-                          borderRadius: "50%",
-                        },
-                      }}
-                    >
-                      {user.initials}
-                    </MuiAvatar>
-                  ))}
+                  <Box sx={{ textAlign: "center" }}>
+                    <Box sx={{ display: "flex", justifyContent: "center", mb: "8px" }}>
+                      <VWAvatar user={sampleUsers[0]} size="small" showBorder />
+                    </Box>
+                    <Typography sx={{ fontSize: 11, color: theme.palette.text.tertiary }}>
+                      showBorder
+                    </Typography>
+                  </Box>
+                  <Box sx={{ textAlign: "center" }}>
+                    <Box sx={{ display: "flex", justifyContent: "center", mb: "8px" }}>
+                      <VWAvatar user={sampleUsers[1]} size="small" showBorder={false} />
+                    </Box>
+                    <Typography sx={{ fontSize: 11, color: theme.palette.text.tertiary }}>
+                      no border
+                    </Typography>
+                  </Box>
                 </Box>
               </ExampleWithCode>
             </Stack>
@@ -301,23 +242,24 @@ const AvatarsSection: React.FC = () => {
             <SpecTable
               onCopy={handleCopy}
               specs={[
-                { property: "Small", value: "32px (fontSize: 14px)" },
-                { property: "Medium (default)", value: "40px (fontSize: 16px)" },
-                { property: "Large", value: "64px (fontSize: 22px)" },
+                { property: "small", value: "32px (fontSize: 13px)" },
+                { property: "medium", value: "64px (fontSize: 22px)" },
+                { property: "large", value: "128px (fontSize: 44px)" },
               ]}
             />
 
             <Typography sx={{ fontSize: 12, fontWeight: 600, color: theme.palette.text.secondary, mb: "16px", mt: "24px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
-              Styling specifications
+              Props reference
             </Typography>
             <SpecTable
               onCopy={handleCopy}
               specs={[
-                { property: "Shape", value: "Circle (borderRadius: 50%)" },
-                { property: "Text color", value: "#FFFFFF (white)" },
-                { property: "Font weight", value: "400 (regular)" },
-                { property: "Inner border", value: "2-3px rgba(255,255,255,0.2)" },
-                { property: "Background", value: "Generated from name" },
+                { property: "user", value: "{ firstname, lastname, pathToImage? }" },
+                { property: "size", value: '"small" | "medium" | "large"' },
+                { property: "variant", value: '"circular" | "rounded" | "square"' },
+                { property: "showBorder", value: "boolean (default: true)" },
+                { property: "onClick", value: "() => void" },
+                { property: "alt", value: "string (overrides auto alt text)" },
               ]}
             />
           </Box>
@@ -327,14 +269,16 @@ const AvatarsSection: React.FC = () => {
       {/* Color Generation */}
       <SpecSection title="Color generation">
         <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
-          Avatar colors are deterministically generated from the user's name using a hash function.
-          This ensures the same user always gets the same color across the application.
+          VWAvatar uses the theme's primary color for all initials avatars. Color
+          generation is handled internally — no utility function is needed in
+          consuming code. When a profile image is provided, the background becomes
+          transparent and the border adopts the primary color.
         </Typography>
 
         <Box sx={{ display: "flex", gap: "40px", flexWrap: "wrap" }}>
           <Box sx={{ flex: "1 1 500px", minWidth: 320 }}>
             <ExampleWithCode
-              label="Consistent colors from names"
+              label="Theme-based avatar colors"
               code={avatarSnippets.colorGeneration}
               onCopy={handleCopy}
             >
@@ -348,31 +292,12 @@ const AvatarsSection: React.FC = () => {
                 <Stack spacing="12px">
                   {sampleUsers.map((user) => (
                     <Box
-                      key={user.name}
+                      key={`${user.firstname}-${user.lastname}`}
                       sx={{ display: "flex", alignItems: "center", gap: "12px" }}
                     >
-                      <MuiAvatar
-                        sx={{
-                          width: 32,
-                          height: 32,
-                          fontSize: 12,
-                          backgroundColor: stringToColor(user.name),
-                          color: "white",
-                        }}
-                      >
-                        {user.initials}
-                      </MuiAvatar>
+                      <VWAvatar user={user} size="small" />
                       <Typography sx={{ fontSize: 13, color: theme.palette.text.primary }}>
-                        {user.name}
-                      </Typography>
-                      <Typography
-                        sx={{
-                          fontSize: 11,
-                          fontFamily: "monospace",
-                          color: theme.palette.text.tertiary,
-                        }}
-                      >
-                        {stringToColor(user.name)}
+                        {user.firstname} {user.lastname}
                       </Typography>
                     </Box>
                   ))}
@@ -383,7 +308,7 @@ const AvatarsSection: React.FC = () => {
 
           <Box sx={{ flex: "1 1 300px", minWidth: 280 }}>
             <Typography sx={{ fontSize: 12, fontWeight: 600, color: theme.palette.text.secondary, mb: "16px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
-              Algorithm
+              How colors work
             </Typography>
             <Box
               sx={{
@@ -395,16 +320,16 @@ const AvatarsSection: React.FC = () => {
             >
               <Stack spacing="8px">
                 <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
-                  1. Convert each character to its char code
+                  1. Initials avatars use <code>theme.palette.primary.main</code>
                 </Typography>
                 <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
-                  2. Accumulate hash: charCode + ((hash &lt;&lt; 5) - hash)
+                  2. Image avatars use transparent background
                 </Typography>
                 <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
-                  3. Extract RGB values from hash bits
+                  3. Border color follows primary when image is present
                 </Typography>
                 <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
-                  4. Format as hex color string
+                  4. All color logic lives inside VWAvatar — no manual calculation needed
                 </Typography>
               </Stack>
             </Box>
@@ -415,7 +340,8 @@ const AvatarsSection: React.FC = () => {
       {/* Avatar Groups */}
       <SpecSection title="Avatar groups">
         <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
-          Use MUI AvatarGroup to display multiple avatars with automatic overflow handling.
+          Wrap VWAvatar components inside MUI AvatarGroup to display multiple avatars
+          with automatic overlap and overflow handling.
         </Typography>
 
         <Box sx={{ display: "flex", gap: "40px", flexWrap: "wrap" }}>
@@ -453,15 +379,12 @@ const AvatarsSection: React.FC = () => {
                     }}
                   >
                     {sampleUsers.slice(0, 4).map((user) => (
-                      <MuiAvatar
-                        key={user.name}
-                        sx={{
-                          backgroundColor: stringToColor(user.name),
-                          color: "white",
-                        }}
-                      >
-                        {user.initials}
-                      </MuiAvatar>
+                      <VWAvatar
+                        key={`${user.firstname}-${user.lastname}`}
+                        user={user}
+                        size="small"
+                        showBorder={false}
+                      />
                     ))}
                     <MuiAvatar
                       sx={{
@@ -493,15 +416,12 @@ const AvatarsSection: React.FC = () => {
                     }}
                   >
                     {sampleUsers.slice(0, 3).map((user) => (
-                      <MuiAvatar
-                        key={user.name}
-                        sx={{
-                          backgroundColor: stringToColor(user.name),
-                          color: "white",
-                        }}
-                      >
-                        {user.initials}
-                      </MuiAvatar>
+                      <VWAvatar
+                        key={`${user.firstname}-${user.lastname}`}
+                        user={user}
+                        size="small"
+                        showBorder={false}
+                      />
                     ))}
                     <MuiAvatar
                       sx={{
@@ -569,13 +489,13 @@ const AvatarsSection: React.FC = () => {
         </Typography>
         <Stack spacing="8px">
           {[
-            "Use stringToColor() for consistent avatar colors across the app",
-            "Always provide alt text for accessibility",
-            "Use 32px for compact lists, 40px default, 64px for profiles",
-            "Add inner border (rgba(255,255,255,0.2)) for visual polish",
-            "Use AvatarGroup with max prop to handle overflow gracefully",
-            "Fallback to initials when image fails to load",
-            "Keep initials to 2 characters (first name + last name)",
+            "Use VWAvatar component (not raw MUI Avatar) for all user avatars",
+            "VWAvatar handles color generation automatically from the theme — no manual stringToColor() needed",
+            "Pass user as { firstname, lastname, pathToImage? } — never pass raw initials strings",
+            "Use size=\"small\" (32px) for compact lists, size=\"medium\" (64px) for profiles, size=\"large\" (128px) for hero displays",
+            "Set showBorder={false} when composing into AvatarGroup to avoid double borders",
+            "VWAvatar falls back to initials automatically when image fails to load",
+            "Always provide meaningful alt text via the alt prop when the avatar context is not self-evident",
           ].map((item, index) => (
             <Box
               key={index}

--- a/Clients/src/presentation/pages/StyleGuide/sections/ButtonsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ButtonsSection.tsx
@@ -135,8 +135,8 @@ const ButtonsSection: React.FC = () => {
           <SpecCard title="Font weight" value="500" note="Medium weight" onCopy={handleCopy} />
           <SpecCard title="Primary color" value="#13715B" note="Main action buttons" onCopy={handleCopy} />
           <SpecCard title="Primary hover" value="#0f604d" note="Hover state" onCopy={handleCopy} />
-          <SpecCard title="Secondary color" value="#6B7280" note="Utility buttons" onCopy={handleCopy} />
-          <SpecCard title="Error color" value="#DB504A" note="Destructive actions" onCopy={handleCopy} />
+          <SpecCard title="Secondary color" value="#F4F4F4" note="Utility buttons (light bg)" onCopy={handleCopy} />
+          <SpecCard title="Error color" value="#D32F2F" note="Destructive actions" onCopy={handleCopy} />
           <SpecCard title="Disabled bg" value="#E5E7EB" note="Disabled state" onCopy={handleCopy} />
           <SpecCard title="Disabled text" value="#9CA3AF" note="Disabled text" onCopy={handleCopy} />
           <SpecCard title="Transition" value="0.2s ease" note="All interactions" onCopy={handleCopy} />
@@ -324,11 +324,11 @@ const ButtonsSection: React.FC = () => {
 
         <Box sx={{ display: "flex", gap: "16px", flexWrap: "wrap", mb: "24px" }}>
           <ColorSwatch label="Primary" color="#13715B" hoverColor="#0f604d" onCopy={handleCopy} />
-          <ColorSwatch label="Secondary" color="#6B7280" hoverColor="#4B5563" onCopy={handleCopy} />
-          <ColorSwatch label="Success" color="#059669" hoverColor="#047857" onCopy={handleCopy} />
-          <ColorSwatch label="Warning" color="#D97706" hoverColor="#B45309" onCopy={handleCopy} />
-          <ColorSwatch label="Error" color="#DB504A" hoverColor="#B91C1C" onCopy={handleCopy} />
-          <ColorSwatch label="Info" color="#3B82F6" hoverColor="#2563EB" onCopy={handleCopy} />
+          <ColorSwatch label="Secondary" color="#F4F4F4" hoverColor="#e3e3e3" onCopy={handleCopy} />
+          <ColorSwatch label="Success" color="#138A5E" hoverColor="#0F5A47" onCopy={handleCopy} />
+          <ColorSwatch label="Warning" color="#795548" hoverColor="#5D4037" onCopy={handleCopy} />
+          <ColorSwatch label="Error" color="#D32F2F" hoverColor="#B71C1C" onCopy={handleCopy} />
+          <ColorSwatch label="Info" color="#1565C0" hoverColor="#0D47A1" onCopy={handleCopy} />
         </Box>
 
         <Box sx={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>

--- a/Clients/src/presentation/pages/StyleGuide/sections/CardsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/CardsSection.tsx
@@ -290,8 +290,8 @@ const CardsSection: React.FC = () => {
           {/* Success Alert */}
           <Box
             sx={{
-              backgroundColor: "#ecfdf3",
-              border: "1px solid #17b26a",
+              backgroundColor: "#E6F4EA",
+              border: "1px solid #138A5E",
               borderRadius: "4px",
               p: "12px 16px",
               display: "flex",
@@ -299,8 +299,8 @@ const CardsSection: React.FC = () => {
               gap: "12px",
             }}
           >
-            <CheckCircle size={16} color="#079455" />
-            <Typography sx={{ fontSize: 13, color: "#079455" }}>
+            <CheckCircle size={16} color="#138A5E" />
+            <Typography sx={{ fontSize: 13, color: "#138A5E" }}>
               Success! Your changes have been saved.
             </Typography>
           </Box>
@@ -308,8 +308,8 @@ const CardsSection: React.FC = () => {
           {/* Error Alert */}
           <Box
             sx={{
-              backgroundColor: "#f9eced",
-              border: "1px solid #d32f2f",
+              backgroundColor: "#FFD6D6",
+              border: "1px solid #D32F2F",
               borderRadius: "4px",
               p: "12px 16px",
               display: "flex",
@@ -317,8 +317,8 @@ const CardsSection: React.FC = () => {
               gap: "12px",
             }}
           >
-            <AlertCircle size={16} color="#f04438" />
-            <Typography sx={{ fontSize: 13, color: "#f04438" }}>
+            <AlertCircle size={16} color="#D32F2F" />
+            <Typography sx={{ fontSize: 13, color: "#D32F2F" }}>
               Error: Something went wrong. Please try again.
             </Typography>
           </Box>
@@ -326,8 +326,8 @@ const CardsSection: React.FC = () => {
           {/* Warning Alert */}
           <Box
             sx={{
-              backgroundColor: "#fffcf5",
-              border: "1px solid #fdb022",
+              backgroundColor: "#FFF8E1",
+              border: "1px solid #795548",
               borderRadius: "4px",
               p: "12px 16px",
               display: "flex",
@@ -335,8 +335,8 @@ const CardsSection: React.FC = () => {
               gap: "12px",
             }}
           >
-            <AlertTriangle size={16} color="#DC6803" />
-            <Typography sx={{ fontSize: 13, color: "#DC6803" }}>
+            <AlertTriangle size={16} color="#795548" />
+            <Typography sx={{ fontSize: 13, color: "#795548" }}>
               Warning: This action cannot be undone.
             </Typography>
           </Box>
@@ -344,8 +344,8 @@ const CardsSection: React.FC = () => {
           {/* Info Alert */}
           <Box
             sx={{
-              backgroundColor: theme.palette.background.main,
-              border: "1px solid #d0d5dd",
+              backgroundColor: "#E3F2FD",
+              border: "1px solid #1565C0",
               borderRadius: "4px",
               p: "12px 16px",
               display: "flex",
@@ -353,8 +353,8 @@ const CardsSection: React.FC = () => {
               gap: "12px",
             }}
           >
-            <Info size={16} color="#475467" />
-            <Typography sx={{ fontSize: 13, color: "#475467" }}>
+            <Info size={16} color="#1565C0" />
+            <Typography sx={{ fontSize: 13, color: "#1565C0" }}>
               Info: Here's some additional information.
             </Typography>
           </Box>
@@ -385,30 +385,30 @@ const CardsSection: React.FC = () => {
         >
           <AlertColorCard
             type="Success"
-            bgColor="#ecfdf3"
-            borderColor="#17b26a"
-            textColor="#079455"
+            bgColor="#E6F4EA"
+            borderColor="#138A5E"
+            textColor="#138A5E"
             onCopy={handleCopy}
           />
           <AlertColorCard
             type="Error"
-            bgColor="#f9eced"
-            borderColor="#d32f2f"
-            textColor="#f04438"
+            bgColor="#FFD6D6"
+            borderColor="#D32F2F"
+            textColor="#D32F2F"
             onCopy={handleCopy}
           />
           <AlertColorCard
             type="Warning"
-            bgColor="#fffcf5"
-            borderColor="#fdb022"
-            textColor="#DC6803"
+            bgColor="#FFF8E1"
+            borderColor="#795548"
+            textColor="#795548"
             onCopy={handleCopy}
           />
           <AlertColorCard
             type="Info"
-            bgColor="#FFFFFF"
-            borderColor="#d0d5dd"
-            textColor="#475467"
+            bgColor="#E3F2FD"
+            borderColor="#1565C0"
+            textColor="#1565C0"
             onCopy={handleCopy}
           />
         </Box>

--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -160,7 +160,7 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Fill background"
-            color="#F4F4F4"
+            color="#E6F0EC"
             usage="Hover states, filled inputs"
             themeKey="theme.palette.background.fill"
             onCopy={handleCopy}
@@ -219,10 +219,10 @@ const ColorsSection: React.FC = () => {
         <Typography sx={{ fontSize: 12, fontWeight: 600, color: theme.palette.text.secondary, mb: "12px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
           Success
         </Typography>
-        <ColorGrid columns={4} sx={{ mb: "24px" }}>
+        <ColorGrid columns={5} sx={{ mb: "24px" }}>
           <ColorCard
             label="Success text"
-            color="#079455"
+            color="#138A5E"
             usage="Success messages"
             themeKey="theme.palette.status.success.text"
             onCopy={handleCopy}
@@ -230,7 +230,7 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Success main"
-            color="#17b26a"
+            color="#138A5E"
             usage="Success icons, indicators"
             themeKey="theme.palette.status.success.main"
             onCopy={handleCopy}
@@ -238,16 +238,23 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Success light"
-            color="#d4f4e1"
+            color="#C8E6D0"
             usage="Success badges"
             themeKey="theme.palette.status.success.light"
             onCopy={handleCopy}
           />
           <ColorCard
             label="Success bg"
-            color="#ecfdf3"
+            color="#E6F4EA"
             usage="Success backgrounds"
             themeKey="theme.palette.status.success.bg"
+            onCopy={handleCopy}
+          />
+          <ColorCard
+            label="Success border"
+            color="#C8E6D0"
+            usage="Success borders"
+            themeKey="theme.palette.status.success.border"
             onCopy={handleCopy}
           />
         </ColorGrid>
@@ -259,7 +266,7 @@ const ColorsSection: React.FC = () => {
         <ColorGrid columns={5} sx={{ mb: "24px" }}>
           <ColorCard
             label="Error text"
-            color="#f04438"
+            color="#D32F2F"
             usage="Error messages"
             themeKey="theme.palette.status.error.text"
             onCopy={handleCopy}
@@ -267,7 +274,7 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Error main"
-            color="#d32f2f"
+            color="#D32F2F"
             usage="Error icons"
             themeKey="theme.palette.status.error.main"
             onCopy={handleCopy}
@@ -275,21 +282,21 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Error light"
-            color="#fbd1d1"
+            color="#F5B8B8"
             usage="Error badges"
             themeKey="theme.palette.status.error.light"
             onCopy={handleCopy}
           />
           <ColorCard
             label="Error bg"
-            color="#f9eced"
+            color="#FFD6D6"
             usage="Error backgrounds"
             themeKey="theme.palette.status.error.bg"
             onCopy={handleCopy}
           />
           <ColorCard
             label="Error border"
-            color="#FDA29B"
+            color="#F5B8B8"
             usage="Error input borders"
             themeKey="theme.palette.status.error.border"
             onCopy={handleCopy}
@@ -303,7 +310,7 @@ const ColorsSection: React.FC = () => {
         <ColorGrid columns={5} sx={{ mb: "24px" }}>
           <ColorCard
             label="Warning text"
-            color="#DC6803"
+            color="#795548"
             usage="Warning messages"
             themeKey="theme.palette.status.warning.text"
             onCopy={handleCopy}
@@ -311,28 +318,29 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Warning main"
-            color="#fdb022"
+            color="#795548"
             usage="Warning icons"
             themeKey="theme.palette.status.warning.main"
             onCopy={handleCopy}
+            textColor="#fff"
           />
           <ColorCard
             label="Warning light"
-            color="#ffecbc"
+            color="#F5E6B8"
             usage="Warning badges"
             themeKey="theme.palette.status.warning.light"
             onCopy={handleCopy}
           />
           <ColorCard
             label="Warning bg"
-            color="#fffcf5"
+            color="#FFF8E1"
             usage="Warning backgrounds"
             themeKey="theme.palette.status.warning.bg"
             onCopy={handleCopy}
           />
           <ColorCard
             label="Warning border"
-            color="#fec84b"
+            color="#F5E6B8"
             usage="Warning borders"
             themeKey="theme.palette.status.warning.border"
             onCopy={handleCopy}
@@ -343,10 +351,10 @@ const ColorsSection: React.FC = () => {
         <Typography sx={{ fontSize: 12, fontWeight: 600, color: theme.palette.text.secondary, mb: "12px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
           Info / Default
         </Typography>
-        <ColorGrid columns={4}>
+        <ColorGrid columns={5}>
           <ColorCard
             label="Info text"
-            color="#1c2130"
+            color="#1565C0"
             usage="Info messages"
             themeKey="theme.palette.status.info.text"
             onCopy={handleCopy}
@@ -354,23 +362,29 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Info main"
-            color="#475467"
+            color="#1565C0"
             usage="Info icons"
             themeKey="theme.palette.status.info.main"
             onCopy={handleCopy}
             textColor="#fff"
           />
           <ColorCard
+            label="Info light"
+            color="#BBDEFB"
+            usage="Info badges"
+            themeKey="theme.palette.status.info.light"
+            onCopy={handleCopy}
+          />
+          <ColorCard
             label="Info bg"
-            color="#FFFFFF"
+            color="#E3F2FD"
             usage="Info backgrounds"
             themeKey="theme.palette.status.info.bg"
             onCopy={handleCopy}
-            hasBorder
           />
           <ColorCard
             label="Info border"
-            color="#d0d5dd"
+            color="#BBDEFB"
             usage="Info borders"
             themeKey="theme.palette.status.info.border"
             onCopy={handleCopy}
@@ -396,15 +410,15 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Secondary"
-            color="#6B7280"
+            color="#F4F4F4"
             usage="Utility actions"
             themeKey="secondary"
             onCopy={handleCopy}
-            textColor="#fff"
+            textColor="#475467"
           />
           <ColorCard
             label="Success"
-            color="#059669"
+            color="#138A5E"
             usage="Positive actions"
             themeKey="success"
             onCopy={handleCopy}
@@ -412,7 +426,7 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Warning"
-            color="#D97706"
+            color="#795548"
             usage="Caution actions"
             themeKey="warning"
             onCopy={handleCopy}
@@ -420,7 +434,7 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Error"
-            color="#DB504A"
+            color="#D32F2F"
             usage="Destructive actions"
             themeKey="error"
             onCopy={handleCopy}
@@ -428,7 +442,7 @@ const ColorsSection: React.FC = () => {
           />
           <ColorCard
             label="Info"
-            color="#3B82F6"
+            color="#1565C0"
             usage="Informational actions"
             themeKey="info"
             onCopy={handleCopy}
@@ -473,6 +487,74 @@ const ColorsSection: React.FC = () => {
             usage="Grid lines"
             themeKey="theme.palette.other.grid"
             onCopy={handleCopy}
+          />
+        </ColorGrid>
+      </SpecSection>
+
+      <Divider sx={{ my: "32px" }} />
+
+      {/* Unresolved Colors */}
+      <SpecSection title="Unresolved colors">
+        <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
+          Colors for unresolved or pending states.
+        </Typography>
+        <ColorGrid columns={3}>
+          <ColorCard
+            label="Unresolved main"
+            color="#4e5ba6"
+            usage="Unresolved indicators"
+            themeKey="theme.palette.unresolved.main"
+            onCopy={handleCopy}
+            textColor="#fff"
+          />
+          <ColorCard
+            label="Unresolved light"
+            color="#e2eaf7"
+            usage="Unresolved badges"
+            themeKey="theme.palette.unresolved.light"
+            onCopy={handleCopy}
+          />
+          <ColorCard
+            label="Unresolved bg"
+            color="#f2f4f7"
+            usage="Unresolved backgrounds"
+            themeKey="theme.palette.unresolved.bg"
+            onCopy={handleCopy}
+          />
+        </ColorGrid>
+      </SpecSection>
+
+      <Divider sx={{ my: "32px" }} />
+
+      {/* Tooltip Colors */}
+      <SpecSection title="Tooltip colors">
+        <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
+          Colors for tooltip components. Defined in theme component overrides.
+        </Typography>
+        <ColorGrid columns={3}>
+          <ColorCard
+            label="Tooltip background"
+            color="#1F2937"
+            usage="Tooltip surface"
+            themeKey="MuiTooltip override"
+            onCopy={handleCopy}
+            textColor="#fff"
+          />
+          <ColorCard
+            label="Tooltip arrow"
+            color="#1F2937"
+            usage="Tooltip arrow"
+            themeKey="MuiTooltip.arrow override"
+            onCopy={handleCopy}
+            textColor="#fff"
+          />
+          <ColorCard
+            label="Tooltip text"
+            color="#FFFFFF"
+            usage="Tooltip text color"
+            themeKey="Default (white)"
+            onCopy={handleCopy}
+            hasBorder
           />
         </ColorGrid>
       </SpecSection>

--- a/Clients/src/presentation/pages/StyleGuide/sections/IconsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/IconsSection.tsx
@@ -51,7 +51,7 @@ const iconSnippets = {
 // Using hex colors
 <AlertCircle
   size={16}
-  color="#f04438"  // Error red
+  color="#D32F2F"  // Error red
 />`,
   withStroke: `// Adjust stroke width (default: 2)
 <User size={16} strokeWidth={1.5} />  // Thinner
@@ -262,19 +262,19 @@ const IconsSection: React.FC = () => {
                   }}
                 >
                   <Box sx={{ textAlign: "center" }}>
-                    <LucideIcons.CheckCircle size={20} color="#17b26a" />
+                    <LucideIcons.CheckCircle size={20} color="#138A5E" />
                     <Typography sx={{ fontSize: 10, color: theme.palette.text.tertiary, mt: "4px" }}>Success</Typography>
                   </Box>
                   <Box sx={{ textAlign: "center" }}>
-                    <LucideIcons.AlertCircle size={20} color="#f04438" />
+                    <LucideIcons.AlertCircle size={20} color="#D32F2F" />
                     <Typography sx={{ fontSize: 10, color: theme.palette.text.tertiary, mt: "4px" }}>Error</Typography>
                   </Box>
                   <Box sx={{ textAlign: "center" }}>
-                    <LucideIcons.AlertTriangle size={20} color="#fdb022" />
+                    <LucideIcons.AlertTriangle size={20} color="#795548" />
                     <Typography sx={{ fontSize: 10, color: theme.palette.text.tertiary, mt: "4px" }}>Warning</Typography>
                   </Box>
                   <Box sx={{ textAlign: "center" }}>
-                    <LucideIcons.Info size={20} color="#667085" />
+                    <LucideIcons.Info size={20} color="#1565C0" />
                     <Typography sx={{ fontSize: 10, color: theme.palette.text.tertiary, mt: "4px" }}>Info</Typography>
                   </Box>
                 </Box>
@@ -336,9 +336,10 @@ const IconsSection: React.FC = () => {
               specs={[
                 { property: "Default", value: "#667085 (text.tertiary)" },
                 { property: "Primary", value: "#13715B (primary.main)" },
-                { property: "Success", value: "#17b26a" },
-                { property: "Error", value: "#f04438" },
-                { property: "Warning", value: "#fdb022" },
+                { property: "Success", value: "#138A5E (status.success.main)" },
+                { property: "Error", value: "#D32F2F (status.error.main)" },
+                { property: "Warning", value: "#795548 (status.warning.main)" },
+                { property: "Info", value: "#1565C0 (status.info.main)" },
               ]}
             />
 

--- a/Clients/src/presentation/pages/StyleGuide/sections/StatusSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/StatusSection.tsx
@@ -8,18 +8,18 @@ import CodeBlock from "../components/CodeBlock";
 const statusColorsSnippet = `import { statusColorSchemes, getStatusColor } from "../utils/statusColors";
 
 // Direct access to color schemes
-const modelProductionColor = statusColorSchemes.models.production; // "#10B981"
+const modelProductionColor = statusColorSchemes.models.production; // "#138A5E"
 
 // Using helper function
-const color = getStatusColor("models", "production"); // "#10B981"
-const vendorColor = getStatusColor("vendors", "in review"); // "#F59E0B"`;
+const color = getStatusColor("models", "production"); // "#138A5E"
+const vendorColor = getStatusColor("vendors", "in review"); // "#795548"`;
 
 const chipSnippet = `<Chip
   label="Active"
   size="small"
   sx={{
     backgroundColor: "#E6F4EA",
-    color: "#10B981",
+    color: "#138A5E",
     fontSize: 12,
     height: 24,
     "& .MuiChip-label": { px: "8px" },
@@ -32,7 +32,7 @@ const chipWithIconSnippet = `<Chip
   size="small"
   sx={{
     backgroundColor: "#E6F4EA",
-    color: "#10B981",
+    color: "#138A5E",
     fontSize: 12,
     height: 24,
     "& .MuiChip-icon": { color: "inherit", ml: "6px" },
@@ -46,7 +46,7 @@ const dotIndicatorSnippet = `// Status dot with label
     width: 8,
     height: 8,
     borderRadius: "50%",
-    backgroundColor: "#10B981"
+    backgroundColor: "#138A5E"
   }} />
   <Typography sx={{ fontSize: 13 }}>Active</Typography>
 </Box>`;
@@ -271,10 +271,10 @@ const StatusSection: React.FC = () => {
                 onCopy={handleCopy}
               >
                 <Box sx={{ display: "flex", gap: "24px", flexWrap: "wrap" }}>
-                  <DotIndicator label="Active" color="#10B981" />
-                  <DotIndicator label="Pending" color="#F59E0B" />
+                  <DotIndicator label="Active" color="#138A5E" />
+                  <DotIndicator label="Pending" color="#795548" />
                   <DotIndicator label="Inactive" color="#6B7280" />
-                  <DotIndicator label="Error" color="#EF4444" />
+                  <DotIndicator label="Error" color="#D32F2F" />
                 </Box>
               </ExampleWithCode>
             </Stack>
@@ -326,29 +326,29 @@ const StatusSection: React.FC = () => {
         <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: "16px" }}>
           <SemanticColorCard
             name="Success / Active"
-            textColor="#10B981"
+            textColor="#138A5E"
             bgColor="#E6F4EA"
             usage="Completed, Active, Production, Low risk"
             onCopy={handleCopy}
           />
           <SemanticColorCard
             name="Warning / Pending"
-            textColor="#F59E0B"
-            bgColor="#FEF3C7"
+            textColor="#795548"
+            bgColor="#FFF8E1"
             usage="In progress, In review, Medium risk"
             onCopy={handleCopy}
           />
           <SemanticColorCard
             name="Error / Critical"
-            textColor="#EF4444"
-            bgColor="#FEE2E2"
+            textColor="#D32F2F"
+            bgColor="#FFD6D6"
             usage="Failed, Open incidents, High risk"
             onCopy={handleCopy}
           />
           <SemanticColorCard
             name="Info / Development"
-            textColor="#3B82F6"
-            bgColor="#DBEAFE"
+            textColor="#1565C0"
+            bgColor="#E3F2FD"
             usage="Development, Published, Info states"
             onCopy={handleCopy}
           />
@@ -512,10 +512,10 @@ const StatusSchemeCard: React.FC<StatusSchemeCardProps> = ({ title, entityType, 
 };
 
 const statusVariants = {
-  success: { bg: "#E6F4EA", text: "#10B981" },
-  warning: { bg: "#FEF3C7", text: "#F59E0B" },
-  error: { bg: "#FEE2E2", text: "#EF4444" },
-  info: { bg: "#DBEAFE", text: "#3B82F6" },
+  success: { bg: "#E6F4EA", text: "#138A5E" },
+  warning: { bg: "#FFF8E1", text: "#795548" },
+  error: { bg: "#FFD6D6", text: "#D32F2F" },
+  info: { bg: "#E3F2FD", text: "#1565C0" },
   neutral: { bg: "#F3F4F6", text: "#6B7280" },
 };
 


### PR DESCRIPTION
## Summary
- Fix all hardcoded color values across 7 StyleGuide sections to match the current `light.ts` theme palette
- Add missing Unresolved and Tooltip color sections to ColorsSection
- Update AvatarsSection to reference VWAvatar instead of raw MUI Avatar

## Test plan
- [ ] Open `/style-guide/colors` — verify all swatches match `light.ts` values
- [ ] Open `/style-guide/status` — verify semantic colors and chip previews use theme colors
- [ ] Open `/style-guide/alerts` — verify alert previews use updated status palette
- [ ] Open `/style-guide/cards` — verify alert box examples use correct colors
- [ ] Open `/style-guide/icons` — verify icon color examples match theme
- [ ] Open `/style-guide/buttons` — verify color palette swatches are correct
- [ ] Open `/style-guide/avatars` — verify VWAvatar references and demos work