### PR TITLE
docs: purge old schema-per-tenant architecture references

### DIFF
--- a/docs/INTAKE_FORM_IMPLEMENTATION_PLAN.md
+++ b/docs/INTAKE_FORM_IMPLEMENTATION_PLAN.md
@@ -122,7 +122,7 @@ CREATE TABLE intake_forms (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
   -- Constraints
-  UNIQUE(slug)  -- Unique within tenant schema
+  UNIQUE(slug)  -- Unique within organization
 );
 
 CREATE INDEX idx_intake_forms_status ON intake_forms(status);

--- a/docs/deployment/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -272,7 +272,7 @@ Note: VerifyWise does not currently have a dedicated health check endpoint. Moni
 
 ## Multi-tenancy configuration
 
-VerifyWise supports multi-tenant deployments with schema-per-tenant isolation:
+VerifyWise supports multi-tenant deployments with shared-schema isolation:
 
 ```bash
 # Enable multi-tenancy
@@ -280,9 +280,9 @@ MULTI_TENANCY_ENABLED=true
 ```
 
 When enabled:
-- Each organization gets its own PostgreSQL schema
-- Data is isolated between tenants
-- Tenant context is derived from JWT token
+- All data lives in a single `verifywise` PostgreSQL schema
+- Data is isolated between organizations via `organization_id` columns
+- Organization context is derived from JWT token (`req.organizationId`)
 
 ---
 

--- a/docs/technical/architecture/authentication.md
+++ b/docs/technical/architecture/authentication.md
@@ -48,7 +48,7 @@ VerifyWise implements a JWT-based authentication system with refresh token rotat
 │     ├── Payload structure (id, roleName)                                    │
 │     ├── Organization membership                                             │
 │     ├── Role consistency (matches database)                                 │
-│     └── Tenant hash validity                                                │
+│     └── Attach organizationId to request                                    │
 │         │                                                                   │
 │         ▼                                                                   │
 │  3. Attach context to request:                                              │
@@ -99,8 +99,8 @@ interface AccessTokenPayload {
   name: string;            // First name
   surname: string;         // Last name
   roleName: string;        // Role (Admin, Editor, Reviewer, Auditor)
-  tenantId: string;        // Tenant hash (10 chars)
-  organizationId: number;  // Organization ID
+  organizationId: number;  // Organization ID (used for data isolation)
+  tenantId: string;        // Legacy field (backward compat)
   expire: number;          // Expiration timestamp
 }
 
@@ -119,8 +119,8 @@ interface RefreshTokenPayload {
   name: string;
   surname: string;
   roleName: string;
-  tenantId: string;
   organizationId: number;
+  tenantId: string;        // Legacy field
   expire: number;
 }
 
@@ -166,15 +166,12 @@ export const generateRefreshToken = (data: TokenPayload): string => {
 
 // Combined generation for login
 export const generateUserTokens = (user: UserModel, res: Response) => {
-  const tenantId = getTenantHash(user.organization_id!);
-
   const payload = {
     id: user.id!,
     email: user.email,
     name: user.name,
     surname: user.surname,
     roleName: user.roleName!,
-    tenantId,
     organizationId: user.organization_id!,
   };
 
@@ -244,18 +241,9 @@ export const authenticateJWT = async (
       });
     }
 
-    // 7. Validate tenant hash
-    if (!isValidTenantHash(decoded.tenantId)) {
-      return res.status(400).json({ message: "Invalid tenant format" });
-    }
-    if (decoded.tenantId !== getTenantHash(decoded.organizationId)) {
-      return res.status(400).json({ message: "Invalid token" });
-    }
-
-    // 8. Attach context to request
+    // 7. Attach context to request
     req.userId = decoded.id;
     req.role = decoded.roleName;
-    req.tenantId = decoded.tenantId;
     req.organizationId = decoded.organizationId;
 
     next();
@@ -536,7 +524,6 @@ export const refreshToken = async (req: Request, res: Response) => {
       name: decoded.name,
       surname: decoded.surname,
       roleName: decoded.roleName,
-      tenantId: decoded.tenantId,
       organizationId: decoded.organizationId,
     });
 
@@ -758,7 +745,7 @@ api.interceptors.response.use(
 | **HTTPS Enforcement** | secure cookie flag (production) |
 | **CSRF Protection** | SameSite cookie attribute |
 | **Rate Limiting** | 5 login attempts/minute |
-| **Multi-tenant Isolation** | Tenant hash validation |
+| **Multi-tenant Isolation** | organization_id in queries |
 | **Role Verification** | Real-time DB check |
 
 ## Key Files

--- a/docs/technical/architecture/database-schema.md
+++ b/docs/technical/architecture/database-schema.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-VerifyWise uses PostgreSQL with Sequelize ORM. The database implements a schema-per-tenant architecture with shared data in the `public` schema and tenant-specific data in isolated schemas. There are 60+ Sequelize models covering users, organizations, projects, vendors, risks, approvals, and compliance frameworks.
+VerifyWise uses PostgreSQL with Sequelize ORM. All data lives in a single `verifywise` schema, with tenant isolation enforced via `organization_id` columns on tenant-scoped tables. There are 60+ Sequelize models covering users, organizations, projects, vendors, risks, approvals, and compliance frameworks.
 
 ## Schema Architecture
 
@@ -11,18 +11,19 @@ VerifyWise uses PostgreSQL with Sequelize ORM. The database implements a schema-
 │                              PostgreSQL Database                              │
 ├──────────────────────────────────────────────────────────────────────────────┤
 │                                                                              │
-│  PUBLIC SCHEMA (Shared)                                                      │
+│  VERIFYWISE SCHEMA (All data)                                                │
 │  ┌────────────────────────────────────────────────────────────────────────┐ │
-│  │  users          │  organizations  │  roles         │  frameworks       │ │
-│  │  subscriptions  │  tiers          │                │                   │ │
+│  │  Shared tables (no organization_id):                                   │ │
+│  │  organizations  │  users          │  roles         │  frameworks       │ │
+│  │  subscriptions  │  tiers          │  *_struct_*                        │ │
+│  ├────────────────────────────────────────────────────────────────────────┤ │
+│  │  Tenant-scoped tables (with organization_id):                          │ │
+│  │  projects       │  vendors        │  risks         │  files            │ │
+│  │  model_inventories │  tasks       │  approvals     │  assessments      │ │
+│  │  policy_manager │  automations    │  datasets      │  ...30+ more      │ │
 │  └────────────────────────────────────────────────────────────────────────┘ │
 │                                                                              │
-│  TENANT SCHEMAS (Isolated per Organization)                                  │
-│  ┌────────────────────────────────────────────────────────────────────────┐ │
-│  │  projects       │  vendors        │  risks         │  files            │ │
-│  │  model_files    │  tasks          │  approvals     │  assessments      │ │
-│  │  event_logs     │  pmm_*          │  ...30+ more                       │ │
-│  └────────────────────────────────────────────────────────────────────────┘ │
+│  PUBLIC SCHEMA (Extensions only: uuid-ossp, pgcrypto)                        │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -82,7 +83,7 @@ VerifyWise uses PostgreSQL with Sequelize ORM. The database implements a schema-
 
 ### Users
 
-**Table:** `public.users`
+**Table:** `users` (verifywise schema)
 
 ```sql
 CREATE TABLE users (
@@ -115,7 +116,7 @@ CREATE TABLE users (
 
 ### Organizations
 
-**Table:** `public.organizations`
+**Table:** `organizations` (verifywise schema, shared)
 
 ```sql
 CREATE TABLE organizations (
@@ -136,7 +137,7 @@ CREATE TABLE organizations (
 
 ### Roles
 
-**Table:** `public.roles`
+**Table:** `roles` (verifywise schema, shared)
 
 ```sql
 CREATE TABLE roles (
@@ -161,7 +162,7 @@ CREATE TABLE roles (
 
 ### Projects
 
-**Table:** `{tenant}.projects`
+**Table:** `projects`
 
 ```sql
 CREATE TABLE projects (
@@ -205,7 +206,7 @@ CREATE TABLE projects (
 
 ### Project Members (Junction Table)
 
-**Table:** `{tenant}.project_members`
+**Table:** `project_members`
 
 ```sql
 CREATE TABLE project_members (
@@ -220,7 +221,7 @@ CREATE TABLE project_members (
 
 ### Vendors
 
-**Table:** `{tenant}.vendors`
+**Table:** `vendors`
 
 ```sql
 CREATE TABLE vendors (
@@ -271,7 +272,7 @@ CREATE TABLE vendors (
 
 ### Vendor Risks
 
-**Table:** `{tenant}.vendor_risks`
+**Table:** `vendor_risks`
 
 ```sql
 CREATE TABLE vendor_risks (
@@ -298,7 +299,7 @@ CREATE TABLE vendor_risks (
 
 ### Project Risks
 
-**Table:** `{tenant}.project_risks`
+**Table:** `project_risks`
 
 ```sql
 CREATE TABLE project_risks (
@@ -379,7 +380,7 @@ CREATE TABLE project_risks (
 
 ### Files
 
-**Table:** `{tenant}.files`
+**Table:** `files`
 
 ```sql
 CREATE TABLE files (
@@ -425,7 +426,7 @@ CREATE TABLE files (
 
 ### Frameworks
 
-**Table:** `public.frameworks`
+**Table:** `frameworks` (verifywise schema, shared)
 
 ```sql
 CREATE TABLE frameworks (
@@ -448,7 +449,7 @@ CREATE TABLE frameworks (
 
 ### Model Inventories
 
-**Table:** `{tenant}.model_inventories`
+**Table:** `model_inventories`
 
 ```sql
 CREATE TABLE model_inventories (
@@ -482,7 +483,7 @@ CREATE TABLE model_inventories (
 
 ### Tasks
 
-**Table:** `{tenant}.tasks`
+**Table:** `tasks`
 
 ```sql
 CREATE TABLE tasks (
@@ -518,7 +519,7 @@ CREATE TABLE tasks (
 
 ### Approval Workflows
 
-**Table:** `{tenant}.approval_workflows`
+**Table:** `approval_workflows`
 
 ```sql
 CREATE TABLE approval_workflows (
@@ -535,7 +536,7 @@ CREATE TABLE approval_workflows (
 
 ### Approval Workflow Steps
 
-**Table:** `{tenant}.approval_workflow_steps`
+**Table:** `approval_workflow_steps`
 
 ```sql
 CREATE TABLE approval_workflow_steps (
@@ -551,7 +552,7 @@ CREATE TABLE approval_workflow_steps (
 
 ### Approval Step Approvers
 
-**Table:** `{tenant}.approval_step_approvers`
+**Table:** `approval_step_approvers`
 
 ```sql
 CREATE TABLE approval_step_approvers (
@@ -564,7 +565,7 @@ CREATE TABLE approval_step_approvers (
 
 ### Approval Requests
 
-**Table:** `{tenant}.approval_requests`
+**Table:** `approval_requests`
 
 ```sql
 CREATE TABLE approval_requests (
@@ -594,7 +595,7 @@ CREATE TABLE approval_requests (
 
 ### PMM Configurations
 
-**Table:** `{tenant}.post_market_monitoring_configs`
+**Table:** `post_market_monitoring_configs`
 
 ```sql
 CREATE TABLE post_market_monitoring_configs (
@@ -616,7 +617,7 @@ CREATE TABLE post_market_monitoring_configs (
 
 ### PMM Questions
 
-**Table:** `{tenant}.post_market_monitoring_questions`
+**Table:** `post_market_monitoring_questions`
 
 ```sql
 CREATE TABLE post_market_monitoring_questions (
@@ -637,7 +638,7 @@ CREATE TABLE post_market_monitoring_questions (
 
 ### PMM Cycles
 
-**Table:** `{tenant}.post_market_monitoring_cycles`
+**Table:** `post_market_monitoring_cycles`
 
 ```sql
 CREATE TABLE post_market_monitoring_cycles (
@@ -835,7 +836,7 @@ module.exports = {
 | `Servers/database/db.ts` | Sequelize instance and model registration |
 | `Servers/database/migrations/` | Schema migrations |
 | `Servers/domain.layer/models/` | Sequelize model definitions |
-| `Servers/scripts/createNewTenant.ts` | Tenant schema creation |
+| `Servers/database/db.ts` | Sequelize instance, search_path hook |
 | `Servers/utils/*.utils.ts` | Database query functions |
 
 ## Related Documentation

--- a/docs/technical/architecture/multi-tenancy.md
+++ b/docs/technical/architecture/multi-tenancy.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-VerifyWise implements a **schema-per-tenant** isolation strategy using PostgreSQL. Each organization (tenant) gets its own dedicated database schema, providing complete data isolation at the database level while maintaining a single codebase and connection pool.
+VerifyWise implements a **shared-schema** multi-tenancy strategy using PostgreSQL. All organizations share a single `verifywise` schema, with data isolation enforced at the application level via `organization_id` columns on all tenant-scoped tables.
 
 ## Architecture Diagram
 
@@ -11,67 +11,72 @@ VerifyWise implements a **schema-per-tenant** isolation strategy using PostgreSQ
 │                              PostgreSQL Database                              │
 ├──────────────────────────────────────────────────────────────────────────────┤
 │                                                                              │
-│  ┌─────────────────────┐                                                     │
-│  │   public schema     │  ← Shared data (users, organizations, frameworks)   │
-│  │  ─────────────────  │                                                     │
-│  │  users              │                                                     │
-│  │  organizations      │                                                     │
-│  │  roles              │                                                     │
-│  │  frameworks         │                                                     │
-│  │  subscriptions      │                                                     │
-│  │  tiers              │                                                     │
-│  └─────────────────────┘                                                     │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                        verifywise schema                                │ │
+│  │  ─────────────────────────────────────────────────────────────────────  │ │
+│  │                                                                         │ │
+│  │  SHARED TABLES (no organization_id)                                     │ │
+│  │  ┌────────────────────────────────────────────────────────────────────┐ │ │
+│  │  │  organizations  │  users        │  roles      │  frameworks       │ │ │
+│  │  │  subscriptions  │  tiers        │  *_struct_* │                   │ │ │
+│  │  └────────────────────────────────────────────────────────────────────┘ │ │
+│  │                                                                         │ │
+│  │  TENANT-SCOPED TABLES (with organization_id)                            │ │
+│  │  ┌────────────────────────────────────────────────────────────────────┐ │ │
+│  │  │  projects       │  vendors        │  risks         │  files       │ │ │
+│  │  │  model_inventories │  tasks       │  approvals     │  assessments │ │ │
+│  │  │  policy_manager │  automations    │  datasets      │  ...30+ more │ │ │
+│  │  └────────────────────────────────────────────────────────────────────┘ │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
 │                                                                              │
-│  ┌─────────────────────┐  ┌─────────────────────┐  ┌─────────────────────┐  │
-│  │  a1b2c3d4e5 schema  │  │  x9y8z7w6v5 schema  │  │  m3n4o5p6q7 schema  │  │
-│  │  (Org ID: 1)        │  │  (Org ID: 2)        │  │  (Org ID: 3)        │  │
-│  │  ─────────────────  │  │  ─────────────────  │  │  ─────────────────  │  │
-│  │  projects           │  │  projects           │  │  projects           │  │
-│  │  vendors            │  │  vendors            │  │  vendors            │  │
-│  │  risks              │  │  risks              │  │  risks              │  │
-│  │  files              │  │  files              │  │  files              │  │
-│  │  model_files        │  │  model_files        │  │  model_files        │  │
-│  │  ...30+ tables      │  │  ...30+ tables      │  │  ...30+ tables      │  │
-│  └─────────────────────┘  └─────────────────────┘  └─────────────────────┘  │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │  public schema (extensions only: uuid-ossp, pgcrypto)                   │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-## Tenant Identification
+## How It Works
 
-### Tenant Hash Generation
+### Search Path
 
-Each organization is identified by a deterministic hash derived from its ID:
+Sequelize sets `search_path = verifywise` via an `afterConnect` hook on every database connection:
 
 ```typescript
-// File: Servers/tools/getTenantHash.ts
-import { createHash } from "crypto";
-
-export const getTenantHash = (tenantId: number): string => {
-  const hash = createHash('sha256').update(tenantId.toString()).digest('base64');
-  return hash.replace(/[^a-zA-Z0-9]/g, '').slice(0, 10);
+// File: Servers/database/db.ts
+hooks: {
+  afterConnect: async (connection: any) => {
+    await connection.query("SET search_path TO verifywise;");
+  },
 }
 ```
 
-**Process:**
-1. SHA256 hash of organization ID (as string)
-2. Convert to base64
-3. Remove all non-alphanumeric characters
-4. Take first 10 characters
+This means all application SQL uses **unqualified table names** (e.g., `SELECT * FROM projects`, not `SELECT * FROM verifywise.projects`). The search path resolves them automatically.
 
-**Example:**
-- Organization ID: `1` → Schema: `a1b2c3d4e5`
-- Organization ID: `2` → Schema: `x9y8z7w6v5`
+### Organization ID Isolation
 
-### Why This Approach?
+Every tenant-scoped table has an `organization_id` column:
 
-| Benefit | Explanation |
-|---------|-------------|
-| **Deterministic** | Same org ID always produces same schema name |
-| **Collision-resistant** | SHA256 provides strong uniqueness |
-| **SQL-safe** | Alphanumeric only, safe for SQL identifiers |
-| **Compact** | 10 characters is reasonable for schema names |
-| **Not guessable** | Can't easily derive org ID from schema name |
+```sql
+-- Example: projects table
+CREATE TABLE verifywise.projects (
+  id SERIAL PRIMARY KEY,
+  organization_id INTEGER NOT NULL REFERENCES verifywise.organizations(id) ON DELETE CASCADE,
+  project_title VARCHAR(255),
+  ...
+);
+CREATE INDEX idx_projects_org ON verifywise.projects(organization_id);
+```
+
+Every query for tenant-scoped data **must** include `organization_id` in the WHERE clause:
+
+```typescript
+// File: Servers/utils/project.utils.ts
+const result = await sequelize.query(
+  `SELECT * FROM projects WHERE organization_id = :organizationId AND id = :id`,
+  { replacements: { organizationId, id } }
+);
+```
 
 ## Request Flow with Tenant Context
 
@@ -82,35 +87,26 @@ export const getTenantHash = (tenantId: number): string => {
 2. Express Middleware Chain
    ├── CORS
    ├── Rate Limiting
-   ├── authMiddleware ────────────────────────────────┐
-   │   │                                              │
-   │   ├── Extract JWT from Authorization header      │
-   │   ├── Verify token signature                     │
-   │   ├── Validate tenantId format (regex)           │
-   │   ├── Verify tenantId === getTenantHash(orgId)   │
-   │   ├── Check user belongs to organization         │
-   │   └── Attach to request:                         │
-   │       req.userId = decoded.id                    │
-   │       req.tenantId = decoded.tenantId            │
-   │       req.organizationId = decoded.organizationId│
-   │                                                  │
-   └── contextMiddleware ─────────────────────────────┤
-       │                                              │
-       └── Store in AsyncLocalStorage:                │
-           { userId, tenantId, organizationId }       │
-                      │                               │
-                      ▼                               │
-3. Controller                                         │
-        │                                             │
-        ▼                                             │
-4. Service Layer                                      │
-        │                                             │
-        ▼                                             │
-5. Database Query                                     │
-   │                                                  │
-   ├── Get tenantId from AsyncLocalStorage ◄─────────┘
+   ├── authMiddleware
+   │   ├── Extract JWT from Authorization header
+   │   ├── Verify token signature
+   │   ├── Check user belongs to organization
+   │   └── Attach to request:
+   │       req.userId = decoded.id
+   │       req.organizationId = decoded.organizationId
    │
-   └── Execute: SELECT * FROM "${tenantId}".projects ...
+   └── contextMiddleware
+       └── Store in AsyncLocalStorage:
+           { userId, organizationId }
+                  │
+                  ▼
+3. Controller
+   │  const organizationId = req.organizationId;
+   ▼
+4. Utils (Database Query)
+   │  WHERE organization_id = :organizationId
+   ▼
+5. PostgreSQL (verifywise schema)
 ```
 
 ## Middleware Implementation
@@ -120,33 +116,21 @@ export const getTenantHash = (tenantId: number): string => {
 ```typescript
 // File: Servers/middleware/auth.middleware.ts
 
-export const authMiddleware = async (
+export const authenticateJWT = async (
   req: AuthenticatedRequest,
   res: Response,
   next: NextFunction
 ) => {
-  const authHeader = req.headers["authorization"];
-  const token = authHeader && authHeader.split(" ")[1];
+  const token = req.headers["authorization"]?.split(" ")[1];
 
   if (!token) {
-    return res.status(401).json({ message: "Access token required" });
+    return res.status(400).json({ message: "Access token missing" });
   }
 
   try {
-    // 1. Verify and decode JWT
     const decoded = getTokenPayload(token);
 
-    // 2. Validate tenant hash format (10 alphanumeric chars)
-    if (!isValidTenantHash(decoded.tenantId)) {
-      return res.status(400).json({ message: "Invalid tenant format" });
-    }
-
-    // 3. Verify tenant hash matches organization ID
-    if (decoded.tenantId !== getTenantHash(decoded.organizationId)) {
-      return res.status(400).json({ message: "Invalid token" });
-    }
-
-    // 4. Verify user belongs to organization
+    // Verify user belongs to organization
     const belongs = await doesUserBelongsToOrganizationQuery(
       decoded.id,
       decoded.organizationId
@@ -157,245 +141,103 @@ export const authMiddleware = async (
       });
     }
 
-    // 5. Attach context to request
+    // Attach context to request
     req.userId = decoded.id;
-    req.tenantId = decoded.tenantId;
     req.organizationId = decoded.organizationId;
 
     next();
   } catch (error) {
-    return res.status(403).json({ message: "Invalid or expired token" });
+    return res.status(401).json({ message: "Invalid token" });
   }
 };
 ```
 
-### Context Middleware
+## Query Patterns
+
+### Tenant-scoped query
 
 ```typescript
-// File: Servers/middleware/context.middleware.ts
-
-import { asyncLocalStorage } from "../utils/context/context";
-
-export default function contextMiddleware(
-  req: AuthenticatedRequest,
-  res: Response,
-  next: NextFunction
-): void {
-  const { userId, tenantId, organizationId } = req;
-
-  // Wrap the rest of the request in AsyncLocalStorage
-  asyncLocalStorage.run({
-    userId: typeof userId === "number" ? userId : undefined,
-    tenantId,
-    organizationId
-  }, () => {
-    next();
-  });
-}
-```
-
-### AsyncLocalStorage Context
-
-```typescript
-// File: Servers/utils/context/context.ts
-
-import { AsyncLocalStorage } from "async_hooks";
-
-type RequestContext = {
-  userId?: number;
-  tenantId?: string;
-  organizationId?: number;
-};
-
-export const asyncLocalStorage = new AsyncLocalStorage<RequestContext>();
-```
-
-### Retrieving Context
-
-```typescript
-// File: Servers/utils/context/tenantContext.ts
-
-export function getCurrentTenantContext(): TenantContext {
-  const store = asyncLocalStorage.getStore();
-  return {
-    tenantId: store?.tenantId,
-    organizationId: store?.organizationId,
-    userId: store?.userId
-  };
-}
-
-// Usage in any service/util:
-const { tenantId } = getCurrentTenantContext();
-const query = `SELECT * FROM "${tenantId}".projects WHERE id = :id`;
-```
-
-## Database Schema Switching
-
-Schema switching happens at query time, not connection time. All connections use the same database with schema specified in SQL:
-
-### Query Patterns
-
-**Tenant-scoped query:**
-```typescript
-// File: Servers/utils/project.utils.ts
-
-const { tenantId } = getCurrentTenantContext();
-
+// Unqualified table name — resolved by search_path
 const query = `
-  SELECT * FROM "${tenantId}".projects
-  WHERE id = :projectId
+  SELECT * FROM projects
+  WHERE organization_id = :organizationId AND id = :id
 `;
 
-const [projects] = await sequelize.query(query, {
-  replacements: { projectId },
+const [project] = await sequelize.query(query, {
+  replacements: { organizationId, id },
   type: QueryTypes.SELECT
 });
 ```
 
-**Cross-schema join (tenant + public):**
+### Join with shared tables
+
 ```typescript
+// users table is also in verifywise schema — no prefix needed
 const query = `
-  SELECT
-    p.id,
-    p.project_title,
-    u.name || ' ' || u.surname AS owner_name
-  FROM "${tenantId}".projects p
-  JOIN public.users u ON p.owner = u.id
-  WHERE p.id = :projectId
+  SELECT p.*, u.name || ' ' || u.surname AS owner_name
+  FROM projects p
+  JOIN users u ON p.owner = u.id
+  WHERE p.organization_id = :organizationId AND p.id = :id
 `;
 ```
 
-**Public schema only:**
-```typescript
-// File: Servers/utils/user.utils.ts
-
-const query = `
-  SELECT * FROM public.users
-  WHERE id = :userId
-`;
-```
-
-### SQL Injection Prevention
+### Insert with organization_id
 
 ```typescript
-// File: Servers/repositories/file.repository.ts
-
-function validateTenant(tenant: string): void {
-  if (!/^[A-Za-z0-9_]{1,30}$/.test(tenant)) {
-    throw new ValidationException("Invalid tenant identifier");
-  }
-}
-
-function escapePgIdentifier(ident: string): string {
-  validateTenant(ident);
-  return '"' + ident.replace(/"/g, '""') + '"';
-}
-
-// Safe usage:
 const query = `
-  INSERT INTO ${escapePgIdentifier(tenantId)}.files
-  (filename, content, type)
-  VALUES (:filename, :content, :type)
+  INSERT INTO projects (organization_id, project_title, owner)
+  VALUES (:organizationId, :title, :ownerId)
+  RETURNING *
 `;
 ```
 
 ## Schema Structure
 
-### Public Schema Tables
-
-Shared across all tenants:
+### Shared Tables (no organization_id)
 
 | Table | Purpose |
 |-------|---------|
-| `users` | User accounts (with `organization_id` FK) |
 | `organizations` | Organization records |
+| `users` | User accounts (has `organization_id` FK) |
 | `roles` | System roles (Admin, Reviewer, Editor, Auditor) |
-| `frameworks` | Compliance frameworks (EU AI Act, ISO 42001, etc.) |
+| `frameworks` | Compliance framework definitions |
 | `subscriptions` | Billing information |
 | `tiers` | Service tier definitions |
+| `*_struct_*` | Framework structure tables (shared templates) |
 
-### Tenant Schema Tables
-
-Each tenant schema contains identical structure:
+### Tenant-scoped Tables (with organization_id)
 
 | Table | Purpose |
 |-------|---------|
 | `projects` | AI use cases/projects |
 | `vendors` | Third-party vendors |
-| `model_files` | AI model inventory |
+| `model_inventories` | AI model inventory |
 | `risks` | Risk definitions |
 | `projects_risks` | Project-risk associations |
 | `files` | Uploaded documents |
 | `approval_workflows` | Workflow definitions |
 | `approval_requests` | Approval instances |
-| `event_logs` | Audit trail |
-| `post_market_monitoring_*` | PMM feature tables |
+| `tasks` | Task management |
+| `policy_manager` | Policies |
+| `automations` | Automation rules |
+| `datasets` | Dataset registry |
 | ...and 30+ more |
 
-## Tenant Creation
+## JWT Token Structure
 
-When a new organization is created, the system:
-
-1. Creates the organization record in `public.organizations`
-2. Generates the tenant hash
-3. Creates the tenant schema with all tables
+Tokens contain organization context:
 
 ```typescript
-// File: Servers/scripts/createNewTenant.ts
-
-export const createNewTenant = async (
-  organization_id: number,
-  transaction: Transaction
-) => {
-  const tenantHash = getTenantHash(organization_id);
-
-  // 1. Create schema
-  await sequelize.query(
-    `CREATE SCHEMA "${tenantHash}";`,
-    { transaction }
-  );
-
-  // 2. Create tenant-specific ENUM types
-  await sequelize.query(`
-    CREATE TYPE "${tenantHash}".enum_vendors_data_sensitivity AS ENUM (
-      'None',
-      'Internal only',
-      'Personally identifiable information (PII)',
-      ...
-    );
-  `, { transaction });
-
-  // 3. Create trigger functions
-  await sequelize.query(`
-    CREATE OR REPLACE FUNCTION "${tenantHash}".check_only_one_organizational_project()
-    RETURNS TRIGGER AS $$
-    BEGIN
-      IF NEW.is_organizational = TRUE THEN
-        IF EXISTS (
-          SELECT 1 FROM "${tenantHash}".projects
-          WHERE is_organizational = TRUE AND id <> NEW.id
-        ) THEN
-          RAISE EXCEPTION 'Only one project can have is_organizational = TRUE';
-        END IF;
-      END IF;
-      RETURN NEW;
-    END;
-    $$ LANGUAGE plpgsql;
-  `, { transaction });
-
-  // 4. Create all tables
-  await sequelize.query(`
-    CREATE TABLE "${tenantHash}".projects (
-      id SERIAL PRIMARY KEY,
-      project_title VARCHAR(255),
-      owner INTEGER REFERENCES public.users(id),
-      ...
-    );
-  `, { transaction });
-
-  // 5. Create indexes
-  // 6. Create foreign key constraints
-};
+interface TokenPayload {
+  id: number;              // User ID
+  email: string;
+  name: string;
+  surname: string;
+  organizationId: number;  // Organization ID (used for data isolation)
+  tenantId: string;        // Legacy field (backward compat)
+  roleName: string;        // User's role
+  expire: Date;
+}
 ```
 
 ## Multi-Tenancy Enforcement
@@ -405,9 +247,6 @@ export const createNewTenant = async (
 ```env
 # Enable/disable multi-tenancy (SaaS mode)
 MULTI_TENANCY_ENABLED=true
-
-# Allowed domains for organization creation
-# (only app.verifywise.ai and test.verifywise.ai can create orgs)
 ```
 
 ### Organization Creation Guard
@@ -415,17 +254,12 @@ MULTI_TENANCY_ENABLED=true
 ```typescript
 // File: Servers/middleware/multiTenancy.middleware.ts
 
-export const checkMultiTenancy = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
+export const checkMultiTenancy = async (req, res, next) => {
   const requestOrigin = req.headers.origin || req.headers.host;
   const organizationExists = await getOrganizationsExistsQuery();
 
-  // Allow if:
-  // 1. Multi-tenancy enabled AND request from authorized domains
-  // 2. OR no organizations exist yet (initial setup)
+  // Allow if multi-tenancy enabled and from authorized domain,
+  // or no organizations exist yet (initial setup)
   if (
     (process.env.MULTI_TENANCY_ENABLED === "true" &&
       (requestOrigin?.includes("app.verifywise.ai") ||
@@ -441,117 +275,41 @@ export const checkMultiTenancy = async (
 };
 ```
 
-## JWT Token Structure
-
-Tokens contain tenant information:
-
-```typescript
-interface TokenPayload {
-  id: number;              // User ID
-  email: string;
-  name: string;
-  surname: string;
-  organizationId: number;  // Organization ID
-  tenantId: string;        // Tenant hash (e.g., "a1b2c3d4e5")
-  roleName: string;        // User's role
-  expire: Date;
-}
-```
-
 ## Security Considerations
 
 ### Defense in Depth
 
-1. **JWT Validation**: Token must be valid and not expired
-2. **Tenant Hash Validation**: Must match regex `^[a-zA-Z0-9]{10}$`
-3. **Hash Verification**: `tenantId === getTenantHash(organizationId)`
-4. **Organization Membership**: User must belong to the organization
-5. **SQL Identifier Validation**: Schema names validated before use
+1. **JWT validation**: Token must be valid and not expired
+2. **Organization membership**: User must belong to the organization in the token
+3. **Role verification**: Real-time DB check that role matches token
+4. **Query-level isolation**: Every tenant-scoped query includes `organization_id`
 
-### Validation Functions
+### Migration from Schema-per-Tenant
 
-```typescript
-// File: Servers/utils/security.utils.ts
-
-// Validates tenant hash format
-export function isValidTenantHash(tenantId: string): boolean {
-  return /^[a-zA-Z0-9]{10}$/.test(tenantId);
-}
-
-// Validates SQL identifiers
-export function isValidSQLIdentifier(value: string): boolean {
-  return /^[a-zA-Z0-9_]{1,63}$/.test(value);
-}
-
-// Creates safe SQL identifier
-export function safeSQLIdentifier(identifier: string): string {
-  if (!isValidSQLIdentifier(identifier)) {
-    throw new Error("Invalid SQL identifier");
-  }
-  return identifier;
-}
-```
-
-## Data Migration Between Schemas
-
-When migrating data from public to tenant schemas:
-
-```javascript
-// File: Servers/database/migrations/20260114142551-*.js
-
-// 1. Read data with organization context
-const rows = await queryInterface.sequelize.query(`
-  SELECT e.*, u.organization_id
-  FROM public.event_logs AS e
-  INNER JOIN users u ON e.user_id = u.id
-`);
-
-// 2. Group by tenant
-const map = new Map();
-for (let row of rows[0]) {
-  const tenantHash = getTenantHash(row.organization_id);
-  if (!map.has(tenantHash)) {
-    map.set(tenantHash, []);
-  }
-  map.get(tenantHash).push(row);
-}
-
-// 3. Insert into each tenant schema
-for (let [tenantHash, rows] of map) {
-  await queryInterface.sequelize.query(`
-    INSERT INTO "${tenantHash}".event_logs (...)
-    VALUES ...
-  `);
-}
-```
+The codebase previously used schema-per-tenant isolation (one PostgreSQL schema per organization). This was migrated to the current shared-schema model. The migration script `Servers/scripts/migrateToSharedSchema.ts` handles moving data from old tenant schemas to the shared `verifywise` schema with `organization_id` columns. No active code uses the old pattern.
 
 ## Summary Table
 
 | Aspect | Implementation |
 |--------|----------------|
-| **Isolation Strategy** | Schema-per-tenant (PostgreSQL named schemas) |
-| **Tenant Identifier** | Organization ID (integer) |
-| **Schema Name** | SHA256(orgId) → base64 → alphanumeric → 10 chars |
-| **Context Storage** | AsyncLocalStorage (async_hooks) |
-| **Context Propagation** | authMiddleware → contextMiddleware → asyncLocalStorage.run() |
-| **Database Connections** | Single connection pool; schema specified in SQL queries |
-| **Public Schema** | users, organizations, roles, frameworks, subscriptions |
-| **Tenant Schema** | projects, vendors, risks, files, and 30+ more tables |
-| **Tenant Validation** | Regex + getTenantHash verification |
-| **SQL Injection Prevention** | Parameterized queries + identifier validation |
+| **Isolation strategy** | Shared schema with `organization_id` column |
+| **Schema** | Single `verifywise` schema for all data |
+| **Public schema** | Extensions only (uuid-ossp, pgcrypto) |
+| **Table references** | Unqualified names (resolved via `search_path`) |
+| **Tenant identifier** | `organizationId` (integer) from JWT |
+| **Context propagation** | `req.organizationId` from auth middleware |
+| **Query pattern** | `WHERE organization_id = :organizationId` |
+| **Database connections** | Single connection pool, shared schema |
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `Servers/tools/getTenantHash.ts` | Hash generation function |
-| `Servers/middleware/auth.middleware.ts` | JWT validation, tenant verification |
-| `Servers/middleware/context.middleware.ts` | AsyncLocalStorage setup |
+| `Servers/database/db.ts` | Sequelize init, search_path hook |
+| `Servers/database/config/config.js` | DB config with `schema: "verifywise"` |
+| `Servers/middleware/auth.middleware.ts` | JWT validation, org membership check |
 | `Servers/middleware/multiTenancy.middleware.ts` | Organization creation guard |
-| `Servers/utils/context/context.ts` | AsyncLocalStorage instance |
-| `Servers/utils/context/tenantContext.ts` | Context retrieval helpers |
-| `Servers/utils/security.utils.ts` | Validation functions |
-| `Servers/scripts/createNewTenant.ts` | Tenant schema creation |
+| `Servers/scripts/migrateToSharedSchema.ts` | Legacy migration script |
 
 ## Related Documentation
 

--- a/docs/technical/architecture/overview.md
+++ b/docs/technical/architecture/overview.md
@@ -52,13 +52,13 @@ VerifyWise is a full-stack AI governance platform built with a modern JavaScript
 ┌─────────────────────┐                   ┌─────────────────────┐
 │     PostgreSQL      │                   │       Redis         │
 │  ┌───────────────┐  │                   │  ┌───────────────┐  │
-│  │ public schema │  │                   │  │  Job Queues   │  │
-│  │ (shared data) │  │                   │  │  (BullMQ)     │  │
-│  ├───────────────┤  │                   │  ├───────────────┤  │
-│  │ tenant_abc    │  │                   │  │  Pub/Sub      │  │
-│  │ tenant_xyz    │  │                   │  │  (Notifs)     │  │
-│  │ (per-org)     │  │                   │  ├───────────────┤  │
-│  └───────────────┘  │                   │  │  Cache        │  │
+│  │  verifywise   │  │                   │  │  Job Queues   │  │
+│  │  schema       │  │                   │  │  (BullMQ)     │  │
+│  │  (all data,   │  │                   │  ├───────────────┤  │
+│  │  org_id       │  │                   │  │  Pub/Sub      │  │
+│  │  isolation)   │  │                   │  │  (Notifs)     │  │
+│  └───────────────┘  │                   │  ├───────────────┤  │
+│                      │                   │  │  Cache        │  │
 └─────────────────────┘                   │  └───────────────┘  │
                                           └─────────────────────┘
 ```
@@ -215,9 +215,9 @@ Clients/src/
 ## Key Architectural Patterns
 
 ### 1. Multi-Tenancy
-- Schema-per-tenant isolation in PostgreSQL
-- Tenant context propagated via middleware
-- Shared `public` schema for cross-tenant data (users, organizations)
+- Single `verifywise` schema with `organization_id` column on tenant-scoped tables
+- `req.organizationId` propagated via auth middleware
+- All queries include `WHERE organization_id = :organizationId`
 - See: [Multi-tenancy Documentation](./multi-tenancy.md)
 
 ### 2. Clean Architecture (Frontend)
@@ -288,8 +288,7 @@ JWT_SECRET=****
 REFRESH_TOKEN_SECRET=****
 
 # Multi-tenancy
-TENANT_HASH_SALT=****
-TENANT_ENTROPY_SOURCE=****
+MULTI_TENANCY_ENABLED=true
 
 # Encryption
 ENCRYPTION_KEY=****

--- a/docs/technical/domains/search.md
+++ b/docs/technical/domains/search.md
@@ -114,8 +114,9 @@ Some entities filtered by `organization_id`:
 ## Query Implementation
 
 ```sql
-SELECT DISTINCT * FROM "{tenantId}".{tableName}
-WHERE (
+SELECT DISTINCT * FROM {tableName}
+WHERE organization_id = :organizationId
+AND (
   column1::text ILIKE :pattern
   OR column2::text ILIKE :pattern
   OR ...
@@ -175,8 +176,8 @@ Global search UI using `cmdk` library:
 
 ### Multi-Tenant Isolation
 
-- All queries scoped to tenant schema: `"{tenantId}".{tableName}`
-- Tenant ID validated with regex: `/^[a-zA-Z0-9_-]+$/`
+- All queries include `WHERE organization_id = :organizationId`
+- Organization ID comes from JWT middleware (`req.organizationId`)
 
 ## Key Files
 

--- a/docs/technical/guides/adding-new-feature.md
+++ b/docs/technical/guides/adding-new-feature.md
@@ -20,56 +20,41 @@ Create a migration file in `Servers/database/migrations/`:
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    // Get all tenant schemas
-    const [tenants] = await queryInterface.sequelize.query(
-      `SELECT schema_name FROM information_schema.schemata
-       WHERE schema_name LIKE 'tenant_%'`
-    );
-
-    for (const tenant of tenants) {
-      const schema = tenant.schema_name;
-
-      await queryInterface.createTable(
-        { tableName: "features", schema },
-        {
-          id: {
-            type: Sequelize.INTEGER,
-            primaryKey: true,
-            autoIncrement: true,
-          },
-          name: {
-            type: Sequelize.STRING(255),
-            allowNull: false,
-          },
-          status: {
-            type: Sequelize.ENUM("Active", "Inactive"),
-            defaultValue: "Active",
-          },
-          created_at: {
-            type: Sequelize.DATE,
-            defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
-          },
-          updated_at: {
-            type: Sequelize.DATE,
-            defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
-          },
-        }
-      );
-    }
+    // All tables live in the verifywise schema (resolved via search_path).
+    // Use unqualified table names — no schema prefix needed.
+    await queryInterface.createTable("features", {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      organization_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: "organizations", key: "id" },
+        onDelete: "CASCADE",
+      },
+      name: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      status: {
+        type: Sequelize.ENUM("Active", "Inactive"),
+        defaultValue: "Active",
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+    });
   },
 
   async down(queryInterface, Sequelize) {
-    const [tenants] = await queryInterface.sequelize.query(
-      `SELECT schema_name FROM information_schema.schemata
-       WHERE schema_name LIKE 'tenant_%'`
-    );
-
-    for (const tenant of tenants) {
-      await queryInterface.dropTable({
-        tableName: "features",
-        schema: tenant.schema_name,
-      });
-    }
+    await queryInterface.dropTable("features");
   },
 };
 ```
@@ -170,49 +155,52 @@ import { IFeature } from "../domain.layer/interfaces/i.feature";
 import { FeatureModel } from "../domain.layer/models/feature/feature.model";
 
 export const getAllFeaturesQuery = async (
-  tenant: string
+  organizationId: number
 ): Promise<FeatureModel[]> => {
   const query = `
-    SELECT * FROM "${tenant}".features
+    SELECT * FROM features
+    WHERE organization_id = :organizationId
     ORDER BY created_at DESC
   `;
   return sequelize.query(query, {
     type: QueryTypes.SELECT,
     model: FeatureModel,
     mapToModel: true,
+    replacements: { organizationId },
   });
 };
 
 export const getFeatureByIdQuery = async (
   id: number,
-  tenant: string
+  organizationId: number
 ): Promise<FeatureModel | null> => {
   const query = `
-    SELECT * FROM "${tenant}".features
-    WHERE id = :id
+    SELECT * FROM features
+    WHERE id = :id AND organization_id = :organizationId
   `;
   const results = await sequelize.query(query, {
     type: QueryTypes.SELECT,
     model: FeatureModel,
     mapToModel: true,
-    replacements: { id },
+    replacements: { id, organizationId },
   });
   return results[0] || null;
 };
 
 export const createFeatureQuery = async (
   feature: IFeature,
-  tenant: string,
+  organizationId: number,
   transaction?: Transaction
 ): Promise<FeatureModel> => {
   const query = `
-    INSERT INTO "${tenant}".features (name, status, created_at, updated_at)
-    VALUES (:name, :status, NOW(), NOW())
+    INSERT INTO features (organization_id, name, status, created_at, updated_at)
+    VALUES (:organizationId, :name, :status, NOW(), NOW())
     RETURNING *
   `;
   const [result] = await sequelize.query(query, {
     type: QueryTypes.INSERT,
     replacements: {
+      organizationId,
       name: feature.name,
       status: feature.status || "Active",
     },
@@ -224,11 +212,11 @@ export const createFeatureQuery = async (
 export const updateFeatureQuery = async (
   id: number,
   feature: Partial<IFeature>,
-  tenant: string,
+  organizationId: number,
   transaction?: Transaction
 ): Promise<FeatureModel | null> => {
   const setClauses: string[] = [];
-  const replacements: Record<string, any> = { id };
+  const replacements: Record<string, any> = { id, organizationId };
 
   if (feature.name !== undefined) {
     setClauses.push("name = :name");
@@ -241,9 +229,9 @@ export const updateFeatureQuery = async (
   setClauses.push("updated_at = NOW()");
 
   const query = `
-    UPDATE "${tenant}".features
+    UPDATE features
     SET ${setClauses.join(", ")}
-    WHERE id = :id
+    WHERE id = :id AND organization_id = :organizationId
     RETURNING *
   `;
   const [result] = await sequelize.query(query, {
@@ -256,16 +244,16 @@ export const updateFeatureQuery = async (
 
 export const deleteFeatureQuery = async (
   id: number,
-  tenant: string,
+  organizationId: number,
   transaction?: Transaction
 ): Promise<boolean> => {
   const query = `
-    DELETE FROM "${tenant}".features
-    WHERE id = :id
+    DELETE FROM features
+    WHERE id = :id AND organization_id = :organizationId
   `;
   await sequelize.query(query, {
     type: QueryTypes.DELETE,
-    replacements: { id },
+    replacements: { id, organizationId },
     transaction,
   });
   return true;
@@ -293,8 +281,8 @@ export const getAllFeatures = async (
   res: Response
 ): Promise<Response> => {
   try {
-    const tenant = req.tenantId;
-    const features = await getAllFeaturesQuery(tenant);
+    const organizationId = req.organizationId;
+    const features = await getAllFeaturesQuery(organizationId);
 
     if (!features.length) {
       return res.status(204).json([]);
@@ -313,13 +301,13 @@ export const getFeatureById = async (
 ): Promise<Response> => {
   try {
     const { id } = req.params;
-    const tenant = req.tenantId;
+    const organizationId = req.organizationId;
 
     if (!Number.isSafeInteger(Number(id))) {
       return res.status(400).json({ message: "Invalid ID" });
     }
 
-    const feature = await getFeatureByIdQuery(Number(id), tenant);
+    const feature = await getFeatureByIdQuery(Number(id), organizationId);
 
     if (!feature) {
       return res.status(404).json({ message: "Feature not found" });
@@ -338,10 +326,10 @@ export const createFeature = async (
 ): Promise<Response> => {
   const transaction = await sequelize.transaction();
   try {
-    const tenant = req.tenantId;
+    const organizationId = req.organizationId;
     const featureData = req.body;
 
-    const feature = await createFeatureQuery(featureData, tenant, transaction);
+    const feature = await createFeatureQuery(featureData, organizationId, transaction);
 
     await transaction.commit();
     return res.status(201).json(feature);
@@ -359,7 +347,7 @@ export const updateFeature = async (
   const transaction = await sequelize.transaction();
   try {
     const { id } = req.params;
-    const tenant = req.tenantId;
+    const organizationId = req.organizationId;
     const updateData = req.body;
 
     if (!Number.isSafeInteger(Number(id))) {
@@ -369,7 +357,7 @@ export const updateFeature = async (
     const feature = await updateFeatureQuery(
       Number(id),
       updateData,
-      tenant,
+      organizationId,
       transaction
     );
 
@@ -394,13 +382,13 @@ export const deleteFeature = async (
   const transaction = await sequelize.transaction();
   try {
     const { id } = req.params;
-    const tenant = req.tenantId;
+    const organizationId = req.organizationId;
 
     if (!Number.isSafeInteger(Number(id))) {
       return res.status(400).json({ message: "Invalid ID" });
     }
 
-    await deleteFeatureQuery(Number(id), tenant, transaction);
+    await deleteFeatureQuery(Number(id), organizationId, transaction);
 
     await transaction.commit();
     return res.status(202).json({ message: "Feature deleted" });
@@ -638,7 +626,7 @@ Add to sidebar in `Clients/src/presentation/components/Sidebar/`:
 
 Before submitting your feature:
 
-- [ ] Migration creates tables in all tenant schemas
+- [ ] Migration creates table in the verifywise schema with `organization_id` column
 - [ ] Model uses `toSafeJSON()` for API responses
 - [ ] Controller uses transactions for create/update/delete
 - [ ] Routes are protected with `authenticateJWT`

--- a/docs/technical/guides/adding-new-framework.md
+++ b/docs/technical/guides/adding-new-framework.md
@@ -44,140 +44,50 @@ Create migration in `Servers/database/migrations/`:
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    const [tenants] = await queryInterface.sequelize.query(
-      `SELECT schema_name FROM information_schema.schemata
-       WHERE schema_name LIKE 'tenant_%'`
-    );
+    // All tables created once in verifywise schema
+    // Tenant-scoped tables include organization_id column
 
-    for (const tenant of tenants) {
-      const schema = tenant.schema_name;
+    // Categories table (struct — shared, no org_id)
+    await queryInterface.sequelize.query(`
+      CREATE TABLE verifywise.soc2_categories (
+        id SERIAL PRIMARY KEY,
+        category_id VARCHAR(50) NOT NULL,
+        name VARCHAR(255) NOT NULL,
+        description TEXT,
+        order_no INTEGER DEFAULT 0,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
 
-      // Categories table
-      await queryInterface.createTable(
-        { tableName: "soc2_categories", schema },
-        {
-          id: {
-            type: Sequelize.INTEGER,
-            primaryKey: true,
-            autoIncrement: true,
-          },
-          category_id: {
-            type: Sequelize.STRING(50),
-            allowNull: false,
-          },
-          name: {
-            type: Sequelize.STRING(255),
-            allowNull: false,
-          },
-          description: {
-            type: Sequelize.TEXT,
-          },
-          order_no: {
-            type: Sequelize.INTEGER,
-            defaultValue: 0,
-          },
-          created_at: {
-            type: Sequelize.DATE,
-            defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
-          },
-        }
+    // Controls table (tenant-scoped — with org_id)
+    await queryInterface.sequelize.query(`
+      CREATE TABLE verifywise.soc2_controls (
+        id SERIAL PRIMARY KEY,
+        organization_id INTEGER NOT NULL REFERENCES verifywise.organizations(id) ON DELETE CASCADE,
+        control_id VARCHAR(50) NOT NULL,
+        category_id INTEGER REFERENCES verifywise.soc2_categories(id),
+        title VARCHAR(500) NOT NULL,
+        description TEXT,
+        status VARCHAR(20) DEFAULT 'Not started',
+        owner VARCHAR(255),
+        implementation_notes TEXT,
+        evidence_links JSONB DEFAULT '[]',
+        order_no INTEGER DEFAULT 0,
+        project_framework_id INTEGER,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
-
-      // Controls table
-      await queryInterface.createTable(
-        { tableName: "soc2_controls", schema },
-        {
-          id: {
-            type: Sequelize.INTEGER,
-            primaryKey: true,
-            autoIncrement: true,
-          },
-          control_id: {
-            type: Sequelize.STRING(50),
-            allowNull: false,
-          },
-          category_id: {
-            type: Sequelize.INTEGER,
-            references: {
-              model: { tableName: "soc2_categories", schema },
-              key: "id",
-            },
-          },
-          title: {
-            type: Sequelize.STRING(500),
-            allowNull: false,
-          },
-          description: {
-            type: Sequelize.TEXT,
-          },
-          status: {
-            type: Sequelize.ENUM(
-              "Not started",
-              "In progress",
-              "Compliant",
-              "Non-compliant",
-              "Not applicable"
-            ),
-            defaultValue: "Not started",
-          },
-          owner: {
-            type: Sequelize.STRING(255),
-          },
-          implementation_notes: {
-            type: Sequelize.TEXT,
-          },
-          evidence_links: {
-            type: Sequelize.JSONB,
-            defaultValue: [],
-          },
-          order_no: {
-            type: Sequelize.INTEGER,
-            defaultValue: 0,
-          },
-          project_framework_id: {
-            type: Sequelize.INTEGER,
-          },
-          created_at: {
-            type: Sequelize.DATE,
-            defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
-          },
-          updated_at: {
-            type: Sequelize.DATE,
-            defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
-          },
-        }
-      );
-
-      // Create indexes
-      await queryInterface.addIndex(
-        { tableName: "soc2_controls", schema },
-        ["category_id"],
-        { name: `${schema}_soc2_controls_category_idx` }
-      );
-      await queryInterface.addIndex(
-        { tableName: "soc2_controls", schema },
-        ["project_framework_id"],
-        { name: `${schema}_soc2_controls_pf_idx` }
-      );
-    }
+      CREATE INDEX idx_soc2_controls_org ON verifywise.soc2_controls(organization_id);
+      CREATE INDEX idx_soc2_controls_category ON verifywise.soc2_controls(category_id);
+      CREATE INDEX idx_soc2_controls_pf ON verifywise.soc2_controls(project_framework_id);
+    `);
   },
 
   async down(queryInterface, Sequelize) {
-    const [tenants] = await queryInterface.sequelize.query(
-      `SELECT schema_name FROM information_schema.schemata
-       WHERE schema_name LIKE 'tenant_%'`
-    );
-
-    for (const tenant of tenants) {
-      await queryInterface.dropTable({
-        tableName: "soc2_controls",
-        schema: tenant.schema_name,
-      });
-      await queryInterface.dropTable({
-        tableName: "soc2_categories",
-        schema: tenant.schema_name,
-      });
-    }
+    await queryInterface.sequelize.query(`
+      DROP TABLE IF EXISTS verifywise.soc2_controls;
+      DROP TABLE IF EXISTS verifywise.soc2_categories;
+    `);
   },
 };
 ```
@@ -207,49 +117,28 @@ Create seed file in `Servers/database/seeders/`:
 // soc2-framework-seed.js
 module.exports = {
   async up(queryInterface, Sequelize) {
-    const [tenants] = await queryInterface.sequelize.query(
-      `SELECT schema_name FROM information_schema.schemata
-       WHERE schema_name LIKE 'tenant_%'`
+    // Seed shared struct data (no org_id needed)
+    await queryInterface.bulkInsert(
+      "soc2_categories",
+      [
+        {
+          category_id: "CC",
+          name: "Common Criteria",
+          description: "Common Criteria related to...",
+          order_no: 1,
+        },
+        {
+          category_id: "A",
+          name: "Availability",
+          description: "Availability criteria...",
+          order_no: 2,
+        },
+        // ... more categories
+      ]
     );
 
-    for (const tenant of tenants) {
-      const schema = tenant.schema_name;
-
-      // Seed categories
-      await queryInterface.bulkInsert(
-        { tableName: "soc2_categories", schema },
-        [
-          {
-            category_id: "CC",
-            name: "Common Criteria",
-            description: "Common Criteria related to...",
-            order_no: 1,
-          },
-          {
-            category_id: "A",
-            name: "Availability",
-            description: "Availability criteria...",
-            order_no: 2,
-          },
-          // ... more categories
-        ]
-      );
-
-      // Seed controls
-      await queryInterface.bulkInsert(
-        { tableName: "soc2_controls", schema },
-        [
-          {
-            control_id: "CC1.1",
-            category_id: 1,
-            title: "COSO Principle 1",
-            description: "The entity demonstrates a commitment to integrity...",
-            order_no: 1,
-          },
-          // ... more controls
-        ]
-      );
-    }
+    // Note: Tenant-scoped controls are created per-project
+    // when a project subscribes to this framework, not in the seeder.
   },
 };
 ```
@@ -343,9 +232,9 @@ Create utils in `Servers/utils/`:
 import { sequelize } from "../config/database";
 import { QueryTypes, Transaction } from "sequelize";
 
-export const getSOC2CategoriesQuery = async (tenant: string) => {
+export const getSOC2CategoriesQuery = async () => {
   const query = `
-    SELECT * FROM "${tenant}".soc2_categories
+    SELECT * FROM soc2_categories
     ORDER BY order_no
   `;
   return sequelize.query(query, { type: QueryTypes.SELECT });
@@ -353,29 +242,30 @@ export const getSOC2CategoriesQuery = async (tenant: string) => {
 
 export const getSOC2ControlsQuery = async (
   projectFrameworkId: number,
-  tenant: string
+  organizationId: number
 ) => {
   const query = `
     SELECT c.*, cat.name as category_name
-    FROM "${tenant}".soc2_controls c
-    JOIN "${tenant}".soc2_categories cat ON c.category_id = cat.id
+    FROM soc2_controls c
+    JOIN soc2_categories cat ON c.category_id = cat.id
     WHERE c.project_framework_id = :projectFrameworkId
+      AND c.organization_id = :organizationId
     ORDER BY cat.order_no, c.order_no
   `;
   return sequelize.query(query, {
     type: QueryTypes.SELECT,
-    replacements: { projectFrameworkId },
+    replacements: { projectFrameworkId, organizationId },
   });
 };
 
 export const updateSOC2ControlQuery = async (
   id: number,
   data: Partial<any>,
-  tenant: string,
+  organizationId: number,
   transaction?: Transaction
 ) => {
   const setClauses: string[] = [];
-  const replacements: Record<string, any> = { id };
+  const replacements: Record<string, any> = { id, organizationId };
 
   if (data.status !== undefined) {
     setClauses.push("status = :status");
@@ -396,9 +286,9 @@ export const updateSOC2ControlQuery = async (
   setClauses.push("updated_at = NOW()");
 
   const query = `
-    UPDATE "${tenant}".soc2_controls
+    UPDATE soc2_controls
     SET ${setClauses.join(", ")}
-    WHERE id = :id
+    WHERE id = :id AND organization_id = :organizationId
     RETURNING *
   `;
   return sequelize.query(query, {
@@ -410,20 +300,20 @@ export const updateSOC2ControlQuery = async (
 
 export const createSOC2ControlsForProjectQuery = async (
   projectFrameworkId: number,
-  tenant: string,
+  organizationId: number,
   transaction?: Transaction
 ) => {
   // Copy template controls to project-specific records
   const query = `
-    INSERT INTO "${tenant}".soc2_controls
-      (control_id, category_id, title, description, status, order_no, project_framework_id)
-    SELECT control_id, category_id, title, description, 'Not started', order_no, :pfId
-    FROM "${tenant}".soc2_controls
-    WHERE project_framework_id IS NULL
+    INSERT INTO soc2_controls
+      (organization_id, control_id, category_id, title, description, status, order_no, project_framework_id)
+    SELECT :organizationId, control_id, category_id, title, description, 'Not started', order_no, :pfId
+    FROM soc2_controls
+    WHERE project_framework_id IS NULL AND organization_id = :organizationId
   `;
   return sequelize.query(query, {
     type: QueryTypes.INSERT,
-    replacements: { pfId: projectFrameworkId },
+    replacements: { pfId: projectFrameworkId, organizationId },
     transaction,
   });
 };
@@ -518,15 +408,16 @@ Add to `dataCollector.ts`:
 private async collectSOC2Controls(): Promise<SOC2SectionData> {
   const query = `
     SELECT c.*, cat.name as category_name
-    FROM "${this.tenantId}".soc2_controls c
-    JOIN "${this.tenantId}".soc2_categories cat ON c.category_id = cat.id
+    FROM soc2_controls c
+    JOIN soc2_categories cat ON c.category_id = cat.id
     WHERE c.project_framework_id = :pfId
+      AND c.organization_id = :organizationId
     ORDER BY cat.order_no, c.order_no
   `;
 
   const controls = await sequelize.query(query, {
     type: QueryTypes.SELECT,
-    replacements: { pfId: this.projectFrameworkId },
+    replacements: { pfId: this.projectFrameworkId, organizationId: this.organizationId },
   });
 
   const grouped = this.groupByCategory(controls);
@@ -600,7 +491,7 @@ Add to `approvalRequest.utils.ts` for automatic framework creation on approval:
 ```typescript
 // In createFrameworkRecords function
 case 5: // SOC 2
-  await createSOC2ControlsForProjectQuery(projectFrameworkId, tenant, transaction);
+  await createSOC2ControlsForProjectQuery(projectFrameworkId, organizationId, transaction);
   break;
 ```
 

--- a/docs/technical/guides/api-conventions.md
+++ b/docs/technical/guides/api-conventions.md
@@ -288,15 +288,13 @@ GET /vendors?sort=vendor_name&order=asc
 
 ## Multi-tenancy
 
-### Tenant Header
+### Organization Isolation
 
-Tenant is determined from JWT token, not request headers.
+Organization context is determined from JWT token (`req.organizationId`), not request headers.
 
-### Tenant Isolation
-
-All data queries include tenant schema:
+All data queries include organization_id:
 ```sql
-SELECT * FROM "tenant_abc123".risks WHERE ...
+SELECT * FROM risks WHERE organization_id = :organizationId AND ...
 ```
 
 ## Rate Limiting

--- a/docs/technical/guides/backend-patterns.md
+++ b/docs/technical/guides/backend-patterns.md
@@ -57,7 +57,7 @@ export async function getTaskById(
     functionName: "getTaskById",
     fileName: "task.ctrl.ts",
     userId: req.userId!,
-    tenantId: req.tenantId!,
+    organizationId: req.organizationId!,
   });
 
   try {
@@ -69,7 +69,7 @@ export async function getTaskById(
     }
 
     // Delegate to utils
-    const task = await getTaskByIdQuery(Number(id), req.tenantId!);
+    const task = await getTaskByIdQuery(Number(id), req.organizationId!);
 
     if (!task) {
       return res.status(404).json(STATUS_CODE[404]("Task not found"));
@@ -81,7 +81,7 @@ export async function getTaskById(
       functionName: "getTaskById",
       fileName: "task.ctrl.ts",
       userId: req.userId!,
-      tenantId: req.tenantId!,
+      organizationId: req.organizationId!,
     });
 
     return res.status(200).json(STATUS_CODE[200](task));
@@ -92,7 +92,7 @@ export async function getTaskById(
       functionName: "getTaskById",
       fileName: "task.ctrl.ts",
       userId: req.userId!,
-      tenantId: req.tenantId!,
+      organizationId: req.organizationId!,
     });
 
     if (error instanceof ValidationException) {
@@ -184,33 +184,33 @@ import { TaskModel } from "../domain.layer/models/tasks/tasks.model";
 import { ITask, ITaskJSON } from "../domain.layer/interfaces/i.task";
 
 /**
- * Get all tasks for a tenant with optional filters
+ * Get all tasks for an organization with optional filters
  */
 export async function getTasksQuery(
-  tenant: string,
+  organizationId: number,
   filters?: {
     status?: string;
     priority?: string;
     assigneeId?: number;
   }
 ): Promise<ITaskJSON[]> {
-  const whereConditions: string[] = ["1=1"];
-  const replacements: Record<string, any> = {};
+  const whereConditions: string[] = ["t.organization_id = :organizationId"];
+  const replacements: Record<string, any> = { organizationId };
 
   if (filters?.status) {
-    whereConditions.push("status = :status");
+    whereConditions.push("t.status = :status");
     replacements.status = filters.status;
   }
 
   if (filters?.priority) {
-    whereConditions.push("priority = :priority");
+    whereConditions.push("t.priority = :priority");
     replacements.priority = filters.priority;
   }
 
   if (filters?.assigneeId) {
     whereConditions.push(`
-      id IN (
-        SELECT task_id FROM "${tenant}".task_assignees
+      t.id IN (
+        SELECT task_id FROM task_assignees
         WHERE user_id = :assigneeId
       )
     `);
@@ -224,9 +224,9 @@ export async function getTasksQuery(
              json_agg(DISTINCT ta.user_id) FILTER (WHERE ta.user_id IS NOT NULL),
              '[]'
            ) as assignees
-    FROM "${tenant}".tasks t
-    LEFT JOIN public.users u ON t.creator_id = u.id
-    LEFT JOIN "${tenant}".task_assignees ta ON t.id = ta.task_id
+    FROM tasks t
+    LEFT JOIN users u ON t.creator_id = u.id
+    LEFT JOIN task_assignees ta ON t.id = ta.task_id
     WHERE ${whereConditions.join(" AND ")}
     GROUP BY t.id, u.name
     ORDER BY t.created_at DESC
@@ -245,24 +245,24 @@ export async function getTasksQuery(
  */
 export async function createTaskQuery(
   data: Partial<ITask>,
-  tenant: string,
+  organizationId: number,
   assigneeIds?: number[],
   transaction?: Transaction
 ): Promise<ITask> {
   const query = `
-    INSERT INTO "${tenant}".tasks
-      (title, description, creator_id, organization_id, due_date, priority, status, categories)
+    INSERT INTO tasks
+      (organization_id, title, description, creator_id, due_date, priority, status, categories)
     VALUES
-      (:title, :description, :creatorId, :orgId, :dueDate, :priority, :status, :categories)
+      (:organizationId, :title, :description, :creatorId, :dueDate, :priority, :status, :categories)
     RETURNING *
   `;
 
   const [result] = await sequelize.query(query, {
     replacements: {
+      organizationId,
       title: data.title,
       description: data.description || null,
       creatorId: data.creator_id,
-      orgId: data.organization_id,
       dueDate: data.due_date || null,
       priority: data.priority || "Medium",
       status: data.status || "Open",
@@ -276,7 +276,7 @@ export async function createTaskQuery(
 
   // Add assignees if provided
   if (assigneeIds?.length) {
-    await addTaskAssigneesQuery(task.id!, assigneeIds, tenant, transaction);
+    await addTaskAssigneesQuery(task.id!, assigneeIds, organizationId, transaction);
   }
 
   return task;
@@ -289,52 +289,28 @@ export async function createTaskQuery(
 2. **Use parameterized queries** - Prevent SQL injection
 3. **Support transactions** - Accept optional transaction parameter
 4. **Return typed results** - Use interfaces for return types
-5. **Handle multi-tenancy** - Always include tenant in queries
+5. **Handle multi-tenancy** - Always include `organization_id` in queries
 
 ## Multi-Tenant Queries
 
-All queries must be scoped to the tenant schema.
+All tenant-scoped queries must include `organization_id`. Use unqualified table names (resolved via `search_path = verifywise`).
 
 ### Pattern
 
 ```typescript
-// Always use tenant schema prefix
+// Unqualified table name — no schema prefix needed
 const query = `
-  SELECT * FROM "${tenant}".tasks
-  WHERE id = :id
+  SELECT * FROM tasks
+  WHERE organization_id = :organizationId AND id = :id
 `;
 
-// For joins across schemas
+// For joins with other tables (all in verifywise schema)
 const query = `
   SELECT t.*, u.name as creator_name
-  FROM "${tenant}".tasks t
-  LEFT JOIN public.users u ON t.creator_id = u.id
-  WHERE t.id = :id
+  FROM tasks t
+  LEFT JOIN users u ON t.creator_id = u.id
+  WHERE t.organization_id = :organizationId AND t.id = :id
 `;
-
-// Validate tenant before use
-import { isValidTenantHash } from "../utils/security.utils";
-
-if (!isValidTenantHash(tenant)) {
-  throw new ValidationException("Invalid tenant");
-}
-```
-
-### Tenant Validation
-
-```typescript
-// utils/security.utils.ts
-export function isValidTenantHash(tenantId: string): boolean {
-  // 10-character alphanumeric hash
-  return /^[a-zA-Z0-9]{10}$/.test(tenantId);
-}
-
-export function safeSQLIdentifier(tenantId: string): string {
-  if (!isValidTenantHash(tenantId)) {
-    throw new Error("Invalid tenant identifier");
-  }
-  return tenantId;
-}
 ```
 
 ## Error Handling
@@ -492,11 +468,11 @@ export async function createTask(req: Request, res: Response) {
     functionName: "createTask",
     fileName: "task.ctrl.ts",
     userId: req.userId!,
-    tenantId: req.tenantId!,
+    organizationId: req.organizationId!,
   });
 
   try {
-    const task = await createTaskQuery(req.body, req.tenantId!);
+    const task = await createTaskQuery(req.body, req.organizationId!);
 
     await logSuccess({
       eventType: "Create",
@@ -504,7 +480,7 @@ export async function createTask(req: Request, res: Response) {
       functionName: "createTask",
       fileName: "task.ctrl.ts",
       userId: req.userId!,
-      tenantId: req.tenantId!,
+      organizationId: req.organizationId!,
     });
 
     return res.status(201).json(STATUS_CODE[201](task));
@@ -515,7 +491,7 @@ export async function createTask(req: Request, res: Response) {
       functionName: "createTask",
       fileName: "task.ctrl.ts",
       userId: req.userId!,
-      tenantId: req.tenantId!,
+      organizationId: req.organizationId!,
     });
 
     throw error;
@@ -550,9 +526,8 @@ export async function authenticateJWT(
 
     // Attach user info to request
     req.userId = decoded.userId;
-    req.tenantId = decoded.tenantId;
-    req.userRole = decoded.role;
     req.organizationId = decoded.organizationId;
+    req.userRole = decoded.role;
 
     next();
   } catch (error) {
@@ -744,21 +719,21 @@ Use transactions for operations that modify multiple tables.
 export async function createTaskWithAssignees(
   taskData: Partial<ITask>,
   assigneeIds: number[],
-  tenant: string
+  organizationId: number
 ): Promise<ITask> {
   const transaction = await sequelize.transaction();
 
   try {
     // Create task
-    const task = await createTaskQuery(taskData, tenant, undefined, transaction);
+    const task = await createTaskQuery(taskData, organizationId, undefined, transaction);
 
     // Add assignees
     for (const userId of assigneeIds) {
-      await addTaskAssigneeQuery(task.id!, userId, tenant, transaction);
+      await addTaskAssigneeQuery(task.id!, userId, organizationId, transaction);
     }
 
     // Trigger automation
-    await triggerTaskAutomation("task_added", task, tenant, transaction);
+    await triggerTaskAutomation("task_added", task, organizationId, transaction);
 
     await transaction.commit();
     return task;
@@ -776,14 +751,14 @@ For complex business logic that spans multiple utils.
 ```typescript
 // services/postMarketMonitoring/pmmScheduler.ts
 export class PMMSchedulerService {
-  private readonly tenant: string;
+  private readonly organizationId: number;
 
-  constructor(tenant: string) {
-    this.tenant = tenant;
+  constructor(organizationId: number) {
+    this.organizationId = organizationId;
   }
 
   async checkAndSendNotifications(): Promise<void> {
-    const pendingCycles = await getPendingCyclesQuery(this.tenant);
+    const pendingCycles = await getPendingCyclesQuery(this.organizationId);
 
     for (const cycle of pendingCycles) {
       if (this.shouldSendReminder(cycle)) {

--- a/docs/technical/guides/code-style.md
+++ b/docs/technical/guides/code-style.md
@@ -174,12 +174,12 @@ import { containerStyle } from "./styles";
  * Retrieves a task by its ID with full details.
  *
  * @param id - The unique task identifier
- * @param tenant - The tenant schema name
+ * @param organizationId - The organization ID for data isolation
  * @returns The task with assignees and creator info, or null if not found
  * @throws {ValidationException} If ID is invalid
  *
  * @example
- * const task = await getTaskByIdQuery(123, "tenant_abc");
+ * const task = await getTaskByIdQuery(123, organizationId);
  */
 export async function getTaskByIdQuery(
   id: number,

--- a/docs/technical/infrastructure/ai-advisor.md
+++ b/docs/technical/infrastructure/ai-advisor.md
@@ -402,8 +402,8 @@ async function fetchRisks(params, tenant) {
 ```
 
 All queries:
-- Include tenant parameter for multi-tenant isolation
-- Use schema-prefixed tables: `"${tenant}".risks`
+- Include `organizationId` parameter for multi-tenant isolation
+- Use unqualified table names with `WHERE organization_id = :organizationId`
 - Leverage existing utility functions
 
 ## Key Files

--- a/docs/technical/infrastructure/automations.md
+++ b/docs/technical/infrastructure/automations.md
@@ -467,7 +467,7 @@ await logAutomationExecution(
   automationId,
   triggerData,
   actionResults,
-  tenantHash,
+  organizationId,
   startTime
 );
 ```
@@ -485,7 +485,7 @@ await logAutomationExecution(
 
 export const getAutomationExecutionStats = async (
   automationId: number,
-  tenantHash: string
+  organizationId: number
 ) => {
   const query = `
     SELECT
@@ -493,8 +493,8 @@ export const getAutomationExecutionStats = async (
       COUNT(*) FILTER (WHERE status = 'success') as successful,
       COUNT(*) FILTER (WHERE status = 'failure') as failed,
       AVG(execution_time_ms) as avg_execution_time
-    FROM "${tenantHash}".automation_execution_logs
-    WHERE automation_id = :automationId
+    FROM automation_execution_logs
+    WHERE organization_id = :organizationId AND automation_id = :automationId
   `;
   // ...
 };

--- a/docs/technical/infrastructure/plugin-system.md
+++ b/docs/technical/infrastructure/plugin-system.md
@@ -174,29 +174,26 @@ CREATE INDEX idx_plugin_installations_key_{tenantId}
 
 **File:** `Servers/database/migrations/20251226151729-create-plugin-installations-table.js`
 
-The migration iterates through all organizations and creates the table in each tenant schema:
+The migration creates the table once in the `verifywise` schema:
 
 ```javascript
 async up(queryInterface, Sequelize) {
   const transaction = await queryInterface.sequelize.transaction();
   try {
-    const organizations = await queryInterface.sequelize.query(
-      `SELECT id FROM organizations;`,
-      { transaction }
-    );
+    await queryInterface.sequelize.query(`
+      CREATE TABLE verifywise.plugin_installations (
+        ...
+        organization_id INTEGER NOT NULL REFERENCES verifywise.organizations(id) ON DELETE CASCADE
+      )
+    `, { transaction });
 
-    for (let organization of organizations[0]) {
-      const tenantHash = getTenantHash(organization.id);
-      await queryInterface.sequelize.query(`
-        CREATE TABLE "${tenantHash}".plugin_installations (...)
-      `, { transaction });
+    await queryInterface.sequelize.query(`
+      CREATE INDEX idx_plugin_installations_key
+      ON verifywise.plugin_installations(plugin_key);
+      CREATE INDEX idx_plugin_installations_org
+      ON verifywise.plugin_installations(organization_id);
+    `, { transaction });
 
-      // Add index
-      await queryInterface.sequelize.query(`
-        CREATE INDEX idx_plugin_installations_key_${tenantHash}
-        ON "${tenantHash}".plugin_installations(plugin_key);
-      `, { transaction });
-    }
     await transaction.commit();
   } catch (error) {
     await transaction.rollback();
@@ -2605,7 +2602,7 @@ The `plugins.json` file is the central registry that defines all available plugi
 | Type | Description | Use Case |
 |------|-------------|----------|
 | `standard` | Uses shared/public tables | OAuth integrations (Slack), global configs |
-| `tenant_scoped` | Creates tables in tenant schema | Data storage per organization (MLflow, Risk Import) |
+| `tenant_scoped` | Creates tables with organization_id column | Data storage per organization (MLflow, Risk Import) |
 
 #### Available Categories
 
@@ -5088,18 +5085,20 @@ Check if the table exists before querying:
 // Servers/utils/framework.utils.ts
 const [[{ can_remove }]] = await sequelize.query(
   `SELECT (
-    (SELECT COUNT(*) FROM "${tenant}".projects_frameworks WHERE project_id = :projectId) +
+    (SELECT COUNT(*) FROM projects_frameworks
+     WHERE project_id = :projectId AND organization_id = :organizationId) +
     CASE
       WHEN EXISTS (
         SELECT 1 FROM information_schema.tables
-        WHERE table_schema = :tenant
+        WHERE table_schema = 'verifywise'
         AND table_name = 'custom_framework_projects'
       )
-      THEN (SELECT COUNT(*) FROM "${tenant}".custom_framework_projects WHERE project_id = :projectId)
+      THEN (SELECT COUNT(*) FROM custom_framework_projects
+            WHERE project_id = :projectId AND organization_id = :organizationId)
       ELSE 0
     END
   ) > 1 AS can_remove;`,
-  { replacements: { projectId, tenant }, transaction }
+  { replacements: { projectId, organizationId }, transaction }
 );
 ```
 


### PR DESCRIPTION
## Summary

- Replaced all references to the deprecated schema-per-tenant architecture with the current shared-schema pattern across 15 documentation files
- Old pattern: `getTenantHash()`, `"${tenant}".tablename`, per-tenant schema creation, tenant hash validation
- New pattern: single `verifywise` schema, `organization_id` column, unqualified table names via `search_path`

## Files changed

| File | Change |
|------|--------|
| `multi-tenancy.md` | Complete rewrite for shared-schema pattern |
| `database-schema.md` | Remove `{tenant}.` prefixes, update schema diagram |
| `authentication.md` | Remove tenant hash from token flow |
| `overview.md` | Update architecture diagram and multi-tenancy description |
| `backend-patterns.md` | Update controller/utils examples to use `organizationId` |
| `adding-new-feature.md` | Update migration, utils, controller patterns |
| `adding-new-framework.md` | Update migration, seed, utils, controller patterns |
| `api-conventions.md` | Update tenant isolation section |
| `code-style.md` | Update JSDoc param naming |
| `plugin-system.md` | Update migration and framework utils examples |
| `ai-advisor.md` | Update query pattern |
| `automations.md` | Update execution stats field |
| `search.md` | Update query pattern and isolation section |
| `PRODUCTION_DEPLOYMENT_GUIDE.md` | Update multi-tenancy config |
| `INTAKE_FORM_IMPLEMENTATION_PLAN.md` | Fix inline comment |

## Test plan

- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm no remaining references to old `getTenantHash` or `${tenant}` patterns