### PR TITLE
Enhance intake form builder UX and add LLM questions panel

### DIFF
--- a/Clients/src/application/repository/intakeForm.repository.ts
+++ b/Clients/src/application/repository/intakeForm.repository.ts
@@ -410,6 +410,56 @@ export async function getEntityIntakeSubmission(
 }
 
 // ============================================================================
+// LLM Features API (Admin - Authenticated)
+// ============================================================================
+
+/**
+ * LLM-suggested question returned by the backend
+ */
+export interface LLMSuggestedQuestion {
+  label: string;
+  fieldType: "text" | "textarea" | "select";
+  category: string;
+  entityFieldMapping?: string;
+  guidanceText?: string;
+  options?: Array<{ value: string; label: string }>;
+}
+
+/**
+ * Generate LLM-suggested questions for intake form building
+ */
+export async function getLLMSuggestedQuestions(
+  entityType: string,
+  context: string,
+  llmKeyId: number,
+  signal?: AbortSignal
+): Promise<{ data: LLMSuggestedQuestion[] }> {
+  const response = await apiServices.post(
+    `${BASE_URL}/forms/suggested-questions`,
+    { entityType, context, llmKeyId },
+    { signal }
+  );
+  return response.data as { data: LLMSuggestedQuestion[] };
+}
+
+/**
+ * Generate LLM guidance text for a field
+ */
+export async function getLLMFieldGuidance(
+  fieldLabel: string,
+  entityType: string,
+  llmKeyId: number,
+  signal?: AbortSignal
+): Promise<{ data: { guidanceText: string } }> {
+  const response = await apiServices.post(
+    `${BASE_URL}/forms/field-guidance`,
+    { fieldLabel, entityType, llmKeyId },
+    { signal }
+  );
+  return response.data as { data: { guidanceText: string } };
+}
+
+// ============================================================================
 // Public Form API (No authentication required)
 // ============================================================================
 
@@ -440,6 +490,7 @@ export async function getPublicForm(
       submitButtonText: string;
       designSettings?: FormDesignSettings | null;
     };
+    organizationLogo?: string | null;
     previousData?: Record<string, unknown>;
     previousSubmitterName?: string;
     previousSubmitterEmail?: string;
@@ -459,6 +510,7 @@ export async function getPublicForm(
         submitButtonText: string;
         designSettings?: FormDesignSettings | null;
       };
+      organizationLogo?: string | null;
       previousData?: Record<string, unknown>;
       previousSubmitterName?: string;
       previousSubmitterEmail?: string;
@@ -509,6 +561,7 @@ export async function getPublicFormById(
       submitButtonText: string;
       designSettings?: FormDesignSettings | null;
     };
+    organizationLogo?: string | null;
     previousData?: Record<string, unknown>;
     previousSubmitterName?: string;
     previousSubmitterEmail?: string;
@@ -528,6 +581,7 @@ export async function getPublicFormById(
         submitButtonText: string;
         designSettings?: FormDesignSettings | null;
       };
+      organizationLogo?: string | null;
       previousData?: Record<string, unknown>;
       previousSubmitterName?: string;
       previousSubmitterEmail?: string;

--- a/Clients/src/presentation/components/Inputs/Field/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Field/index.tsx
@@ -135,8 +135,8 @@ const Field = forwardRef(
           autoComplete={autoComplete}
           autoFocus={autoFocus}
           placeholder={placeholder}
-          multiline={type === "description"}
-          rows={type === "description" ? (rows || 4) : 1}
+          multiline={type === "description" || (rows !== undefined && rows > 1)}
+          rows={type === "description" ? (rows || 4) : (rows || 1)}
           value={value}
           onInput={onInput as React.FormEventHandler<HTMLDivElement>}
           onChange={onChange}

--- a/Clients/src/presentation/pages/IntakeFormBuilder/FieldCard.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/FieldCard.tsx
@@ -3,13 +3,6 @@ import {
   Typography,
   IconButton,
   Tooltip,
-  Select as MuiSelect,
-  MenuItem,
-  FormControl,
-  FormControlLabel,
-  Checkbox as MuiCheckbox,
-  OutlinedInput,
-  FormHelperText,
   useTheme,
 } from "@mui/material";
 import {
@@ -20,6 +13,9 @@ import {
   Info,
 } from "lucide-react";
 import Field from "../../components/Inputs/Field";
+import Select from "../../components/Inputs/Select";
+import Checkbox from "../../components/Inputs/Checkbox";
+import Chip from "../../components/Chip";
 import { FormField, FieldType } from "./types";
 
 const TYPE_LABELS: Record<FieldType, string> = {
@@ -171,29 +167,20 @@ function FieldPreview({ field }: { field: FormField }) {
       return (
         <>
           <PreviewFieldLabel label={field.label} guidanceText={field.guidanceText} required={isRequired} />
-          <FormControl fullWidth disabled>
-            <MuiSelect
-              value=""
-              displayEmpty
-              sx={{
-                fontSize: "13px",
-                borderRadius: "4px",
-                "& .MuiOutlinedInput-notchedOutline": { borderColor: theme.palette.border.dark },
-              }}
-            >
-              <MenuItem value="" disabled>
-                <em style={{ color: theme.palette.text.accent }}>Select an option</em>
-              </MenuItem>
-              {field.options?.map((option) => (
-                <MenuItem key={option.value} value={option.value}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </MuiSelect>
-            {field.helpText && (
-              <FormHelperText>{field.helpText}</FormHelperText>
-            )}
-          </FormControl>
+          <Select
+            id={`preview-${field.id}`}
+            label=""
+            placeholder="Select an option"
+            value=""
+            onChange={() => {}}
+            items={(field.options || []).map((opt) => ({ _id: opt.value, name: opt.label }))}
+            disabled
+          />
+          {field.helpText && (
+            <Typography sx={{ color: theme.palette.other.icon, fontSize: "11px", mt: "2px" }}>
+              {field.helpText}
+            </Typography>
+          )}
         </>
       );
 
@@ -201,66 +188,52 @@ function FieldPreview({ field }: { field: FormField }) {
       return (
         <>
           <PreviewFieldLabel label={field.label} guidanceText={field.guidanceText} required={isRequired} />
-          <FormControl fullWidth disabled>
-            <MuiSelect
-              multiple
-              value={[]}
-              input={<OutlinedInput />}
-              displayEmpty
-              renderValue={() => (
-                <em style={{ color: theme.palette.text.accent }}>Select options</em>
-              )}
-              sx={{
-                fontSize: "13px",
-                borderRadius: "4px",
-                "& .MuiOutlinedInput-notchedOutline": { borderColor: theme.palette.border.dark },
-              }}
-            >
-              {field.options?.map((option) => (
-                <MenuItem key={option.value} value={option.value}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </MuiSelect>
-            {field.helpText && (
-              <FormHelperText>{field.helpText}</FormHelperText>
-            )}
-          </FormControl>
+          <Select
+            id={`preview-${field.id}`}
+            label=""
+            placeholder="Select options"
+            value=""
+            onChange={() => {}}
+            items={(field.options || []).map((opt) => ({ _id: opt.value, name: opt.label }))}
+            disabled
+          />
+          {field.helpText && (
+            <Typography sx={{ color: theme.palette.other.icon, fontSize: "11px", mt: "2px" }}>
+              {field.helpText}
+            </Typography>
+          )}
         </>
       );
 
     case "checkbox":
       return (
         <Box>
-          <FormControlLabel
-            disabled
-            control={
-              <MuiCheckbox
-                checked={false}
-                sx={{
-                  color: theme.palette.border.dark,
-                  "&.Mui-checked": { color: theme.palette.primary.main },
-                }}
-              />
-            }
-            label={
-              <Box sx={{ display: "flex", alignItems: "center", gap: "4px" }}>
-                <Typography sx={{ fontSize: "13px", color: theme.palette.text.secondary }}>
-                  {field.label}
-                  {isRequired && <span style={{ color: theme.palette.status.error.text }}> *</span>}
-                </Typography>
-                {field.guidanceText && (
-                  <Tooltip title={field.guidanceText} placement="top" arrow>
-                    <span style={{ display: "inline-flex", alignItems: "center", cursor: "help" }}>
-                      <Info size={14} strokeWidth={1.5} color={theme.palette.text.accent} />
-                    </span>
-                  </Tooltip>
-                )}
-              </Box>
-            }
-          />
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            <Checkbox
+              id={`preview-${field.id}`}
+              isChecked={false}
+              value={field.id}
+              onChange={() => {}}
+              isDisabled
+              label={
+                isRequired
+                  ? `${field.label} *`
+                  : field.label
+              }
+              size="small"
+            />
+            {field.guidanceText && (
+              <Tooltip title={field.guidanceText} placement="top" arrow>
+                <span style={{ display: "inline-flex", alignItems: "center", cursor: "help", marginLeft: 4 }}>
+                  <Info size={14} strokeWidth={1.5} color={theme.palette.text.accent} />
+                </span>
+              </Tooltip>
+            )}
+          </Box>
           {field.helpText && (
-            <FormHelperText sx={{ ml: 4 }}>{field.helpText}</FormHelperText>
+            <Typography sx={{ color: theme.palette.other.icon, fontSize: "11px", mt: "2px", ml: "32px" }}>
+              {field.helpText}
+            </Typography>
           )}
         </Box>
       );
@@ -330,41 +303,13 @@ export function FieldCard({
         <FieldPreview field={field} />
       </Box>
 
-      {/* Metadata badges — shown only when selected */}
-      {isSelected && (
-        <Box sx={{ display: "flex", alignItems: "center", gap: "6px", mt: "8px", flexWrap: "wrap" }}>
-          <Box
-            sx={{
-              display: "inline-flex",
-              alignItems: "center",
-              height: 20,
-              px: "6px",
-              borderRadius: "4px",
-              backgroundColor: theme.palette.background.accent,
-              fontSize: "11px",
-              color: theme.palette.other.icon,
-            }}
-          >
-            {TYPE_LABELS[field.type]}
-          </Box>
-          {field.entityFieldMapping && (
-            <Box
-              sx={{
-                display: "inline-flex",
-                alignItems: "center",
-                height: 20,
-                px: "6px",
-                borderRadius: "4px",
-                backgroundColor: "#dbeafe",
-                fontSize: "11px",
-                color: "#1d4ed8",
-              }}
-            >
-              Maps to: {field.entityFieldMapping}
-            </Box>
-          )}
-        </Box>
-      )}
+      {/* Metadata badges — always visible */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: "6px", mt: "8px", flexWrap: "wrap" }}>
+        <Chip label={TYPE_LABELS[field.type]} variant="default" size="small" uppercase={false} />
+        {field.entityFieldMapping && (
+          <Chip label={`Maps to: ${field.entityFieldMapping}`} variant="info" size="small" uppercase={false} />
+        )}
+      </Box>
 
       {/* Action toolbar — appears on hover/selection */}
       <Box

--- a/Clients/src/presentation/pages/IntakeFormBuilder/FieldEditor.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/FieldEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Box, Typography, Tooltip, Divider, useTheme } from "@mui/material";
-import { X, Plus, Trash2 } from "lucide-react";
+import { Box, Typography, Tooltip, Divider, CircularProgress, useTheme } from "@mui/material";
+import { X, Plus, Trash2, Sparkles } from "lucide-react";
 import Field from "../../components/Inputs/Field";
 import Select from "../../components/Inputs/Select";
 import Checkbox from "../../components/Inputs/Checkbox";
@@ -13,6 +13,7 @@ import {
   EntityFieldMapping,
 } from "./types";
 import { IntakeEntityType } from "../../../domain/intake/enums";
+import { getLLMFieldGuidance } from "../../../application/repository/intakeForm.repository";
 
 const FIELD_TYPE_LABELS: Record<FieldType, string> = {
   text: "Short text",
@@ -132,11 +133,12 @@ interface FieldEditorProps {
   field: FormField;
   entityType: IntakeEntityType;
   usedEntityMappings?: string[];
+  llmKeyId?: number | null;
   onChange: (field: FormField) => void;
   onClose: () => void;
 }
 
-export function FieldEditor({ field, entityType, usedEntityMappings = [], onChange, onClose }: FieldEditorProps) {
+export function FieldEditor({ field, entityType, usedEntityMappings = [], llmKeyId, onChange, onClose }: FieldEditorProps) {
   const theme = useTheme();
   const [localField, setLocalField] = useState<FormField>(field);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -180,6 +182,27 @@ export function FieldEditor({ field, entityType, usedEntityMappings = [], onChan
     setLocalField(updated);
     debouncedOnChange(updated);
   };
+
+  // LLM guidance generation
+  const [guidanceLoading, setGuidanceLoading] = useState(false);
+
+  const generateGuidance = useCallback(async () => {
+    if (!llmKeyId || !localField.label) return;
+    setGuidanceLoading(true);
+    try {
+      const result = await getLLMFieldGuidance(localField.label, entityType, llmKeyId);
+      const text = result.data?.guidanceText;
+      if (text) {
+        const updated = { ...localField, guidanceText: text };
+        setLocalField(updated);
+        onChange(updated);
+      }
+    } catch {
+      // Silently fail — the field stays as is
+    } finally {
+      setGuidanceLoading(false);
+    }
+  }, [llmKeyId, localField, entityType, onChange]);
 
   const entityMappings = ENTITY_FIELD_MAPPINGS[entityType] || [];
   const compatibleMappings = entityMappings.filter((mapping: EntityFieldMapping) =>
@@ -285,9 +308,42 @@ export function FieldEditor({ field, entityType, usedEntityMappings = [], onChan
                 rows={2}
               />
               <Box>
+                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: "4px" }}>
+                  <Typography sx={{ fontSize: "13px", fontWeight: 500, color: theme.palette.text.secondary }}>
+                    Guidance text
+                  </Typography>
+                  {llmKeyId && (
+                    <Tooltip title={localField.label ? "Generate with AI" : "Add a label first"} placement="top">
+                      <Box
+                        onClick={!guidanceLoading && localField.label ? generateGuidance : undefined}
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "3px",
+                          cursor: !guidanceLoading && localField.label ? "pointer" : "default",
+                          opacity: !localField.label ? 0.4 : 1,
+                          color: theme.palette.primary.main,
+                          borderRadius: "4px",
+                          px: "6px",
+                          py: "2px",
+                          "&:hover": localField.label ? { backgroundColor: theme.palette.background.fill } : {},
+                        }}
+                      >
+                        {guidanceLoading ? (
+                          <CircularProgress size={12} sx={{ color: theme.palette.primary.main }} />
+                        ) : (
+                          <Sparkles size={12} />
+                        )}
+                        <Typography sx={{ fontSize: "11px", fontWeight: 500 }}>
+                          {guidanceLoading ? "Generating..." : "AI"}
+                        </Typography>
+                      </Box>
+                    </Tooltip>
+                  )}
+                </Box>
                 <Field
                   id="field-guidance"
-                  label="Guidance text"
+                  label=""
                   placeholder="Explain why this field matters for governance..."
                   value={localField.guidanceText || ""}
                   onChange={(e) => handleChange("guidanceText", e.target.value)}
@@ -345,7 +401,7 @@ export function FieldEditor({ field, entityType, usedEntityMappings = [], onChan
                     id="field-minlength"
                     label="Min length"
                     type="number"
-                    value={String(localField.validation?.minLength || "")}
+                    value={String(localField.validation?.minLength ?? "")}
                     onChange={(e) => {
                       const v = e.target.value;
                       handleValidationChange("minLength", v === "" ? undefined : parseInt(v));

--- a/Clients/src/presentation/pages/IntakeFormBuilder/FieldPalette.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/FieldPalette.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Collapse, useTheme } from "@mui/material";
+import { Box, Typography, Collapse, CircularProgress, useTheme, keyframes } from "@mui/material";
 import {
   Type,
   FileText,
@@ -11,8 +11,12 @@ import {
   CheckSquare,
   Plus,
   ChevronRight,
+  Sparkles,
+  RefreshCw,
+  AlertCircle,
+  X,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect, useCallback, useRef, useImperativeHandle, forwardRef } from "react";
 import {
   PALETTE_ITEMS,
   PaletteItem,
@@ -22,6 +26,18 @@ import {
   generateFieldId,
   createFieldFromPalette,
 } from "./types";
+import {
+  getLLMSuggestedQuestions,
+  LLMSuggestedQuestion,
+} from "../../../application/repository/intakeForm.repository";
+import { CustomizableButton } from "../../components/button/customizable-button";
+
+// Sparkle shimmer animation
+const sparkleShimmer = keyframes`
+  0% { opacity: 0.6; filter: brightness(1); }
+  50% { opacity: 1; filter: brightness(1.4); }
+  100% { opacity: 0.6; filter: brightness(1); }
+`;
 
 const ICON_MAP: Record<string, React.ElementType> = {
   TextFields: Type,
@@ -96,19 +112,23 @@ interface SuggestedCategoryProps {
   category: string;
   questions: SuggestedQuestion[];
   fieldCount: number;
+  addedLabels: Set<string>;
   onAdd: (field: FormField) => void;
 }
 
-function SuggestedCategory({ category, questions, fieldCount, onAdd }: SuggestedCategoryProps) {
+function SuggestedCategory({ category, questions, fieldCount, addedLabels, onAdd }: SuggestedCategoryProps) {
   const theme = useTheme();
   const [open, setOpen] = useState(false);
+
+  const availableQuestions = questions.filter((q) => !addedLabels.has(q.label));
+  if (availableQuestions.length === 0) return null;
 
   const handleAdd = (question: SuggestedQuestion) => {
     const field: FormField = {
       id: generateFieldId(),
       type: question.fieldType,
       label: question.label,
-      guidanceText: question.guidanceText,
+      helpText: question.guidanceText,
       options: question.options,
       order: fieldCount,
     };
@@ -145,13 +165,13 @@ function SuggestedCategory({ category, questions, fieldCount, onAdd }: Suggested
           {category}
         </Typography>
         <Typography sx={{ color: theme.palette.text.accent, fontSize: "11px" }}>
-          {questions.length}
+          {availableQuestions.length}
         </Typography>
       </Box>
 
       <Collapse in={open} timeout="auto" unmountOnExit>
         <Box sx={{ pl: 1, display: "flex", flexDirection: "column" }}>
-          {questions.map((question, index) => (
+          {availableQuestions.map((question, index) => (
             <Box
               key={index}
               onClick={() => handleAdd(question)}
@@ -195,43 +215,476 @@ function SuggestedCategory({ category, questions, fieldCount, onAdd }: Suggested
   );
 }
 
-export interface SuggestedQuestionsPanelProps {
+// ============================================================================
+// LLM Question Item — flat list (no categories)
+// ============================================================================
+
+interface LLMQuestionItemProps {
+  question: LLMSuggestedQuestion;
   fieldCount: number;
   onAdd: (field: FormField) => void;
+  onDismiss: (question: LLMSuggestedQuestion) => void;
 }
 
-export function SuggestedQuestionsPanel({ fieldCount, onAdd }: SuggestedQuestionsPanelProps) {
+function LLMQuestionItem({ question, fieldCount, onAdd, onDismiss }: LLMQuestionItemProps) {
   const theme = useTheme();
-  const grouped = groupByCategory(HARDCODED_SUGGESTED_QUESTIONS);
-  const categories = Object.keys(grouped);
+
+  const handleAdd = () => {
+    const field: FormField = {
+      id: generateFieldId(),
+      type: question.fieldType,
+      label: question.label,
+      helpText: question.guidanceText,
+      options: question.options,
+      order: fieldCount,
+    };
+    onAdd(field);
+  };
 
   return (
     <Box
+      onClick={handleAdd}
       sx={{
-        borderTop: `1px solid ${theme.palette.border.dark}`,
-        backgroundColor: theme.palette.background.accent,
-        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        py: "6px",
+        px: "6px",
+        borderRadius: "4px",
+        cursor: "pointer",
+        "&:hover": {
+          backgroundColor: theme.palette.background.fill,
+          "& .add-icon": { opacity: 1 },
+          "& .dismiss-icon": { opacity: 1 },
+        },
       }}
     >
-      <Box sx={{ px: "16px", py: "12px" }}>
-        <Typography sx={{ fontWeight: 600, color: theme.palette.text.primary, fontSize: "13px", mb: "8px" }}>
-          Suggested questions
-        </Typography>
-        <Box sx={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
-          {categories.map((category) => (
-            <SuggestedCategory
-              key={category}
-              category={category}
-              questions={grouped[category]}
-              fieldCount={fieldCount}
-              onAdd={onAdd}
-            />
-          ))}
-        </Box>
+      <Typography sx={{ flex: 1, color: theme.palette.text.secondary, fontSize: "13px", lineHeight: 1.4, minWidth: 0 }}>
+        {question.label}
+      </Typography>
+      <Box
+        className="dismiss-icon"
+        onClick={(e) => { e.stopPropagation(); onDismiss(question); }}
+        sx={{
+          opacity: 0,
+          transition: "opacity 0.15s ease",
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          color: theme.palette.text.accent,
+          borderRadius: "4px",
+          p: "2px",
+          "&:hover": { color: theme.palette.status.error.text, backgroundColor: theme.palette.background.main },
+        }}
+      >
+        <X size={13} />
+      </Box>
+      <Box
+        className="add-icon"
+        sx={{
+          opacity: 0,
+          transition: "opacity 0.15s ease",
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          color: theme.palette.primary.main,
+        }}
+      >
+        <Plus size={14} />
       </Box>
     </Box>
   );
 }
+
+// ============================================================================
+// SuggestedQuestionsPanel — LLM mode (Option B) or hardcoded fallback
+// ============================================================================
+
+export interface SuggestedQuestionsPanelHandle {
+  /** Called by the parent whenever a field is added (from any source). */
+  onFieldAdded: () => void;
+}
+
+export interface SuggestedQuestionsPanelProps {
+  fieldCount: number;
+  existingFieldLabels: string[];
+  entityType: string;
+  llmKeyId?: number | null;
+  onAdd: (field: FormField) => void;
+}
+
+export const SuggestedQuestionsPanel = forwardRef<SuggestedQuestionsPanelHandle, SuggestedQuestionsPanelProps>(
+  function SuggestedQuestionsPanel(
+    { fieldCount, existingFieldLabels, entityType, llmKeyId, onAdd },
+    ref
+  ) {
+    const theme = useTheme();
+    const hasLLM = !!llmKeyId;
+
+    // Collapse state
+    const [isOpen, setIsOpen] = useState(true);
+
+    // Sparkle animation state — triggered when new questions arrive
+    const [isSparkleAnimating, setIsSparkleAnimating] = useState(false);
+    const sparkleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const triggerSparkle = useCallback(() => {
+      setIsSparkleAnimating(true);
+      if (sparkleTimerRef.current) clearTimeout(sparkleTimerRef.current);
+      sparkleTimerRef.current = setTimeout(() => setIsSparkleAnimating(false), 2400);
+    }, []);
+
+    // Track which questions have already been added (by label match)
+    const addedLabels = new Set(existingFieldLabels.map((l) => l.toLowerCase()));
+
+    // Track dismissed questions so they never come back
+    const [dismissedLabels, setDismissedLabels] = useState<Set<string>>(new Set());
+
+    // LLM state
+    const [llmQuestions, setLlmQuestions] = useState<LLMSuggestedQuestion[]>([]);
+    const [llmLoading, setLlmLoading] = useState(false);
+    const [llmError, setLlmError] = useState<string | null>(null);
+    const [llmFetched, setLlmFetched] = useState(false);
+    const abortRef = useRef<AbortController | null>(null);
+    // Debounce timer for re-fetch after field add
+    const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const buildContext = useCallback((extraDismissed?: string[]) => {
+      const parts: string[] = [];
+      if (existingFieldLabels.length > 0) {
+        parts.push(`Existing fields: ${existingFieldLabels.join(", ")}`);
+      }
+      const allDismissed = [...dismissedLabels, ...(extraDismissed || [])];
+      if (allDismissed.length > 0) {
+        parts.push(`Do NOT suggest these questions (already dismissed): ${allDismissed.join(", ")}`);
+      }
+      return parts.join(". ");
+    }, [existingFieldLabels, dismissedLabels]);
+
+    const fetchLLMQuestions = useCallback(async (autoOpen?: boolean) => {
+      if (!llmKeyId) return;
+      if (abortRef.current) abortRef.current.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLlmLoading(true);
+      setLlmError(null);
+      try {
+        const result = await getLLMSuggestedQuestions(
+          entityType,
+          buildContext(),
+          llmKeyId,
+          controller.signal
+        );
+        if (!controller.signal.aborted) {
+          const newQuestions = result.data || [];
+          setLlmQuestions(newQuestions);
+          setLlmFetched(true);
+          // If we got new questions and the pane should auto-open
+          if (autoOpen && newQuestions.length > 0) {
+            setIsOpen(true);
+            triggerSparkle();
+          }
+        }
+      } catch (err: unknown) {
+        if (!controller.signal.aborted) {
+          setLlmError("Could not generate questions. Check your LLM key.");
+          setLlmFetched(true);
+        }
+      } finally {
+        if (!controller.signal.aborted) setLlmLoading(false);
+      }
+    }, [llmKeyId, entityType, buildContext, triggerSparkle]);
+
+    // Fetch a single replacement question after dismissal
+    const fetchSingleReplacement = useCallback(async (dismissedLabel: string) => {
+      if (!llmKeyId) return;
+      const controller = new AbortController();
+      try {
+        const result = await getLLMSuggestedQuestions(
+          entityType,
+          buildContext([dismissedLabel]) + ". Generate exactly 1 new question only.",
+          llmKeyId,
+          controller.signal
+        );
+        if (!controller.signal.aborted) {
+          const newQuestions = result.data || [];
+          if (newQuestions.length > 0) {
+            // Only add the first replacement, filter out any that are already present or dismissed
+            const replacement = newQuestions.find(
+              (q) =>
+                !addedLabels.has(q.label.toLowerCase()) &&
+                !dismissedLabels.has(q.label) &&
+                q.label !== dismissedLabel &&
+                !llmQuestions.some((existing) => existing.label === q.label)
+            );
+            if (replacement) {
+              setLlmQuestions((prev) => [...prev, replacement]);
+            }
+          }
+        }
+      } catch {
+        // Silently fail — the question was already removed, no need to show an error
+      }
+    }, [llmKeyId, entityType, buildContext, addedLabels, dismissedLabels, llmQuestions]);
+
+    // Auto-fetch on mount when LLM key is set
+    useEffect(() => {
+      if (hasLLM && !llmFetched && !llmLoading) {
+        fetchLLMQuestions();
+        triggerSparkle();
+      }
+      return () => {
+        if (abortRef.current) abortRef.current.abort();
+      };
+    }, [hasLLM]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Cleanup timers on unmount
+    useEffect(() => {
+      return () => {
+        if (sparkleTimerRef.current) clearTimeout(sparkleTimerRef.current);
+        if (refetchTimerRef.current) clearTimeout(refetchTimerRef.current);
+      };
+    }, []);
+
+    // Expose onFieldAdded to parent via ref (no-op now — re-fetch is not triggered on add)
+    useImperativeHandle(ref, () => ({
+      onFieldAdded: () => {},
+    }), []);
+
+    const handleAdd = useCallback(
+      (field: FormField) => {
+        onAdd(field);
+        // Remove from LLM list when added
+        setLlmQuestions((prev) => prev.filter((q) => q.label !== field.label));
+      },
+      [onAdd]
+    );
+
+    const handleDismiss = useCallback(
+      (question: LLMSuggestedQuestion) => {
+        // Permanently mark as dismissed
+        setDismissedLabels((prev) => new Set(prev).add(question.label));
+        // Remove from current list
+        setLlmQuestions((prev) => prev.filter((q) => q.label !== question.label));
+        // Fetch a single replacement in the background
+        fetchSingleReplacement(question.label);
+      },
+      [fetchSingleReplacement]
+    );
+
+    // Filter out already-added and dismissed questions
+    const filteredLLMQuestions = llmQuestions.filter(
+      (q) => !addedLabels.has(q.label.toLowerCase()) && !dismissedLabels.has(q.label)
+    );
+
+    const sparkleSx = isSparkleAnimating
+      ? { animation: `${sparkleShimmer} 0.8s ease-in-out 3` }
+      : {};
+
+    // ── LLM mode ──
+    if (hasLLM) {
+      return (
+        <Box
+          sx={{
+            borderTop: `1px solid ${theme.palette.border.dark}`,
+            backgroundColor: theme.palette.background.accent,
+            flexShrink: 0,
+          }}
+        >
+          {/* Collapsible header */}
+          <Box
+            onClick={() => setIsOpen((prev) => !prev)}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              px: "16px",
+              py: "10px",
+              cursor: "pointer",
+              userSelect: "none",
+              "&:hover": { backgroundColor: theme.palette.background.fill },
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: "6px" }}>
+              <Box sx={{ display: "flex", ...sparkleSx }}>
+                <Sparkles size={14} color={theme.palette.primary.main} />
+              </Box>
+              <Typography
+                sx={{
+                  fontWeight: 600,
+                  color: theme.palette.text.primary,
+                  fontSize: "13px",
+                  ...sparkleSx,
+                }}
+              >
+                AI-suggested questions
+              </Typography>
+              {filteredLLMQuestions.length > 0 && !llmLoading && (
+                <Typography
+                  sx={{
+                    fontSize: "11px",
+                    color: theme.palette.text.accent,
+                    backgroundColor: theme.palette.background.fill,
+                    borderRadius: "10px",
+                    px: "6px",
+                    py: "1px",
+                    fontWeight: 500,
+                  }}
+                >
+                  {filteredLLMQuestions.length}
+                </Typography>
+              )}
+            </Box>
+            <Box sx={{ display: "flex", alignItems: "center", gap: "4px" }}>
+              {llmFetched && !llmLoading && (
+                <Box
+                  onClick={(e) => { e.stopPropagation(); setDismissedLabels(new Set()); fetchLLMQuestions(); }}
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "4px",
+                    color: theme.palette.text.accent,
+                    borderRadius: "4px",
+                    px: "6px",
+                    py: "2px",
+                    "&:hover": { backgroundColor: theme.palette.background.main, color: theme.palette.primary.main },
+                  }}
+                >
+                  <RefreshCw size={12} />
+                  <Typography sx={{ fontSize: "11px" }}>Regenerate</Typography>
+                </Box>
+              )}
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  transition: "transform 0.2s ease",
+                  transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
+                  color: theme.palette.other.icon,
+                }}
+              >
+                <ChevronDown size={14} />
+              </Box>
+            </Box>
+          </Box>
+
+          <Collapse in={isOpen} timeout={300}>
+            <Box sx={{ px: "16px", pb: "12px" }}>
+              {llmLoading && (
+                <Box sx={{ display: "flex", alignItems: "center", gap: "8px", py: "12px" }}>
+                  <CircularProgress size={16} sx={{ color: theme.palette.primary.main }} />
+                  <Typography sx={{ fontSize: "12px", color: theme.palette.text.accent }}>
+                    Generating questions...
+                  </Typography>
+                </Box>
+              )}
+
+              {llmError && (
+                <Box sx={{ display: "flex", alignItems: "center", gap: "6px", py: "8px" }}>
+                  <AlertCircle size={14} color={theme.palette.status.error.text} />
+                  <Typography sx={{ fontSize: "11px", color: theme.palette.status.error.text, flex: 1 }}>
+                    {llmError}
+                  </Typography>
+                  <CustomizableButton
+                    variant="text"
+                    onClick={fetchLLMQuestions}
+                    sx={{ height: 24, fontSize: "11px", color: theme.palette.primary.main, minWidth: 0, px: "8px" }}
+                  >
+                    Retry
+                  </CustomizableButton>
+                </Box>
+              )}
+
+              {!llmLoading && !llmError && filteredLLMQuestions.length > 0 && (
+                <Box sx={{ display: "flex", flexDirection: "column" }}>
+                  {filteredLLMQuestions.map((question, index) => (
+                    <LLMQuestionItem
+                      key={`${question.label}-${index}`}
+                      question={question}
+                      fieldCount={fieldCount}
+                      onAdd={handleAdd}
+                      onDismiss={handleDismiss}
+                    />
+                  ))}
+                </Box>
+              )}
+
+              {!llmLoading && !llmError && llmFetched && filteredLLMQuestions.length === 0 && (
+                <Box sx={{ py: "8px" }}>
+                  <Typography sx={{ fontSize: "11px", color: theme.palette.text.accent }}>
+                    All suggested questions have been added. Click regenerate for more.
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+          </Collapse>
+        </Box>
+      );
+    }
+
+    // ── Hardcoded fallback ──
+    const grouped = groupByCategory(HARDCODED_SUGGESTED_QUESTIONS);
+    const categories = Object.keys(grouped);
+
+    return (
+      <Box
+        sx={{
+          borderTop: `1px solid ${theme.palette.border.dark}`,
+          backgroundColor: theme.palette.background.accent,
+          flexShrink: 0,
+        }}
+      >
+        {/* Collapsible header */}
+        <Box
+          onClick={() => setIsOpen((prev) => !prev)}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            px: "16px",
+            py: "10px",
+            cursor: "pointer",
+            userSelect: "none",
+            "&:hover": { backgroundColor: theme.palette.background.fill },
+          }}
+        >
+          <Typography sx={{ fontWeight: 600, color: theme.palette.text.primary, fontSize: "13px" }}>
+            Suggested questions
+          </Typography>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              transition: "transform 0.2s ease",
+              transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
+              color: theme.palette.other.icon,
+            }}
+          >
+            <ChevronDown size={14} />
+          </Box>
+        </Box>
+
+        <Collapse in={isOpen} timeout={300}>
+          <Box sx={{ px: "16px", pb: "12px" }}>
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+              {categories.map((category) => (
+                <SuggestedCategory
+                  key={category}
+                  category={category}
+                  questions={grouped[category]}
+                  fieldCount={fieldCount}
+                  addedLabels={addedLabels}
+                  onAdd={onAdd}
+                />
+              ))}
+            </Box>
+          </Box>
+        </Collapse>
+      </Box>
+    );
+  }
+);
 
 interface FieldPaletteProps {
   disabled?: boolean;

--- a/Clients/src/presentation/pages/IntakeFormBuilder/FormCanvas.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/FormCanvas.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from "react";
 import { Box, Typography, IconButton, Tooltip, useTheme } from "@mui/material";
 import { Plus, Check, X, User, Mail } from "lucide-react";
 import { FormField } from "./types";
@@ -331,7 +331,7 @@ function ContactInfoPreview() {
           mb: "10px",
         }}
       >
-        Contact information
+        Contact information (always shown)
       </Typography>
       {[
         { icon: <User size={14} />, label: "Full name" },
@@ -385,7 +385,11 @@ interface FormCanvasProps {
   collectContactInfo?: boolean;
 }
 
-export function FormCanvas({
+export interface FormCanvasHandle {
+  scrollToBottom: () => void;
+}
+
+export const FormCanvas = forwardRef<FormCanvasHandle, FormCanvasProps>(function FormCanvas({
   fields,
   selectedFieldId,
   onSelectField,
@@ -398,8 +402,20 @@ export function FormCanvas({
   onNameChange,
   onDescriptionChange,
   collectContactInfo,
-}: FormCanvasProps) {
+}, ref) {
   const theme = useTheme();
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    scrollToBottom() {
+      const el = scrollRef.current;
+      if (!el) return;
+      setTimeout(() => {
+        el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+      }, 50);
+    },
+  }));
+
   const handleCanvasClick = () => {
     onSelectField(null);
   };
@@ -416,6 +432,7 @@ export function FormCanvas({
     >
       {/* Canvas content */}
       <Box
+        ref={scrollRef}
         onClick={handleCanvasClick}
         sx={{ flex: 1, overflowY: "auto", p: 3, minWidth: 0 }}
       >
@@ -493,6 +510,6 @@ export function FormCanvas({
       </Box>
     </Box>
   );
-}
+});
 
 export default FormCanvas;

--- a/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import {
   Box,
@@ -26,9 +26,7 @@ import {
   ClipboardList,
   Pencil,
   PaintBucket,
-  AlertTriangle,
-  CircleCheck,
-  Info,
+  Plus,
 } from "lucide-react";
 import {
   getIntakeForm,
@@ -39,8 +37,8 @@ import {
 } from "../../../application/repository/intakeForm.repository";
 import CustomAxios from "../../../infrastructure/api/customAxios";
 import { LLMKeysModel } from "../../../domain/models/Common/llmKeys/llmKeys.model";
-import { FieldPalette, SuggestedQuestionsPanel } from "./FieldPalette";
-import { FormCanvas } from "./FormCanvas";
+import { FieldPalette, SuggestedQuestionsPanel, SuggestedQuestionsPanelHandle } from "./FieldPalette";
+import { FormCanvas, FormCanvasHandle } from "./FormCanvas";
 import { FieldEditor } from "./FieldEditor";
 import { DesignPanel } from "./DesignPanel";
 import CustomizableMultiSelect from "../../components/Inputs/Select/Multi";
@@ -53,6 +51,7 @@ import {
   DEFAULT_DESIGN_SETTINGS,
   ENTITY_FIELD_MAPPINGS,
   analyzeMappingCoverage,
+  createFieldFromMapping,
 } from "./types";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import StandardModal from "../../components/Modals/StandardModal";
@@ -86,6 +85,8 @@ export function IntakeFormBuilder() {
   const isEditing = Boolean(formId) && formId !== "new";
   const [builderMode, setBuilderMode] = useState<"edit" | "design">("edit");
   const [form, setForm] = useState<IntakeForm>(createEmptyForm());
+  const canvasRef = useRef<FormCanvasHandle>(null);
+  const suggestedPanelRef = useRef<SuggestedQuestionsPanelHandle>(null);
   const [selectedFieldId, setSelectedFieldId] = useState<string | null>(null);
   const [isDirty, setIsDirty] = useState(false);
   const [isLoadingForm, setIsLoadingForm] = useState(false);
@@ -179,6 +180,7 @@ export function IntakeFormBuilder() {
     }));
     setIsDirty(true);
     setSelectedFieldId(field.id);
+    canvasRef.current?.scrollToBottom();
   }, []);
 
   const requestDeleteField = useCallback((fId: string) => {
@@ -747,6 +749,7 @@ export function IntakeFormBuilder() {
                   }}
                 >
                   <FormCanvas
+                    ref={canvasRef}
                     fields={form.schema.fields}
                     selectedFieldId={selectedFieldId}
                     onSelectField={setSelectedFieldId}
@@ -758,10 +761,14 @@ export function IntakeFormBuilder() {
                     formDescription={form.description}
                     onNameChange={(name) => updateForm({ name })}
                     onDescriptionChange={(description) => updateForm({ description })}
-                    collectContactInfo={form.designSettings?.collectContactInfo ?? false}
+                    collectContactInfo
                   />
                   <SuggestedQuestionsPanel
+                    ref={suggestedPanelRef}
                     fieldCount={form.schema.fields.length}
+                    existingFieldLabels={form.schema.fields.map((f) => f.label)}
+                    entityType={form.entityType}
+                    llmKeyId={form.llmKeyId}
                     onAdd={addField}
                   />
                 </Box>
@@ -779,6 +786,7 @@ export function IntakeFormBuilder() {
                     usedEntityMappings={form.schema.fields
                       .filter((f) => f.id !== selectedField.id && f.entityFieldMapping)
                       .map((f) => f.entityFieldMapping!)}
+                    llmKeyId={form.llmKeyId}
                     onChange={updateField}
                     onClose={() => setSelectedFieldId(null)}
                   />
@@ -845,74 +853,94 @@ export function IntakeFormBuilder() {
                           const { missingRequired, missingOptional, typeMismatches } = mappingCoverage;
                           const allMapped = missingRequired.length === 0 && missingOptional.length === 0 && typeMismatches.length === 0;
                           const entityLabel = form.entityType === IntakeEntityType.USE_CASE ? "use case" : "model";
+                          const hasErrors = missingRequired.length > 0 || typeMismatches.length > 0;
+
+                          const handleAddField = (m: typeof missingRequired[0]) => {
+                            const newField = createFieldFromMapping(m, form.schema.fields.length);
+                            addField(newField);
+                            setIsDirty(true);
+                          };
 
                           return (
-                            <Box
-                              sx={{
-                                p: "10px",
-                                borderRadius: "4px",
-                                border: `1px solid ${
-                                  missingRequired.length > 0 || typeMismatches.length > 0
-                                    ? "#FECACA"
-                                    : missingOptional.length > 0
-                                      ? "#FDE68A"
-                                      : "#BBF7D0"
-                                }`,
-                                backgroundColor:
-                                  missingRequired.length > 0 || typeMismatches.length > 0
-                                    ? "#FEF2F2"
-                                    : missingOptional.length > 0
-                                      ? "#FFFBEB"
-                                      : "#F0FDF4",
-                              }}
-                            >
-                              <Stack direction="row" gap="6px" alignItems="center" sx={{ mb: missingRequired.length > 0 || missingOptional.length > 0 || typeMismatches.length > 0 ? "6px" : 0 }}>
-                                {allMapped ? (
-                                  <CircleCheck size={14} color="#16A34A" strokeWidth={1.5} />
-                                ) : missingRequired.length > 0 || typeMismatches.length > 0 ? (
-                                  <AlertTriangle size={14} color="#DC2626" strokeWidth={1.5} />
-                                ) : (
-                                  <Info size={14} color="#D97706" strokeWidth={1.5} />
-                                )}
-                                <Typography sx={{ fontSize: "12px", fontWeight: 600, color: theme.palette.text.primary }}>
-                                  {allMapped
-                                    ? `All ${entityLabel} fields mapped`
-                                    : `${entityLabel.charAt(0).toUpperCase() + entityLabel.slice(1)} field mapping`}
-                                </Typography>
-                              </Stack>
+                            <Box>
+                              <Typography sx={{ fontSize: 13, fontWeight: 500, color: theme.palette.text.secondary, mb: allMapped ? 0 : "4px" }}>
+                                {allMapped
+                                  ? `All ${entityLabel} fields mapped`
+                                  : "Optional but not mapped fields"}
+                              </Typography>
                               {missingRequired.length > 0 && (
-                                <Box sx={{ mb: "4px" }}>
-                                  <Typography sx={{ fontSize: "11px", color: "#DC2626", fontWeight: 500 }}>
+                                <Box sx={{ mb: "6px" }}>
+                                  <Typography sx={{ fontSize: 11, color: "#DC2626", fontWeight: 500, mb: "2px" }}>
                                     Required (blocks publishing):
                                   </Typography>
                                   {missingRequired.map((m) => (
-                                    <Typography key={m.field} sx={{ fontSize: "11px", color: theme.palette.text.secondary, pl: "12px" }}>
-                                      &bull; {m.label} ({m.requiredFieldType.join(" or ")})
-                                    </Typography>
+                                    <Stack key={m.field} direction="row" alignItems="center" justifyContent="space-between" sx={{ py: "2px" }}>
+                                      <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
+                                        {m.label}
+                                        <Typography component="span" sx={{ fontSize: 11, color: theme.palette.text.accent, ml: "4px" }}>
+                                          ({m.requiredFieldType.join(" or ")})
+                                        </Typography>
+                                      </Typography>
+                                      <Typography
+                                        component="span"
+                                        onClick={() => handleAddField(m)}
+                                        sx={{
+                                          fontSize: 11,
+                                          fontWeight: 500,
+                                          color: "#13715B",
+                                          cursor: "pointer",
+                                          display: "flex",
+                                          alignItems: "center",
+                                          gap: "2px",
+                                          whiteSpace: "nowrap",
+                                          "&:hover": { textDecoration: "underline" },
+                                        }}
+                                      >
+                                        <Plus size={11} strokeWidth={2} />
+                                        Add field
+                                      </Typography>
+                                    </Stack>
                                   ))}
                                 </Box>
                               )}
                               {typeMismatches.length > 0 && (
-                                <Box sx={{ mb: "4px" }}>
-                                  <Typography sx={{ fontSize: "11px", color: "#DC2626", fontWeight: 500 }}>
+                                <Box sx={{ mb: "6px" }}>
+                                  <Typography sx={{ fontSize: 11, color: "#DC2626", fontWeight: 500, mb: "2px" }}>
                                     Type mismatch (blocks publishing):
                                   </Typography>
                                   {typeMismatches.map((m) => (
-                                    <Typography key={m.formField.id} sx={{ fontSize: "11px", color: theme.palette.text.secondary, pl: "12px" }}>
-                                      &bull; &quot;{m.formField.label}&quot; is {m.formField.type}, needs {m.entityMapping.requiredFieldType.join(" or ")}
+                                    <Typography key={m.formField.id} sx={{ fontSize: 12, color: theme.palette.text.secondary, py: "2px" }}>
+                                      &quot;{m.formField.label}&quot; is {m.formField.type}, needs {m.entityMapping.requiredFieldType.join(" or ")}
                                     </Typography>
                                   ))}
                                 </Box>
                               )}
                               {missingOptional.length > 0 && (
                                 <Box>
-                                  <Typography sx={{ fontSize: "11px", color: "#D97706", fontWeight: 500 }}>
-                                    Optional (not mapped):
-                                  </Typography>
                                   {missingOptional.map((m) => (
-                                    <Typography key={m.field} sx={{ fontSize: "11px", color: theme.palette.text.secondary, pl: "12px" }}>
-                                      &bull; {m.label}
-                                    </Typography>
+                                    <Stack key={m.field} direction="row" alignItems="center" justifyContent="space-between" sx={{ py: "2px" }}>
+                                      <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
+                                        {m.label}
+                                      </Typography>
+                                      <Typography
+                                        component="span"
+                                        onClick={() => handleAddField(m)}
+                                        sx={{
+                                          fontSize: 11,
+                                          fontWeight: 500,
+                                          color: "#13715B",
+                                          cursor: "pointer",
+                                          display: "flex",
+                                          alignItems: "center",
+                                          gap: "2px",
+                                          whiteSpace: "nowrap",
+                                          "&:hover": { textDecoration: "underline" },
+                                        }}
+                                      >
+                                        <Plus size={11} strokeWidth={2} />
+                                        Add field
+                                      </Typography>
+                                    </Stack>
                                   ))}
                                 </Box>
                               )}
@@ -937,7 +965,14 @@ export function IntakeFormBuilder() {
                             }))}
                             placeholder="Select recipients"
                             sx={{
-                              fontSize: "12px",
+                              fontSize: 13,
+                              minHeight: 34,
+                              backgroundColor: theme.palette.background.main,
+                              borderRadius: "4px",
+                              "& .MuiOutlinedInput-input": {
+                                paddingTop: "6px",
+                                paddingBottom: "6px",
+                              },
                             }}
                           />
                           <Typography
@@ -954,8 +989,8 @@ export function IntakeFormBuilder() {
                         <Box>
                           <Typography
                             sx={{
-                              fontSize: "12px",
-                              fontWeight: 600,
+                              fontSize: 13,
+                              fontWeight: 500,
                               color: theme.palette.text.secondary,
                               mb: "4px",
                             }}
@@ -989,7 +1024,7 @@ export function IntakeFormBuilder() {
                               label={
                                 <Typography
                                   sx={{
-                                    fontSize: "12px",
+                                    fontSize: 13,
                                     color: theme.palette.text.secondary,
                                   }}
                                 >
@@ -1015,7 +1050,7 @@ export function IntakeFormBuilder() {
                               label={
                                 <Typography
                                   sx={{
-                                    fontSize: "12px",
+                                    fontSize: 13,
                                     color: theme.palette.text.secondary,
                                   }}
                                 >
@@ -1030,8 +1065,8 @@ export function IntakeFormBuilder() {
                         <Box>
                           <Typography
                             sx={{
-                              fontSize: "12px",
-                              fontWeight: 600,
+                              fontSize: 13,
+                              fontWeight: 500,
                               color: theme.palette.text.secondary,
                               mb: "4px",
                             }}
@@ -1056,10 +1091,22 @@ export function IntakeFormBuilder() {
                             sx={{
                               "& .MuiOutlinedInput-root": {
                                 height: 34,
-                                fontSize: "12px",
+                                fontSize: 13,
                               },
                             }}
                           />
+                          <Typography
+                            sx={{
+                              fontSize: "11px",
+                              color: theme.palette.text.accent,
+                              mt: "6px",
+                              lineHeight: 1.4,
+                            }}
+                          >
+                            {form.llmKeyId
+                              ? "Submissions will be scored using AI-enhanced risk analysis. You can also generate suggested questions and field guidance text with AI."
+                              : "Without an LLM key, submissions are scored using rule-based risk analysis only. Add a key in Settings > LLM keys to enable AI features."}
+                          </Typography>
                         </Box>
 
                         <Box
@@ -1110,59 +1157,6 @@ export function IntakeFormBuilder() {
                           </Box>
                         </Box>
 
-                        <Box
-                          sx={{
-                            display: "flex",
-                            alignItems: "flex-start",
-                            gap: "4px",
-                            cursor: "pointer",
-                          }}
-                          onClick={() => {
-                            const ds = form.designSettings ?? { ...DEFAULT_DESIGN_SETTINGS };
-                            updateForm({
-                              designSettings: {
-                                ...DEFAULT_DESIGN_SETTINGS,
-                                ...ds,
-                                collectContactInfo: !(ds.collectContactInfo ?? false),
-                              },
-                            });
-                          }}
-                        >
-                          <Checkbox
-                            id="collect-contact-info"
-                            isChecked={form.designSettings?.collectContactInfo ?? false}
-                            value="collectContactInfo"
-                            onChange={() => {
-                              const ds = form.designSettings ?? { ...DEFAULT_DESIGN_SETTINGS };
-                              updateForm({
-                                designSettings: {
-                                  ...DEFAULT_DESIGN_SETTINGS,
-                                  ...ds,
-                                  collectContactInfo: !(ds.collectContactInfo ?? false),
-                                },
-                              });
-                            }}
-                            size="small"
-                            label=""
-                            sx={{ p: 0, mt: "1px", flexShrink: 0 }}
-                          />
-                          <Box>
-                            <Typography
-                              sx={{
-                                fontSize: "12px",
-                                fontWeight: 600,
-                                color: theme.palette.text.secondary,
-                              }}
-                            >
-                              Collect contact information
-                            </Typography>
-                            <Typography
-                              sx={{ fontSize: "11px", color: theme.palette.text.accent }}
-                            >
-                              Show name and email fields on the public form
-                            </Typography>
-                          </Box>
-                        </Box>
                       </Box>
                     </Collapse>
                   </Box>

--- a/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
@@ -83,7 +83,7 @@ export const DEFAULT_DESIGN_SETTINGS: FormDesignSettings = {
   backgroundColor: "#fafafa",
   logoUrl: "",
   fontFamily: "Inter",
-  collectContactInfo: false,
+  collectContactInfo: true,
 };
 
 /**
@@ -180,7 +180,6 @@ export const ENTITY_FIELD_MAPPINGS: Record<IntakeEntityType, EntityFieldMapping[
     { field: "description", label: "Description", description: "Model description", requiredFieldType: ["text", "textarea"] },
     { field: "modelVersion", label: "Model version", description: "Version of the model", requiredFieldType: ["text"] },
     { field: "provider", label: "Provider", description: "Model provider/vendor", requiredFieldType: ["text", "select"] },
-    { field: "owner", label: "Owner", description: "Model owner", requiredFieldType: ["text", "email"] },
     { field: "modelType", label: "Model type", description: "Type of AI model", requiredFieldType: ["text", "select"] },
     { field: "intendedUse", label: "Intended use", description: "Intended use of the model", requiredFieldType: ["text", "textarea"] },
     { field: "riskLevel", label: "Risk level", description: "Risk classification", requiredFieldType: ["select"] },
@@ -188,7 +187,6 @@ export const ENTITY_FIELD_MAPPINGS: Record<IntakeEntityType, EntityFieldMapping[
   [IntakeEntityType.USE_CASE]: [
     { field: "project_title", label: "Project title", description: "Title of the use case/project", requiredFieldType: ["text"], entityRequired: true },
     { field: "goal", label: "Goal", description: "Goal of the project", requiredFieldType: ["text", "textarea"], entityRequired: true },
-    { field: "owner", label: "Owner", description: "Project owner", requiredFieldType: ["text", "email"] },
     { field: "start_date", label: "Start date", description: "Project start date", requiredFieldType: ["date"] },
     { field: "ai_risk_classification", label: "AI risk classification", description: "Risk classification", requiredFieldType: ["select"] },
     { field: "type_of_high_risk_role", label: "High risk role type", description: "Type of high-risk role", requiredFieldType: ["text", "select"] },
@@ -318,6 +316,22 @@ export function createFieldFromPalette(paletteItem: PaletteItem, order: number):
     label: paletteItem.label,
     order,
     ...paletteItem.defaultConfig,
+  };
+}
+
+/**
+ * Create a form field from an entity field mapping definition
+ */
+export function createFieldFromMapping(mapping: EntityFieldMapping, order: number): FormField {
+  const type = mapping.requiredFieldType[0];
+  return {
+    id: generateFieldId(),
+    type,
+    label: mapping.label,
+    placeholder: mapping.description,
+    validation: mapping.entityRequired ? { required: true } : undefined,
+    entityFieldMapping: mapping.field,
+    order,
   };
 }
 

--- a/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
@@ -38,6 +38,7 @@ import { CustomizableButton } from "../../../components/button/customizable-butt
 import { Save as SaveIcon, Trash2 as DeleteIcon } from "lucide-react";
 import CustomizableToast from "../../../components/Toast";
 import CustomizableSkeleton from "../../../components/Skeletons";
+import IntakeSubmissionCard from "../IntakeSubmissionCard";
 import useFrameworks from "../../../../application/hooks/useFrameworks";
 import { Framework } from "../../../../domain/types/Framework";
 import allowedRoles from "../../../../application/constants/permissions";
@@ -1482,6 +1483,9 @@ const ProjectSettings = React.memo(
                   />
                 </Box>
               </Box>
+
+              {/* Intake Form Submission */}
+              <IntakeSubmissionCard projectId={parseInt(projectId, 10) || 0} />
 
               {/* Save Button Row */}
               <Stack sx={{ width: "100%" }}>

--- a/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/Overview/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/Overview/index.tsx
@@ -257,8 +257,8 @@ const VWProjectOverview = ({ project }: { project?: Project }) => {
           {project ? (
             <>
               <DescriptionCard
-                title="Goal"
-                body={project.goal}
+                title="Description"
+                body={project.description || ""}
                 icon={<TargetIcon size={16} />}
               />
               <TeamCard

--- a/Clients/src/presentation/pages/PublicIntakeForm/index.tsx
+++ b/Clients/src/presentation/pages/PublicIntakeForm/index.tsx
@@ -42,15 +42,17 @@ function buildGradient(hex: string): string {
 }
 
 /**
- * Reusable gradient banner component
+ * Reusable gradient banner component with optional logo
  */
 function GradientBanner({
   height = 160,
   colorTheme,
+  logoSrc,
   children,
 }: {
   height?: number;
   colorTheme?: string;
+  logoSrc?: string | null;
   children?: React.ReactNode;
 }) {
   const gradient = buildGradient(colorTheme || "#13715B");
@@ -58,15 +60,43 @@ function GradientBanner({
     <Box
       sx={{
         background: gradient,
-        height,
+        minHeight: height,
         borderRadius: "12px 12px 0 0",
         display: "flex",
         flexDirection: "column",
         justifyContent: "flex-end",
         px: "32px",
-        pb: "32px",
+        pb: "24px",
+        pt: logoSrc ? "24px" : "32px",
       }}
     >
+      {logoSrc && (
+        <Box
+          sx={{
+            width: 56,
+            height: 56,
+            backgroundColor: "#fff",
+            borderRadius: "10px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            mb: "16px",
+            boxShadow: "0 1px 4px rgba(0,0,0,0.12)",
+            flexShrink: 0,
+          }}
+        >
+          <Box
+            component="img"
+            src={logoSrc}
+            alt="Organization logo"
+            sx={{
+              maxWidth: 40,
+              maxHeight: 40,
+              objectFit: "contain",
+            }}
+          />
+        </Box>
+      )}
       {children}
     </Box>
   );
@@ -106,6 +136,7 @@ export function PublicIntakeForm() {
 
   // State
   const [formData, setFormData] = useState<PublicFormData | null>(null);
+  const [organizationLogo, setOrganizationLogo] = useState<string | null>(null);
   const [previousData, setPreviousData] = useState<Record<string, unknown> | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -143,6 +174,9 @@ export function PublicIntakeForm() {
         : await getPublicForm(tenantSlug!, formSlug!, resubmissionToken);
       if (response.data) {
         setFormData(response.data.form as PublicFormData);
+        if (response.data.organizationLogo) {
+          setOrganizationLogo(response.data.organizationLogo);
+        }
         if (response.data.previousData) {
           setPreviousData(response.data.previousData);
           // Pre-fill form with previous data
@@ -326,7 +360,7 @@ export function PublicIntakeForm() {
 
   // Resolve design settings
   const ds = formData.designSettings ?? DEFAULT_DESIGN_SETTINGS;
-  const collectContactInfo = ds.collectContactInfo ?? true;
+  const collectContactInfo = true;
   const maxWidth = ds.format === "wide" ? 820 : 620;
   const formMargin =
     ds.alignment === "left"
@@ -353,11 +387,12 @@ export function PublicIntakeForm() {
             borderRadius: "12px",
             overflow: "hidden",
             backgroundColor: "#fff",
+            border: "1px solid #d0d5dd",
             boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
           }}
         >
           {/* Banner */}
-          <GradientBanner height={160} colorTheme={ds.colorTheme}>
+          <GradientBanner height={160} colorTheme={ds.colorTheme} logoSrc={organizationLogo}>
             <Typography
               sx={{
                 color: "#fff",

--- a/Servers/controllers/intakeForm.ctrl.ts
+++ b/Servers/controllers/intakeForm.ctrl.ts
@@ -49,6 +49,7 @@ import {
   generateSuggestedQuestions,
   generateFieldGuidance,
 } from "../services/intakeLLM.service";
+import { getCompanyLogoQuery } from "../utils/aiTrustCentre.utils";
 
 /** Safely extract a single string from req.params (which may be string | string[]). */
 const paramStr = (val: string | string[]): string =>
@@ -1308,6 +1309,21 @@ export async function getPublicFormByPublicId(req: Request, res: Response) {
       return res.status(404).json(STATUS_CODE[404]("Form not found or not available"));
     }
 
+    // Fetch org logo (non-blocking — null if missing)
+    let organizationLogo: string | null = null;
+    try {
+      const logoRow = await getCompanyLogoQuery(tenantInfo.tenantHash);
+      if (logoRow && (logoRow as any).content) {
+        const buf = Buffer.isBuffer((logoRow as any).content)
+          ? (logoRow as any).content
+          : Buffer.from((logoRow as any).content);
+        const mimeType = (logoRow as any).type || "image/png";
+        organizationLogo = `data:${mimeType};base64,${buf.toString("base64")}`;
+      }
+    } catch {
+      // Logo is optional — swallow errors silently
+    }
+
     // Check for resubmission token
     let previousData: Record<string, unknown> | undefined;
     let previousSubmitterName: string | undefined;
@@ -1351,6 +1367,7 @@ export async function getPublicFormByPublicId(req: Request, res: Response) {
         publicId: form.publicId,
         designSettings: form.designSettings ?? null,
       },
+      organizationLogo,
       previousData,
       previousSubmitterName,
       previousSubmitterEmail,
@@ -1387,18 +1404,15 @@ export async function submitPublicFormByPublicId(req: Request, res: Response) {
 
     const { submitterEmail, submitterName, formData, captchaToken, captchaAnswer, resubmissionToken } = req.body;
 
-    // Determine if contact info is required based on form design settings
+    // Validate contact info (always required)
     const fullFormForValidation = await getIntakeFormByIdQuery(form.id, tenantInfo.tenantHash);
-    const collectContactInfo = (fullFormForValidation?.designSettings as any)?.collectContactInfo ?? true;
 
-    if (collectContactInfo) {
-      if (!submitterEmail) {
-        return res.status(400).json(STATUS_CODE[400]("Submitter email is required"));
-      }
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-      if (!emailRegex.test(submitterEmail)) {
-        return res.status(400).json(STATUS_CODE[400]("Invalid email format"));
-      }
+    if (!submitterEmail) {
+      return res.status(400).json(STATUS_CODE[400]("Submitter email is required"));
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(submitterEmail)) {
+      return res.status(400).json(STATUS_CODE[400]("Invalid email format"));
     }
 
     if (!formData) {
@@ -1439,8 +1453,8 @@ export async function submitPublicFormByPublicId(req: Request, res: Response) {
       return res.status(400).json(STATUS_CODE[400]("Incorrect CAPTCHA answer"));
     }
 
-    const resolvedEmail = collectContactInfo ? submitterEmail : null;
-    const resolvedName = collectContactInfo ? (submitterName || (submitterEmail ? submitterEmail.split("@")[0] : null)) : null;
+    const resolvedEmail = submitterEmail;
+    const resolvedName = submitterName || (submitterEmail ? submitterEmail.split("@")[0] : null);
 
     // Handle resubmission (7-day expiry on resubmission tokens)
     let originalSubmissionId: number | undefined;
@@ -1579,6 +1593,21 @@ export async function getPublicForm(req: Request, res: Response) {
       return res.status(404).json(STATUS_CODE[404]("Form not found or not available"));
     }
 
+    // Fetch org logo (non-blocking — null if missing)
+    let organizationLogo: string | null = null;
+    try {
+      const logoRow = await getCompanyLogoQuery(tenantInfo.hash);
+      if (logoRow && (logoRow as any).content) {
+        const buf = Buffer.isBuffer((logoRow as any).content)
+          ? (logoRow as any).content
+          : Buffer.from((logoRow as any).content);
+        const mimeType = (logoRow as any).type || "image/png";
+        organizationLogo = `data:${mimeType};base64,${buf.toString("base64")}`;
+      }
+    } catch {
+      // Logo is optional — swallow errors silently
+    }
+
     let previousData: Record<string, unknown> | undefined;
     let previousSubmitterName: string | undefined;
     let previousSubmitterEmail: string | undefined;
@@ -1621,6 +1650,7 @@ export async function getPublicForm(req: Request, res: Response) {
         publicId: form.publicId,
         designSettings: form.designSettings ?? null,
       },
+      organizationLogo,
       previousData,
       previousSubmitterName,
       previousSubmitterEmail,
@@ -1660,18 +1690,15 @@ export async function submitPublicForm(req: Request, res: Response) {
 
     const { submitterEmail, submitterName, formData, captchaToken, captchaAnswer, resubmissionToken } = req.body;
 
-    // Determine if contact info is required based on form design settings
+    // Validate contact info (always required)
     const fullFormForValidation = await getIntakeFormByIdQuery(form.id, tenantInfo.hash);
-    const collectContactInfo = (fullFormForValidation?.designSettings as any)?.collectContactInfo ?? true;
 
-    if (collectContactInfo) {
-      if (!submitterEmail) {
-        return res.status(400).json(STATUS_CODE[400]("Submitter email is required"));
-      }
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-      if (!emailRegex.test(submitterEmail)) {
-        return res.status(400).json(STATUS_CODE[400]("Invalid email format"));
-      }
+    if (!submitterEmail) {
+      return res.status(400).json(STATUS_CODE[400]("Submitter email is required"));
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(submitterEmail)) {
+      return res.status(400).json(STATUS_CODE[400]("Invalid email format"));
     }
 
     if (!formData) {
@@ -1711,8 +1738,8 @@ export async function submitPublicForm(req: Request, res: Response) {
       return res.status(400).json(STATUS_CODE[400]("Incorrect CAPTCHA answer"));
     }
 
-    const resolvedEmail = collectContactInfo ? submitterEmail : null;
-    const resolvedName = collectContactInfo ? (submitterName || (submitterEmail ? submitterEmail.split("@")[0] : null)) : null;
+    const resolvedEmail = submitterEmail;
+    const resolvedName = submitterName || (submitterEmail ? submitterEmail.split("@")[0] : null);
 
     // Handle resubmission (7-day expiry on resubmission tokens)
     let originalSubmissionId: number | undefined;

--- a/Servers/services/intakeLLM.service.ts
+++ b/Servers/services/intakeLLM.service.ts
@@ -76,6 +76,7 @@ Return ONLY valid JSON array. Each question should help assess AI governance ris
       model,
       prompt,
       maxOutputTokens: 1000,
+      abortSignal: AbortSignal.timeout(30_000),
     });
 
     const jsonMatch = result.text.match(/\[[\s\S]*\]/);
@@ -113,6 +114,7 @@ Return ONLY the guidance text, no quotes or formatting.`;
       model,
       prompt,
       maxOutputTokens: 100,
+      abortSignal: AbortSignal.timeout(15_000),
     });
 
     return result.text.trim();


### PR DESCRIPTION
## Summary

- **AI-suggested questions panel**: Collapsible panel below the form canvas that generates questions via LLM. Each row has add (+) and dismiss (x) buttons. Dismissed questions are permanently excluded and a single replacement is fetched instead of regenerating all 5. Sparkle animation on new question arrival.
- **Organization logo on public form**: Logo fetched server-side as base64, displayed in a white rounded card on the gradient banner.
- **Contact info toggle**: New checkbox in form settings to control whether name/email fields appear on the public form (off by default for new forms).
- **VW component consistency**: Replaced raw MUI components with VW wrappers (Select, Checkbox, Chip) in FieldCard. Standardized all form settings labels to 13px/500 font weight.
- **Field mapping section cleanup**: Renamed to "Optional but not mapped fields", removed bounding box and redundant sub-header.
- **LLM timeout**: Added 30s timeout for question generation and 15s for guidance to prevent indefinite hanging.

## Test plan

- [ ] Open form builder, verify AI-suggested questions panel appears when LLM key is set
- [ ] Click (+) on a suggested question — verify it adds to the form without triggering regeneration
- [ ] Click (x) on a suggested question — verify it disappears and a replacement appears
- [ ] Click "Regenerate" — verify all questions refresh and dismissed state resets
- [ ] Open public form for a form with org logo — verify logo appears in white card on banner
- [ ] Toggle "Collect contact information" off, publish, open public form — verify no name/email fields
- [ ] Verify form settings labels (Recipients, Risk tier system, LLM key) all use same font size
- [ ] Verify "Optional but not mapped fields" shows without a bounding box