### PR TITLE
fix(evals): custom scorer judge now receives test case data and returns reasoning

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/CreateScorerModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/CreateScorerModal.tsx
@@ -773,7 +773,14 @@ export default function CreateScorerModal({
       topP: 1,
     },
     messages: initialConfig?.messages || [
-      { role: "system", content: "You are a helpful assistant" },
+      {
+        role: "system",
+        content: "You are an AI evaluator. Assess the quality of the AI response based on accuracy and relevance to the input.",
+      },
+      {
+        role: "user",
+        content: "Input: {{input}}\n\nAI Response: {{output}}\n\nExpected Answer: {{expected}}\n\nEvaluate whether the AI response is satisfactory. Reply with JSON only, in this exact format: {\"verdict\": \"PASS\", \"reason\": \"brief explanation\"}",
+      },
     ],
     useChainOfThought: initialConfig?.useChainOfThought ?? true,
     choiceScores: initialConfig?.choiceScores || [{ label: "", score: 0 }],
@@ -809,7 +816,14 @@ export default function CreateScorerModal({
           topP: 1,
         },
         messages: initialConfig.messages || [
-          { role: "system", content: "You are a helpful assistant" },
+          {
+            role: "system",
+            content: "You are an AI evaluator. Assess the quality of the AI response based on accuracy and relevance to the input.",
+          },
+          {
+            role: "user",
+            content: "Input: {{input}}\n\nAI Response: {{output}}\n\nExpected Answer: {{expected}}\n\nEvaluate whether the AI response is satisfactory. Reply with JSON only, in this exact format: {\"verdict\": \"PASS\", \"reason\": \"brief explanation\"}",
+          },
         ],
         useChainOfThought: initialConfig.useChainOfThought ?? true,
         choiceScores: initialConfig.choiceScores || [{ label: "", score: 0 }],
@@ -832,7 +846,14 @@ export default function CreateScorerModal({
           topP: 1,
         },
         messages: [
-          { role: "system", content: "You are a helpful assistant" },
+          {
+            role: "system",
+            content: "You are an AI evaluator. Assess the quality of the AI response based on accuracy and relevance to the input.",
+          },
+          {
+            role: "user",
+            content: "Input: {{input}}\n\nAI Response: {{output}}\n\nExpected Answer: {{expected}}\n\nEvaluate whether the AI response is satisfactory. Reply with JSON only, in this exact format: {\"verdict\": \"PASS\", \"reason\": \"brief explanation\"}",
+          },
         ],
         useChainOfThought: true,
         choiceScores: [{ label: "", score: 0 }],
@@ -1220,6 +1241,15 @@ export default function CreateScorerModal({
           >
             Prompt
           </Typography>
+          <Typography
+            sx={{
+              fontSize: "12px",
+              color: theme.palette.text.tertiary,
+              mb: 1,
+            }}
+          >
+            Available variables: {"{{input}}"}, {"{{output}}"}, {"{{expected}}"}
+          </Typography>
           <Stack spacing={2}>
             {config.messages.map((msg, index) => (
               <Box
@@ -1278,7 +1308,7 @@ export default function CreateScorerModal({
                   placeholder={
                     msg.role === "system"
                       ? "You are a helpful assistant that evaluates..."
-                      : "Enter message content..."
+                      : "Use {{input}}, {{output}}, {{expected}} to reference test case data"
                   }
                   value={msg.content}
                   onChange={(e) =>

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectScorers.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectScorers.tsx
@@ -172,7 +172,16 @@ export default function ProjectScorers({ projectId, orgId }: ProjectScorersProps
         provider: provider || "",
         model: model || "",
         modelParams,
-        messages: scorerConfig.messages || [{ role: "system", content: "You are a helpful assistant" }],
+        messages: scorerConfig.messages || [
+          {
+            role: "system",
+            content: "You are an AI evaluator. Assess the quality of the AI response based on accuracy and relevance to the input.",
+          },
+          {
+            role: "user",
+            content: "Input: {{input}}\n\nAI Response: {{output}}\n\nExpected Answer: {{expected}}\n\nEvaluate whether the AI response is satisfactory. Reply with JSON only, in this exact format: {\"verdict\": \"PASS\", \"reason\": \"brief explanation\"}",
+          },
+        ],
         useChainOfThought: scorerConfig.useChainOfThought ?? true,
         choiceScores: scorerConfig.choiceScores || [{ label: "", score: 0 }],
         passThreshold: scorer.defaultThreshold ?? 0.5,

--- a/EvalServer/src/utils/run_custom_scorer.py
+++ b/EvalServer/src/utils/run_custom_scorer.py
@@ -9,6 +9,7 @@ Supports multiple providers: OpenAI, Anthropic, Mistral, xAI, Google (Gemini), e
 
 import re
 import os
+import json
 from typing import Dict, Any, List, Optional, Tuple, Union
 from dataclasses import dataclass
 
@@ -28,6 +29,7 @@ class ScorerResult:
     score: float
     raw_response: str
     passed: bool
+    reason: Optional[str] = None
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
     total_tokens: Optional[int] = None
@@ -297,7 +299,17 @@ async def run_custom_scorer(
     
     if not messages_templates:
         raise ValueError(f"Scorer {scorer_name} has no message templates configured")
-    
+
+    has_output_placeholder = any(
+        "{{output}}" in (msg.get("content") or msg.get("template", ""))
+        for msg in messages_templates
+    )
+    if not has_output_placeholder:
+        print(
+            f"⚠️  Warning: Scorer '{scorer_name}' has no {{{{output}}}} placeholder in its "
+            f"messages. The model response will not be sent to the judge LLM."
+        )
+
     # Render message templates with actual values
     values = {
         "input": input_text,
@@ -332,12 +344,27 @@ async def run_custom_scorer(
         
         raw_response = response.choices[0].message.content.strip()
         usage = response.usage
-        
+
+        # Try to parse a JSON response of the form {"verdict": "PASS", "reason": "..."}
+        extracted_reason: Optional[str] = None
+        json_label: Optional[str] = None
+        try:
+            json_text = re.sub(r"^```(?:json)?\s*", "", raw_response, flags=re.IGNORECASE)
+            json_text = re.sub(r"```\s*$", "", json_text).strip()
+            parsed = json.loads(json_text)
+            verdict = str(parsed.get("verdict") or parsed.get("label") or "").strip().upper()
+            known_labels = {c.get("label", "").upper() for c in choice_scores}
+            if verdict in known_labels:
+                json_label = verdict
+            extracted_reason = str(parsed.get("reason", "")).strip() or None
+        except (json.JSONDecodeError, AttributeError, ValueError, TypeError):
+            pass
+
         # Extract label and map to score
-        label = extract_label(raw_response, choice_scores)
+        label = json_label if json_label else extract_label(raw_response, choice_scores)
         score = label_to_score(label, choice_scores)
         passed = score >= threshold if threshold is not None else True
-        
+
         return ScorerResult(
             scorer_id=scorer_id,
             scorer_name=scorer_name,
@@ -345,6 +372,7 @@ async def run_custom_scorer(
             score=score,
             raw_response=raw_response,
             passed=passed,
+            reason=extracted_reason,
             prompt_tokens=getattr(usage, "prompt_tokens", None),
             completion_tokens=getattr(usage, "completion_tokens", None),
             total_tokens=getattr(usage, "total_tokens", None),

--- a/EvalServer/src/utils/run_evaluation.py
+++ b/EvalServer/src/utils/run_evaluation.py
@@ -983,7 +983,7 @@ async def run_evaluation(
                                         "score": result.score,
                                         "label": result.label,
                                         "passed": result.passed,
-                                        "reason": result.raw_response if result.raw_response else "",
+                                        "reason": result.reason if result.reason else (result.raw_response if result.raw_response else ""),
                                     }
                                 
                             except Exception as scorer_err:


### PR DESCRIPTION
## Describe your changes

Problem

  When using a custom scorer as a judge in an experiment, the judge LLM was not functioning correctly for two reasons:

  1. No test case data injected — The default scorer template ("You are a helpful assistant") had no {{input}}, {{output}}, or
  {{expected}} placeholders, so the actual model response being evaluated was never sent to the judge LLM.
  2. No reasoning returned — The template instructed the judge to reply with only PASS or FAIL, leaving no reasoning text to display in
  the experiment detail view. This is inconsistent with the standard judge, which surfaces a detailed explanation alongside the verdict.

  Changes

  EvalServer

  - Added a reason field to the ScorerResult dataclass to carry extracted reasoning separately from the raw LLM response
  - Added JSON parsing in run_custom_scorer.py to extract verdict and reason from structured responses — falls back gracefully to
  plain-text label extraction for existing scorers
  - Updated run_evaluation.py to store result.reason in metric_scores so the frontend can display it
  - Added a warning log when a scorer template contains no {{output}} placeholder

  Frontend

  - Replaced the default single-message template with a two-message evaluation template (system + user) that includes {{input}},
  {{output}}, and {{expected}} placeholders
  - Updated the default user message to request a JSON response in the format {"verdict": "PASS", "reason": "..."} so reasoning is always
  captured
  - Added an "Available variables" hint below the Prompt label in the scorer creation UI
  - Updated the user-role message TextField placeholder to guide users toward using the available variables

  Backward Compatibility

  Existing scorers that return plain PASS/FAIL text continue to work without changes — the JSON parsing falls back to the existing
  extract_label logic when the response is not valid JSON.

## Write your issue number after "Fixes "

This PR does not intend to fix any specific issues.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
