### PR TITLE
fix(evals): fix Params button form submission and false API key warning in experiment wizard

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/CreateScorerModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/CreateScorerModal.tsx
@@ -1073,6 +1073,7 @@ export default function CreateScorerModal({
                   </Box>
                   <Box
                     component="button"
+                    type="button"
                     ref={paramsButtonRef}
                     onClick={() => setParamsPopoverOpen(!paramsPopoverOpen)}
                     sx={{

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -514,8 +514,8 @@ export default function NewExperimentModal({
       const modelName = config.model.name;
       const modelProvider = config.model.accessMethod;
 
-      // Skip validation if user already acknowledged the warning
-      if (!apiKeyWarningAcknowledged && modelName && modelProvider !== "ollama" && modelProvider !== "huggingface") {
+      // Skip validation if user already acknowledged the warning, or if they provided a key inline
+      if (!apiKeyWarningAcknowledged && !config.model.apiKey && modelName && modelProvider !== "ollama" && modelProvider !== "huggingface") {
         try {
           const validation = await validateModel(modelName, modelProvider);
           if (!validation.valid) {


### PR DESCRIPTION
## Describe your changes

This PR fixes two bugs in the LLM Evals section:

1. Params button closes scorer editor unexpectedly

      The "Params" button in the scorer edit panel was rendered as <Box component="button"> without an explicit type
      attribute. Inside an HTML form, buttons default to type="submit", so clicking Params was submitting the form — saving
      the scorer and closing the panel — instead of opening the model parameters popover.
      
      Fixed by adding type="button" to the element.

2. False "API key may not be configured" warning in New Experiment wizard

      When a user selected a model provider (e.g. Mistral) and entered an API key directly in Step 1 of the experiment
      wizard, clicking "Start Experiment" would show a warning: "MISTRAL_API_KEY is not configured. Please add your API key
      in settings or enable OpenRouter."
      
      The root cause was an ordering issue: the validation check ran against environment variables and the database before
      the inline key was saved. Since the freshly-typed key didn't exist in either place yet, validation returned invalid
      and showed the warning, requiring the user to click a second time.
      
      Fixed by skipping the validation check when config.model.apiKey is already present — if the user provided a key in the
       form, there is nothing to warn about.

## Write your issue number after "Fixes "

This PR does not intend to fix any specific issues.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
