### PR TITLE
feat(intake): supersede old submissions on resubmission

### DIFF
--- a/Clients/src/application/repository/intakeForm.repository.ts
+++ b/Clients/src/application/repository/intakeForm.repository.ts
@@ -135,6 +135,7 @@ export interface IntakeSubmission {
   createdEntityId?: number;
   createdEntityType?: string;
   resubmissionToken?: string;
+  originalSubmissionId?: number | null;
   resubmissionCount: number;
   ipAddress?: string;
   riskAssessment?: RiskAssessment | null;

--- a/Clients/src/domain/intake/enums.ts
+++ b/Clients/src/domain/intake/enums.ts
@@ -22,4 +22,5 @@ export enum IntakeSubmissionStatus {
   PENDING = "pending",
   APPROVED = "approved",
   REJECTED = "rejected",
+  SUPERSEDED = "superseded",
 }

--- a/Clients/src/presentation/components/Chip.tsx
+++ b/Clients/src/presentation/components/Chip.tsx
@@ -83,6 +83,7 @@ const LABEL_TO_VARIANT: Record<string, ChipVariant> = {
   "under review": "warning",
   draft: "default",
   superseded: "default",
+  resubmitted: "info",
   expired: "warning",
   blocked: "error",
   rejected: "error",

--- a/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
@@ -623,12 +623,13 @@ export function IntakeFormsListPage() {
                       <TableRow
                         key={submission.id}
                         onClick={() => {
+                          if (submission.status === "superseded") return;
                           setSelectedSubmissionId(submission.id);
                           setPreviewOpen(true);
                         }}
                         sx={{
                           ...singleTheme.tableStyles.primary.body.row,
-                          cursor: "pointer",
+                          cursor: submission.status === "superseded" ? "default" : "pointer",
                           ...(submission.status === "superseded" && { opacity: 0.5 }),
                         }}
                       >
@@ -650,7 +651,7 @@ export function IntakeFormsListPage() {
                           </Typography>
                         </TableCell>
                         <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                          <Stack direction="row" alignItems="center" spacing={0.5}>
+                          <Stack direction="row" alignItems="center" gap="8px">
                             <Chip label={submission.status} />
                             {submission.resubmissionCount > 0 && submission.status !== "superseded" && (
                               <Chip label="resubmitted" />
@@ -666,25 +667,27 @@ export function IntakeFormsListPage() {
                           </Typography>
                         </TableCell>
                         <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                          <CustomizableButton
-                            variant="outlined"
-                            onClick={() => {
-                              setSelectedSubmissionId(submission.id);
-                              setPreviewOpen(true);
-                            }}
-                            sx={{
-                              height: 28,
-                              fontSize: "12px",
-                              borderColor: theme.palette.border.dark,
-                              color: theme.palette.text.secondary,
-                              "&:hover": {
-                                borderColor: theme.palette.primary.main,
-                                backgroundColor: theme.palette.background.fill,
-                              },
-                            }}
-                          >
-                            {submission.status === "superseded" ? "View" : "Review"}
-                          </CustomizableButton>
+                          {submission.status !== "superseded" && (
+                            <CustomizableButton
+                              variant="outlined"
+                              onClick={() => {
+                                setSelectedSubmissionId(submission.id);
+                                setPreviewOpen(true);
+                              }}
+                              sx={{
+                                height: 28,
+                                fontSize: "12px",
+                                borderColor: theme.palette.border.dark,
+                                color: theme.palette.text.secondary,
+                                "&:hover": {
+                                  borderColor: theme.palette.primary.main,
+                                  backgroundColor: theme.palette.background.fill,
+                                },
+                              }}
+                            >
+                              Review
+                            </CustomizableButton>
+                          )}
                         </TableCell>
                       </TableRow>
                     );

--- a/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
@@ -581,6 +581,7 @@ export function IntakeFormsListPage() {
                 { _id: "pending", name: "Pending" },
                 { _id: "approved", name: "Approved" },
                 { _id: "rejected", name: "Rejected" },
+                { _id: "superseded", name: "Superseded" },
               ]}
               sx={{ width: 180, backgroundColor: theme.palette.background.main }}
             />
@@ -628,6 +629,7 @@ export function IntakeFormsListPage() {
                         sx={{
                           ...singleTheme.tableStyles.primary.body.row,
                           cursor: "pointer",
+                          ...(submission.status === "superseded" && { opacity: 0.5 }),
                         }}
                       >
                         <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
@@ -648,7 +650,12 @@ export function IntakeFormsListPage() {
                           </Typography>
                         </TableCell>
                         <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                          <Chip label={submission.status} />
+                          <Stack direction="row" alignItems="center" spacing={0.5}>
+                            <Chip label={submission.status} />
+                            {submission.resubmissionCount > 0 && submission.status !== "superseded" && (
+                              <Chip label="resubmitted" />
+                            )}
+                          </Stack>
                         </TableCell>
                         <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
                           <RiskTierChip submission={submission} />
@@ -676,7 +683,7 @@ export function IntakeFormsListPage() {
                               },
                             }}
                           >
-                            Review
+                            {submission.status === "superseded" ? "View" : "Review"}
                           </CustomizableButton>
                         </TableCell>
                       </TableRow>

--- a/Servers/domain.layer/enums/intake-submission-status.enum.ts
+++ b/Servers/domain.layer/enums/intake-submission-status.enum.ts
@@ -2,4 +2,5 @@ export enum IntakeSubmissionStatus {
   PENDING = "pending",
   APPROVED = "approved",
   REJECTED = "rejected",
+  SUPERSEDED = "superseded",
 }

--- a/Servers/domain.layer/interfaces/i.intakeSubmission.ts
+++ b/Servers/domain.layer/interfaces/i.intakeSubmission.ts
@@ -113,5 +113,6 @@ export interface IIntakeSubmissionStats {
   pending: number;
   approved: number;
   rejected: number;
+  superseded: number;
   total: number;
 }

--- a/Servers/utils/intakeForm.utils.ts
+++ b/Servers/utils/intakeForm.utils.ts
@@ -496,6 +496,26 @@ export const createSubmissionQuery = async (
     }
   );
 
+  // Supersede the original submission when this is a resubmission
+  if (data.originalSubmissionId) {
+    await sequelize.query(
+      `UPDATE "${tenant}".intake_submissions
+       SET status = :superseded, updated_at = NOW()
+       WHERE id = :originalId
+         AND status IN (:pending, :rejected)`,
+      {
+        replacements: {
+          originalId: data.originalSubmissionId,
+          superseded: IntakeSubmissionStatus.SUPERSEDED,
+          pending: IntakeSubmissionStatus.PENDING,
+          rejected: IntakeSubmissionStatus.REJECTED,
+        },
+        type: QueryTypes.UPDATE,
+        transaction,
+      }
+    );
+  }
+
   return result[0] as IIntakeSubmission;
 };
 
@@ -622,6 +642,7 @@ export const getSubmissionStatsQuery = async (
       COUNT(*) FILTER (WHERE status = :pending) as pending,
       COUNT(*) FILTER (WHERE status = :approved) as approved,
       COUNT(*) FILTER (WHERE status = :rejected) as rejected,
+      COUNT(*) FILTER (WHERE status = :superseded) as superseded,
       COUNT(*) as total
     FROM "${tenant}".intake_submissions`,
     {
@@ -629,6 +650,7 @@ export const getSubmissionStatsQuery = async (
         pending: IntakeSubmissionStatus.PENDING,
         approved: IntakeSubmissionStatus.APPROVED,
         rejected: IntakeSubmissionStatus.REJECTED,
+        superseded: IntakeSubmissionStatus.SUPERSEDED,
       },
       type: QueryTypes.SELECT,
     }
@@ -639,6 +661,7 @@ export const getSubmissionStatsQuery = async (
     pending: parseInt(stats.pending, 10) || 0,
     approved: parseInt(stats.approved, 10) || 0,
     rejected: parseInt(stats.rejected, 10) || 0,
+    superseded: parseInt(stats.superseded, 10) || 0,
     total: parseInt(stats.total, 10) || 0,
   };
 };


### PR DESCRIPTION
## Summary
- When a user resubmits an intake form, the old submission is automatically marked as "superseded" (only if it was pending or rejected)
- Superseded submissions appear greyed out, are not clickable, and have no Review button
- New resubmissions show a blue "Resubmitted" badge next to their status chip
- Added "Superseded" option to the status filter dropdown
- No database migration needed — the status column is VARCHAR(20) with no CHECK constraint

## Test plan
- [ ] Reject a submission, use resubmission link, submit again
- [ ] Verify old submission shows "Superseded" chip (grey, opacity 0.5, no button, not clickable)
- [ ] Verify new submission shows "Pending" + "Resubmitted" badge
- [ ] Verify "Superseded" appears in the filter dropdown
- [ ] Open superseded submission row — should not open modal
- [ ] Existing approved submissions remain unchanged