### PR TITLE
fix(arena): resolve model selection, settings navigation, and Mistral connection errors

### DIFF
--- a/Clients/src/presentation/components/Inputs/ModelSelector/index.tsx
+++ b/Clients/src/presentation/components/Inputs/ModelSelector/index.tsx
@@ -105,8 +105,7 @@ function ModelSelector({
 
   const handleProviderSelect = (newProvider: string) => {
     onProviderChange(newProvider);
-    onModelChange(""); // Reset model when provider changes
-    setCustomModel(""); // Reset custom model too
+    setCustomModel("");
     setSearchQuery("");
   };
 

--- a/Clients/src/presentation/pages/EvalsDashboard/ArenaPage.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ArenaPage.tsx
@@ -759,7 +759,7 @@ export default function ArenaPage({ orgId }: ArenaPageProps) {
                 onProviderChange={(provider) => setNewComparison({ ...newComparison, judgeProvider: provider, judgeModel: "" })}
                 onModelChange={(model) => setNewComparison({ ...newComparison, judgeModel: model })}
                 configuredProviders={configuredProviders}
-                onNavigateToSettings={() => navigate("/evals#settings")}
+                onNavigateToSettings={() => navigate("/evals/settings")}
                 label="Judge model"
               />
               <Typography sx={{ fontSize: 11, color: palette.text.disabled, mt: 1 }}>
@@ -1008,7 +1008,7 @@ export default function ArenaPage({ orgId }: ArenaPageProps) {
                           onProviderChange={(newProvider) => updateContestant(index, "provider", newProvider)}
                           onModelChange={(newModel) => updateContestant(index, "model", newModel)}
                           configuredProviders={configuredProviders}
-                          onNavigateToSettings={() => navigate("/evals#settings")}
+                          onNavigateToSettings={() => navigate("/evals/settings")}
                           label=""
                         />
                       </Box>

--- a/EvalServer/src/controllers/deepeval_arena.py
+++ b/EvalServer/src/controllers/deepeval_arena.py
@@ -180,7 +180,13 @@ async def call_llm_model(
         
         else:
             # For other providers, try OpenAI-compatible API
-            client = openai.OpenAI(api_key=api_key, base_url=f"https://api.{provider}.com/v1")
+            provider_base_urls = {
+                "mistral": "https://api.mistral.ai/v1",
+                "xai": "https://api.x.ai/v1",
+                "openrouter": "https://openrouter.ai/api/v1",
+            }
+            base_url = provider_base_urls.get(provider.lower(), f"https://api.{provider}.com/v1")
+            client = openai.OpenAI(api_key=api_key, base_url=base_url)
             response = client.chat.completions.create(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],


### PR DESCRIPTION
## Describe your changes

Summary

  - Fixed a stale closure bug in ModelSelector that prevented changing the judge/contestant provider away from OpenAI —
  provider state was always reverting to "openai" due to two setState calls closing over the same snapshot
  - Fixed "Go to settings" button navigating to the Overview page instead of the LLM Eval Settings page — the URL was
  "/evals#settings" (ignored hash) instead of "/evals/settings"
  - Fixed Mistral (and xAI, OpenRouter) arena battles failing with a connection error — the EvalServer was constructing
  https://api.mistral.com/v1 instead of the correct https://api.mistral.ai/v1

  Test plan

  - Open New Battle modal, change the judge provider to Mistral/Anthropic/Google — confirm the model list updates to
  that provider's models
  - Open New Battle modal, select a provider without an API key, click "Go to settings" — confirm it navigates to the
  LLM Eval Settings page
  - Start an arena battle using Mistral as a contestant or judge — confirm it completes without a connection error

## Write your issue number after "Fixes "

This PR does not intend to fix any specific issues.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
