### PR TITLE
fix(db): add missing task_entity_links table to new tenant creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ EvaluationModule/data/uploads/*
 !EvaluationModule/data/uploads/.gitkeep
 nul
 agent-plan.md
+pdf-templates/

--- a/Servers/scripts/createNewTenant.ts
+++ b/Servers/scripts/createNewTenant.ts
@@ -1549,6 +1549,45 @@ export const createNewTenant = async (
       ].map((query) => sequelize.query(query, { transaction }))
     );
 
+    // Create task_entity_links table
+    await sequelize.query(
+      `DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'enum_task_entity_links_entity_type') THEN
+          CREATE TYPE enum_task_entity_links_entity_type AS ENUM (
+            'vendor', 'model', 'policy', 'nist_subcategory',
+            'iso42001_subclause', 'iso42001_annexcategory',
+            'iso27001_subclause', 'iso27001_annexcontrol',
+            'eu_control', 'eu_subcontrol'
+          );
+        END IF;
+      END $$;`,
+      { transaction }
+    );
+    await sequelize.query(
+      `CREATE TABLE IF NOT EXISTS "${tenantHash}".task_entity_links (
+        id SERIAL PRIMARY KEY,
+        task_id INTEGER NOT NULL,
+        entity_id INTEGER NOT NULL,
+        entity_type enum_task_entity_links_entity_type NOT NULL,
+        entity_name VARCHAR(500),
+        created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        CONSTRAINT task_entity_links_task_id_fkey FOREIGN KEY (task_id)
+          REFERENCES "${tenantHash}".tasks (id) MATCH SIMPLE
+          ON UPDATE CASCADE ON DELETE CASCADE,
+        CONSTRAINT unique_task_entity_link UNIQUE (task_id, entity_id, entity_type)
+      );`,
+      { transaction }
+    );
+    await Promise.all(
+      [
+        `CREATE INDEX IF NOT EXISTS "${tenantHash}_task_entity_links_task_id_idx" ON "${tenantHash}".task_entity_links (task_id);`,
+        `CREATE INDEX IF NOT EXISTS "${tenantHash}_task_entity_links_entity_type_idx" ON "${tenantHash}".task_entity_links (entity_type);`,
+        `CREATE INDEX IF NOT EXISTS "${tenantHash}_task_entity_links_entity_id_entity_type_idx" ON "${tenantHash}".task_entity_links (entity_id, entity_type);`,
+      ].map((query) => sequelize.query(query, { transaction }))
+    );
+
     await sequelize.query(
       `CREATE TABLE IF NOT EXISTS "${tenantHash}".api_tokens
     (


### PR DESCRIPTION
## Summary
- PR #3412 added a migration to create `task_entity_links` for existing tenants but did not update `createNewTenant.ts`
- Any fresh VerifyWise deployment would be missing this table for the first organization, breaking task-entity linking
- Also adds `pdf-templates/` to `.gitignore`

## Test plan
- [ ] Deploy a fresh instance, create a new organization, and verify `task_entity_links` table exists in the tenant schema
- [ ] Confirm task-entity linking works for the newly created tenant