### PR TITLE
feat(policies): assign policies to virtual folders

### DIFF
--- a/Clients/src/application/repository/policyFolder.repository.ts
+++ b/Clients/src/application/repository/policyFolder.repository.ts
@@ -1,0 +1,21 @@
+import CustomAxios from "@/infrastructure/api/customAxios";
+import type { IVirtualFolder } from "@/domain/interfaces/i.virtualFolder";
+
+const BASE_URL = "/policies";
+
+export const getPolicyFolders = async (
+  policyId: number
+): Promise<IVirtualFolder[]> => {
+  const response = await CustomAxios.get(`${BASE_URL}/${policyId}/folders`);
+  return response.data.data;
+};
+
+export const updatePolicyFolders = async (
+  policyId: number,
+  folderIds: number[]
+): Promise<IVirtualFolder[]> => {
+  const response = await CustomAxios.patch(`${BASE_URL}/${policyId}/folders`, {
+    folder_ids: folderIds,
+  });
+  return response.data.data;
+};

--- a/Clients/src/application/repository/policyFolder.repository.ts
+++ b/Clients/src/application/repository/policyFolder.repository.ts
@@ -10,6 +10,13 @@ export const getPolicyFolders = async (
   return response.data.data;
 };
 
+export const getPolicyIdsInFolder = async (
+  folderId: number
+): Promise<number[]> => {
+  const response = await CustomAxios.get(`${BASE_URL}/folders/${folderId}/policies`);
+  return response.data.data;
+};
+
 export const updatePolicyFolders = async (
   policyId: number,
   folderIds: number[]

--- a/Clients/src/application/repository/policyFolder.repository.ts
+++ b/Clients/src/application/repository/policyFolder.repository.ts
@@ -1,5 +1,5 @@
-import CustomAxios from "@/infrastructure/api/customAxios";
-import type { IVirtualFolder } from "@/domain/interfaces/i.virtualFolder";
+import CustomAxios from "../../infrastructure/api/customAxios";
+import type { IVirtualFolder } from "../../domain/interfaces/i.virtualFolder";
 
 const BASE_URL = "/policies";
 

--- a/Clients/src/presentation/components/Cards/StatusTileCards/index.tsx
+++ b/Clients/src/presentation/components/Cards/StatusTileCards/index.tsx
@@ -25,6 +25,8 @@ interface StatusTileCardsProps {
   onCardClick?: (key: string) => void;
   /** Optional: key of the currently selected card */
   selectedKey?: string | null;
+  /** Optional: card size variant. "small" uses compact dimensions. Default: "original" */
+  size?: "small" | "original";
 }
 
 export function StatusTileCards({
@@ -34,7 +36,20 @@ export function StatusTileCards({
   cardSx,
   onCardClick,
   selectedKey,
+  size = "original",
 }: StatusTileCardsProps) {
+  const isSmall = size === "small";
+
+  const sizeOverrides = isSmall
+    ? {
+        flex: { xs: "1 1 80px", sm: "0 0 100px" },
+        width: { sm: "100px" },
+        height: { sm: "76px" },
+        paddingY: { xs: "6px", sm: "10px" },
+        paddingX: { xs: "10px", sm: "12px" },
+        gap: 2,
+      }
+    : {};
   const getTooltip = (item: StatusTileItem): string => {
     if (tooltipFormat) {
       return tooltipFormat(item);
@@ -49,7 +64,7 @@ export function StatusTileCards({
 
   return (
     <Box sx={{ width: "100%" }}>
-      <Stack className="vw-status-tile-cards" sx={projectRisksCard}>
+      <Stack className="vw-status-tile-cards" sx={{ ...projectRisksCard, ...(isSmall ? { gap: "10px" } : {}) }}>
         {items.map((item) => (
           <Tooltip
             key={item.key}
@@ -61,6 +76,7 @@ export function StatusTileCards({
               className="vw-status-tile"
               sx={{
                 ...projectRisksTileCard,
+                ...sizeOverrides,
                 color: item.color,
                 border: selectedKey === item.key ? `1px solid ${item.color}` : "1px solid #d0d5dd",
                 cursor: onCardClick ? "pointer" : "default",
@@ -69,8 +85,8 @@ export function StatusTileCards({
               }}
               onClick={() => onCardClick?.(item.key)}
             >
-              <Typography sx={projectRisksTileCardKey}>{item.label}</Typography>
-              <Typography sx={projectRisksTileCardvalue}>{item.count}</Typography>
+              <Typography sx={{ ...projectRisksTileCardKey, ...(isSmall ? { fontSize: 11 } : {}) }}>{item.label}</Typography>
+              <Typography sx={{ ...projectRisksTileCardvalue, ...(isSmall ? { fontSize: 22 } : {}) }}>{item.count}</Typography>
             </Stack>
           </Tooltip>
         ))}

--- a/Clients/src/presentation/components/IconButton/index.tsx
+++ b/Clients/src/presentation/components/IconButton/index.tsx
@@ -290,7 +290,7 @@ function IconButton({
     resource: ["edit", "make visible", "download", "remove"],
     incident: ["edit", "view", "archive"],
     integration: ["Send Test", "Activate/Deactivate", "remove"],
-    policy: ["edit", "link_objects", "download_pdf", "download_docx", "remove"],
+    policy: [], // Handled dynamically in getListOfButtons
     linkedobjectstype: ["remove"],
     risk: ["edit", "linked_policies", "remove"],
   };
@@ -317,6 +317,14 @@ function IconButton({
       if (onAssignToFolder) items.push("assign_folder");
       if (onViewHistory) items.push("version_history");
       items.push("linked_policies", "remove");
+      return items;
+    }
+
+    // Handle "policy" type dynamically to include assign_folder when available
+    if (normalizedType === "policy") {
+      const items = ["edit", "link_objects"];
+      if (onAssignToFolder) items.push("assign_folder");
+      items.push("download_pdf", "download_docx", "remove");
       return items;
     }
 

--- a/Clients/src/presentation/components/Policies/PolicyTable.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyTable.tsx
@@ -24,6 +24,7 @@ const PolicyTable: React.FC<PolicyTableProps> = ({
   onOpen,
   onDelete,
   onLinkedObjects,
+  onAssignToFolder,
   isLoading,
   error,
   onRefresh,
@@ -258,6 +259,7 @@ const PolicyTable: React.FC<PolicyTableProps> = ({
                   onLinkedObjects={() => {
                     onLinkedObjects(policy.id);
                   }}
+                  onAssignToFolder={onAssignToFolder ? () => onAssignToFolder(policy.id) : undefined}
                   onDownloadPDF={() => handleDownloadPDF(policy.id, policy.title)}
                   onDownloadDOCX={() => handleDownloadDOCX(policy.id, policy.title)}
                   onMouseEvent={() => {}}

--- a/Clients/src/presentation/components/Policies/PolicyTable.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyTable.tsx
@@ -11,7 +11,6 @@ import { store } from "../../../application/redux/store";
 const tableHeaders = [
   { id: "title", name: "Title" },
   { id: "status", name: "Status" },
-  { id: "tags", name: "Tags" },
   { id: "next_review", name: "Next Review" },
   { id: "author", name: "Author" },
   // { id: "reviewers", name: "Reviewers" },
@@ -199,17 +198,6 @@ const PolicyTable: React.FC<PolicyTableProps> = ({
               }}
             >
               <Chip label={policy.status} />
-            </TableCell>
-            <TableCell
-              sx={{
-                ...cellStyle,
-                backgroundColor: sortConfig?.key && sortConfig.key.toLowerCase().includes("tags") ? singleTheme.tableColors.sortedColumn : undefined,
-              }}
-            >
-              {(() => {
-                const tags = policy.tags?.join(", ") ?? "-";
-                return tags.length > 30 ? `${tags.slice(0, 30)}...` : tags;
-              })()}
             </TableCell>
             <TableCell
               sx={{

--- a/Clients/src/presentation/pages/FileManager/components/FolderTree/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/components/FolderTree/index.tsx
@@ -298,7 +298,6 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
       <Box
         sx={{
           padding: collapsed ? "12px 0" : "12px 16px",
-          borderBottom: "1px solid #E0E4E9",
           display: "flex",
           alignItems: "center",
           justifyContent: collapsed ? "center" : "space-between",

--- a/Clients/src/presentation/pages/FileManager/components/FolderTree/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/components/FolderTree/index.tsx
@@ -38,6 +38,10 @@ interface FolderTreeProps {
   canManage?: boolean;
   collapsed?: boolean;
   onToggleCollapse?: () => void;
+  /** Label for the "All files" item. Defaults to "All files". */
+  allLabel?: string;
+  /** Whether to show the "Uncategorized" item. Defaults to true. */
+  showUncategorized?: boolean;
 }
 
 interface FolderItemProps {
@@ -267,6 +271,8 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
   canManage,
   collapsed = false,
   onToggleCollapse,
+  allLabel = "All files",
+  showUncategorized = true,
 }) => {
   const [expandedFolders, setExpandedFolders] = useState<Set<number>>(new Set());
 
@@ -425,11 +431,12 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
                     color: selectedFolder === "all" ? "#13715B" : "#344054",
                   }}
                 >
-                  All files
+                  {allLabel}
                 </Typography>
               </Box>
 
               {/* Uncategorized */}
+              {showUncategorized && (
               <Box
                 onClick={() => onSelectFolder("uncategorized")}
                 sx={{
@@ -460,6 +467,7 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
                   Uncategorized
                 </Typography>
               </Box>
+              )}
 
               {/* Folder tree */}
               {folders.map((folder) => (

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -45,6 +45,7 @@ import {
   Popover,
   Snackbar,
   Alert,
+  CircularProgress,
 } from "@mui/material";
 import {
   Underline as UnderlineIcon,
@@ -88,6 +89,10 @@ import {
   ChevronDown as ChevronDownIcon,
   ChevronUp as ChevronUpIcon,
   Search,
+  FolderOpen,
+  Link2,
+  CheckCircle2,
+  File as FileIcon,
 } from "lucide-react";
 
 import Select from "../../components/Inputs/Select";
@@ -112,6 +117,16 @@ import { checkStringValidation } from "../../../application/validations/stringVa
 import { store } from "../../../application/redux/store";
 import policyTemplates from "../../../application/data/PolicyTemplates.json";
 import { PageBreadcrumbs } from "../../components/breadcrumbs/PageBreadcrumbs";
+import { useVirtualFolders } from "../../../application/hooks/useVirtualFolders";
+import { useFolderFiles } from "../../../application/hooks/useFolderFiles";
+import { FolderTree } from "../FileManager/components/FolderTree";
+import { CreateFolderModal } from "../FileManager/components/CreateFolderModal";
+import { getAllEntities } from "../../../application/repository/entity.repository";
+import { createPolicyLinkedObjects } from "../../../application/repository/policyLinkedObjects.repository";
+import type {
+  IFolderTreeNode,
+  IVirtualFolderInput,
+} from "../../../domain/interfaces/i.virtualFolder";
 
 // ── Auth image node view with resize ─────────────────────────────────
 const AuthImage: React.FC<NodeViewProps> = ({ node, updateAttributes, selected }) => {
@@ -451,6 +466,24 @@ export default function PolicyEditorPage() {
   const isLoadingContentRef = useRef(false);
   const formRef = useRef<HTMLDivElement>(null);
   const [validationSnackbar, setValidationSnackbar] = useState(false);
+
+  // Folder sidebar state
+  const [folderSidebarOpen, setFolderSidebarOpen] = useState(false);
+  const [folderSidebarCollapsed, setFolderSidebarCollapsed] = useState(false);
+  const [linkedEvidenceIds, setLinkedEvidenceIds] = useState<Set<number>>(new Set());
+  const [createFolderOpen, setCreateFolderOpen] = useState(false);
+  const [createFolderParent, setCreateFolderParent] = useState<IFolderTreeNode | null>(null);
+  const [linkingFileId, setLinkingFileId] = useState<number | null>(null);
+
+  // Virtual folders hooks
+  const {
+    folderTree,
+    selectedFolder,
+    setSelectedFolder,
+    loading: foldersLoading,
+    handleCreateFolder,
+  } = useVirtualFolders();
+  const { files: folderFiles, loading: filesLoading } = useFolderFiles(selectedFolder);
 
   // Color picker state
   const [colorAnchorEl, setColorAnchorEl] = useState<HTMLElement | null>(null);
@@ -910,6 +943,58 @@ export default function PolicyEditorPage() {
       countMatches();
     }
   }, [editor, searchText, replaceText, countMatches]);
+
+  // ── Fetch linked evidence ──────────────────────────────────────────
+  const policyId = isNew ? null : policy?.id ?? null;
+
+  const fetchLinkedEvidence = useCallback(async () => {
+    if (!policyId) return;
+    try {
+      const data = await getAllEntities({
+        routeUrl: `/policy-linked/${policyId}/linked-objects`,
+      });
+      const evidenceIds: number[] = (data?.evidence ?? []).map(
+        (e: { object_id: number }) => e.object_id
+      );
+      setLinkedEvidenceIds(new Set(evidenceIds));
+    } catch {
+      // Not critical — leave set empty
+    }
+  }, [policyId]);
+
+  useEffect(() => {
+    fetchLinkedEvidence();
+  }, [fetchLinkedEvidence]);
+
+  // ── Link file handler ──────────────────────────────────────────────
+  const handleLinkFile = useCallback(
+    async (fileId: number) => {
+      if (!policyId) return;
+      setLinkingFileId(fileId);
+      try {
+        await createPolicyLinkedObjects(
+          `/policy-linked/${policyId}/linked-objects`,
+          { object_type: "evidence", object_ids: [fileId] }
+        );
+        setLinkedEvidenceIds((prev) => new Set([...prev, fileId]));
+      } catch {
+        // Silently fail — user can retry
+      } finally {
+        setLinkingFileId(null);
+      }
+    },
+    [policyId]
+  );
+
+  // ── Create folder handler ──────────────────────────────────────────
+  const handleCreateFolderSubmit = useCallback(
+    async (input: IVirtualFolderInput) => {
+      await handleCreateFolder(input);
+      setCreateFolderOpen(false);
+      setCreateFolderParent(null);
+    },
+    [handleCreateFolder]
+  );
 
   // ── Toolbar config ────────────────────────────────────────────────
   const toolbarConfig: Array<{
@@ -1392,6 +1477,16 @@ export default function PolicyEditorPage() {
         selectedText={selectedTextForLink}
       />
 
+      <CreateFolderModal
+        isOpen={createFolderOpen}
+        onClose={() => {
+          setCreateFolderOpen(false);
+          setCreateFolderParent(null);
+        }}
+        onSubmit={handleCreateFolderSubmit}
+        parentFolder={createFolderParent}
+      />
+
       <input
         ref={imageInputRef}
         type="file"
@@ -1455,6 +1550,29 @@ export default function PolicyEditorPage() {
                 {exportError}
               </Typography>
             )}
+
+            {/* Documents sidebar toggle */}
+            <Tooltip title="Documents" arrow>
+              <IconButton
+                onClick={() => setFolderSidebarOpen((prev) => !prev)}
+                size="small"
+                sx={{
+                  color: folderSidebarOpen ? "#13715B" : "#98A2B3",
+                  padding: "4px",
+                  borderRadius: "4px",
+                  backgroundColor: folderSidebarOpen
+                    ? "#E6F4F1"
+                    : "transparent",
+                  "&:hover": {
+                    backgroundColor: folderSidebarOpen
+                      ? "#D1EDE6"
+                      : "#F2F4F7",
+                  },
+                }}
+              >
+                <FolderOpen size={16} />
+              </IconButton>
+            </Tooltip>
 
             {/* History toggle */}
             {!isNew && policy?.id && (
@@ -1887,11 +2005,135 @@ export default function PolicyEditorPage() {
           </Stack>
         </Popover>
 
-        {/* ── Editor + History sidebar ─────────────────────────────── */}
+        {/* ── Folder sidebar + Editor + History sidebar ────────────── */}
         <Stack
           direction="row"
           sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}
         >
+          {/* Folder sidebar */}
+          {folderSidebarOpen && (
+            <Stack
+              sx={{
+                width: folderSidebarCollapsed ? 48 : 260,
+                minWidth: folderSidebarCollapsed ? 48 : 260,
+                borderRight: "1px solid #D0D5DD",
+                backgroundColor: "#FAFBFC",
+                overflow: "hidden",
+                transition: "width 200ms ease, min-width 200ms ease",
+              }}
+            >
+              {/* Folder tree (top) */}
+              <FolderTree
+                folders={folderTree}
+                selectedFolder={selectedFolder}
+                onSelectFolder={setSelectedFolder}
+                onCreateFolder={(parentId) => {
+                  const parent = parentId !== null
+                    ? folderTree.find((f) => f.id === parentId) ?? null
+                    : null;
+                  setCreateFolderParent(parent);
+                  setCreateFolderOpen(true);
+                }}
+                loading={foldersLoading}
+                canManage
+                collapsed={folderSidebarCollapsed}
+                onToggleCollapse={() => setFolderSidebarCollapsed((p) => !p)}
+              />
+
+              {/* File list (bottom) */}
+              {!folderSidebarCollapsed && (
+                <>
+                  <Divider />
+                  <Stack
+                    sx={{
+                      flex: 1,
+                      overflow: "auto",
+                      padding: "8px",
+                    }}
+                  >
+                    {filesLoading ? (
+                      <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+                        <CircularProgress size={20} sx={{ color: "#98A2B3" }} />
+                      </Box>
+                    ) : folderFiles.length === 0 ? (
+                      <Typography
+                        sx={{
+                          fontSize: 12,
+                          color: "#98A2B3",
+                          textAlign: "center",
+                          py: 2,
+                        }}
+                      >
+                        No files in this folder
+                      </Typography>
+                    ) : (
+                      folderFiles.map((file) => {
+                        const isLinked = linkedEvidenceIds.has(file.id);
+                        const isLinking = linkingFileId === file.id;
+                        return (
+                          <Box
+                            key={file.id}
+                            sx={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "8px",
+                              padding: "6px 8px",
+                              borderRadius: "4px",
+                              "&:hover": { backgroundColor: "#F0F2F5" },
+                            }}
+                          >
+                            <FileIcon size={14} color="#667085" style={{ flexShrink: 0 }} />
+                            <Tooltip title={file.filename} placement="top">
+                              <Typography
+                                sx={{
+                                  flex: 1,
+                                  fontSize: 12,
+                                  color: "#344054",
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {file.filename}
+                              </Typography>
+                            </Tooltip>
+                            {isLinked ? (
+                              <Tooltip title="Already linked" placement="top">
+                                <CheckCircle2 size={14} color="#079455" style={{ flexShrink: 0 }} />
+                              </Tooltip>
+                            ) : isLinking ? (
+                              <CircularProgress size={14} sx={{ color: "#13715B", flexShrink: 0 }} />
+                            ) : (
+                              <Tooltip
+                                title={isNew ? "Save the policy first" : "Link to policy"}
+                                placement="top"
+                              >
+                                <span>
+                                  <IconButton
+                                    size="small"
+                                    disabled={isNew}
+                                    onClick={() => handleLinkFile(file.id)}
+                                    sx={{
+                                      padding: "2px",
+                                      "&:hover": { backgroundColor: "#E8F5F1" },
+                                      "&:disabled": { opacity: 0.4 },
+                                    }}
+                                  >
+                                    <Link2 size={14} color="#13715B" />
+                                  </IconButton>
+                                </span>
+                              </Tooltip>
+                            )}
+                          </Box>
+                        );
+                      })
+                    )}
+                  </Stack>
+                </>
+              )}
+            </Stack>
+          )}
+
           {/* Editor */}
           <Box
             sx={{

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -45,7 +45,6 @@ import {
   Popover,
   Snackbar,
   Alert,
-  CircularProgress,
 } from "@mui/material";
 import {
   Underline as UnderlineIcon,
@@ -89,10 +88,6 @@ import {
   ChevronDown as ChevronDownIcon,
   ChevronUp as ChevronUpIcon,
   Search,
-  FolderOpen,
-  Link2,
-  CheckCircle2,
-  File as FileIcon,
 } from "lucide-react";
 
 import Select from "../../components/Inputs/Select";
@@ -117,16 +112,6 @@ import { checkStringValidation } from "../../../application/validations/stringVa
 import { store } from "../../../application/redux/store";
 import policyTemplates from "../../../application/data/PolicyTemplates.json";
 import { PageBreadcrumbs } from "../../components/breadcrumbs/PageBreadcrumbs";
-import { useVirtualFolders } from "../../../application/hooks/useVirtualFolders";
-import { useFolderFiles } from "../../../application/hooks/useFolderFiles";
-import { FolderTree } from "../FileManager/components/FolderTree";
-import { CreateFolderModal } from "../FileManager/components/CreateFolderModal";
-import { getAllEntities } from "../../../application/repository/entity.repository";
-import { createPolicyLinkedObjects } from "../../../application/repository/policyLinkedObjects.repository";
-import type {
-  IFolderTreeNode,
-  IVirtualFolderInput,
-} from "../../../domain/interfaces/i.virtualFolder";
 
 // ── Auth image node view with resize ─────────────────────────────────
 const AuthImage: React.FC<NodeViewProps> = ({ node, updateAttributes, selected }) => {
@@ -466,24 +451,6 @@ export default function PolicyEditorPage() {
   const isLoadingContentRef = useRef(false);
   const formRef = useRef<HTMLDivElement>(null);
   const [validationSnackbar, setValidationSnackbar] = useState(false);
-
-  // Folder sidebar state
-  const [folderSidebarOpen, setFolderSidebarOpen] = useState(false);
-  const [folderSidebarCollapsed, setFolderSidebarCollapsed] = useState(false);
-  const [linkedEvidenceIds, setLinkedEvidenceIds] = useState<Set<number>>(new Set());
-  const [createFolderOpen, setCreateFolderOpen] = useState(false);
-  const [createFolderParent, setCreateFolderParent] = useState<IFolderTreeNode | null>(null);
-  const [linkingFileId, setLinkingFileId] = useState<number | null>(null);
-
-  // Virtual folders hooks
-  const {
-    folderTree,
-    selectedFolder,
-    setSelectedFolder,
-    loading: foldersLoading,
-    handleCreateFolder,
-  } = useVirtualFolders();
-  const { files: folderFiles, loading: filesLoading } = useFolderFiles(selectedFolder);
 
   // Color picker state
   const [colorAnchorEl, setColorAnchorEl] = useState<HTMLElement | null>(null);
@@ -943,58 +910,6 @@ export default function PolicyEditorPage() {
       countMatches();
     }
   }, [editor, searchText, replaceText, countMatches]);
-
-  // ── Fetch linked evidence ──────────────────────────────────────────
-  const policyId = isNew ? null : policy?.id ?? null;
-
-  const fetchLinkedEvidence = useCallback(async () => {
-    if (!policyId) return;
-    try {
-      const data = await getAllEntities({
-        routeUrl: `/policy-linked/${policyId}/linked-objects`,
-      });
-      const evidenceIds: number[] = (data?.evidence ?? []).map(
-        (e: { object_id: number }) => e.object_id
-      );
-      setLinkedEvidenceIds(new Set(evidenceIds));
-    } catch {
-      // Not critical — leave set empty
-    }
-  }, [policyId]);
-
-  useEffect(() => {
-    fetchLinkedEvidence();
-  }, [fetchLinkedEvidence]);
-
-  // ── Link file handler ──────────────────────────────────────────────
-  const handleLinkFile = useCallback(
-    async (fileId: number) => {
-      if (!policyId) return;
-      setLinkingFileId(fileId);
-      try {
-        await createPolicyLinkedObjects(
-          `/policy-linked/${policyId}/linked-objects`,
-          { object_type: "evidence", object_ids: [fileId] }
-        );
-        setLinkedEvidenceIds((prev) => new Set([...prev, fileId]));
-      } catch {
-        // Silently fail — user can retry
-      } finally {
-        setLinkingFileId(null);
-      }
-    },
-    [policyId]
-  );
-
-  // ── Create folder handler ──────────────────────────────────────────
-  const handleCreateFolderSubmit = useCallback(
-    async (input: IVirtualFolderInput) => {
-      await handleCreateFolder(input);
-      setCreateFolderOpen(false);
-      setCreateFolderParent(null);
-    },
-    [handleCreateFolder]
-  );
 
   // ── Toolbar config ────────────────────────────────────────────────
   const toolbarConfig: Array<{
@@ -1477,16 +1392,6 @@ export default function PolicyEditorPage() {
         selectedText={selectedTextForLink}
       />
 
-      <CreateFolderModal
-        isOpen={createFolderOpen}
-        onClose={() => {
-          setCreateFolderOpen(false);
-          setCreateFolderParent(null);
-        }}
-        onSubmit={handleCreateFolderSubmit}
-        parentFolder={createFolderParent}
-      />
-
       <input
         ref={imageInputRef}
         type="file"
@@ -1550,29 +1455,6 @@ export default function PolicyEditorPage() {
                 {exportError}
               </Typography>
             )}
-
-            {/* Documents sidebar toggle */}
-            <Tooltip title="Documents" arrow>
-              <IconButton
-                onClick={() => setFolderSidebarOpen((prev) => !prev)}
-                size="small"
-                sx={{
-                  color: folderSidebarOpen ? "#13715B" : "#98A2B3",
-                  padding: "4px",
-                  borderRadius: "4px",
-                  backgroundColor: folderSidebarOpen
-                    ? "#E6F4F1"
-                    : "transparent",
-                  "&:hover": {
-                    backgroundColor: folderSidebarOpen
-                      ? "#D1EDE6"
-                      : "#F2F4F7",
-                  },
-                }}
-              >
-                <FolderOpen size={16} />
-              </IconButton>
-            </Tooltip>
 
             {/* History toggle */}
             {!isNew && policy?.id && (
@@ -2005,135 +1887,11 @@ export default function PolicyEditorPage() {
           </Stack>
         </Popover>
 
-        {/* ── Folder sidebar + Editor + History sidebar ────────────── */}
+        {/* ── Editor + History sidebar ────────────────────────────── */}
         <Stack
           direction="row"
           sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}
         >
-          {/* Folder sidebar */}
-          {folderSidebarOpen && (
-            <Stack
-              sx={{
-                width: folderSidebarCollapsed ? 48 : 260,
-                minWidth: folderSidebarCollapsed ? 48 : 260,
-                borderRight: "1px solid #D0D5DD",
-                backgroundColor: "#FAFBFC",
-                overflow: "hidden",
-                transition: "width 200ms ease, min-width 200ms ease",
-              }}
-            >
-              {/* Folder tree (top) */}
-              <FolderTree
-                folders={folderTree}
-                selectedFolder={selectedFolder}
-                onSelectFolder={setSelectedFolder}
-                onCreateFolder={(parentId) => {
-                  const parent = parentId !== null
-                    ? folderTree.find((f) => f.id === parentId) ?? null
-                    : null;
-                  setCreateFolderParent(parent);
-                  setCreateFolderOpen(true);
-                }}
-                loading={foldersLoading}
-                canManage
-                collapsed={folderSidebarCollapsed}
-                onToggleCollapse={() => setFolderSidebarCollapsed((p) => !p)}
-              />
-
-              {/* File list (bottom) */}
-              {!folderSidebarCollapsed && (
-                <>
-                  <Divider />
-                  <Stack
-                    sx={{
-                      flex: 1,
-                      overflow: "auto",
-                      padding: "8px",
-                    }}
-                  >
-                    {filesLoading ? (
-                      <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-                        <CircularProgress size={20} sx={{ color: "#98A2B3" }} />
-                      </Box>
-                    ) : folderFiles.length === 0 ? (
-                      <Typography
-                        sx={{
-                          fontSize: 12,
-                          color: "#98A2B3",
-                          textAlign: "center",
-                          py: 2,
-                        }}
-                      >
-                        No files in this folder
-                      </Typography>
-                    ) : (
-                      folderFiles.map((file) => {
-                        const isLinked = linkedEvidenceIds.has(file.id);
-                        const isLinking = linkingFileId === file.id;
-                        return (
-                          <Box
-                            key={file.id}
-                            sx={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "8px",
-                              padding: "6px 8px",
-                              borderRadius: "4px",
-                              "&:hover": { backgroundColor: "#F0F2F5" },
-                            }}
-                          >
-                            <FileIcon size={14} color="#667085" style={{ flexShrink: 0 }} />
-                            <Tooltip title={file.filename} placement="top">
-                              <Typography
-                                sx={{
-                                  flex: 1,
-                                  fontSize: 12,
-                                  color: "#344054",
-                                  overflow: "hidden",
-                                  textOverflow: "ellipsis",
-                                  whiteSpace: "nowrap",
-                                }}
-                              >
-                                {file.filename}
-                              </Typography>
-                            </Tooltip>
-                            {isLinked ? (
-                              <Tooltip title="Already linked" placement="top">
-                                <CheckCircle2 size={14} color="#079455" style={{ flexShrink: 0 }} />
-                              </Tooltip>
-                            ) : isLinking ? (
-                              <CircularProgress size={14} sx={{ color: "#13715B", flexShrink: 0 }} />
-                            ) : (
-                              <Tooltip
-                                title={isNew ? "Save the policy first" : "Link to policy"}
-                                placement="top"
-                              >
-                                <span>
-                                  <IconButton
-                                    size="small"
-                                    disabled={isNew}
-                                    onClick={() => handleLinkFile(file.id)}
-                                    sx={{
-                                      padding: "2px",
-                                      "&:hover": { backgroundColor: "#E8F5F1" },
-                                      "&:disabled": { opacity: 0.4 },
-                                    }}
-                                  >
-                                    <Link2 size={14} color="#13715B" />
-                                  </IconButton>
-                                </span>
-                              </Tooltip>
-                            )}
-                          </Box>
-                        );
-                      })
-                    )}
-                  </Stack>
-                </>
-              )}
-            </Stack>
-          )}
-
           {/* Editor */}
           <Box
             sx={{

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -586,6 +586,8 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
               canManage
               collapsed={folderSidebarCollapsed}
               onToggleCollapse={() => setFolderSidebarCollapsed((p) => !p)}
+              allLabel="All policies"
+              showUncategorized={false}
             />
           </Stack>
         )}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -1,7 +1,20 @@
 import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { Box, Stack, Fade } from "@mui/material";
-import { CirclePlus as AddCircleOutlineIcon } from "lucide-react";
+import {
+  Box,
+  Stack,
+  Fade,
+  Divider,
+  Tooltip,
+  IconButton,
+  Typography,
+  CircularProgress,
+} from "@mui/material";
+import {
+  CirclePlus as AddCircleOutlineIcon,
+  FolderOpen,
+  File as FileIcon,
+} from "lucide-react";
 import PolicyTable from "../../components/Policies/PolicyTable";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { deletePolicy } from "../../../application/repository/policy.repository";
@@ -22,6 +35,14 @@ import { FilterBy, FilterColumn } from "../../components/Table/FilterBy";
 import { useFilterBy } from "../../../application/hooks/useFilterBy";
 import LinkedPolicyModal from "../../components/Policies/LinkedPolicyModal";
 import { displayFormattedDate } from "../../tools/isoDateToString";
+import { useVirtualFolders } from "../../../application/hooks/useVirtualFolders";
+import { useFolderFiles } from "../../../application/hooks/useFolderFiles";
+import { FolderTree } from "../FileManager/components/FolderTree";
+import { CreateFolderModal } from "../FileManager/components/CreateFolderModal";
+import type {
+  IFolderTreeNode,
+  IVirtualFolderInput,
+} from "../../../domain/interfaces/i.virtualFolder";
 
 const PolicyManager: React.FC<PolicyManagerProps> = ({
   policies: policyList,
@@ -40,6 +61,31 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
   useEffect(() => {
     setPolicies(policyList);
   }, [policyList]);
+
+  // Folder sidebar state
+  const [folderSidebarOpen, setFolderSidebarOpen] = useState(false);
+  const [folderSidebarCollapsed, setFolderSidebarCollapsed] = useState(false);
+  const [createFolderOpen, setCreateFolderOpen] = useState(false);
+  const [createFolderParent, setCreateFolderParent] = useState<IFolderTreeNode | null>(null);
+
+  // Virtual folders hooks
+  const {
+    folderTree,
+    selectedFolder,
+    setSelectedFolder,
+    loading: foldersLoading,
+    handleCreateFolder,
+  } = useVirtualFolders();
+  const { files: folderFiles, loading: filesLoading } = useFolderFiles(selectedFolder);
+
+  const handleCreateFolderSubmit = useCallback(
+    async (input: IVirtualFolderInput) => {
+      await handleCreateFolder(input);
+      setCreateFolderOpen(false);
+      setCreateFolderParent(null);
+    },
+    [handleCreateFolder]
+  );
 
   // New state for filter + search
   const [searchTerm, setSearchTerm] = useState("");
@@ -324,7 +370,113 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
   }, [filteredPolicies, users]);
 
   return (
-    <Stack className="vwhome" gap={"16px"}>
+    <>
+    <CreateFolderModal
+      isOpen={createFolderOpen}
+      onClose={() => {
+        setCreateFolderOpen(false);
+        setCreateFolderParent(null);
+      }}
+      onSubmit={handleCreateFolderSubmit}
+      parentFolder={createFolderParent}
+    />
+
+    <Stack direction="row" sx={{ gap: 0 }}>
+      {/* Folder sidebar */}
+      {folderSidebarOpen && (
+        <Stack
+          sx={{
+            width: folderSidebarCollapsed ? 48 : 260,
+            minWidth: folderSidebarCollapsed ? 48 : 260,
+            borderRight: "1px solid #D0D5DD",
+            backgroundColor: "#FAFBFC",
+            overflow: "hidden",
+            transition: "width 200ms ease, min-width 200ms ease",
+            maxHeight: "calc(100vh - 120px)",
+          }}
+        >
+          {/* Folder tree (top) */}
+          <FolderTree
+            folders={folderTree}
+            selectedFolder={selectedFolder}
+            onSelectFolder={setSelectedFolder}
+            onCreateFolder={(parentId) => {
+              const parent = parentId !== null
+                ? folderTree.find((f) => f.id === parentId) ?? null
+                : null;
+              setCreateFolderParent(parent);
+              setCreateFolderOpen(true);
+            }}
+            loading={foldersLoading}
+            canManage
+            collapsed={folderSidebarCollapsed}
+            onToggleCollapse={() => setFolderSidebarCollapsed((p) => !p)}
+          />
+
+          {/* File list (bottom) */}
+          {!folderSidebarCollapsed && (
+            <>
+              <Divider />
+              <Stack
+                sx={{
+                  flex: 1,
+                  overflow: "auto",
+                  padding: "8px",
+                }}
+              >
+                {filesLoading ? (
+                  <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+                    <CircularProgress size={20} sx={{ color: "#98A2B3" }} />
+                  </Box>
+                ) : folderFiles.length === 0 ? (
+                  <Typography
+                    sx={{
+                      fontSize: 12,
+                      color: "#98A2B3",
+                      textAlign: "center",
+                      py: 2,
+                    }}
+                  >
+                    No files in this folder
+                  </Typography>
+                ) : (
+                  folderFiles.map((file) => (
+                    <Box
+                      key={file.id}
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        padding: "6px 8px",
+                        borderRadius: "4px",
+                        "&:hover": { backgroundColor: "#F0F2F5" },
+                      }}
+                    >
+                      <FileIcon size={14} color="#667085" style={{ flexShrink: 0 }} />
+                      <Tooltip title={file.filename} placement="top">
+                        <Typography
+                          sx={{
+                            flex: 1,
+                            fontSize: 12,
+                            color: "#344054",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {file.filename}
+                        </Typography>
+                      </Tooltip>
+                    </Box>
+                  ))
+                )}
+              </Stack>
+            </>
+          )}
+        </Stack>
+      )}
+
+    <Stack className="vwhome" gap={"16px"} sx={{ flex: 1, minWidth: 0 }}>
       {/* Policy by Status Cards */}
       <Box data-joyride-id="policy-status-cards">
         <PolicyStatusCard
@@ -373,8 +525,29 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
           </Box>
         </Stack>
 
-        {/* Right side: Export and Add Button */}
+        {/* Right side: Documents toggle, Export and Add Button */}
         <Stack direction="row" gap="8px" alignItems="center">
+          <Tooltip title="Documents" arrow>
+            <IconButton
+              onClick={() => setFolderSidebarOpen((prev) => !prev)}
+              size="small"
+              sx={{
+                color: folderSidebarOpen ? "#13715B" : "#98A2B3",
+                padding: "4px",
+                borderRadius: "4px",
+                backgroundColor: folderSidebarOpen
+                  ? "#E6F4F1"
+                  : "transparent",
+                "&:hover": {
+                  backgroundColor: folderSidebarOpen
+                    ? "#D1EDE6"
+                    : "#F2F4F7",
+                },
+              }}
+            >
+              <FolderOpen size={16} />
+            </IconButton>
+          </Tooltip>
           <ExportMenu
             data={exportData}
             columns={exportColumns}
@@ -453,6 +626,8 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
         </Fade>
       )}
     </Stack>
+    </Stack>
+    </>
   );
 };
 

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -373,41 +373,7 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
       parentFolder={createFolderParent}
     />
 
-    <Stack direction="row" sx={{ gap: 0 }}>
-      {/* Folder sidebar */}
-      {folderSidebarOpen && (
-        <Stack
-          sx={{
-            width: folderSidebarCollapsed ? 48 : 260,
-            minWidth: folderSidebarCollapsed ? 48 : 260,
-            borderRight: "1px solid #D0D5DD",
-            backgroundColor: "#FAFBFC",
-            overflow: "hidden",
-            transition: "width 200ms ease, min-width 200ms ease",
-            maxHeight: "calc(100vh - 120px)",
-          }}
-        >
-          {/* Folder tree (top) */}
-          <FolderTree
-            folders={folderTree}
-            selectedFolder={selectedFolder}
-            onSelectFolder={setSelectedFolder}
-            onCreateFolder={(parentId) => {
-              const parent = parentId !== null
-                ? folderTree.find((f) => f.id === parentId) ?? null
-                : null;
-              setCreateFolderParent(parent);
-              setCreateFolderOpen(true);
-            }}
-            loading={foldersLoading}
-            canManage
-            collapsed={folderSidebarCollapsed}
-            onToggleCollapse={() => setFolderSidebarCollapsed((p) => !p)}
-          />
-        </Stack>
-      )}
-
-    <Stack className="vwhome" gap={"16px"} sx={{ flex: 1, minWidth: 0 }}>
+    <Stack className="vwhome" gap={"16px"}>
       {/* Policy by Status Cards */}
       <Box data-joyride-id="policy-status-cards">
         <PolicyStatusCard
@@ -501,34 +467,69 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
         </Stack>
       </Stack>
 
-      {/* Table / Empty state */}
-      <Box sx={{ mt: 1 }}>
-        {filteredPolicies.length === 0 ? (
-          <EmptyState
-            message={
-              searchTerm
-                ? "No matching policies found."
-                : "There is currently no data in this table."
-            }
-            imageAlt="No policies available"
-          />
-        ) : (
-          <GroupedTableView
-            groupedData={groupedPolicies}
-            ungroupedData={filteredPolicies}
-            renderTable={(data, options) => (
-              <PolicyTable
-                data={data}
-                onOpen={handleOpen}
-                onDelete={handleDelete}
-                onLinkedObjects={handleLinkedObject}
-                hidePagination={options?.hidePagination}
-                flashRowId={flashRowId}
-              />
-            )}
-          />
+      {/* Folder sidebar + Table */}
+      <Stack direction="row" sx={{ gap: 0, mt: 1 }}>
+        {/* Folder sidebar */}
+        {folderSidebarOpen && (
+          <Stack
+            sx={{
+              width: folderSidebarCollapsed ? 48 : 260,
+              minWidth: folderSidebarCollapsed ? 48 : 260,
+              borderRight: "1px solid #D0D5DD",
+              backgroundColor: "#FAFBFC",
+              borderRadius: "4px 0 0 4px",
+              overflow: "hidden",
+              transition: "width 200ms ease, min-width 200ms ease",
+            }}
+          >
+            <FolderTree
+              folders={folderTree}
+              selectedFolder={selectedFolder}
+              onSelectFolder={setSelectedFolder}
+              onCreateFolder={(parentId) => {
+                const parent = parentId !== null
+                  ? folderTree.find((f) => f.id === parentId) ?? null
+                  : null;
+                setCreateFolderParent(parent);
+                setCreateFolderOpen(true);
+              }}
+              loading={foldersLoading}
+              canManage
+              collapsed={folderSidebarCollapsed}
+              onToggleCollapse={() => setFolderSidebarCollapsed((p) => !p)}
+            />
+          </Stack>
         )}
-      </Box>
+
+        {/* Table / Empty state */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          {filteredPolicies.length === 0 ? (
+            <EmptyState
+              message={
+                searchTerm
+                  ? "No matching policies found."
+                  : "There is currently no data in this table."
+              }
+              imageAlt="No policies available"
+            />
+          ) : (
+            <GroupedTableView
+              groupedData={groupedPolicies}
+              ungroupedData={filteredPolicies}
+              renderTable={(data, options) => (
+                <PolicyTable
+                  data={data}
+                  onOpen={handleOpen}
+                  onDelete={handleDelete}
+                  onLinkedObjects={handleLinkedObject}
+                  hidePagination={options?.hidePagination}
+                  flashRowId={flashRowId}
+                />
+              )}
+            />
+          )}
+        </Box>
+      </Stack>
 
       {/* Linked Objects Modal */}
       {showLinkedObjectModal && (
@@ -556,7 +557,6 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
           </Box>
         </Fade>
       )}
-    </Stack>
     </Stack>
     </>
   );

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -475,7 +475,6 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
             sx={{
               width: folderSidebarCollapsed ? 48 : 260,
               minWidth: folderSidebarCollapsed ? 48 : 260,
-              borderRight: "1px solid #D0D5DD",
               backgroundColor: "#FAFBFC",
               borderRadius: "4px 0 0 4px",
               overflow: "hidden",

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -4,16 +4,12 @@ import {
   Box,
   Stack,
   Fade,
-  Divider,
   Tooltip,
   IconButton,
-  Typography,
-  CircularProgress,
 } from "@mui/material";
 import {
   CirclePlus as AddCircleOutlineIcon,
   FolderOpen,
-  File as FileIcon,
 } from "lucide-react";
 import PolicyTable from "../../components/Policies/PolicyTable";
 import { CustomizableButton } from "../../components/button/customizable-button";
@@ -36,7 +32,6 @@ import { useFilterBy } from "../../../application/hooks/useFilterBy";
 import LinkedPolicyModal from "../../components/Policies/LinkedPolicyModal";
 import { displayFormattedDate } from "../../tools/isoDateToString";
 import { useVirtualFolders } from "../../../application/hooks/useVirtualFolders";
-import { useFolderFiles } from "../../../application/hooks/useFolderFiles";
 import { FolderTree } from "../FileManager/components/FolderTree";
 import { CreateFolderModal } from "../FileManager/components/CreateFolderModal";
 import type {
@@ -76,7 +71,6 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
     loading: foldersLoading,
     handleCreateFolder,
   } = useVirtualFolders();
-  const { files: folderFiles, loading: filesLoading } = useFolderFiles(selectedFolder);
 
   const handleCreateFolderSubmit = useCallback(
     async (input: IVirtualFolderInput) => {
@@ -340,7 +334,6 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
     return [
       { id: 'title', label: 'Title' },
       { id: 'status', label: 'Status' },
-      { id: 'tags', label: 'Tags' },
       { id: 'next_review', label: 'Next Review' },
       { id: 'author', label: 'Author' },
       { id: 'last_updated', label: 'Last Updated' },
@@ -360,7 +353,6 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
       return {
         title: policy.title || '-',
         status: policy.status || '-',
-        tags: policy.tags?.join(', ') || '-',
         next_review: policy.next_review_date ? displayFormattedDate(policy.next_review_date) : '-',
         author: authorName,
         last_updated: policy.last_updated_at ? displayFormattedDate(policy.last_updated_at) : '-',
@@ -412,67 +404,6 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
             collapsed={folderSidebarCollapsed}
             onToggleCollapse={() => setFolderSidebarCollapsed((p) => !p)}
           />
-
-          {/* File list (bottom) */}
-          {!folderSidebarCollapsed && (
-            <>
-              <Divider />
-              <Stack
-                sx={{
-                  flex: 1,
-                  overflow: "auto",
-                  padding: "8px",
-                }}
-              >
-                {filesLoading ? (
-                  <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-                    <CircularProgress size={20} sx={{ color: "#98A2B3" }} />
-                  </Box>
-                ) : folderFiles.length === 0 ? (
-                  <Typography
-                    sx={{
-                      fontSize: 12,
-                      color: "#98A2B3",
-                      textAlign: "center",
-                      py: 2,
-                    }}
-                  >
-                    No files in this folder
-                  </Typography>
-                ) : (
-                  folderFiles.map((file) => (
-                    <Box
-                      key={file.id}
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "8px",
-                        padding: "6px 8px",
-                        borderRadius: "4px",
-                        "&:hover": { backgroundColor: "#F0F2F5" },
-                      }}
-                    >
-                      <FileIcon size={14} color="#667085" style={{ flexShrink: 0 }} />
-                      <Tooltip title={file.filename} placement="top">
-                        <Typography
-                          sx={{
-                            flex: 1,
-                            fontSize: 12,
-                            color: "#344054",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {file.filename}
-                        </Typography>
-                      </Tooltip>
-                    </Box>
-                  ))
-                )}
-              </Stack>
-            </>
-          )}
         </Stack>
       )}
 

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -37,6 +37,7 @@ import { CreateFolderModal } from "../FileManager/components/CreateFolderModal";
 import { AssignToFolderModal } from "../FileManager/components/AssignToFolderModal";
 import {
   getPolicyFolders,
+  getPolicyIdsInFolder,
   updatePolicyFolders,
 } from "../../../application/repository/policyFolder.repository";
 import type {
@@ -75,6 +76,9 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
   const [assignFolderCurrentFolders, setAssignFolderCurrentFolders] = useState<IVirtualFolder[]>([]);
   const [assignFolderSubmitting, setAssignFolderSubmitting] = useState(false);
 
+  // Policy IDs filtered by selected folder
+  const [folderPolicyIds, setFolderPolicyIds] = useState<number[] | null>(null);
+
   // Virtual folders hooks
   const {
     folderTree,
@@ -93,6 +97,17 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
     },
     [handleCreateFolder]
   );
+
+  // Fetch policy IDs when a folder is selected
+  useEffect(() => {
+    if (typeof selectedFolder === "number") {
+      getPolicyIdsInFolder(selectedFolder)
+        .then(setFolderPolicyIds)
+        .catch(() => setFolderPolicyIds([]));
+    } else {
+      setFolderPolicyIds(null);
+    }
+  }, [selectedFolder]);
 
   // New state for filter + search
   const [searchTerm, setSearchTerm] = useState("");
@@ -223,6 +238,11 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
       setAssignFolderPolicyId(null);
       setAssignFolderCurrentFolders([]);
       await refreshFolders();
+      // Refresh folder filter if a folder is currently selected
+      if (typeof selectedFolder === "number") {
+        const updatedIds = await getPolicyIdsInFolder(selectedFolder);
+        setFolderPolicyIds(updatedIds);
+      }
       handleAlert({
         variant: "success",
         body: "Folder assignment updated.",
@@ -348,6 +368,12 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
   const filteredPolicies = useMemo(() => {
     let result = filterPolicyData(policies);
 
+    // Apply folder filter
+    if (folderPolicyIds !== null) {
+      const idSet = new Set(folderPolicyIds);
+      result = result.filter((p) => idSet.has(p.id));
+    }
+
     // Apply card filter for status
     if (selectedStatus) {
       result = result.filter((p) => p.status === selectedStatus);
@@ -362,7 +388,7 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
     }
 
     return result;
-  }, [filterPolicyData, policies, selectedStatus, searchTerm]);
+  }, [filterPolicyData, policies, selectedStatus, searchTerm, folderPolicyIds]);
 
   // Define how to get the group key for each policy
   const getPolicyGroupKey = useCallback((policy: PolicyManagerModel, field: string): string => {
@@ -527,7 +553,7 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
       </Stack>
 
       {/* Folder sidebar + Table */}
-      <Stack direction="row" sx={{ gap: 0, mt: 1 }}>
+      <Stack direction="row" sx={{ gap: "8px", mt: 1 }}>
         {/* Folder sidebar */}
         {folderSidebarOpen && (
           <Stack
@@ -535,9 +561,14 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
               width: folderSidebarCollapsed ? 48 : 260,
               minWidth: folderSidebarCollapsed ? 48 : 260,
               backgroundColor: "#FAFBFC",
-              borderRadius: "4px 0 0 4px",
+              border: "1px solid #d0d5dd",
+              borderRadius: "4px",
               overflow: "hidden",
               transition: "width 200ms ease, min-width 200ms ease",
+              // Override FolderTree's internal borderRight since this wrapper already has a full border
+              "& > .MuiStack-root": {
+                borderRight: "none",
+              },
             }}
           >
             <FolderTree

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -34,8 +34,14 @@ import { displayFormattedDate } from "../../tools/isoDateToString";
 import { useVirtualFolders } from "../../../application/hooks/useVirtualFolders";
 import { FolderTree } from "../FileManager/components/FolderTree";
 import { CreateFolderModal } from "../FileManager/components/CreateFolderModal";
+import { AssignToFolderModal } from "../FileManager/components/AssignToFolderModal";
+import {
+  getPolicyFolders,
+  updatePolicyFolders,
+} from "../../../application/repository/policyFolder.repository";
 import type {
   IFolderTreeNode,
+  IVirtualFolder,
   IVirtualFolderInput,
 } from "../../../domain/interfaces/i.virtualFolder";
 
@@ -63,6 +69,12 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
   const [createFolderOpen, setCreateFolderOpen] = useState(false);
   const [createFolderParent, setCreateFolderParent] = useState<IFolderTreeNode | null>(null);
 
+  // Assign to folder modal state
+  const [assignFolderOpen, setAssignFolderOpen] = useState(false);
+  const [assignFolderPolicyId, setAssignFolderPolicyId] = useState<number | null>(null);
+  const [assignFolderCurrentFolders, setAssignFolderCurrentFolders] = useState<IVirtualFolder[]>([]);
+  const [assignFolderSubmitting, setAssignFolderSubmitting] = useState(false);
+
   // Virtual folders hooks
   const {
     folderTree,
@@ -70,6 +82,7 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
     setSelectedFolder,
     loading: foldersLoading,
     handleCreateFolder,
+    refreshFolders,
   } = useVirtualFolders();
 
   const handleCreateFolderSubmit = useCallback(
@@ -182,6 +195,52 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
   const handleCloseLinkedObjects = () => {
     setLinkedObjectsModalOpen(false);
   };
+
+  // Assign to folder handlers
+  const handleAssignToFolder = useCallback(async (id: number) => {
+    try {
+      const currentFolders = await getPolicyFolders(id);
+      setAssignFolderPolicyId(id);
+      setAssignFolderCurrentFolders(currentFolders);
+      setAssignFolderOpen(true);
+    } catch (err) {
+      console.error("Failed to fetch policy folders:", err);
+      handleAlert({
+        variant: "error",
+        body: "Failed to load folder assignments.",
+        setAlert,
+        alertTimeout: 4000,
+      });
+    }
+  }, []);
+
+  const handleAssignFolderSubmit = useCallback(async (folderIds: number[]) => {
+    if (!assignFolderPolicyId) return;
+    setAssignFolderSubmitting(true);
+    try {
+      await updatePolicyFolders(assignFolderPolicyId, folderIds);
+      setAssignFolderOpen(false);
+      setAssignFolderPolicyId(null);
+      setAssignFolderCurrentFolders([]);
+      await refreshFolders();
+      handleAlert({
+        variant: "success",
+        body: "Folder assignment updated.",
+        setAlert,
+        alertTimeout: 4000,
+      });
+    } catch (err) {
+      console.error("Failed to update policy folders:", err);
+      handleAlert({
+        variant: "error",
+        body: "Failed to update folder assignment.",
+        setAlert,
+        alertTimeout: 4000,
+      });
+    } finally {
+      setAssignFolderSubmitting(false);
+    }
+  }, [assignFolderPolicyId, refreshFolders]);
 
   // Handle policy card click to filter by status
   const handleStatusCardClick = useCallback((status: string) => {
@@ -521,6 +580,7 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
                   onOpen={handleOpen}
                   onDelete={handleDelete}
                   onLinkedObjects={handleLinkedObject}
+                  onAssignToFolder={handleAssignToFolder}
                   hidePagination={options?.hidePagination}
                   flashRowId={flashRowId}
                 />
@@ -537,8 +597,26 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
         policyId = {policyId}
         isOpen = {showLinkedObjectModal}
       />
-      
       )}
+
+      {/* Assign to Folder Modal */}
+      <AssignToFolderModal
+        isOpen={assignFolderOpen}
+        onClose={() => {
+          setAssignFolderOpen(false);
+          setAssignFolderPolicyId(null);
+          setAssignFolderCurrentFolders([]);
+        }}
+        onSubmit={handleAssignFolderSubmit}
+        folders={folderTree}
+        currentFolders={assignFolderCurrentFolders}
+        fileName={
+          assignFolderPolicyId
+            ? policies.find((p) => p.id === assignFolderPolicyId)?.title
+            : undefined
+        }
+        isSubmitting={assignFolderSubmitting}
+      />
 
       {alert && (
         <Fade in={showAlert} timeout={300}>

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyStatusCard.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyStatusCard.tsx
@@ -48,7 +48,7 @@ const PolicyStatusCard: React.FC<PolicyStatusCardProps> = ({
     <StatusTileCards
       items={items}
       entityName="policy"
-      cardSx={{ paddingX: { xs: "15px", sm: "20px" } }}
+      size="small"
       onCardClick={handleCardClick}
       selectedKey={selectedStatus || undefined}
     />

--- a/Clients/src/presentation/types/interfaces/i.policy.ts
+++ b/Clients/src/presentation/types/interfaces/i.policy.ts
@@ -22,6 +22,7 @@ export interface PolicyTableProps {
   onOpen: (id: number) => void;
   onDelete: (id: number) => void;
   onLinkedObjects: (id: number) => void;
+  onAssignToFolder?: (id: number) => void;
   onRefresh?: () => void;
   isLoading?: boolean;
   error?: Error | null;

--- a/Servers/controllers/policyFolder.ctrl.ts
+++ b/Servers/controllers/policyFolder.ctrl.ts
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Policy Folder Controller
+ *
+ * HTTP handlers for policy-to-virtual-folder assignment operations.
+ *
+ * Authorization:
+ * - GET endpoints: All authenticated users
+ * - PATCH endpoints: Admin and Editor roles only
+ *
+ * @module controllers/policyFolder.ctrl
+ */
+
+import { Request, Response } from "express";
+import { STATUS_CODE } from "../utils/statusCode.utils";
+import {
+  getPolicyFoldersQuery,
+  bulkUpdatePolicyFoldersQuery,
+} from "../utils/policyFolder.utils";
+import { sequelize } from "../database/db";
+
+const ALLOWED_ROLES = ["Admin", "Editor"];
+
+const hasManagePermission = (userRole: string | undefined): boolean => {
+  return userRole ? ALLOWED_ROLES.includes(userRole) : false;
+};
+
+const parseParamId = (param: string | string[] | undefined): number => {
+  const value = Array.isArray(param) ? param[0] : param;
+  return parseInt(value || "", 10);
+};
+
+/**
+ * GET /policies/:id/folders
+ * Get all folders a policy belongs to
+ */
+export const getPolicyFolders = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  try {
+    const policyId = parseParamId(req.params.id);
+    if (isNaN(policyId)) {
+      return res.status(400).json(STATUS_CODE[400]("Invalid policy ID"));
+    }
+
+    const folders = await getPolicyFoldersQuery(req.tenantId!, policyId);
+    return res.status(200).json(STATUS_CODE[200](folders));
+  } catch (error) {
+    console.error("Error getting policy folders:", error);
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+};
+
+/**
+ * PATCH /policies/:id/folders
+ * Bulk update policy folder assignments
+ */
+export const updatePolicyFolders = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const transaction = await sequelize.transaction();
+  try {
+    if (!hasManagePermission(req.role)) {
+      await transaction.rollback();
+      return res.status(403).json(STATUS_CODE[403]("Insufficient permissions"));
+    }
+
+    const policyId = parseParamId(req.params.id);
+    if (isNaN(policyId)) {
+      await transaction.rollback();
+      return res.status(400).json(STATUS_CODE[400]("Invalid policy ID"));
+    }
+
+    const { folder_ids } = req.body as { folder_ids: number[] };
+    if (!Array.isArray(folder_ids)) {
+      await transaction.rollback();
+      return res.status(400).json(STATUS_CODE[400]("Folder IDs array is required"));
+    }
+
+    await bulkUpdatePolicyFoldersQuery(
+      req.tenantId!,
+      policyId,
+      folder_ids,
+      req.userId!,
+      transaction
+    );
+
+    const updatedFolders = await getPolicyFoldersQuery(req.tenantId!, policyId);
+
+    await transaction.commit();
+    return res.status(200).json(STATUS_CODE[200](updatedFolders));
+  } catch (error) {
+    await transaction.rollback();
+    console.error("Error updating policy folders:", error);
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+};

--- a/Servers/controllers/policyFolder.ctrl.ts
+++ b/Servers/controllers/policyFolder.ctrl.ts
@@ -14,6 +14,7 @@ import { Request, Response } from "express";
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import {
   getPolicyFoldersQuery,
+  getPolicyIdsInFolderQuery,
   bulkUpdatePolicyFoldersQuery,
 } from "../utils/policyFolder.utils";
 import { sequelize } from "../database/db";
@@ -47,6 +48,28 @@ export const getPolicyFolders = async (
     return res.status(200).json(STATUS_CODE[200](folders));
   } catch (error) {
     console.error("Error getting policy folders:", error);
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+};
+
+/**
+ * GET /folders/:folderId/policies
+ * Get all policy IDs in a folder
+ */
+export const getPoliciesInFolder = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  try {
+    const folderId = parseParamId(req.params.folderId);
+    if (isNaN(folderId)) {
+      return res.status(400).json(STATUS_CODE[400]("Invalid folder ID"));
+    }
+
+    const policyIds = await getPolicyIdsInFolderQuery(req.tenantId!, folderId);
+    return res.status(200).json(STATUS_CODE[200](policyIds));
+  } catch (error) {
+    console.error("Error getting policies in folder:", error);
     return res.status(500).json(STATUS_CODE[500]((error as Error).message));
   }
 };

--- a/Servers/database/migrations/20260227043715-add-policy-folder-mappings.js
+++ b/Servers/database/migrations/20260227043715-add-policy-folder-mappings.js
@@ -1,0 +1,82 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      // 1. Get all organizations
+      const [organizations] = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      // 2. Import getTenantHash (MUST use dist path)
+      const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+      // 3. Loop over all tenants
+      for (const organization of organizations) {
+        const tenantHash = getTenantHash(organization.id);
+
+        // Create policy_folder_mappings table
+        await queryInterface.sequelize.query(`
+          CREATE TABLE IF NOT EXISTS "${tenantHash}".policy_folder_mappings (
+            id SERIAL PRIMARY KEY,
+            policy_id INTEGER NOT NULL,
+            folder_id INTEGER NOT NULL REFERENCES "${tenantHash}".virtual_folders(id) ON DELETE CASCADE,
+            assigned_by INTEGER NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+            assigned_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            CONSTRAINT unique_policy_folder UNIQUE (policy_id, folder_id)
+          );
+        `, { transaction });
+
+        // Create indexes
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_policy_folder_mappings_policy_id ON "${tenantHash}".policy_folder_mappings(policy_id);
+        `, { transaction });
+
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_policy_folder_mappings_folder_id ON "${tenantHash}".policy_folder_mappings(folder_id);
+        `, { transaction });
+
+        await queryInterface.sequelize.query(`
+          CREATE INDEX IF NOT EXISTS idx_policy_folder_mappings_assigned_by ON "${tenantHash}".policy_folder_mappings(assigned_by);
+        `, { transaction });
+
+        console.log(`Created policy_folder_mappings for tenant ${tenantHash}`);
+      }
+
+      // 4. Commit
+      await transaction.commit();
+      console.log('Migration completed successfully');
+    } catch (error) {
+      await transaction.rollback();
+      console.error('Migration failed:', error);
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const [organizations] = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+      for (const organization of organizations) {
+        const tenantHash = getTenantHash(organization.id);
+
+        await queryInterface.sequelize.query(`
+          DROP TABLE IF EXISTS "${tenantHash}".policy_folder_mappings;
+        `, { transaction });
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};

--- a/Servers/index.ts
+++ b/Servers/index.ts
@@ -23,6 +23,7 @@ import isoRoutes from "./routes/iso42001.route";
 import trainingRoutes from "./routes/trainingRegistar.route";
 import aiTrustCentreRoutes from "./routes/aiTrustCentre.route";
 import policyRoutes from "./routes/policy.route";
+import policyFolderRoutes from "./routes/policyFolder.route";
 import loggerRoutes from "./routes/logger.route";
 import dashboardRoutes from "./routes/dashboard.route";
 import iso27001Routes from "./routes/iso27001.route";
@@ -193,6 +194,7 @@ try {
   app.use("/api/tasks", taskRoutes);
   app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerDoc));
   app.use("/api/policies", policyRoutes);
+  app.use("/api/policies", policyFolderRoutes);
   app.use("/api/slackWebhooks", slackWebhookRoutes);
   app.use("/api/plugins", pluginRoutes);
   app.use("/api/tokens", tokenRoutes);

--- a/Servers/routes/policyFolder.route.ts
+++ b/Servers/routes/policyFolder.route.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Policy Folder Routes
+ *
+ * Express routes for policy-to-virtual-folder assignments.
+ * Mounted at /api/policies via index.ts (merges with existing policy routes).
+ *
+ * @module routes/policyFolder.route
+ */
+
+import { Router } from "express";
+import authenticateJWT from "../middleware/auth.middleware";
+import {
+  getPolicyFolders,
+  updatePolicyFolders,
+} from "../controllers/policyFolder.ctrl";
+
+const router = Router();
+
+/**
+ * GET /policies/:id/folders
+ * Get all folders a policy belongs to
+ */
+router.get("/:id/folders", authenticateJWT, getPolicyFolders);
+
+/**
+ * PATCH /policies/:id/folders
+ * Bulk update policy folder assignments
+ */
+router.patch("/:id/folders", authenticateJWT, updatePolicyFolders);
+
+export default router;

--- a/Servers/routes/policyFolder.route.ts
+++ b/Servers/routes/policyFolder.route.ts
@@ -11,10 +11,17 @@ import { Router } from "express";
 import authenticateJWT from "../middleware/auth.middleware";
 import {
   getPolicyFolders,
+  getPoliciesInFolder,
   updatePolicyFolders,
 } from "../controllers/policyFolder.ctrl";
 
 const router = Router();
+
+/**
+ * GET /policies/folders/:folderId/policies
+ * Get all policy IDs assigned to a folder
+ */
+router.get("/folders/:folderId/policies", authenticateJWT, getPoliciesInFolder);
 
 /**
  * GET /policies/:id/folders

--- a/Servers/scripts/createNewTenant.ts
+++ b/Servers/scripts/createNewTenant.ts
@@ -604,6 +604,33 @@ export const createNewTenant = async (
       { transaction }
     );
 
+    // Policy folder mappings junction table
+    await sequelize.query(
+      `CREATE TABLE IF NOT EXISTS "${tenantHash}".policy_folder_mappings (
+        id SERIAL PRIMARY KEY,
+        policy_id INTEGER NOT NULL,
+        folder_id INTEGER NOT NULL REFERENCES "${tenantHash}".virtual_folders(id) ON DELETE CASCADE,
+        assigned_by INTEGER NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+        assigned_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        CONSTRAINT unique_policy_folder UNIQUE (policy_id, folder_id)
+      );`,
+      { transaction }
+    );
+
+    // Indexes for policy_folder_mappings table
+    await sequelize.query(
+      `CREATE INDEX IF NOT EXISTS idx_policy_folder_mappings_policy_id ON "${tenantHash}".policy_folder_mappings(policy_id);`,
+      { transaction }
+    );
+    await sequelize.query(
+      `CREATE INDEX IF NOT EXISTS idx_policy_folder_mappings_folder_id ON "${tenantHash}".policy_folder_mappings(folder_id);`,
+      { transaction }
+    );
+    await sequelize.query(
+      `CREATE INDEX IF NOT EXISTS idx_policy_folder_mappings_assigned_by ON "${tenantHash}".policy_folder_mappings(assigned_by);`,
+      { transaction }
+    );
+
     await sequelize.query(
       `CREATE TABLE IF NOT EXISTS "${tenantHash}".projects_frameworks
     (

--- a/Servers/utils/policyFolder.utils.ts
+++ b/Servers/utils/policyFolder.utils.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Policy Folder Utility Functions
+ *
+ * Database query functions for policy-to-virtual-folder mappings.
+ * Mirrors the file_folder_mappings pattern for policies.
+ *
+ * @module utils/policyFolder.utils
+ */
+
+import { QueryTypes, Transaction } from "sequelize";
+import { sequelize } from "../database/db";
+import { IVirtualFolder } from "../domain.layer/interfaces/i.virtualFolder";
+
+/**
+ * Validate tenant identifier to prevent SQL injection.
+ */
+const validateTenant = (tenant: string): void => {
+  if (!tenant || !/^[a-zA-Z0-9]+$/.test(tenant)) {
+    throw new Error("Invalid tenant identifier");
+  }
+};
+
+/**
+ * Get all folders that a policy belongs to
+ */
+export const getPolicyFoldersQuery = async (
+  tenant: string,
+  policyId: number
+): Promise<IVirtualFolder[]> => {
+  validateTenant(tenant);
+  const result = await sequelize.query(
+    `SELECT vf.*
+    FROM "${tenant}".virtual_folders vf
+    INNER JOIN "${tenant}".policy_folder_mappings pfm ON vf.id = pfm.folder_id
+    WHERE pfm.policy_id = :policyId
+    ORDER BY vf.name ASC`,
+    {
+      replacements: { policyId },
+      type: QueryTypes.SELECT,
+    }
+  );
+  return result as IVirtualFolder[];
+};
+
+/**
+ * Bulk update policy folder assignments (replace all folder assignments for a policy)
+ */
+export const bulkUpdatePolicyFoldersQuery = async (
+  tenant: string,
+  policyId: number,
+  folderIds: number[],
+  userId: number,
+  transaction?: Transaction
+): Promise<void> => {
+  validateTenant(tenant);
+
+  // Delete existing assignments
+  await sequelize.query(
+    `DELETE FROM "${tenant}".policy_folder_mappings WHERE policy_id = :policyId`,
+    {
+      replacements: { policyId },
+      transaction,
+    }
+  );
+
+  // Add new assignments
+  if (folderIds.length > 0) {
+    const values = folderIds
+      .map((_, i) => `(:policyId, :folder_id_${i}, :userId, NOW())`)
+      .join(", ");
+
+    const replacements: Record<string, unknown> = {
+      policyId,
+      userId,
+    };
+    folderIds.forEach((folderId, i) => {
+      replacements[`folder_id_${i}`] = folderId;
+    });
+
+    await sequelize.query(
+      `INSERT INTO "${tenant}".policy_folder_mappings (policy_id, folder_id, assigned_by, assigned_at)
+       VALUES ${values}`,
+      {
+        replacements,
+        transaction,
+      }
+    );
+  }
+};

--- a/Servers/utils/policyFolder.utils.ts
+++ b/Servers/utils/policyFolder.utils.ts
@@ -43,6 +43,24 @@ export const getPolicyFoldersQuery = async (
 };
 
 /**
+ * Get all policy IDs assigned to a specific folder
+ */
+export const getPolicyIdsInFolderQuery = async (
+  tenant: string,
+  folderId: number
+): Promise<number[]> => {
+  validateTenant(tenant);
+  const result = await sequelize.query<{ policy_id: number }>(
+    `SELECT policy_id FROM "${tenant}".policy_folder_mappings WHERE folder_id = :folderId`,
+    {
+      replacements: { folderId },
+      type: QueryTypes.SELECT,
+    }
+  );
+  return result.map((r) => r.policy_id);
+};
+
+/**
  * Bulk update policy folder assignments (replace all folder assignments for a policy)
  */
 export const bulkUpdatePolicyFoldersQuery = async (

--- a/Servers/utils/virtualFolder.utils.ts
+++ b/Servers/utils/virtualFolder.utils.ts
@@ -42,10 +42,14 @@ export const getAllFoldersQuery = async (
   const result = await sequelize.query(
     `SELECT
       vf.*,
-      COALESCE(COUNT(ffm.id), 0)::INTEGER as file_count
+      (COALESCE(file_counts.cnt, 0) + COALESCE(policy_counts.cnt, 0))::INTEGER as file_count
     FROM "${tenant}".virtual_folders vf
-    LEFT JOIN "${tenant}".file_folder_mappings ffm ON vf.id = ffm.folder_id
-    GROUP BY vf.id
+    LEFT JOIN (
+      SELECT folder_id, COUNT(*) as cnt FROM "${tenant}".file_folder_mappings GROUP BY folder_id
+    ) file_counts ON vf.id = file_counts.folder_id
+    LEFT JOIN (
+      SELECT folder_id, COUNT(*) as cnt FROM "${tenant}".policy_folder_mappings GROUP BY folder_id
+    ) policy_counts ON vf.id = policy_counts.folder_id
     ORDER BY vf.name ASC`,
     {
       type: QueryTypes.SELECT,
@@ -112,11 +116,15 @@ export const getFolderByIdQuery = async (
   const result = await sequelize.query(
     `SELECT
       vf.*,
-      COALESCE(COUNT(ffm.id), 0)::INTEGER as file_count
+      (COALESCE(file_counts.cnt, 0) + COALESCE(policy_counts.cnt, 0))::INTEGER as file_count
     FROM "${tenant}".virtual_folders vf
-    LEFT JOIN "${tenant}".file_folder_mappings ffm ON vf.id = ffm.folder_id
-    WHERE vf.id = :id
-    GROUP BY vf.id`,
+    LEFT JOIN (
+      SELECT folder_id, COUNT(*) as cnt FROM "${tenant}".file_folder_mappings GROUP BY folder_id
+    ) file_counts ON vf.id = file_counts.folder_id
+    LEFT JOIN (
+      SELECT folder_id, COUNT(*) as cnt FROM "${tenant}".policy_folder_mappings GROUP BY folder_id
+    ) policy_counts ON vf.id = policy_counts.folder_id
+    WHERE vf.id = :id`,
     {
       replacements: { id },
       type: QueryTypes.SELECT,


### PR DESCRIPTION
## Summary

- Add ability to assign policies to virtual folders via the gear icon menu on each policy row
- New `policy_folder_mappings` junction table (migration + new tenant support) mirrors the existing file-folder pattern
- Backend API: GET/PATCH endpoints for policy-folder assignments, plus GET endpoint to list policy IDs in a folder
- Folder sidebar on policies page filters the table by selected folder, with context-appropriate labels ("All policies" instead of "All files", no "Uncategorized")
- Folder item counts now include both files and policies

## Changes

**Backend (6 files)**
- New migration for `policy_folder_mappings` table across all tenant schemas
- Updated `createNewTenant.ts` so new tenants get the table
- New `policyFolder.utils.ts`, `policyFolder.ctrl.ts`, `policyFolder.route.ts` for CRUD operations
- Updated `virtualFolder.utils.ts` to count policies in folder item counts

**Frontend (8 files)**
- New `policyFolder.repository.ts` API client
- Updated `IconButton` to dynamically show "Assign to folder" for policies
- Updated `PolicyTable` with `onAssignToFolder` prop
- Updated `PolicyManager` with folder sidebar, assign modal, and folder-based filtering
- Updated `FolderTree` with `allLabel` and `showUncategorized` props for reuse across contexts

## Test plan

- [ ] Run migration (`npx sequelize db:migrate`) — succeeds on existing database
- [ ] Navigate to `/policies` — folder toggle button appears in toolbar
- [ ] Open folder sidebar — shows "All policies" (not "All files"), no "Uncategorized" item
- [ ] Click gear icon on any policy — "Assign to folder" option appears
- [ ] Assign a policy to a folder — folder count updates, modal closes with success alert
- [ ] Click a folder in sidebar — table filters to show only assigned policies
- [ ] Click "All policies" — table shows all policies again
- [ ] Verify file manager still works normally (labels unchanged, uncategorized still visible)
- [ ] Create a new tenant — verify `policy_folder_mappings` table exists