### PR TITLE
Fix intake form critical bugs: race condition, field mapping, validation, and UX

### DIFF
--- a/Clients/src/application/repository/intakeForm.repository.ts
+++ b/Clients/src/application/repository/intakeForm.repository.ts
@@ -264,6 +264,7 @@ export async function getPendingSubmissions(
     page?: number;
     limit?: number;
     formId?: number;
+    status?: string;
   } = {},
   signal?: AbortSignal
 ): Promise<{ data: IntakeSubmission[]; pagination?: { total: number; page: number; limit: number } }> {
@@ -271,6 +272,7 @@ export async function getPendingSubmissions(
   if (params.page) queryParams.append("page", String(params.page));
   if (params.limit) queryParams.append("limit", String(params.limit));
   if (params.formId) queryParams.append("formId", String(params.formId));
+  if (params.status) queryParams.append("status", params.status);
 
   const url = `${BASE_URL}/submissions${queryParams.toString() ? `?${queryParams}` : ""}`;
   const response = await apiServices.get(url, { signal });

--- a/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
@@ -162,6 +162,7 @@ export function IntakeFormsListPage() {
   const [submissions, setSubmissions] = useState<IntakeSubmission[]>([]);
   const [isLoadingSubmissions, setIsLoadingSubmissions] = useState(false);
   const [submissionsSearch, setSubmissionsSearch] = useState("");
+  const [submissionStatusFilter, setSubmissionStatusFilter] = useState<string>("all");
   const [previewOpen, setPreviewOpen] = useState(false);
   const [selectedSubmissionId, setSelectedSubmissionId] = useState<number | null>(null);
 
@@ -190,14 +191,18 @@ export function IntakeFormsListPage() {
   const loadSubmissions = useCallback(async () => {
     setIsLoadingSubmissions(true);
     try {
-      const response = await getPendingSubmissions();
+      const params: { status?: string } = {};
+      if (submissionStatusFilter !== "all") {
+        params.status = submissionStatusFilter;
+      }
+      const response = await getPendingSubmissions(params);
       setSubmissions(Array.isArray(response.data) ? response.data : []);
     } catch {
       setSnackbar({ open: true, message: "Failed to load submissions", severity: "error" });
     } finally {
       setIsLoadingSubmissions(false);
     }
-  }, []);
+  }, [submissionStatusFilter]);
 
   useEffect(() => {
     if (mainTab === "submissions") {
@@ -567,8 +572,40 @@ export function IntakeFormsListPage() {
       {/* ================================================================ */}
       {mainTab === "submissions" && (
         <>
-          {/* Search */}
-          <Stack direction="row" justifyContent="flex-end" alignItems="center">
+          {/* Filter + Search */}
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Stack direction="row" gap={1}>
+              {[
+                { value: "all", label: "All" },
+                { value: "pending", label: "Pending" },
+                { value: "approved", label: "Approved" },
+                { value: "rejected", label: "Rejected" },
+              ].map((opt) => (
+                <Chip
+                  key={opt.value}
+                  label={opt.label}
+                  onClick={() => setSubmissionStatusFilter(opt.value)}
+                  sx={{
+                    cursor: "pointer",
+                    fontWeight: submissionStatusFilter === opt.value ? 600 : 400,
+                    backgroundColor: submissionStatusFilter === opt.value
+                      ? theme.palette.primary.main
+                      : theme.palette.background.default,
+                    color: submissionStatusFilter === opt.value
+                      ? "#fff"
+                      : theme.palette.text.primary,
+                    border: submissionStatusFilter === opt.value
+                      ? "none"
+                      : `1px solid ${theme.palette.border.dark}`,
+                    "&:hover": {
+                      backgroundColor: submissionStatusFilter === opt.value
+                        ? theme.palette.primary.main
+                        : theme.palette.action.hover,
+                    },
+                  }}
+                />
+              ))}
+            </Stack>
             <SearchBox
               placeholder="Search submissions..."
               value={submissionsSearch}

--- a/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
@@ -311,28 +311,54 @@ export function IntakeFormBuilder() {
       });
       return;
     }
+    if (!form.name.trim()) {
+      setSnackbar({
+        open: true,
+        message: "Form name is required",
+        severity: "error",
+      });
+      return;
+    }
+    setIsSaving(true);
     try {
-      const savedId = await handleSave();
-      if (savedId) {
-        const publishResponse = await updateIntakeForm(savedId, { status: IntakeFormStatus.ACTIVE });
-        const publishedData = publishResponse.data;
-        setForm((prev) => ({
-          ...prev,
-          status: IntakeFormStatus.ACTIVE,
-          ...(publishedData?.publicId ? { publicId: publishedData.publicId } : {}),
-        }));
-        setSnackbar({
-          open: true,
-          message: "Form published successfully",
-          severity: "success",
-        });
+      const formData = {
+        ...form,
+        slug: form.slug || generateSlug(form.name),
+        recipients: form.recipients ?? [],
+        riskTierSystem: form.riskTierSystem ?? "generic",
+        llmKeyId: form.llmKeyId ?? null,
+        suggestedQuestionsEnabled: form.suggestedQuestionsEnabled ?? false,
+        status: IntakeFormStatus.ACTIVE,
+      };
+      const formIdNum = isEditing && formId ? parseInt(formId) : undefined;
+      let publishedData;
+      if (formIdNum) {
+        const response = await updateIntakeForm(formIdNum, formData);
+        publishedData = response.data;
+      } else {
+        const response = await createIntakeForm(formData);
+        publishedData = response.data;
+        if (publishedData?.id) {
+          navigate(`/intake-forms/${publishedData.id}/edit`, { replace: true });
+        }
       }
+      if (publishedData) {
+        setForm((prev) => ({ ...prev, ...publishedData, status: IntakeFormStatus.ACTIVE }));
+      }
+      setIsDirty(false);
+      setSnackbar({
+        open: true,
+        message: "Form published successfully",
+        severity: "success",
+      });
     } catch {
       setSnackbar({
         open: true,
         message: "Failed to publish form",
         severity: "error",
       });
+    } finally {
+      setIsSaving(false);
     }
   };
 

--- a/Servers/controllers/intakeForm.ctrl.ts
+++ b/Servers/controllers/intakeForm.ctrl.ts
@@ -122,8 +122,9 @@ function validateFormData(
     const value = formData[field.id];
     const isEmpty = value === undefined || value === null || value === "";
 
-    // Required check
-    if (field.required && isEmpty) {
+    // Required check — field.required (backend interface) or field.validation.required (frontend schema)
+    const isRequired = field.required || field.validation?.required;
+    if (isRequired && isEmpty) {
       errors.push(`"${field.label}" is required`);
       continue;
     }
@@ -863,7 +864,7 @@ export async function approveSubmission(req: Request, res: Response) {
   const transaction = await sequelize.transaction();
 
   try {
-    const submission = await getSubmissionByIdQuery(submissionId, req.tenantId!);
+    const submission = await getSubmissionByIdQuery(submissionId, req.tenantId!, transaction, true);
 
     if (!submission) {
       await transaction.rollback();
@@ -909,15 +910,15 @@ export async function approveSubmission(req: Request, res: Response) {
     if (submission.entityType === IntakeEntityType.MODEL) {
       const model = ModelInventoryModel.createNewModelInventory({
         provider: (entityData.provider as string) || "",
-        model: (entityData.model as string) || "",
-        version: (entityData.version as string) || "",
+        model: (entityData.name as string) || (entityData.model as string) || "",
+        version: (entityData.modelVersion as string) || (entityData.version as string) || "",
         approver: entityData.approver ? Number(entityData.approver) : undefined,
-        capabilities: (entityData.capabilities as string) || "",
+        capabilities: (entityData.capabilities as string) || (entityData.intendedUse as string) || "",
         security_assessment: (entityData.security_assessment as boolean) || false,
         reference_link: (entityData.reference_link as string) || "",
         biases: (entityData.biases as string) || "",
         limitations: (entityData.limitations as string) || "",
-        hosting_provider: (entityData.hosting_provider as string) || "",
+        hosting_provider: (entityData.hosting_provider as string) || (entityData.modelType as string) || "",
         status: ModelInventoryStatus.PENDING,
       });
 
@@ -1024,7 +1025,7 @@ export async function rejectSubmission(req: Request, res: Response) {
       return res.status(400).json(STATUS_CODE[400]("Rejection reason is required"));
     }
 
-    const submission = await getSubmissionByIdQuery(submissionId, req.tenantId!);
+    const submission = await getSubmissionByIdQuery(submissionId, req.tenantId!, transaction, true);
 
     if (!submission) {
       await transaction.rollback();

--- a/Servers/controllers/intakeForm.ctrl.ts
+++ b/Servers/controllers/intakeForm.ctrl.ts
@@ -632,7 +632,8 @@ export async function getPendingSubmissions(req: Request, res: Response) {
   });
 
   try {
-    const submissions = await getPendingSubmissionsQuery(req.tenantId!);
+    const status = req.query.status as IntakeSubmissionStatus | undefined;
+    const submissions = await getPendingSubmissionsQuery(req.tenantId!, status);
     return res.status(200).json(STATUS_CODE[200](submissions));
   } catch (error) {
     await logFailure({
@@ -935,7 +936,7 @@ export async function approveSubmission(req: Request, res: Response) {
         {
           project_title: (entityData.project_title as string) || "",
           description: (entityData.description as string) || "",
-          start_date: new Date(),
+          start_date: entityData.start_date ? new Date(entityData.start_date as string) : new Date(),
           goal: (entityData.goal as string) || (entityData.description as string) || "",
           owner: req.userId!,
           ai_risk_classification: mapToAiRiskClassification(entityData.ai_risk_classification as string) as any,
@@ -1037,6 +1038,13 @@ export async function rejectSubmission(req: Request, res: Response) {
       return res.status(400).json(STATUS_CODE[400]("Only pending submissions can be rejected"));
     }
 
+    // Fetch form and tenant info before commit so email data is available atomically
+    const form = await getIntakeFormByIdQuery(submission.formId, req.tenantId!);
+    const formName = form?.name || "Unknown Form";
+    const formPublicId = form?.publicId;
+    const tenantSlug = await getTenantSlugById(req.organizationId!);
+    const formSlug = form?.slug || "";
+
     const updatedSubmission = await rejectSubmissionQuery(
       submissionId,
       rejectionReason,
@@ -1046,12 +1054,6 @@ export async function rejectSubmission(req: Request, res: Response) {
     );
 
     await transaction.commit();
-
-    const form = await getIntakeFormByIdQuery(submission.formId, req.tenantId!);
-    const formName = form?.name || "Unknown Form";
-    const formPublicId = form?.publicId;
-    const tenantSlug = await getTenantSlugById(req.organizationId!);
-    const formSlug = form?.slug || "";
 
     if (submission.submitterEmail) {
       // Generate HMAC-signed resubmission token

--- a/Servers/domain.layer/interfaces/i.intakeForm.ts
+++ b/Servers/domain.layer/interfaces/i.intakeForm.ts
@@ -30,6 +30,7 @@ export interface IIntakeFormField {
   guidanceText?: string; // Tooltip text explaining why this field matters
   options?: Array<{ value: string; label: string }>; // For select/multiselect
   validation?: {
+    required?: boolean;
     minLength?: number;
     maxLength?: number;
     min?: number;

--- a/Servers/utils/intakeForm.utils.ts
+++ b/Servers/utils/intakeForm.utils.ts
@@ -405,8 +405,10 @@ export const getSubmissionsByFormIdQuery = async (
  * Get pending submissions for a tenant (for dashboard, capped at 500)
  */
 export const getPendingSubmissionsQuery = async (
-  tenant: string
+  tenant: string,
+  status?: IntakeSubmissionStatus
 ): Promise<IIntakeSubmission[]> => {
+  const statusFilter = status ? "WHERE s.status = :status" : "";
   const submissions = await sequelize.query(
     `SELECT
       s.id, s.form_id as "formId", s.submitter_email as "submitterEmail",
@@ -421,11 +423,11 @@ export const getPendingSubmissionsQuery = async (
       f.name as "formName", f.entity_type as "formEntityType"
     FROM "${tenant}".intake_submissions s
     JOIN "${tenant}".intake_forms f ON s.form_id = f.id
-    WHERE s.status = :status
+    ${statusFilter}
     ORDER BY s.created_at DESC
     LIMIT 500`,
     {
-      replacements: { status: IntakeSubmissionStatus.PENDING },
+      replacements: status ? { status } : {},
       type: QueryTypes.SELECT,
     }
   );

--- a/Servers/utils/intakeForm.utils.ts
+++ b/Servers/utils/intakeForm.utils.ts
@@ -438,15 +438,19 @@ export const getPendingSubmissionsQuery = async (
  */
 export const getSubmissionByIdQuery = async (
   id: number,
-  tenant: string
+  tenant: string,
+  transaction?: Transaction,
+  forUpdate?: boolean
 ): Promise<IIntakeSubmission | null> => {
+  const lock = forUpdate ? " FOR UPDATE" : "";
   const submissions = await sequelize.query(
     `SELECT ${SUBMISSION_SELECT_COLUMNS}
     FROM "${tenant}".intake_submissions
-    WHERE id = :id`,
+    WHERE id = :id${lock}`,
     {
       replacements: { id },
       type: QueryTypes.SELECT,
+      transaction,
     }
   );
 

--- a/Servers/utils/intakeForm.utils.ts
+++ b/Servers/utils/intakeForm.utils.ts
@@ -648,7 +648,7 @@ export const getSubmissionStatsQuery = async (
 // ============================================================================
 
 /**
- * Check rate limit for IP address (100 submissions per hour)
+ * Check rate limit for IP address (10 submissions per hour per tenant)
  */
 export const checkRateLimitQuery = async (
   ipAddress: string,
@@ -666,7 +666,7 @@ export const checkRateLimitQuery = async (
   );
 
   const count = parseInt((result[0] as any).count, 10) || 0;
-  return count < 100;
+  return count < 10;
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

End-to-end review of the intake forms workflow uncovered several bugs affecting data integrity, validation, and admin UX. This PR fixes 8 issues across 3 priority tiers.

### Critical fixes
- **Race condition in approve/reject**: Two concurrent approvals could both read `PENDING` and create duplicate entities. Fixed with `SELECT FOR UPDATE` lock inside the transaction.
- **MODEL field mapping mismatch**: Frontend entity mappings define `name`, `modelVersion`, `modelType` but the controller read `model`, `version`. Every approved model submission was creating entries with blank fields. Now maps both naming conventions.
- **Required field validation never ran server-side**: Frontend stores `required` at `field.validation.required` but backend only checked `field.required` (top-level), which was always `undefined`. Now checks both locations.

### High severity fixes
- **USE_CASE start_date hardcoded to today**: Submitter's chosen start date was silently discarded. Now uses the mapped value when available.
- **Rejection email fetched after commit**: Form and tenant lookups moved before `transaction.commit()` so if they fail, the rejection rolls back instead of silently dropping the email.
- **No submission history visible**: Approved/rejected submissions disappeared from the admin list. Added status filter (All/Pending/Approved/Rejected) with backend `?status=` query param support.

### Medium severity fixes
- **Rate limit too generous**: Reduced from 100 to 10 submissions per hour per IP per tenant.
- **Publish made two sequential API calls**: Collapsed into a single PATCH with `status: ACTIVE`, eliminating a brief window where content was saved but form was still DRAFT.

### Deferred (separate PRs)
- UNION ALL tenant scan optimization (needs migration)
- URL hardcodes `use-case-form-intake` for all entity types (would break published URLs)
- Resubmission token in URL query string (needs architectural change)

## Test plan
- [ ] Create a model intake form, map fields (name, version, provider), publish, submit, approve — verify model inventory entry has correct field values
- [ ] Create a use case form with start_date field mapped, submit with a future date, approve — verify project has the submitted start_date
- [ ] Mark a field as required in the builder, submit the public form with that field empty — verify server rejects with validation error
- [ ] Open two browser tabs on the same pending submission, click approve in both simultaneously — verify only one entity is created
- [ ] Go to submissions tab, use filter chips to switch between All/Pending/Approved/Rejected — verify correct submissions appear
- [ ] Reject a submission — verify rejection email is sent (check logs)
- [ ] Submit more than 10 times from the same IP within an hour — verify rate limit kicks in
- [ ] Publish a new form directly (not previously saved) — verify single API call creates and publishes in one step