### PR TITLE
feat(intake): polish UX, fix bugs, and add field mappings

### DIFF
--- a/Clients/src/application/repository/intakeForm.repository.ts
+++ b/Clients/src/application/repository/intakeForm.repository.ts
@@ -89,7 +89,9 @@ export interface IntakeForm {
  * Risk dimension scores
  */
 export interface RiskDimensionScore {
-  name: string;
+  key: string;
+  label: string;
+  name?: string;
   score: number;
   weight: number;
   signals: string[];

--- a/Clients/src/presentation/pages/IntakeFormBuilder/FieldPalette.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/FieldPalette.tsx
@@ -39,6 +39,14 @@ const sparkleShimmer = keyframes`
   100% { opacity: 0.6; filter: brightness(1); }
 `;
 
+const sparkleIdle = keyframes`
+  0% { transform: scale(1) rotate(0deg); opacity: 0.85; }
+  25% { transform: scale(1.15) rotate(8deg); opacity: 1; }
+  50% { transform: scale(1) rotate(0deg); opacity: 0.85; }
+  75% { transform: scale(1.1) rotate(-6deg); opacity: 1; }
+  100% { transform: scale(1) rotate(0deg); opacity: 0.85; }
+`;
+
 const ICON_MAP: Record<string, React.ElementType> = {
   TextFields: Type,
   Notes: FileText,
@@ -507,15 +515,22 @@ export const SuggestedQuestionsPanel = forwardRef<SuggestedQuestionsPanelHandle,
             }}
           >
             <Box sx={{ display: "flex", alignItems: "center", gap: "6px" }}>
-              <Box sx={{ display: "flex", ...sparkleSx }}>
-                <Sparkles size={14} color={theme.palette.primary.main} />
+              <Box
+                sx={{
+                  display: "flex",
+                  animation: isSparkleAnimating
+                    ? `${sparkleShimmer} 0.8s ease-in-out 3`
+                    : `${sparkleIdle} 3s ease-in-out infinite`,
+                }}
+              >
+                <Sparkles size={14} color="#7c3aed" />
               </Box>
               <Typography
                 sx={{
                   fontWeight: 600,
-                  color: theme.palette.text.primary,
+                  color: "#7c3aed",
                   fontSize: "13px",
-                  ...sparkleSx,
+                  ...(isSparkleAnimating ? { animation: `${sparkleShimmer} 0.8s ease-in-out 3` } : {}),
                 }}
               >
                 AI-suggested questions
@@ -597,7 +612,7 @@ export const SuggestedQuestionsPanel = forwardRef<SuggestedQuestionsPanelHandle,
               )}
 
               {!llmLoading && !llmError && filteredLLMQuestions.length > 0 && (
-                <Box sx={{ display: "flex", flexDirection: "column" }}>
+                <Box sx={{ display: "flex", flexDirection: "column", gap: "16px" }}>
                   {filteredLLMQuestions.map((question, index) => (
                     <LLMQuestionItem
                       key={`${question.label}-${index}`}

--- a/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
@@ -50,6 +50,7 @@ import { SubmissionPreviewModal } from "./SubmissionPreviewModal";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import StandardModal from "../../components/Modals/StandardModal";
 import Chip from "../../components/Chip";
+import Select from "../../components/Inputs/Select";
 import { EmptyState } from "../../components/EmptyState";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
 import SearchBox from "../../components/Search/SearchBox";
@@ -204,13 +205,10 @@ export function IntakeFormsListPage() {
     }
   }, [submissionStatusFilter]);
 
+  // Always load submissions so the tab badge count is accurate
   useEffect(() => {
-    if (mainTab === "submissions") {
-      loadSubmissions();
-      // Also load forms so we can resolve form names in submissions table
-      if (forms.length === 0) loadForms();
-    }
-  }, [mainTab, loadSubmissions]); // eslint-disable-line react-hooks/exhaustive-deps
+    loadSubmissions();
+  }, [loadSubmissions]);
 
   // Filter forms by search query
   const filteredForms = forms.filter((form) => {
@@ -573,39 +571,19 @@ export function IntakeFormsListPage() {
       {mainTab === "submissions" && (
         <>
           {/* Filter + Search */}
-          <Stack direction="row" justifyContent="space-between" alignItems="center">
-            <Stack direction="row" gap={1}>
-              {[
-                { value: "all", label: "All" },
-                { value: "pending", label: "Pending" },
-                { value: "approved", label: "Approved" },
-                { value: "rejected", label: "Rejected" },
-              ].map((opt) => (
-                <Chip
-                  key={opt.value}
-                  label={opt.label}
-                  onClick={() => setSubmissionStatusFilter(opt.value)}
-                  sx={{
-                    cursor: "pointer",
-                    fontWeight: submissionStatusFilter === opt.value ? 600 : 400,
-                    backgroundColor: submissionStatusFilter === opt.value
-                      ? theme.palette.primary.main
-                      : theme.palette.background.default,
-                    color: submissionStatusFilter === opt.value
-                      ? "#fff"
-                      : theme.palette.text.primary,
-                    border: submissionStatusFilter === opt.value
-                      ? "none"
-                      : `1px solid ${theme.palette.border.dark}`,
-                    "&:hover": {
-                      backgroundColor: submissionStatusFilter === opt.value
-                        ? theme.palette.primary.main
-                        : theme.palette.action.hover,
-                    },
-                  }}
-                />
-              ))}
-            </Stack>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: "8px" }}>
+            <Select
+              id="submission-status-filter"
+              value={submissionStatusFilter}
+              onChange={(e) => setSubmissionStatusFilter(e.target.value as string)}
+              items={[
+                { _id: "all", name: "All submissions" },
+                { _id: "pending", name: "Pending" },
+                { _id: "approved", name: "Approved" },
+                { _id: "rejected", name: "Rejected" },
+              ]}
+              sx={{ width: 180, backgroundColor: theme.palette.background.main }}
+            />
             <SearchBox
               placeholder="Search submissions..."
               value={submissionsSearch}
@@ -643,7 +621,14 @@ export function IntakeFormsListPage() {
                     return (
                       <TableRow
                         key={submission.id}
-                        sx={singleTheme.tableStyles.primary.body.row}
+                        onClick={() => {
+                          setSelectedSubmissionId(submission.id);
+                          setPreviewOpen(true);
+                        }}
+                        sx={{
+                          ...singleTheme.tableStyles.primary.body.row,
+                          cursor: "pointer",
+                        }}
                       >
                         <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
                           <Typography

--- a/Clients/src/presentation/pages/IntakeFormBuilder/SubmissionPreviewModal.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/SubmissionPreviewModal.tsx
@@ -39,6 +39,7 @@ interface PreviewData {
   formSchema: FormSchema;
   formName: string;
   entityType: string;
+  submissionStatus: string;
 }
 
 // ============================================================================
@@ -106,10 +107,11 @@ function RiskSection({ riskAssessment }: RiskSectionProps) {
       {/* Dimension bars */}
       {riskAssessment.dimensions && riskAssessment.dimensions.length > 0 && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-          {riskAssessment.dimensions.map((dim) => {
+          {riskAssessment.dimensions.map((dim, idx) => {
             const barColor = getDimensionBarColor(dim.score);
+            const dimLabel = dim.label || dim.name || dim.key || `Dimension ${idx + 1}`;
             return (
-              <Box key={dim.name}>
+              <Box key={`${dimLabel}-${idx}`}>
                 <Box
                   sx={{
                     display: "flex",
@@ -119,9 +121,9 @@ function RiskSection({ riskAssessment }: RiskSectionProps) {
                   }}
                 >
                   <Typography
-                    sx={{ fontSize: "12px", color: theme.palette.text.tertiary, textTransform: "capitalize" }}
+                    sx={{ fontSize: "12px", color: theme.palette.text.tertiary }}
                   >
-                    {dim.name}
+                    {dimLabel}
                   </Typography>
                   <Typography sx={{ fontSize: "12px", fontWeight: 600, color: barColor }}>
                     {dim.score}/100
@@ -143,6 +145,23 @@ function RiskSection({ riskAssessment }: RiskSectionProps) {
               </Box>
             );
           })}
+
+          {/* Color legend */}
+          <Box sx={{ display: "flex", gap: "12px", mt: "4px", flexWrap: "wrap" }}>
+            {[
+              { color: "#16a34a", label: "Low (0-25)" },
+              { color: "#d97706", label: "Medium (26-50)" },
+              { color: "#ea580c", label: "High (51-75)" },
+              { color: "#dc2626", label: "Critical (76-100)" },
+            ].map((item) => (
+              <Box key={item.label} sx={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                <Box sx={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: item.color }} />
+                <Typography sx={{ fontSize: "11px", color: theme.palette.text.accent }}>
+                  {item.label}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
         </Box>
       )}
     </Box>
@@ -257,7 +276,7 @@ function SubmissionPreviewModal({
         const response = await getSubmissionPreview(submissionId as number, controller.signal);
         if (cancelled) return;
 
-        const { riskAssessment, entityPreview, form } = response.data;
+        const { riskAssessment, entityPreview, form, submission: sub } = response.data;
 
         setPreviewData({
           riskAssessment,
@@ -265,6 +284,7 @@ function SubmissionPreviewModal({
           formSchema: form?.schema ?? { version: "1.0", fields: [] },
           formName: form?.name ?? "Unknown form",
           entityType: form?.entityType ?? "use_case",
+          submissionStatus: sub?.status ?? "pending",
         });
         setEditedEntityData({ ...(entityPreview || {}) });
       } catch (err) {
@@ -366,6 +386,8 @@ function SubmissionPreviewModal({
 
   // ============================================================================
   // Render
+  const isPending = previewData?.submissionStatus === "pending";
+
   // ============================================================================
 
   return (
@@ -373,12 +395,18 @@ function SubmissionPreviewModal({
       isOpen={isOpen}
       onClose={onClose}
       title="Review submission"
-      description="Review risk assessment and entity data before approving or rejecting"
-      onSubmit={showRejectForm ? handleReject : handleApprove}
+      description={
+        isPending
+          ? "Review risk assessment and entity data before approving or rejecting"
+          : `This submission has been ${previewData?.submissionStatus ?? "processed"}`
+      }
+      onSubmit={isPending ? (showRejectForm ? handleReject : handleApprove) : undefined}
       submitButtonText={
-        showRejectForm
-          ? "Reject submission"
-          : `Approve and create ${entityLabel}`
+        !isPending
+          ? undefined
+          : showRejectForm
+            ? "Reject submission"
+            : `Approve and create ${entityLabel}`
       }
       submitButtonColor={showRejectForm ? "#c62828" : undefined}
       isSubmitting={isApproving || isRejecting}
@@ -422,161 +450,171 @@ function SubmissionPreviewModal({
 
             <RiskSection riskAssessment={previewData?.riskAssessment ?? null} />
 
-            {/* Override toggle */}
-            <Box
-              component="button"
-              type="button"
-              onClick={() => setOverrideExpanded((prev) => !prev)}
-              sx={{
-                mt: 2.5,
-                display: "flex",
-                alignItems: "center",
-                gap: "6px",
-                background: "none",
-                border: "none",
-                cursor: "pointer",
-                padding: 0,
-                color: theme.palette.text.tertiary,
-                fontSize: "13px",
-                fontWeight: 500,
-                "&:hover": { color: theme.palette.text.primary },
-              }}
-            >
-              {overrideExpanded ? (
-                <ChevronUp size={15} strokeWidth={1.5} />
-              ) : (
-                <ChevronDown size={15} strokeWidth={1.5} />
-              )}
-              Override risk assessment
-            </Box>
-
-            <Collapse in={overrideExpanded} timeout="auto" unmountOnExit>
-              <Box sx={{ mt: 2 }}>
-                <OverrideSection
-                  overrideTier={overrideTier}
-                  overrideJustification={overrideJustification}
-                  onTierChange={setOverrideTier}
-                  onJustificationChange={setOverrideJustification}
-                />
-              </Box>
-            </Collapse>
-          </Box>
-
-          {/* ------------------------------------------------------------------ */}
-          {/* Section 2: Entity preview (editable)                                */}
-          {/* ------------------------------------------------------------------ */}
-          <Box
-            sx={{
-              border: `1px solid ${theme.palette.border.dark}`,
-              borderRadius: "4px",
-              p: 2.5,
-            }}
-          >
-            <Typography sx={{ fontSize: "14px", fontWeight: 600, color: theme.palette.text.primary, mb: 2 }}>
-              {previewData?.entityType === "model"
-                ? "Model inventory preview"
-                : "Use case preview"}
-            </Typography>
-
-            {mappedFields.length === 0 ? (
-              <Typography sx={{ fontSize: "13px", color: theme.palette.text.accent }}>
-                No entity field mappings defined for this form.
-              </Typography>
-            ) : (
-              <Box sx={{ display: "flex", flexDirection: "column", gap: "16px" }}>
-                {mappedFields.map((field) => {
-                  const fieldKey = field.entityFieldMapping as string;
-                  const currentValue = String(editedEntityData[fieldKey] ?? "");
-
-                  return (
-                    <Field
-                      key={field.id}
-                      id={`entity-${field.id}`}
-                      label={field.label}
-                      value={currentValue}
-                      onChange={(e) => handleFieldChange(fieldKey, e.target.value)}
-                      rows={field.type === "textarea" ? 2 : undefined}
-                      placeholder={field.placeholder ?? ""}
-                    />
-                  );
-                })}
-              </Box>
-            )}
-          </Box>
-
-          {/* Reject toggle + reason */}
-          {!showRejectForm ? (
-            <Box
-              component="button"
-              type="button"
-              onClick={() => setShowRejectForm(true)}
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: "6px",
-                background: "none",
-                border: "none",
-                cursor: "pointer",
-                padding: 0,
-                color: theme.palette.status.error.text,
-                fontSize: "13px",
-                fontWeight: 500,
-                "&:hover": { textDecoration: "underline" },
-              }}
-            >
-              Reject this submission instead
-            </Box>
-          ) : (
-            <Box
-              sx={{
-                border: "1px solid #fecaca",
-                borderRadius: "4px",
-                p: 2.5,
-                backgroundColor: "#fef2f2",
-              }}
-            >
-              <Box
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  mb: 2,
-                }}
-              >
-                <Typography
-                  sx={{ fontSize: "14px", fontWeight: 600, color: "#991b1b" }}
-                >
-                  Reject submission
-                </Typography>
+            {/* Override toggle — only for pending submissions */}
+            {isPending && (
+              <>
                 <Box
                   component="button"
                   type="button"
-                  onClick={() => {
-                    setShowRejectForm(false);
-                    setRejectReason("");
-                    setApproveError(null);
-                  }}
+                  onClick={() => setOverrideExpanded((prev) => !prev)}
                   sx={{
+                    mt: "16px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "6px",
                     background: "none",
                     border: "none",
                     cursor: "pointer",
-                    color: theme.palette.other.icon,
-                    fontSize: "12px",
+                    padding: 0,
+                    color: theme.palette.text.tertiary,
+                    fontSize: "13px",
+                    fontWeight: 500,
                     "&:hover": { color: theme.palette.text.primary },
                   }}
                 >
-                  Cancel
+                  {overrideExpanded ? (
+                    <ChevronUp size={15} strokeWidth={1.5} />
+                  ) : (
+                    <ChevronDown size={15} strokeWidth={1.5} />
+                  )}
+                  Override risk assessment
                 </Box>
-              </Box>
-              <Field
-                id="reject-reason"
-                label="Reason for rejection"
-                placeholder="Explain why this submission is being rejected (min. 10 characters)"
-                value={rejectReason}
-                onChange={(e) => setRejectReason(e.target.value)}
-                rows={3}
-              />
+
+                <Collapse in={overrideExpanded} timeout="auto" unmountOnExit>
+                  <Box sx={{ mt: 2 }}>
+                    <OverrideSection
+                      overrideTier={overrideTier}
+                      overrideJustification={overrideJustification}
+                      onTierChange={setOverrideTier}
+                      onJustificationChange={setOverrideJustification}
+                    />
+                  </Box>
+                </Collapse>
+              </>
+            )}
+          </Box>
+
+          {/* ------------------------------------------------------------------ */}
+          {/* Section 2: Entity preview (editable for pending, read-only otherwise) */}
+          {/* ------------------------------------------------------------------ */}
+          {isPending && (
+            <Box
+              sx={{
+                border: `1px solid ${theme.palette.border.dark}`,
+                borderRadius: "4px",
+                p: 2.5,
+              }}
+            >
+              <Typography sx={{ fontSize: "14px", fontWeight: 600, color: theme.palette.text.primary, mb: 2 }}>
+                {previewData?.entityType === "model"
+                  ? "Model inventory preview"
+                  : "Use case preview"}
+              </Typography>
+
+              {mappedFields.length === 0 ? (
+                <Typography sx={{ fontSize: "13px", color: theme.palette.text.accent }}>
+                  No entity field mappings defined for this form.
+                </Typography>
+              ) : (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+                  {mappedFields.map((field) => {
+                    const fieldKey = field.entityFieldMapping as string;
+                    const currentValue = String(editedEntityData[fieldKey] ?? "");
+
+                    return (
+                      <Field
+                        key={field.id}
+                        id={`entity-${field.id}`}
+                        label={field.label}
+                        value={currentValue}
+                        onChange={(e) => handleFieldChange(fieldKey, e.target.value)}
+                        rows={field.type === "textarea" ? 2 : undefined}
+                        placeholder={field.placeholder ?? ""}
+                      />
+                    );
+                  })}
+                </Box>
+              )}
             </Box>
+          )}
+
+          {/* Reject toggle + reason — only for pending submissions */}
+          {isPending && (
+            <>
+              {!showRejectForm ? (
+                <Box
+                  component="button"
+                  type="button"
+                  onClick={() => setShowRejectForm(true)}
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "6px",
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    padding: 0,
+                    color: theme.palette.status.error.text,
+                    fontSize: "13px",
+                    fontWeight: 500,
+                    "&:hover": { textDecoration: "underline" },
+                  }}
+                >
+                  Reject this submission instead
+                </Box>
+              ) : (
+                <Box
+                  sx={{
+                    border: "1px solid #fecaca",
+                    borderRadius: "4px",
+                    p: 2.5,
+                    backgroundColor: "#fef2f2",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      mb: 2,
+                    }}
+                  >
+                    <Typography
+                      sx={{ fontSize: "14px", fontWeight: 600, color: "#991b1b" }}
+                    >
+                      Reject submission
+                    </Typography>
+                    <Box
+                      component="button"
+                      type="button"
+                      onClick={() => {
+                        setShowRejectForm(false);
+                        setRejectReason("");
+                        setApproveError(null);
+                      }}
+                      sx={{
+                        background: "none",
+                        border: "none",
+                        cursor: "pointer",
+                        color: theme.palette.other.icon,
+                        fontSize: "12px",
+                        "&:hover": { color: theme.palette.text.primary },
+                      }}
+                    >
+                      Cancel
+                    </Box>
+                  </Box>
+                  <Field
+                    id="reject-reason"
+                    label="Reason for rejection"
+                    placeholder="Explain why this submission is being rejected (min. 10 characters)"
+                    value={rejectReason}
+                    onChange={(e) => setRejectReason(e.target.value)}
+                    rows={3}
+                  />
+                </Box>
+              )}
+            </>
           )}
 
           {/* Action error */}

--- a/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
@@ -373,12 +373,7 @@ export function IntakeFormBuilder() {
 
     // Block publish if required entity fields are unmapped
     if (mappingCoverage.missingRequired.length > 0) {
-      const names = mappingCoverage.missingRequired.map((m) => m.label).join(", ");
-      setSnackbar({
-        open: true,
-        message: `Required fields not mapped: ${names}. Add form fields mapped to these before publishing.`,
-        severity: "error",
-      });
+      setRequiredFieldsModalOpen(true);
       return;
     }
 
@@ -453,6 +448,7 @@ export function IntakeFormBuilder() {
   };
 
   const [publishWarningOpen, setPublishWarningOpen] = useState(false);
+  const [requiredFieldsModalOpen, setRequiredFieldsModalOpen] = useState(false);
 
   // ============================================================================
   // Derived values
@@ -1204,6 +1200,33 @@ export function IntakeFormBuilder() {
         </Typography>
         <Box component="ul" sx={{ pl: "20px", m: 0 }}>
           {mappingCoverage.missingOptional.map((m) => (
+            <Typography
+              key={m.field}
+              component="li"
+              sx={{ fontSize: 13, color: theme.palette.text.secondary, mb: "4px" }}
+            >
+              {m.label}
+            </Typography>
+          ))}
+        </Box>
+      </StandardModal>
+
+      {/* Required fields not mapped modal */}
+      <StandardModal
+        title="Required fields not mapped"
+        description=""
+        isOpen={requiredFieldsModalOpen}
+        onClose={() => setRequiredFieldsModalOpen(false)}
+        onSubmit={() => setRequiredFieldsModalOpen(false)}
+        submitButtonText="OK"
+        maxWidth="480px"
+        fitContent
+      >
+        <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary, mb: "12px" }}>
+          The following required fields are not mapped to any form field. Add form fields mapped to these before publishing.
+        </Typography>
+        <Box component="ul" sx={{ pl: "20px", m: 0 }}>
+          {mappingCoverage.missingRequired.map((m) => (
             <Typography
               key={m.field}
               component="li"

--- a/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
@@ -1188,7 +1188,7 @@ export function IntakeFormBuilder() {
       {/* Publish warning modal (optional fields unmapped) */}
       <StandardModal
         title="Publish with unmapped fields?"
-        description="The following optional fields are not mapped to any form field. These fields will be empty when the entity is created."
+        description=""
         isOpen={publishWarningOpen}
         onClose={() => setPublishWarningOpen(false)}
         onSubmit={async () => {
@@ -1199,7 +1199,10 @@ export function IntakeFormBuilder() {
         maxWidth="480px"
         fitContent
       >
-        <Box component="ul" sx={{ pl: "20px", m: 0, mt: "4px" }}>
+        <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary, mb: "12px" }}>
+          The following optional fields are not mapped to any form field. These fields will be empty when the entity is created.
+        </Typography>
+        <Box component="ul" sx={{ pl: "20px", m: 0 }}>
           {mappingCoverage.missingOptional.map((m) => (
             <Typography
               key={m.field}

--- a/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
@@ -1188,7 +1188,7 @@ export function IntakeFormBuilder() {
       {/* Publish warning modal (optional fields unmapped) */}
       <StandardModal
         title="Publish with unmapped fields?"
-        description={`The following optional fields are not mapped to any form field: ${mappingCoverage.missingOptional.map((m) => m.label).join(", ")}. These fields will be empty when the entity is created. Publish anyway?`}
+        description="The following optional fields are not mapped to any form field. These fields will be empty when the entity is created."
         isOpen={publishWarningOpen}
         onClose={() => setPublishWarningOpen(false)}
         onSubmit={async () => {
@@ -1198,7 +1198,19 @@ export function IntakeFormBuilder() {
         submitButtonText="Publish anyway"
         maxWidth="480px"
         fitContent
-      />
+      >
+        <Box component="ul" sx={{ pl: "20px", m: 0, mt: "4px" }}>
+          {mappingCoverage.missingOptional.map((m) => (
+            <Typography
+              key={m.field}
+              component="li"
+              sx={{ fontSize: 13, color: theme.palette.text.secondary, mb: "4px" }}
+            >
+              {m.label}
+            </Typography>
+          ))}
+        </Box>
+      </StandardModal>
 
       {/* Snackbar */}
       <Snackbar

--- a/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
@@ -1109,6 +1109,7 @@ export function IntakeFormBuilder() {
                           </Typography>
                         </Box>
 
+                        {form.llmKeyId && (
                         <Box
                           sx={{
                             display: "flex",
@@ -1156,6 +1157,7 @@ export function IntakeFormBuilder() {
                             </Typography>
                           </Box>
                         </Box>
+                        )}
 
                       </Box>
                     </Collapse>

--- a/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
@@ -853,7 +853,10 @@ export function IntakeFormBuilder() {
 
                           const handleAddField = (m: typeof missingRequired[0]) => {
                             const newField = createFieldFromMapping(m, form.schema.fields.length);
-                            addField(newField);
+                            setForm((prev) => ({
+                              ...prev,
+                              schema: { ...prev.schema, fields: [...prev.schema.fields, newField] },
+                            }));
                             setIsDirty(true);
                           };
 

--- a/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
@@ -177,11 +177,11 @@ export interface EntityFieldMapping {
 export const ENTITY_FIELD_MAPPINGS: Record<IntakeEntityType, EntityFieldMapping[]> = {
   [IntakeEntityType.MODEL]: [
     { field: "name", label: "Model name", description: "Name of the AI model", requiredFieldType: ["text"], entityRequired: true },
-    { field: "description", label: "Description", description: "Model description", requiredFieldType: ["text", "textarea"] },
+    { field: "description", label: "Description", description: "Model description", requiredFieldType: ["textarea", "text"] },
     { field: "modelVersion", label: "Model version", description: "Version of the model", requiredFieldType: ["text"] },
     { field: "provider", label: "Provider", description: "Model provider/vendor", requiredFieldType: ["text", "select"] },
     { field: "modelType", label: "Model type", description: "Type of AI model", requiredFieldType: ["text", "select"] },
-    { field: "intendedUse", label: "Intended use", description: "Intended use of the model", requiredFieldType: ["text", "textarea"] },
+    { field: "intendedUse", label: "Intended use", description: "Intended use of the model", requiredFieldType: ["textarea", "text"] },
     { field: "riskLevel", label: "Risk level", description: "Risk classification", requiredFieldType: ["select"] },
   ],
   [IntakeEntityType.USE_CASE]: [
@@ -444,6 +444,69 @@ export const DEFAULT_USE_CASE_FIELDS: FormField[] = [
 ];
 
 /**
+ * Default model inventory fields pre-populated for new forms
+ */
+export const DEFAULT_MODEL_FIELDS: FormField[] = [
+  {
+    id: generateFieldId(),
+    type: "text",
+    label: "Model name",
+    placeholder: "Enter the name of your AI model",
+    guidanceText: "A clear name helps reviewers identify and track this model across the organization.",
+    validation: { required: true, maxLength: 255 },
+    entityFieldMapping: "name",
+    order: 0,
+  },
+  {
+    id: generateFieldId(),
+    type: "textarea",
+    label: "Description",
+    placeholder: "Describe what this model does and how it works",
+    guidanceText: "Include the model's purpose, training approach, and key capabilities.",
+    validation: { maxLength: 2000 },
+    entityFieldMapping: "description",
+    order: 1,
+  },
+  {
+    id: generateFieldId(),
+    type: "text",
+    label: "Model version",
+    placeholder: "e.g. v1.0, 2024-Q1",
+    guidanceText: "Version tracking is important for audit trails and rollback planning.",
+    entityFieldMapping: "modelVersion",
+    order: 2,
+  },
+  {
+    id: generateFieldId(),
+    type: "text",
+    label: "Provider",
+    placeholder: "e.g. OpenAI, Anthropic, in-house",
+    guidanceText: "Knowing the provider helps assess supply chain risk and vendor dependencies.",
+    entityFieldMapping: "provider",
+    order: 3,
+  },
+  {
+    id: generateFieldId(),
+    type: "text",
+    label: "Model type",
+    placeholder: "e.g. LLM, classification, regression, computer vision",
+    guidanceText: "The model type affects which governance controls and testing procedures apply.",
+    entityFieldMapping: "modelType",
+    order: 4,
+  },
+  {
+    id: generateFieldId(),
+    type: "textarea",
+    label: "Intended use",
+    placeholder: "Describe how this model will be used in production",
+    guidanceText: "Intended use determines whether the model falls under high-risk categories in the EU AI Act.",
+    validation: { maxLength: 2000 },
+    entityFieldMapping: "intendedUse",
+    order: 5,
+  },
+];
+
+/**
  * Mapping coverage analysis result
  */
 export interface MappingCoverage {
@@ -543,6 +606,8 @@ export function createEmptyForm(entityType?: IntakeEntityType): IntakeForm {
       version: "1.0",
       fields: type === IntakeEntityType.USE_CASE
         ? DEFAULT_USE_CASE_FIELDS.map((f, i) => ({ ...f, id: generateFieldId(), order: i }))
+        : type === IntakeEntityType.MODEL
+        ? DEFAULT_MODEL_FIELDS.map((f, i) => ({ ...f, id: generateFieldId(), order: i }))
         : [],
     },
     submitButtonText: "Submit",

--- a/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
@@ -189,7 +189,8 @@ export const ENTITY_FIELD_MAPPINGS: Record<IntakeEntityType, EntityFieldMapping[
     { field: "goal", label: "Goal", description: "Goal of the project", requiredFieldType: ["text", "textarea"], entityRequired: true },
     { field: "start_date", label: "Start date", description: "Project start date", requiredFieldType: ["date"] },
     { field: "ai_risk_classification", label: "AI risk classification", description: "Risk classification", requiredFieldType: ["select"] },
-    { field: "type_of_high_risk_role", label: "High risk role type", description: "Type of high-risk role", requiredFieldType: ["text", "select"] },
+    { field: "type_of_high_risk_role", label: "High risk role type", description: "Type of high-risk role", requiredFieldType: ["select"] },
+    { field: "geography", label: "Geography", description: "Geographic scope of the use case", requiredFieldType: ["select"] },
   ],
 };
 
@@ -386,6 +387,38 @@ export const DEFAULT_USE_CASE_FIELDS: FormField[] = [
   {
     id: generateFieldId(),
     type: "select",
+    label: "High risk role type",
+    guidanceText: "Under the EU AI Act, your role determines your compliance obligations.",
+    options: [
+      { label: "Deployer", value: "Deployer" },
+      { label: "Provider", value: "Provider" },
+      { label: "Distributor", value: "Distributor" },
+      { label: "Importer", value: "Importer" },
+      { label: "Product manufacturer", value: "Product manufacturer" },
+      { label: "Authorized representative", value: "Authorized representative" },
+    ],
+    entityFieldMapping: "type_of_high_risk_role",
+    order: 4,
+  },
+  {
+    id: generateFieldId(),
+    type: "select",
+    label: "Geography",
+    guidanceText: "The geographic scope affects which regulations apply to this use case.",
+    options: [
+      { label: "Global", value: "1" },
+      { label: "Europe", value: "2" },
+      { label: "North America", value: "3" },
+      { label: "South America", value: "4" },
+      { label: "Asia", value: "5" },
+      { label: "Africa", value: "6" },
+    ],
+    entityFieldMapping: "geography",
+    order: 5,
+  },
+  {
+    id: generateFieldId(),
+    type: "select",
     label: "Does this system make autonomous decisions?",
     guidanceText: "Autonomous decision-making increases risk and may require human oversight measures.",
     options: [
@@ -393,7 +426,7 @@ export const DEFAULT_USE_CASE_FIELDS: FormField[] = [
       { label: "Partially — recommends but human decides", value: "partial" },
       { label: "Yes — makes decisions without human review", value: "yes" },
     ],
-    order: 4,
+    order: 6,
   },
   {
     id: generateFieldId(),
@@ -406,7 +439,7 @@ export const DEFAULT_USE_CASE_FIELDS: FormField[] = [
       { label: "Sensitive personal data (health, biometric)", value: "sensitive" },
       { label: "Special category data (racial, political)", value: "special" },
     ],
-    order: 5,
+    order: 7,
   },
 ];
 

--- a/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
@@ -182,7 +182,6 @@ export const ENTITY_FIELD_MAPPINGS: Record<IntakeEntityType, EntityFieldMapping[
     { field: "provider", label: "Provider", description: "Model provider/vendor", requiredFieldType: ["text", "select"] },
     { field: "modelType", label: "Model type", description: "Type of AI model", requiredFieldType: ["text", "select"] },
     { field: "intendedUse", label: "Intended use", description: "Intended use of the model", requiredFieldType: ["textarea", "text"] },
-    { field: "riskLevel", label: "Risk level", description: "Risk classification", requiredFieldType: ["select"] },
   ],
   [IntakeEntityType.USE_CASE]: [
     { field: "project_title", label: "Project title", description: "Title of the use case/project", requiredFieldType: ["text"], entityRequired: true },

--- a/Clients/src/presentation/pages/ProjectView/IntakeSubmissionCard/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/IntakeSubmissionCard/index.tsx
@@ -6,7 +6,7 @@ import {
   Collapse,
   useTheme,
 } from "@mui/material";
-import { FileText, ChevronDown, ChevronUp, ArrowRight } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useEntityIntakeSubmission } from "../../../../application/hooks/useEntityIntakeSubmission";
 import type { IntakeSubmissionField } from "../../../../application/repository/intakeForm.repository";
 import dayjs from "dayjs";
@@ -41,6 +41,40 @@ function renderFieldValue(field: IntakeSubmissionField): string {
   return String(value);
 }
 
+function FieldRow({ field }: { field: IntakeSubmissionField }) {
+  const theme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: "200px 1fr",
+        columnGap: "16px",
+        py: "8px",
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: 13,
+          fontWeight: 500,
+          color: theme.palette.text.secondary,
+        }}
+      >
+        {field.label}
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: 13,
+          color: theme.palette.text.primary,
+          wordBreak: "break-word",
+        }}
+      >
+        {renderFieldValue(field)}
+      </Typography>
+    </Box>
+  );
+}
+
 export default function IntakeSubmissionCard({
   projectId,
 }: IntakeSubmissionCardProps) {
@@ -49,7 +83,7 @@ export default function IntakeSubmissionCard({
     "use_case",
     projectId
   );
-  const [showUnmapped, setShowUnmapped] = useState(true);
+  const [showAdditional, setShowAdditional] = useState(false);
 
   if (isLoading || !submission) return null;
 
@@ -62,173 +96,74 @@ export default function IntakeSubmissionCard({
 
   if (mappedFields.length === 0 && unmappedFields.length === 0) return null;
 
+  const allFields = [...mappedFields, ...unmappedFields];
+  const hasAdditional = unmappedFields.length > 0;
+
   return (
     <Box
       sx={{
-        border: `1px solid ${theme.palette.border.dark}`,
-        borderRadius: "4px",
-        backgroundColor: theme.palette.background.main,
-        mb: 3,
+        background: theme.palette.background.paper,
+        border: `1.5px solid ${theme.palette.border.light}`,
+        borderRadius: theme.shape.borderRadius,
+        padding: theme.spacing(5, 6),
+        marginBottom: theme.spacing(4),
+        boxShadow: "none",
+        width: "100%",
       }}
     >
-      {/* Header */}
-      <Box
+      {/* Section title */}
+      <Typography
         sx={{
-          p: "12px 16px",
-          borderBottom: `1px solid ${theme.palette.border.light}`,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
+          fontWeight: 600,
+          fontSize: 16,
+          color: theme.palette.text.primary,
+          mb: "8px",
         }}
       >
-        <Stack direction="row" gap="8px" alignItems="center">
-          <FileText
-            size={16}
-            color={theme.palette.text.tertiary}
-            strokeWidth={1.5}
-          />
-          <Typography
-            sx={{
-              fontSize: 13,
-              fontWeight: 600,
-              color: theme.palette.text.primary,
-            }}
-          >
-            Intake form submission
-          </Typography>
-          {submission.riskTier && (
-            <Box
-              sx={{
-                fontSize: 11,
-                fontWeight: 500,
-                px: "6px",
-                py: "2px",
-                borderRadius: "4px",
-                backgroundColor:
-                  submission.riskTier.toLowerCase() === "high"
-                    ? "#FFE5D0"
-                    : submission.riskTier.toLowerCase() === "medium"
-                      ? "#FFF8E1"
-                      : "#E6F4EA",
-                color:
-                  submission.riskTier.toLowerCase() === "high"
-                    ? "#E64A19"
-                    : submission.riskTier.toLowerCase() === "medium"
-                      ? "#795548"
-                      : "#138A5E",
-              }}
-            >
-              {submission.riskTier}
-            </Box>
-          )}
-        </Stack>
-        <Typography sx={{ fontSize: 12, color: theme.palette.text.accent }}>
-          From &quot;{submission.formName}&quot;
-          {submission.submittedAt && (
-            <> &mdash; {dayjs(submission.submittedAt).format("MMM D, YYYY")}</>
-          )}
-        </Typography>
-      </Box>
+        Intake form submission
+      </Typography>
 
-      {/* Submitter info */}
-      {(submission.submitterName || submission.submitterEmail) && (
-        <Box sx={{ px: 2, pt: 1.5, pb: 0 }}>
-          <Typography sx={{ fontSize: 12, color: theme.palette.text.accent }}>
-            Submitted by{" "}
-            <Box
-              component="span"
-              sx={{
-                fontWeight: 500,
-                color: theme.palette.text.secondary,
-              }}
-            >
-              {submission.submitterName || submission.submitterEmail}
-            </Box>
-            {submission.submitterName && submission.submitterEmail && (
-              <> ({submission.submitterEmail})</>
-            )}
-          </Typography>
-        </Box>
-      )}
+      {/* Meta line */}
+      <Typography sx={{ fontSize: 12, color: theme.palette.text.accent, mb: 3 }}>
+        {submission.formName}
+        {submission.submittedAt && (
+          <> &middot; {dayjs(submission.submittedAt).format("MMM D, YYYY")}</>
+        )}
+        {(submission.submitterName || submission.submitterEmail) && (
+          <> &middot; {submission.submitterName || submission.submitterEmail}</>
+        )}
+        {submission.riskTier && (
+          <> &middot; Risk: {submission.riskTier}</>
+        )}
+      </Typography>
 
-      {/* Mapped fields */}
-      {mappedFields.length > 0 && (
-        <Box sx={{ p: 2 }}>
-          <Typography
-            sx={{
-              fontSize: 11,
-              fontWeight: 500,
-              color: theme.palette.text.accent,
-              mb: 1.5,
-              textTransform: "uppercase",
-              letterSpacing: "0.5px",
-            }}
-          >
-            Mapped to use case fields
-          </Typography>
-          <Stack gap="12px">
-            {mappedFields.map((field) => (
-              <Box key={field.fieldId}>
-                <Stack
-                  direction="row"
-                  alignItems="center"
-                  gap="4px"
-                  sx={{ mb: 0.25 }}
-                >
-                  <Typography
-                    sx={{
-                      fontSize: 12,
-                      fontWeight: 500,
-                      color: theme.palette.text.secondary,
-                    }}
-                  >
-                    {field.label}
-                  </Typography>
-                  <ArrowRight size={12} color={theme.palette.text.accent} />
-                  <Typography
-                    sx={{
-                      fontSize: 11,
-                      color: theme.palette.text.accent,
-                      fontStyle: "italic",
-                    }}
-                  >
-                    {field.entityFieldMapping?.replace(/_/g, " ")}
-                  </Typography>
-                </Stack>
-                <Typography
-                  sx={{
-                    fontSize: 13,
-                    color: theme.palette.text.primary,
-                    wordBreak: "break-word",
-                  }}
-                >
-                  {renderFieldValue(field)}
-                </Typography>
-              </Box>
-            ))}
-          </Stack>
-        </Box>
-      )}
+      {/* Mapped fields — always visible */}
+      <Stack
+        sx={{
+          borderTop: `1px solid ${theme.palette.border.light}`,
+        }}
+      >
+        {mappedFields.map((field) => (
+          <FieldRow key={field.fieldId} field={field} />
+        ))}
+      </Stack>
 
-      {/* Unmapped fields */}
-      {unmappedFields.length > 0 && (
-        <Box
-          sx={{
-            borderTop: `1px solid ${theme.palette.border.light}`,
-          }}
-        >
+      {/* Additional answers toggle */}
+      {hasAdditional && (
+        <>
           <Box
             component="button"
-            onClick={() => setShowUnmapped((prev) => !prev)}
+            type="button"
+            onClick={() => setShowAdditional((prev) => !prev)}
             sx={{
-              width: "100%",
-              p: "10px 16px",
               display: "flex",
               alignItems: "center",
               gap: "6px",
+              mt: "12px",
               background: "none",
               border: "none",
               cursor: "pointer",
+              padding: 0,
               color: theme.palette.text.tertiary,
               fontSize: "13px",
               fontWeight: 500,
@@ -236,41 +171,39 @@ export default function IntakeSubmissionCard({
               "&:hover": { color: theme.palette.text.primary },
             }}
           >
-            {showUnmapped ? (
-              <ChevronUp size={15} />
+            {showAdditional ? (
+              <ChevronUp size={15} strokeWidth={1.5} />
             ) : (
-              <ChevronDown size={15} />
+              <ChevronDown size={15} strokeWidth={1.5} />
             )}
-            Additional intake answers ({unmappedFields.length})
+            Additional answers ({unmappedFields.length})
           </Box>
-          <Collapse in={showUnmapped} timeout="auto" unmountOnExit>
-            <Stack gap="12px" sx={{ px: 2, pb: 2 }}>
+          <Collapse in={showAdditional} timeout="auto" unmountOnExit>
+            <Stack
+              sx={{
+                mt: "8px",
+                borderTop: `1px solid ${theme.palette.border.light}`,
+              }}
+            >
               {unmappedFields.map((field) => (
-                <Box key={field.fieldId}>
-                  <Typography
-                    sx={{
-                      fontSize: 12,
-                      fontWeight: 500,
-                      color: theme.palette.text.secondary,
-                      mb: 0.25,
-                    }}
-                  >
-                    {field.label}
-                  </Typography>
-                  <Typography
-                    sx={{
-                      fontSize: 13,
-                      color: theme.palette.text.primary,
-                      wordBreak: "break-word",
-                    }}
-                  >
-                    {renderFieldValue(field)}
-                  </Typography>
-                </Box>
+                <FieldRow key={field.fieldId} field={field} />
               ))}
             </Stack>
           </Collapse>
-        </Box>
+        </>
+      )}
+
+      {/* If no mapped fields, show all as flat list */}
+      {mappedFields.length === 0 && unmappedFields.length > 0 && !hasAdditional && (
+        <Stack
+          sx={{
+            borderTop: `1px solid ${theme.palette.border.light}`,
+          }}
+        >
+          {allFields.map((field) => (
+            <FieldRow key={field.fieldId} field={field} />
+          ))}
+        </Stack>
       )}
     </Box>
   );

--- a/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectSettings/index.tsx
@@ -617,28 +617,9 @@ const ProjectSettings = React.memo(
         newErrors.startDate = startDate.message;
       }
 
-      const geography = selectValidation("Geography", values.geography);
-      if (!geography.accepted) {
-        newErrors.geography = geography.message;
-      }
-
       const owner = selectValidation("Owner", values.owner);
       if (!owner.accepted) {
         newErrors.owner = owner.message;
-      }
-      const riskClassification = selectValidation(
-        "AI risk classification",
-        values.riskClassification,
-      );
-      if (!riskClassification.accepted) {
-        newErrors.riskClassification = riskClassification.message;
-      }
-      const typeOfHighRiskRole = selectValidation(
-        "Type of high risk role",
-        values.typeOfHighRiskRole,
-      );
-      if (!typeOfHighRiskRole.accepted) {
-        newErrors.typeOfHighRiskRole = typeOfHighRiskRole.message;
       }
 
       // Skip framework validation if use-case has pending approval (no frameworks created yet)
@@ -1039,7 +1020,6 @@ const ProjectSettings = React.memo(
                     onChange={handleOnSelectChange("geography")}
                     items={geographyItems}
                     sx={{ width: "150px", backgroundColor: theme.palette.background.main }}
-                    isRequired
                   />
 
                   {/* Use case status Row */}
@@ -1447,7 +1427,6 @@ const ProjectSettings = React.memo(
                         backgroundColor: theme.palette.background.main,
                       }}
                       error={errors.riskClassification}
-                      isRequired
                     />
                   </Stack>
 
@@ -1479,7 +1458,6 @@ const ProjectSettings = React.memo(
                       backgroundColor: theme.palette.background.main,
                     }}
                     error={errors.typeOfHighRiskRole}
-                    isRequired
                   />
                 </Box>
               </Box>

--- a/Clients/src/presentation/pages/PublicIntakeForm/SubmissionSuccess.tsx
+++ b/Clients/src/presentation/pages/PublicIntakeForm/SubmissionSuccess.tsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { Box, Typography } from "@mui/material";
-import { Check, Edit, Hash, Clock } from "lucide-react";
+import { Edit, Hash, Clock } from "lucide-react";
 import { useEffect } from "react";
 import { CustomizableButton } from "../../components/button/customizable-button";
 
@@ -69,15 +69,6 @@ export function SubmissionSuccess() {
             textAlign: "center",
           }}
         >
-          <Box sx={{
-            width: 56, height: 56, borderRadius: "14px",
-            background: "linear-gradient(135deg, #6b7280, #9ca3af)",
-            display: "flex", alignItems: "center", justifyContent: "center",
-            mx: "auto", mb: 3,
-          }}>
-            <Check size={32} color="#fff" strokeWidth={3} />
-          </Box>
-
           <Typography sx={{ fontSize: "22px", fontWeight: 700, color: "#1e293b", mb: 1 }}>
             Submission received
           </Typography>
@@ -115,7 +106,7 @@ export function SubmissionSuccess() {
           {/* Details rows */}
           {(() => {
             const rows = [
-              { label: "Reference", value: `#${state.submissionId}`, icon: <Hash size={13} color="#94a3b8" /> },
+              { label: "Reference", value: `${state.submissionId}`, icon: <Hash size={13} color="#94a3b8" /> },
               ...(state.submitterEmail ? [{ label: "Email", value: state.submitterEmail }] : []),
               { label: "Status", value: "Pending review", color: "#f59e0b", icon: <Clock size={13} color="#f59e0b" /> },
             ];

--- a/Servers/controllers/intakeForm.ctrl.ts
+++ b/Servers/controllers/intakeForm.ctrl.ts
@@ -1021,6 +1021,8 @@ export async function approveSubmission(req: Request, res: Response) {
           goal: (entityData.goal as string) || (entityData.description as string) || "",
           owner: req.userId!,
           ai_risk_classification: mapToAiRiskClassification(entityData.ai_risk_classification as string) as any,
+          type_of_high_risk_role: (entityData.type_of_high_risk_role as string as any) || undefined,
+          geography: entityData.geography ? Number(entityData.geography) : 1,
           status: ProjectStatus.UNDER_REVIEW,
         },
         [],


### PR DESCRIPTION
## Summary

- Fix several bugs in the intake form submission review flow (stale badge count, form validation crash, rejected submission errors, missing risk dimension labels)
- Replace raw MUI components with VW components, redesign IntakeSubmissionCard, and add visual polish (sparkle animation, color legend, clickable rows)
- Add geography and high-risk role type as mappable entity fields with default form fields, so intake submissions carry this data through to created use cases

## Changes

**Bug fixes**
- Fix "form validation fails" toast when clicking "Additional intake answers" toggle (missing `type="button"`)
- Fix submission count badge showing 0 until tab is clicked
- Fix React key warning and 400 error on already-processed submissions
- Fix missing dimension bar labels in risk assessment modal
- Fix double `#` in submission success reference number

**UX improvements**
- Replace MUI Select with VW Select for submission filter
- Make submission table rows clickable to open review modal
- Redesign IntakeSubmissionCard to match project settings card style
- Add color legend below risk dimension bars
- Hide approve/reject for non-pending submissions
- Purple sparkle animation for AI-suggested questions

**Entity field mappings**
- Add `geography` and `type_of_high_risk_role` to entity field mappings and default form fields
- Pass both fields through backend approval handler when creating use cases
- Remove `isRequired` from geography, risk classification, and high-risk role type in project settings

## Test plan
- [ ] Create a new intake form — verify geography and high-risk role type appear in default fields
- [ ] Submit a form and approve it — verify geography and high-risk role carry through to the created use case
- [ ] Open submissions tab — badge count should be correct on first load
- [ ] Click a submission row — review modal should open
- [ ] Try to reject an already-processed submission — should see status instead of action buttons
- [ ] Check risk dimension bars show labels and color legend
- [ ] Open project settings — geography, risk classification, and high-risk role should not show as required
- [ ] Click "Additional intake answers" toggle — should not trigger form validation