### PR TITLE
Fix/llm evals scorer api key

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
   Box,
   Typography,
@@ -1701,6 +1701,38 @@ export default function NewExperimentModal({
                         ? `${selectedScorerIds.length} scorer${selectedScorerIds.length > 1 ? 's' : ''} selected. Only these will run during evaluation.`
                         : "No scorers selected. All enabled scorers will run if none are selected."}
                     </FormHelperText>
+                    {missingKeyProviders.length > 0 && (
+                      <Box
+                        sx={{
+                          mt: 1.5,
+                          p: 1.5,
+                          borderRadius: "8px",
+                          backgroundColor: palette.status.warning.bg,
+                          border: `1px solid ${palette.status.warning.text}`,
+                        }}
+                      >
+                        <Typography sx={{ fontSize: "12px", color: palette.status.warning.text }}>
+                          Missing API {missingKeyProviders.length > 1 ? "keys" : "key"} for{" "}
+                          <strong>
+                            {missingKeyProviders
+                              .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+                              .join(", ")}
+                          </strong>
+                          . Save the {missingKeyProviders.length > 1 ? "keys" : "key"} in{" "}
+                          <span
+                            onClick={() => window.open(`/evals/${projectId}#settings`, "_blank")}
+                            style={{
+                              textDecoration: "underline",
+                              cursor: "pointer",
+                              fontWeight: 600,
+                            }}
+                          >
+                            LLM Evals Settings
+                          </span>{" "}
+                          before running the experiment.
+                        </Typography>
+                      </Box>
+                    )}
                   </Box>
                 ) : (
                   <Box sx={{ py: 4, textAlign: "center", border: `1px dashed ${palette.border.dark}`, borderRadius: "8px" }}>
@@ -2684,6 +2716,30 @@ export default function NewExperimentModal({
     }
   };
 
+  // Providers required by selected scorers that have no saved API key in org settings.
+  // Self-hosted / Ollama scorers are excluded since they don't need a cloud key.
+  const missingKeyProviders = useMemo(() => {
+    if (judgeMode !== "scorer" && judgeMode !== "both") return [];
+    const scorersToCheck =
+      selectedScorerIds.length > 0
+        ? userScorers.filter((s) => selectedScorerIds.includes(s.id))
+        : userScorers;
+    const missing: string[] = [];
+    for (const scorer of scorersToCheck) {
+      const judgeModel = scorer.config?.judgeModel;
+      if (typeof judgeModel === "object" && judgeModel?.provider) {
+        const provider = judgeModel.provider.toLowerCase();
+        if (provider !== "self-hosted" && provider !== "ollama") {
+          const hasKey = configuredApiKeys.some((k) => k.provider === provider);
+          if (!hasKey && !missing.includes(provider)) {
+            missing.push(provider);
+          }
+        }
+      }
+    }
+    return missing;
+  }, [judgeMode, selectedScorerIds, userScorers, configuredApiKeys]);
+
   const canProceed = (() => {
     if (activeStep === 0) {
       // Step 1: Model validation
@@ -2718,9 +2774,10 @@ export default function NewExperimentModal({
     if (activeStep === 2) {
       // Step 3: Scorer / Judge validation
       if (judgeMode === "scorer") {
-        // Custom scorer only - can proceed even with no selection (all enabled scorers will run)
-        // But if there are no enabled scorers at all, can't proceed
-        return userScorers.length > 0;
+        // Custom scorer only - must have at least one scorer and all required API keys
+        if (userScorers.length === 0) return false;
+        if (missingKeyProviders.length > 0) return false;
+        return true;
       } else if (judgeMode === "standard") {
         // Standard judge only - must have provider and model (API key is from saved settings)
         const hasBase = !!(config.judgeLlm.provider && config.judgeLlm.model);
@@ -2730,8 +2787,9 @@ export default function NewExperimentModal({
         }
         return hasBase;
       } else {
-        // Both mode - can proceed if scorers exist AND standard judge configured
+        // Both mode - scorers exist, all scorer API keys present, AND standard judge configured
         const hasScorers = userScorers.length > 0;
+        if (missingKeyProviders.length > 0) return false;
         let hasJudge = !!(config.judgeLlm.provider && config.judgeLlm.model);
         if (config.judgeLlm.provider === "custom_api") {
           hasJudge = hasJudge && !!config.judgeLlm.endpointUrl;

--- a/EvalServer/src/utils/run_custom_scorer.py
+++ b/EvalServer/src/utils/run_custom_scorer.py
@@ -135,7 +135,10 @@ def get_provider_client(
 
     resolved_key = api_key or os.getenv(env_var)
     if not resolved_key:
-        raise RuntimeError(f"{env_var} environment variable not set")
+        raise RuntimeError(
+            f"No API key found for provider '{provider}' (expected env var: {env_var}). "
+            f"Please save your {provider.upper()} API key in LLM Evals Settings."
+        )
 
     if base_url:
         client = OpenAI(api_key=resolved_key, base_url=base_url)

--- a/EvaluationModule/src/deepeval_engine/deepeval_evaluator.py
+++ b/EvaluationModule/src/deepeval_engine/deepeval_evaluator.py
@@ -404,14 +404,25 @@ class DeepEvalEvaluator:
             if key not in self.metric_thresholds:
                 self.metric_thresholds[key] = value
         
-        # Check for any supported LLM API key for judge-based metrics (OpenAI / Anthropic / Gemini / xAI)
-        has_openai = bool(os.getenv("OPENAI_API_KEY"))
-        has_anthropic = bool(os.getenv("ANTHROPIC_API_KEY"))
-        has_gemini = bool(os.getenv("GEMINI_API_KEY"))
-        has_xai = bool(os.getenv("XAI_API_KEY"))
-        self.has_llm_key = any([has_openai, has_anthropic, has_gemini, has_xai])
+        # Check for any supported LLM API key for judge-based metrics.
+        # G_EVAL_PROVIDER is set by run_evaluation.py when a judge LLM is configured.
+        # Check each provider's env var so Mistral/Google/OpenRouter judges are recognised.
+        _provider_key_map = {
+            "openai":      os.getenv("OPENAI_API_KEY"),
+            "anthropic":   os.getenv("ANTHROPIC_API_KEY"),
+            # Proxy sets GOOGLE_API_KEY for google/gemini; evaluator historically checked GEMINI_API_KEY
+            "gemini":      os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"),
+            "google":      os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"),
+            "xai":         os.getenv("XAI_API_KEY"),
+            "mistral":     os.getenv("MISTRAL_API_KEY"),
+            "openrouter":  os.getenv("OPENROUTER_API_KEY"),
+        }
+        configured_judge_provider = os.getenv("G_EVAL_PROVIDER", "openai").lower()
+        # For self-hosted/ollama, G_EVAL_PROVIDER is already normalised to "openai" with OPENAI_API_KEY set
+        self.has_llm_key = bool(_provider_key_map.get(configured_judge_provider) or
+                                any(_provider_key_map.values()))
         if not self.has_llm_key:
-            print("\n⚠️  NOTE: G‑Eval metrics require a model API key (OpenAI/Anthropic/Gemini/xAI).")
+            print("\n⚠️  NOTE: G‑Eval metrics require a model API key (OpenAI/Anthropic/Gemini/Mistral/xAI/OpenRouter).")
             print("    No supported LLM API key found; G‑Eval metrics will be skipped.\n")
         
         print(f"✓ Initialized DeepEval evaluator")
@@ -568,7 +579,7 @@ class DeepEvalEvaluator:
         if not self.has_llm_key:
             raise RuntimeError(
                 "No LLM API key configured for metrics evaluation. "
-                "Please provide an OpenAI, Anthropic, or other supported LLM API key."
+                "Please provide an API key for OpenAI, Anthropic, Gemini, Mistral, xAI, or OpenRouter."
             )
         
         print("\n" + "="*70)

--- a/Servers/domain.layer/interfaces/i.evalutationLlmApiKey.ts
+++ b/Servers/domain.layer/interfaces/i.evalutationLlmApiKey.ts
@@ -1,7 +1,7 @@
 export interface IEvaluationLlmApiKey {
   id?: number;
   provider: string;
-  encrypted_api_key?: string;
+  api_key_encrypted?: string;
   created_at?: Date;
   updated_at?: Date;
 }

--- a/Servers/domain.layer/models/evaluationLlmApiKey/evaluationLlmApiKey.model.ts
+++ b/Servers/domain.layer/models/evaluationLlmApiKey/evaluationLlmApiKey.model.ts
@@ -119,9 +119,9 @@ export class EvaluationLlmApiKeyModel extends Model<EvaluationLlmApiKeyModel> im
   @Column({
     type: DataType.TEXT,
     allowNull: false,
-    field: 'encrypted_api_key',
+    field: 'api_key_encrypted',
   })
-  encrypted_api_key!: string;
+  api_key_encrypted!: string;
 
   @Column({
     type: DataType.DATE,

--- a/Servers/utils/evaluationLlmApiKey.utils.ts
+++ b/Servers/utils/evaluationLlmApiKey.utils.ts
@@ -96,7 +96,7 @@ export const getAllKeysForOrganizationQuery = async (
   organizationId: number,
 ): Promise<IMaskedKey[]> => {
   const keys = await sequelize.query(
-    `SELECT id, provider, encrypted_api_key, created_at, updated_at
+    `SELECT id, provider, api_key_encrypted, created_at, updated_at
      FROM llm_evals_api_keys
      WHERE organization_id = :organizationId
      ORDER BY created_at DESC`,
@@ -107,8 +107,8 @@ export const getAllKeysForOrganizationQuery = async (
   return keys[0].map(key => {
     let maskedKey = '***';
     try {
-      if (key.encrypted_api_key) {
-        const plainKey = decrypt(key.encrypted_api_key);
+      if (key.api_key_encrypted) {
+        const plainKey = decrypt(key.api_key_encrypted);
         maskedKey = maskApiKey(plainKey);
       }
     } catch (err) {
@@ -170,14 +170,14 @@ export const createKeyQuery = async (
     // Update existing key
     result = await sequelize.query(
       `UPDATE llm_evals_api_keys
-       SET encrypted_api_key = :encrypted_api_key, updated_at = NOW()
+       SET api_key_encrypted = :api_key_encrypted, updated_at = NOW()
        WHERE organization_id = :organizationId AND provider = :provider
-       RETURNING id, provider, encrypted_api_key, created_at, updated_at`,
+       RETURNING id, provider, api_key_encrypted, created_at, updated_at`,
       {
         replacements: {
           organizationId,
           provider,
-          encrypted_api_key: encryptedKey,
+          api_key_encrypted: encryptedKey,
         },
         transaction,
       }
@@ -185,14 +185,14 @@ export const createKeyQuery = async (
   } else {
     // Insert new key
     result = await sequelize.query(
-      `INSERT INTO llm_evals_api_keys (organization_id, provider, encrypted_api_key)
-       VALUES (:organizationId, :provider, :encrypted_api_key)
-       RETURNING id, provider, encrypted_api_key, created_at, updated_at`,
+      `INSERT INTO llm_evals_api_keys (organization_id, provider, api_key_encrypted)
+       VALUES (:organizationId, :provider, :api_key_encrypted)
+       RETURNING id, provider, api_key_encrypted, created_at, updated_at`,
       {
         replacements: {
           organizationId,
           provider,
-          encrypted_api_key: encryptedKey,
+          api_key_encrypted: encryptedKey,
         },
         transaction,
       }
@@ -222,7 +222,7 @@ export const getDecryptedKeysForOrganizationQuery = async (
   organizationId: number,
 ): Promise<Record<string, string>> => {
   const keys = await sequelize.query(
-    `SELECT provider, encrypted_api_key FROM llm_evals_api_keys WHERE organization_id = :organizationId`,
+    `SELECT provider, api_key_encrypted FROM llm_evals_api_keys WHERE organization_id = :organizationId`,
     { replacements: { organizationId } }
   ) as [IEvaluationLlmApiKey[], number];
 
@@ -230,8 +230,8 @@ export const getDecryptedKeysForOrganizationQuery = async (
   const decryptedKeys: Record<string, string> = {};
   for (const key of keys[0]) {
     try {
-      if (key.encrypted_api_key) {
-        decryptedKeys[key.provider] = decrypt(key.encrypted_api_key);
+      if (key.api_key_encrypted) {
+        decryptedKeys[key.provider] = decrypt(key.api_key_encrypted);
       }
     } catch (err) {
       console.warn(`Failed to decrypt key for provider ${key.provider}:`, err);
@@ -280,18 +280,18 @@ export const getDecryptedKeyForProviderQuery = async (
   validateProvider(provider);
 
   const result = await sequelize.query(
-    `SELECT encrypted_api_key FROM llm_evals_api_keys WHERE organization_id = :organizationId AND provider = :provider`,
+    `SELECT api_key_encrypted FROM llm_evals_api_keys WHERE organization_id = :organizationId AND provider = :provider`,
     {
       replacements: { organizationId, provider },
     }
   ) as [IEvaluationLlmApiKey[], number];
 
-  if (result[0].length === 0 || !result[0][0].encrypted_api_key) {
+  if (result[0].length === 0 || !result[0][0].api_key_encrypted) {
     return null;
   }
 
   try {
-    return decrypt(result[0][0].encrypted_api_key);
+    return decrypt(result[0][0].api_key_encrypted);
   } catch (err) {
     console.error("Failed to decrypt key for provider:", provider, err);
     return null;


### PR DESCRIPTION
## Describe your changes

Problem

  Three related issues were blocking the custom scorer evaluation flow:

  1. Experiment silently failed with "LLM API key detected: False" — The DeepEvalEvaluator only checked for OPENAI_API_KEY,
  ANTHROPIC_API_KEY, GEMINI_API_KEY, and XAI_API_KEY. Configuring a Mistral, OpenRouter, or Google (via GOOGLE_API_KEY) judge LLM set the correct env var but has_llm_key still evaluated to False, causing the experiment to fail even though the key was present.
  2. No feedback before running — When a custom scorer's judge provider had no API key saved in LLM Evals Settings, the
  experiment would start, run through all prompts, and only surface an error at the end (or silently return ERROR scores). There
  was no pre-flight check.
  3. LLM Evals Settings returned 500 on every save/load — The EvalServer Alembic migration creates the column as
  api_key_encrypted, but the Node.js backend was querying encrypted_api_key in all SQL statements, causing a PostgreSQL "column does not exist" error on every API key operation.

  Changes

  EvaluationModule/src/deepeval_engine/deepeval_evaluator.py

  - Extended has_llm_key to check MISTRAL_API_KEY, OPENROUTER_API_KEY, and GOOGLE_API_KEY (in addition to GEMINI_API_KEY)
  - Made the check provider-aware using the G_EVAL_PROVIDER env var set by the runner

  EvalServer/src/utils/run_custom_scorer.py

  - Improved the missing API key error message to explicitly tell the user which provider key is missing and where to save it

  Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx

  - Added missingKeyProviders derived value that computes which selected scorers' providers have no saved API key in org settings
  - Blocks the "Next" button at the scorer step when any required key is missing
  - Shows an inline warning banner naming the missing provider(s) with a link directly to LLM Evals Settings

  Servers/utils/evaluationLlmApiKey.utils.ts · Servers/domain.layer/interfaces/i.evalutationLlmApiKey.ts ·
  Servers/domain.layer/models/evaluationLlmApiKey/evaluationLlmApiKey.model.ts

  - Renamed all references from encrypted_api_key → api_key_encrypted to match the actual DB column name created by EvalServer's Alembic migration

  Root Cause of the Column Mismatch

  The Node.js API key management was introduced in one commit using encrypted_api_key. A later shared-schema migration refactor rewrote the EvalServer Alembic migration using api_key_encrypted, but the Node.js backend was never updated. Because the table is owned by EvalServer (not by Sequelize migrations), there was no compile-time or startup check — the mismatch only surfaced at runtime.

## Write your issue number after "Fixes "

This PR does not intend to fix any specific issue. 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
