### PR TITLE
fix(intake): remove risk tier system toggle, always use EU AI Act

### DIFF
--- a/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/index.tsx
@@ -8,9 +8,6 @@ import {
   CircularProgress,
   Snackbar,
   Alert,
-  RadioGroup,
-  FormControlLabel,
-  Radio,
   Collapse,
   useTheme,
 } from "@mui/material";
@@ -265,7 +262,7 @@ export function IntakeFormBuilder() {
         ...form,
         slug: form.slug || generateSlug(form.name),
         recipients: form.recipients ?? [],
-        riskTierSystem: form.riskTierSystem ?? "generic",
+        riskTierSystem: form.riskTierSystem ?? "eu_ai_act",
         llmKeyId: form.llmKeyId ?? null,
         suggestedQuestionsEnabled: form.suggestedQuestionsEnabled ?? false,
       };
@@ -316,7 +313,7 @@ export function IntakeFormBuilder() {
         ...form,
         slug: form.slug || generateSlug(form.name),
         recipients: form.recipients ?? [],
-        riskTierSystem: form.riskTierSystem ?? "generic",
+        riskTierSystem: form.riskTierSystem ?? "eu_ai_act",
         llmKeyId: form.llmKeyId ?? null,
         suggestedQuestionsEnabled: form.suggestedQuestionsEnabled ?? false,
         status: IntakeFormStatus.ACTIVE,
@@ -983,82 +980,6 @@ export function IntakeFormBuilder() {
                           >
                             Submission responses will be emailed to selected recipients
                           </Typography>
-                        </Box>
-
-                        <Box>
-                          <Typography
-                            sx={{
-                              fontSize: 13,
-                              fontWeight: 500,
-                              color: theme.palette.text.secondary,
-                              mb: "4px",
-                            }}
-                          >
-                            Risk tier system
-                          </Typography>
-                          <RadioGroup
-                            value={form.riskTierSystem ?? "generic"}
-                            onChange={(e) =>
-                              updateForm({
-                                riskTierSystem: e.target.value,
-                              })
-                            }
-                            sx={{ pl: "16px", gap: "8px" }}
-                          >
-                            <FormControlLabel
-                              value="generic"
-                              sx={{ mr: 0 }}
-                              control={
-                                <Radio
-                                  size="small"
-                                  sx={{
-                                    color: theme.palette.text.accent,
-                                    "&.Mui-checked": {
-                                      color: theme.palette.primary.main,
-                                    },
-                                    p: 0.5,
-                                  }}
-                                />
-                              }
-                              label={
-                                <Typography
-                                  sx={{
-                                    fontSize: 13,
-                                    color: theme.palette.text.secondary,
-                                  }}
-                                >
-                                  Generic (Low / Med / High / Critical)
-                                </Typography>
-                              }
-                            />
-                            <FormControlLabel
-                              value="eu_ai_act"
-                              sx={{ mr: 0 }}
-                              control={
-                                <Radio
-                                  size="small"
-                                  sx={{
-                                    color: theme.palette.text.accent,
-                                    "&.Mui-checked": {
-                                      color: theme.palette.primary.main,
-                                    },
-                                    p: 0.5,
-                                  }}
-                                />
-                              }
-                              label={
-                                <Typography
-                                  sx={{
-                                    fontSize: 13,
-                                    color: theme.palette.text.secondary,
-                                  }}
-                                >
-                                  EU AI Act (Minimal / Limited / High /
-                                  Unacceptable)
-                                </Typography>
-                              }
-                            />
-                          </RadioGroup>
                         </Box>
 
                         <Box>

--- a/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/types.ts
@@ -613,7 +613,7 @@ export function createEmptyForm(entityType?: IntakeEntityType): IntakeForm {
     status: IntakeFormStatus.DRAFT,
     ttlExpiresAt: null,
     recipients: [],
-    riskTierSystem: "generic",
+    riskTierSystem: "eu_ai_act",
     llmKeyId: null,
     suggestedQuestionsEnabled: false,
     designSettings: { ...DEFAULT_DESIGN_SETTINGS },

--- a/Clients/src/presentation/pages/PublicIntakeForm/index.tsx
+++ b/Clients/src/presentation/pages/PublicIntakeForm/index.tsx
@@ -403,6 +403,18 @@ export function PublicIntakeForm() {
             >
               {formData.name}
             </Typography>
+            {formData.description && (
+              <Typography
+                sx={{
+                  color: "rgba(255, 255, 255, 0.85)",
+                  fontSize: "15px",
+                  lineHeight: 1.6,
+                  mt: "8px",
+                }}
+              >
+                {formData.description}
+              </Typography>
+            )}
           </GradientBanner>
 
           {/* Form body */}
@@ -411,19 +423,6 @@ export function PublicIntakeForm() {
             onSubmit={handleSubmit(onSubmit)}
             sx={{ p: "32px" }}
           >
-            {/* Description */}
-            {formData.description && (
-              <Typography
-                sx={{
-                  color: "#64748b",
-                  fontSize: "15px",
-                  lineHeight: 1.6,
-                  mb: 3,
-                }}
-              >
-                {formData.description}
-              </Typography>
-            )}
 
             {/* Resubmission alert */}
             {previousData && (

--- a/Servers/controllers/intakeForm.ctrl.ts
+++ b/Servers/controllers/intakeForm.ctrl.ts
@@ -448,11 +448,6 @@ export async function updateIntakeForm(req: Request, res: Response) {
       return res.status(400).json(STATUS_CODE[400]("Invalid entity type"));
     }
 
-    if (riskTierSystem && !["generic", "eu_ai_act", "nist"].includes(riskTierSystem)) {
-      await transaction.rollback();
-      return res.status(400).json(STATUS_CODE[400]("Invalid risk tier system"));
-    }
-
     const form = await updateIntakeFormQuery(
       formId,
       {
@@ -1547,7 +1542,7 @@ export async function submitPublicFormByPublicId(req: Request, res: Response) {
         calculateSubmissionRisk(
           formData,
           fullForm.schema,
-          fullForm.riskTierSystem || "generic",
+          fullForm.riskTierSystem || "eu_ai_act",
           fullForm.llmKeyId,
           tenantInfo.tenantHash
         )
@@ -1845,7 +1840,7 @@ export async function submitPublicForm(req: Request, res: Response) {
         calculateSubmissionRisk(
           formData,
           fullForm.schema,
-          fullForm.riskTierSystem || "generic",
+          fullForm.riskTierSystem || "eu_ai_act",
           fullForm.llmKeyId,
           tenantInfo.hash
         )

--- a/Servers/database/migrations/20260301184601-standardize-risk-tier-to-eu-ai-act.js
+++ b/Servers/database/migrations/20260301184601-standardize-risk-tier-to-eu-ai-act.js
@@ -1,0 +1,65 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const [organizations] = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+      for (const organization of organizations) {
+        const tenantHash = getTenantHash(organization.id);
+
+        await queryInterface.sequelize.query(`
+          UPDATE "${tenantHash}".intake_forms
+          SET risk_tier_system = 'eu_ai_act'
+          WHERE risk_tier_system = 'generic';
+        `, { transaction });
+
+        await queryInterface.sequelize.query(`
+          ALTER TABLE "${tenantHash}".intake_forms
+          ALTER COLUMN risk_tier_system SET DEFAULT 'eu_ai_act';
+        `, { transaction });
+
+        console.log(`Updated risk_tier_system for tenant ${tenantHash}`);
+      }
+
+      await transaction.commit();
+      console.log('Migration completed successfully');
+    } catch (error) {
+      await transaction.rollback();
+      console.error('Migration failed:', error);
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const [organizations] = await queryInterface.sequelize.query(
+        `SELECT id FROM organizations;`,
+        { transaction }
+      );
+
+      const { getTenantHash } = require("../../dist/tools/getTenantHash");
+
+      for (const organization of organizations) {
+        const tenantHash = getTenantHash(organization.id);
+
+        await queryInterface.sequelize.query(`
+          ALTER TABLE "${tenantHash}".intake_forms
+          ALTER COLUMN risk_tier_system SET DEFAULT 'generic';
+        `, { transaction });
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};

--- a/Servers/domain.layer/models/intakeForm/intakeForm.model.ts
+++ b/Servers/domain.layer/models/intakeForm/intakeForm.model.ts
@@ -97,7 +97,7 @@ export class IntakeFormModel extends Model<IntakeFormModel> implements IIntakeFo
   @Column({
     type: DataType.STRING(20),
     allowNull: false,
-    defaultValue: "generic",
+    defaultValue: "eu_ai_act",
     field: "risk_tier_system",
   })
   riskTierSystem!: string;

--- a/Servers/scripts/createNewTenant.ts
+++ b/Servers/scripts/createNewTenant.ts
@@ -3485,7 +3485,7 @@ export const createNewTenant = async (
         ttl_expires_at TIMESTAMPTZ,
         public_id VARCHAR(16) UNIQUE,
         recipients JSONB DEFAULT '[]',
-        risk_tier_system VARCHAR(20) DEFAULT 'generic',
+        risk_tier_system VARCHAR(20) DEFAULT 'eu_ai_act',
         risk_assessment_config JSONB,
         llm_key_id INTEGER,
         suggested_questions_enabled BOOLEAN DEFAULT false,

--- a/Servers/services/intakeRiskScoring.service.ts
+++ b/Servers/services/intakeRiskScoring.service.ts
@@ -123,12 +123,6 @@ const DIMENSION_CONFIGS = [
 // ============================================================================
 
 const TIER_THRESHOLDS: Record<string, Array<{ max: number; tier: string }>> = {
-  generic: [
-    { max: 25, tier: "Low" },
-    { max: 50, tier: "Medium" },
-    { max: 75, tier: "High" },
-    { max: 100, tier: "Critical" },
-  ],
   eu_ai_act: [
     { max: 25, tier: "Minimal" },
     { max: 50, tier: "Limited" },
@@ -338,7 +332,7 @@ For each dimension, provide a refined score adjustment (-15 to +15). Respond ONL
 // ============================================================================
 
 function getTierFromScore(score: number, tierSystem: string): string {
-  const thresholds = TIER_THRESHOLDS[tierSystem] || TIER_THRESHOLDS.generic;
+  const thresholds = TIER_THRESHOLDS[tierSystem] || TIER_THRESHOLDS.eu_ai_act;
   for (const threshold of thresholds) {
     if (score <= threshold.max) return threshold.tier;
   }
@@ -348,7 +342,7 @@ function getTierFromScore(score: number, tierSystem: string): string {
 export async function calculateSubmissionRisk(
   submissionData: Record<string, unknown>,
   schema: FormSchema,
-  tierSystem: string = "generic",
+  tierSystem: string = "eu_ai_act",
   llmKeyId?: number | null,
   tenant?: string
 ): Promise<RiskResult> {

--- a/Servers/utils/intakeForm.utils.ts
+++ b/Servers/utils/intakeForm.utils.ts
@@ -189,7 +189,7 @@ export const createIntakeFormQuery = async (
         ttlExpiresAt: data.ttlExpiresAt || null,
         publicId,
         recipients: JSON.stringify(data.recipients || []),
-        riskTierSystem: data.riskTierSystem || "generic",
+        riskTierSystem: data.riskTierSystem || "eu_ai_act",
         riskAssessmentConfig: data.riskAssessmentConfig
           ? JSON.stringify(data.riskAssessmentConfig)
           : null,


### PR DESCRIPTION
## Summary
- Removed the risk tier system radio toggle (Generic vs EU AI Act) from the intake form builder — all forms now use EU AI Act tiers exclusively (Minimal / Limited / High / Unacceptable)
- Added migration to update existing forms from "generic" to "eu_ai_act" and set the new default
- Moved form description into the gradient banner on the public intake form for better visual hierarchy
- Removed the "generic" tier thresholds from the risk scoring service and updated all fallback defaults to "eu_ai_act"

## Test plan
- [ ] Open the intake form builder and verify the risk tier system radio group is gone
- [ ] Create a new form and confirm `riskTierSystem` defaults to "eu_ai_act"
- [ ] Submit a public intake form and verify risk scoring uses EU AI Act tiers
- [ ] Run migration on a database with existing "generic" forms and confirm they are updated
- [ ] Verify the public form shows the description inside the gradient banner