### PR TITLE
Add explanatory empty state tips across all modules

### DIFF
--- a/Clients/src/presentation/components/EmptyState/EmptyStateTip.tsx
+++ b/Clients/src/presentation/components/EmptyState/EmptyStateTip.tsx
@@ -1,0 +1,109 @@
+import type { FC } from "react";
+import { Box, Typography, useTheme } from "@mui/material";
+import type { LucideIcon } from "lucide-react";
+import { ChevronRight } from "lucide-react";
+
+interface EmptyStateTipProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+/**
+ * Collapsible tip block for empty states.
+ * Uses native <details> for accessible expand/collapse.
+ */
+const EmptyStateTip: FC<EmptyStateTipProps> = ({
+  icon: Icon,
+  title,
+  description,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <Box
+      component="details"
+      sx={{
+        border: `1px solid ${theme.palette.border.light}`,
+        borderRadius: "4px",
+        overflow: "hidden",
+        "&[open] .tip-chevron": {
+          transform: "rotate(90deg)",
+        },
+        "&[open] .tip-summary": {
+          borderBottom: `1px solid ${theme.palette.border.light}`,
+        },
+      }}
+    >
+      <Box
+        component="summary"
+        className="tip-summary"
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: "10px",
+          padding: "10px 14px",
+          cursor: "pointer",
+          listStyle: "none",
+          userSelect: "none",
+          backgroundColor: theme.palette.background.main,
+          transition: "background-color 150ms ease",
+          "&:hover": {
+            backgroundColor: theme.palette.background.fill,
+          },
+          "&::-webkit-details-marker": { display: "none" },
+          "&::marker": { display: "none" },
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 28,
+            height: 28,
+            borderRadius: "4px",
+            backgroundColor: theme.palette.background.fill,
+            flexShrink: 0,
+          }}
+        >
+          <Icon size={14} color={theme.palette.text.secondary} />
+        </Box>
+        <Typography
+          sx={{
+            fontSize: 13,
+            fontWeight: 500,
+            color: theme.palette.text.primary,
+            flex: 1,
+          }}
+        >
+          {title}
+        </Typography>
+        <ChevronRight
+          className="tip-chevron"
+          size={14}
+          color={theme.palette.text.tertiary}
+          style={{ transition: "transform 150ms ease", flexShrink: 0 }}
+        />
+      </Box>
+      <Box
+        sx={{
+          padding: "12px 14px 12px 52px",
+          backgroundColor: theme.palette.background.main,
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: 12,
+            color: theme.palette.text.secondary,
+            lineHeight: 1.6,
+          }}
+        >
+          {description}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default EmptyStateTip;

--- a/Clients/src/presentation/components/EmptyState/EmptyStateTip.tsx
+++ b/Clients/src/presentation/components/EmptyState/EmptyStateTip.tsx
@@ -3,26 +3,45 @@ import { Box, Typography, useTheme } from "@mui/material";
 import type { LucideIcon } from "lucide-react";
 import { ChevronRight } from "lucide-react";
 
+/** Three accent palettes that rotate per-tip */
+const ACCENT_PALETTES = [
+  { bg: "#ECFDF3", bgHover: "#D1FADF", icon: "#039855", border: "#A6F4C5", expandBg: "#F6FEF9" },
+  { bg: "#EFF8FF", bgHover: "#D1E9FF", icon: "#1570EF", border: "#84CAFF", expandBg: "#F5FAFF" },
+  { bg: "#FFFAEB", bgHover: "#FEF0C7", icon: "#DC6803", border: "#FEDF89", expandBg: "#FFFCF5" },
+] as const;
+
 interface EmptyStateTipProps {
   icon: LucideIcon;
   title: string;
   description: string;
+  /** Accent index (0=green, 1=blue, 2=amber). Auto-assigned when omitted. */
+  accentIndex?: number;
 }
+
+/** Global counter so sibling tips cycle through accents automatically */
+let tipMountCounter = 0;
 
 /**
  * Collapsible tip block for empty states.
- * Uses native <details> with animated height transition.
+ * Uses native <details> with animated height transition and colored accents.
  */
 const EmptyStateTip: FC<EmptyStateTipProps> = ({
   icon: Icon,
   title,
   description,
+  accentIndex,
 }) => {
   const theme = useTheme();
   const contentRef = useRef<HTMLDivElement>(null);
   const detailsRef = useRef<HTMLDetailsElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [contentHeight, setContentHeight] = useState(0);
+  const [myAccent] = useState(() => {
+    if (accentIndex !== undefined) return accentIndex % ACCENT_PALETTES.length;
+    return tipMountCounter++ % ACCENT_PALETTES.length;
+  });
+
+  const accent = ACCENT_PALETTES[myAccent];
 
   useEffect(() => {
     if (contentRef.current) {
@@ -50,8 +69,9 @@ const EmptyStateTip: FC<EmptyStateTipProps> = ({
       ref={detailsRef}
       sx={{
         border: `1px solid ${theme.palette.border.light}`,
-        borderRadius: "4px",
+        borderRadius: "6px",
         overflow: "hidden",
+        transition: "border-color 200ms ease",
       }}
     >
       <Box
@@ -82,14 +102,16 @@ const EmptyStateTip: FC<EmptyStateTipProps> = ({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            width: 28,
-            height: 28,
-            borderRadius: "4px",
-            backgroundColor: theme.palette.background.fill,
+            width: 30,
+            height: 30,
+            borderRadius: "6px",
+            backgroundColor: accent.bg,
+            border: `1px solid ${accent.border}40`,
             flexShrink: 0,
+            transition: "background-color 200ms ease, border-color 200ms ease",
           }}
         >
-          <Icon size={14} color={theme.palette.text.secondary} />
+          <Icon size={14} color={accent.icon} />
         </Box>
         <Typography
           sx={{
@@ -122,7 +144,7 @@ const EmptyStateTip: FC<EmptyStateTipProps> = ({
         <Box
           ref={contentRef}
           sx={{
-            padding: "12px 14px 12px 52px",
+            padding: "12px 14px 12px 54px",
             backgroundColor: theme.palette.background.main,
           }}
         >

--- a/Clients/src/presentation/components/EmptyState/EmptyStateTip.tsx
+++ b/Clients/src/presentation/components/EmptyState/EmptyStateTip.tsx
@@ -1,4 +1,4 @@
-import type { FC } from "react";
+import { type FC, useRef, useState, useEffect, useCallback } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
 import type { LucideIcon } from "lucide-react";
 import { ChevronRight } from "lucide-react";
@@ -11,7 +11,7 @@ interface EmptyStateTipProps {
 
 /**
  * Collapsible tip block for empty states.
- * Uses native <details> for accessible expand/collapse.
+ * Uses native <details> with animated height transition.
  */
 const EmptyStateTip: FC<EmptyStateTipProps> = ({
   icon: Icon,
@@ -19,25 +19,44 @@ const EmptyStateTip: FC<EmptyStateTipProps> = ({
   description,
 }) => {
   const theme = useTheme();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setContentHeight(contentRef.current.scrollHeight);
+    }
+  }, [description]);
+
+  const handleToggle = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const details = detailsRef.current;
+    if (!details) return;
+
+    if (isOpen) {
+      setIsOpen(false);
+      setTimeout(() => { details.open = false; }, 200);
+    } else {
+      details.open = true;
+      requestAnimationFrame(() => setIsOpen(true));
+    }
+  }, [isOpen]);
 
   return (
     <Box
       component="details"
+      ref={detailsRef}
       sx={{
         border: `1px solid ${theme.palette.border.light}`,
         borderRadius: "4px",
         overflow: "hidden",
-        "&[open] .tip-chevron": {
-          transform: "rotate(90deg)",
-        },
-        "&[open] .tip-summary": {
-          borderBottom: `1px solid ${theme.palette.border.light}`,
-        },
       }}
     >
       <Box
         component="summary"
-        className="tip-summary"
+        onClick={handleToggle}
         sx={{
           display: "flex",
           alignItems: "center",
@@ -47,7 +66,10 @@ const EmptyStateTip: FC<EmptyStateTipProps> = ({
           listStyle: "none",
           userSelect: "none",
           backgroundColor: theme.palette.background.main,
-          transition: "background-color 150ms ease",
+          borderBottom: isOpen
+            ? `1px solid ${theme.palette.border.light}`
+            : "1px solid transparent",
+          transition: "background-color 150ms ease, border-color 200ms ease",
           "&:hover": {
             backgroundColor: theme.palette.background.fill,
           },
@@ -80,27 +102,40 @@ const EmptyStateTip: FC<EmptyStateTipProps> = ({
           {title}
         </Typography>
         <ChevronRight
-          className="tip-chevron"
           size={14}
           color={theme.palette.text.tertiary}
-          style={{ transition: "transform 150ms ease", flexShrink: 0 }}
+          style={{
+            transition: "transform 200ms ease",
+            flexShrink: 0,
+            transform: isOpen ? "rotate(90deg)" : "rotate(0deg)",
+          }}
         />
       </Box>
       <Box
         sx={{
-          padding: "12px 14px 12px 52px",
-          backgroundColor: theme.palette.background.main,
+          height: isOpen ? contentHeight : 0,
+          opacity: isOpen ? 1 : 0,
+          overflow: "hidden",
+          transition: "height 200ms ease, opacity 200ms ease",
         }}
       >
-        <Typography
+        <Box
+          ref={contentRef}
           sx={{
-            fontSize: 12,
-            color: theme.palette.text.secondary,
-            lineHeight: 1.6,
+            padding: "12px 14px 12px 52px",
+            backgroundColor: theme.palette.background.main,
           }}
         >
-          {description}
-        </Typography>
+          <Typography
+            sx={{
+              fontSize: 13,
+              color: theme.palette.text.secondary,
+              lineHeight: 1.6,
+            }}
+          >
+            {description}
+          </Typography>
+        </Box>
       </Box>
     </Box>
   );

--- a/Clients/src/presentation/components/EmptyState/index.tsx
+++ b/Clients/src/presentation/components/EmptyState/index.tsx
@@ -1,5 +1,5 @@
-import type { FC } from "react";
-import { Stack, Typography, useTheme } from "@mui/material";
+import type { FC, ReactNode } from "react";
+import { Box, Stack, Typography, useTheme } from "@mui/material";
 import type { LucideIcon } from "lucide-react";
 import { Inbox } from "lucide-react";
 import EmptyIllustration from "./EmptyIllustration";
@@ -28,17 +28,23 @@ interface EmptyStateProps {
    * Contextual icon for the illustration (defaults to Inbox)
    */
   icon?: LucideIcon;
+  /**
+   * Optional content below the message (typically EmptyStateTip components)
+   */
+  children?: ReactNode;
 }
 
 /**
  * Reusable EmptyState component for tables and lists.
  * Displays an abstract SVG illustration with a contextual icon.
+ * Optionally renders collapsible tips below the message.
  */
 export const EmptyState: FC<EmptyStateProps> = ({
   message = "There is currently no data in this table.",
   imageAlt = "No data available",
   showBorder = false,
   icon = Inbox,
+  children,
 }) => {
   const theme = useTheme();
 
@@ -52,7 +58,7 @@ export const EmptyState: FC<EmptyStateProps> = ({
           backgroundColor: theme.palette.background.main,
         }),
         pt: "48px",
-        pb: 12,
+        pb: children ? 6 : 12,
       }}
       role="status"
       aria-label={imageAlt}
@@ -72,6 +78,22 @@ export const EmptyState: FC<EmptyStateProps> = ({
       >
         {message}
       </Typography>
+      {children && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+            mt: 4,
+            width: "100%",
+            maxWidth: 440,
+            px: 2,
+            pb: 2,
+          }}
+        >
+          {children}
+        </Box>
+      )}
     </Stack>
   );
 };

--- a/Clients/src/presentation/components/EmptyState/index.tsx
+++ b/Clients/src/presentation/components/EmptyState/index.tsx
@@ -58,7 +58,7 @@ export const EmptyState: FC<EmptyStateProps> = ({
           backgroundColor: theme.palette.background.main,
         }),
         pt: "48px",
-        pb: children ? 6 : 12,
+        pb: children ? 0 : 12,
       }}
       role="status"
       aria-label={imageAlt}
@@ -88,7 +88,7 @@ export const EmptyState: FC<EmptyStateProps> = ({
             width: "100%",
             maxWidth: 440,
             px: 2,
-            pb: 2,
+            pb: "48px",
           }}
         >
           {children}

--- a/Clients/src/presentation/components/EmptyState/index.tsx
+++ b/Clients/src/presentation/components/EmptyState/index.tsx
@@ -84,7 +84,7 @@ export const EmptyState: FC<EmptyStateProps> = ({
             display: "flex",
             flexDirection: "column",
             gap: "8px",
-            mt: 4,
+            mt: "40px",
             width: "100%",
             maxWidth: 440,
             px: 2,

--- a/Clients/src/presentation/components/ProjectsList/ProjectTableView.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectTableView.tsx
@@ -20,7 +20,8 @@ import { EmptyState } from "../EmptyState";
 import Chip from "../Chip";
 import ViewRelationshipsButton from "../ViewRelationshipsButton";
 import IconButton from "../IconButton";
-import { ChevronsUpDown, ChevronUp, ChevronDown, Briefcase } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, Briefcase, PlusCircle, Target, Link2 } from "lucide-react";
+import EmptyStateTip from "../EmptyState/EmptyStateTip";
 import { IProjectTableViewProps } from "../../../domain/interfaces/i.project";
 import { Project } from "../../../domain/types/Project";
 import { deleteProject } from "../../../application/repository/project.repository";
@@ -376,7 +377,23 @@ const ProjectTableView: React.FC<IProjectTableViewProps> = ({
                 align="center"
                 sx={{ border: "none", p: 0 }}
               >
-                <EmptyState icon={Briefcase} message="A use case is a real-world scenario describing how an AI system is applied within an organization. Currently you don't have any use cases in this workspace." />
+                <EmptyState icon={Briefcase} message="No use cases yet. A use case describes how an AI system is applied within your organization.">
+                  <EmptyStateTip
+                    icon={PlusCircle}
+                    title="Create a use case"
+                    description="Define the AI system, its purpose, the data it processes, and the people it affects. This forms the basis for risk and compliance tracking."
+                  />
+                  <EmptyStateTip
+                    icon={Target}
+                    title="Scope and classify"
+                    description="Each use case can be classified by risk level (high, limited, minimal) to determine which compliance controls apply."
+                  />
+                  <EmptyStateTip
+                    icon={Link2}
+                    title="Link to governance artifacts"
+                    description="Connect use cases to risks, policies, models, and evidence. This creates full traceability from business need to compliance proof."
+                  />
+                </EmptyState>
               </TableCell>
             </TableRow>
           </TableBody>

--- a/Clients/src/presentation/components/Sidebar/SidebarFooter.tsx
+++ b/Clients/src/presentation/components/Sidebar/SidebarFooter.tsx
@@ -1017,7 +1017,7 @@ const SidebarFooter: FC<SidebarFooterProps> = ({
                 </Typography>
 
                 <ListItemButton
-                  onClick={() => setDarkMode((prev) => !prev)}
+                  onClick={() => { setDarkMode((prev) => !prev); closePopup(); }}
                   sx={{
                     height: "32px",
                     gap: theme.spacing(4),

--- a/Clients/src/presentation/components/Table/ArenaTable/index.tsx
+++ b/Clients/src/presentation/components/Table/ArenaTable/index.tsx
@@ -13,10 +13,11 @@ import {
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useMemo, useState, useEffect } from "react";
 import TablePaginationActions from "../../TablePagination";
-import { ChevronsUpDown, Swords } from "lucide-react";
+import { ChevronsUpDown, Swords, GitCompare, ListChecks, Trophy } from "lucide-react";
 import ArenaTableHead from "./ArenaTableHead";
 import ArenaTableBody from "./ArenaTableBody";
 import { EmptyState } from "../../EmptyState";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
 import {
   getPaginationRowCount,
   setPaginationRowCount,
@@ -228,7 +229,23 @@ const ArenaTable: React.FC<ArenaTableProps> = ({
           <TableBody>
             <TableRow>
               <TableCell colSpan={columns.length} sx={{ border: "none", p: 0 }}>
-                <EmptyState icon={Swords} message="No arena battles found. Create a new battle to get started." />
+                <EmptyState icon={Swords} message="No arena battles found. Create a new battle to get started.">
+                  <EmptyStateTip
+                    icon={GitCompare}
+                    title="What is an arena battle?"
+                    description="An arena battle runs the same prompts through two or more models side by side, so you can compare outputs directly."
+                  />
+                  <EmptyStateTip
+                    icon={ListChecks}
+                    title="Pick models and scorers"
+                    description="Select which models to pit against each other and which scorers to use for grading. Results are shown in a head-to-head view."
+                  />
+                  <EmptyStateTip
+                    icon={Trophy}
+                    title="Review and rank"
+                    description="After a battle completes, review scored outputs to decide which model performs best for your use case."
+                  />
+                </EmptyState>
               </TableCell>
             </TableRow>
           </TableBody>

--- a/Clients/src/presentation/components/Table/DatasetsTable/index.tsx
+++ b/Clients/src/presentation/components/Table/DatasetsTable/index.tsx
@@ -13,10 +13,11 @@ import {
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useMemo, useState, useEffect } from "react";
 import TablePaginationActions from "../../TablePagination";
-import { ChevronsUpDown, Database } from "lucide-react";
+import { ChevronsUpDown, Database, Upload, FileText, ClipboardCheck } from "lucide-react";
 import DatasetsTableHead from "./DatasetsTableHead";
 import DatasetsTableBody from "./DatasetsTableBody";
 import { EmptyState } from "../../EmptyState";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
 import {
   getPaginationRowCount,
   setPaginationRowCount,
@@ -258,7 +259,23 @@ const DatasetsTable: React.FC<DatasetsTableProps> = ({
           <TableBody>
             <TableRow>
               <TableCell colSpan={columns.length} sx={{ border: "none", p: 0 }}>
-                <EmptyState icon={Database} message={emptyMessage} />
+                <EmptyState icon={Database} message={emptyMessage}>
+                  <EmptyStateTip
+                    icon={Upload}
+                    title="Upload evaluation data"
+                    description="Upload CSV or JSONL files containing prompts and expected responses. These are used to evaluate model performance across experiments."
+                  />
+                  <EmptyStateTip
+                    icon={FileText}
+                    title="Structure your datasets"
+                    description="Each dataset should have a clear prompt column and an expected output column. Add metadata columns for filtering results later."
+                  />
+                  <EmptyStateTip
+                    icon={ClipboardCheck}
+                    title="Reuse across experiments"
+                    description="Once uploaded, datasets can be used across multiple evaluation runs to compare different models or prompt strategies."
+                  />
+                </EmptyState>
               </TableCell>
             </TableRow>
           </TableBody>

--- a/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
@@ -12,7 +12,8 @@ import { Suspense, lazy, useMemo, useState, useCallback, useEffect } from "react
 import TablePaginationActions from "../../TablePagination";
 import TableHeader, { SortConfig } from "./TableHead";
 import { EmptyState } from "../../EmptyState";
-import { ChevronsUpDown, FlaskConical } from "lucide-react";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
+import { ChevronsUpDown, FlaskConical, Play, Database, BarChart3 } from "lucide-react";
 
 const SelectorVertical = (props: React.SVGProps<SVGSVGElement>) => (
   <ChevronsUpDown size={16} {...props} />
@@ -254,7 +255,23 @@ const EvaluationTable: React.FC<IEvaluationTableProps> = ({
               <TableBody>
                 <TableRow>
                   <TableCell colSpan={columns.length} sx={{ border: "none", p: 0 }}>
-                    <EmptyState icon={FlaskConical} message="There is currently no data in this table." />
+                    <EmptyState icon={FlaskConical} message="No experiments run yet. Create an experiment to evaluate model performance.">
+                      <EmptyStateTip
+                        icon={Play}
+                        title="Run your first experiment"
+                        description="Select a dataset, pick one or more models, and choose scorers. The system runs each prompt through the models and grades the outputs."
+                      />
+                      <EmptyStateTip
+                        icon={Database}
+                        title="Prepare a dataset first"
+                        description="Experiments need a dataset with prompts and expected outputs. Upload one in the datasets tab before running an experiment."
+                      />
+                      <EmptyStateTip
+                        icon={BarChart3}
+                        title="Compare results over time"
+                        description="Each experiment run is saved here with scores and metadata. Run the same dataset across different models or configs to track progress."
+                      />
+                    </EmptyState>
                   </TableCell>
                 </TableRow>
               </TableBody>

--- a/Clients/src/presentation/components/Table/ModelsTable/index.tsx
+++ b/Clients/src/presentation/components/Table/ModelsTable/index.tsx
@@ -13,10 +13,11 @@ import {
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useMemo, useState, useEffect } from "react";
 import TablePaginationActions from "../../TablePagination";
-import { ChevronsUpDown, Cpu } from "lucide-react";
+import { ChevronsUpDown, Cpu, Zap, RefreshCw, Key } from "lucide-react";
 import ModelsTableHead from "./ModelsTableHead";
 import ModelsTableBody from "./ModelsTableBody";
 import { EmptyState } from "../../EmptyState";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
 import {
     getPaginationRowCount,
     setPaginationRowCount,
@@ -211,7 +212,23 @@ const ModelsTable: React.FC<ModelsTableProps> = ({
                     <TableBody>
                         <TableRow>
                             <TableCell colSpan={columns.length} sx={{ border: "none", p: 0 }}>
-                                <EmptyState icon={Cpu} message="No models found. Model preferences are automatically saved when you run an experiment." />
+                                <EmptyState icon={Cpu} message="No models found. Model preferences are automatically saved when you run an experiment.">
+                                    <EmptyStateTip
+                                        icon={Zap}
+                                        title="How models get added"
+                                        description="Models appear here automatically after you run an experiment. Each model's provider, name, and parameters are saved for reuse."
+                                    />
+                                    <EmptyStateTip
+                                        icon={Key}
+                                        title="Configure API keys first"
+                                        description="Make sure your API keys are set up in settings before running experiments. Models need valid credentials to generate responses."
+                                    />
+                                    <EmptyStateTip
+                                        icon={RefreshCw}
+                                        title="Reuse model configurations"
+                                        description="Once a model appears here, you can select it again in future experiments without re-entering the configuration."
+                                    />
+                                </EmptyState>
                             </TableCell>
                         </TableRow>
                     </TableBody>

--- a/Clients/src/presentation/components/Table/RisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/RisksTable/index.tsx
@@ -16,11 +16,12 @@ import {
 import { useCallback, useMemo, useState, useEffect } from "react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { EmptyState } from "../../EmptyState";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
 import IconButton from "../../IconButton";
 import ViewRelationshipsButton from "../../ViewRelationshipsButton";
 import TablePaginationActions from "../../TablePagination";
 import Chip from "../../Chip";
-import { ChevronsUpDown, ChevronUp, ChevronDown, ShieldAlert } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, ShieldAlert, TrendingDown, Grid3X3, ListChecks } from "lucide-react";
 import { VendorRisk } from "../../../../domain/types/VendorRisk";
 import { User } from "../../../../domain/types/User";
 import { IRiskTableProps } from "../../../types/interfaces/i.table";
@@ -642,9 +643,25 @@ const RiskTable: React.FC<IRiskTableProps> = ({
       {!vendorRisks || vendorRisks.length === 0 ? (
         <EmptyState
           icon={ShieldAlert}
-          message="No risks identified. Risks will appear here as they are added."
+          message="No risks identified yet. Document and track risks related to your AI systems."
           showBorder
-        />
+        >
+          <EmptyStateTip
+            icon={TrendingDown}
+            title="Identify AI-specific risks"
+            description="Document risks related to bias, data quality, security, transparency, and model drift. Cover both technical and organizational risks."
+          />
+          <EmptyStateTip
+            icon={Grid3X3}
+            title="Assess likelihood and impact"
+            description="Rate each risk by likelihood and impact. The risk score and level help you prioritize what needs attention first."
+          />
+          <EmptyStateTip
+            icon={ListChecks}
+            title="Create treatment plans"
+            description="Define mitigation strategies for each risk and track their progress. Link treatments to specific controls for full traceability."
+          />
+        </EmptyState>
       ) : (
         <TableContainer>
           <Table sx={{ ...singleTheme.tableStyles.primary.frame }}>

--- a/Clients/src/presentation/components/Table/ScorersTable/index.tsx
+++ b/Clients/src/presentation/components/Table/ScorersTable/index.tsx
@@ -13,10 +13,11 @@ import {
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useCallback, useMemo, useState, useEffect } from "react";
 import TablePaginationActions from "../../TablePagination";
-import { ChevronsUpDown, Gauge } from "lucide-react";
+import { ChevronsUpDown, Gauge, Ruler, Settings2, BarChart3 } from "lucide-react";
 import ScorersTableHead from "./ScorersTableHead";
 import ScorersTableBody from "./ScorersTableBody";
 import { EmptyState } from "../../EmptyState";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
 import {
   getPaginationRowCount,
   setPaginationRowCount,
@@ -251,7 +252,23 @@ const ScorersTable: React.FC<ScorersTableProps> = ({
           <TableBody>
             <TableRow>
               <TableCell colSpan={columns.length} sx={{ border: "none", p: 0 }}>
-                <EmptyState icon={Gauge} message="No scorers found. Create a scorer to get started." />
+                <EmptyState icon={Gauge} message="No scorers found. Create a scorer to get started.">
+                  <EmptyStateTip
+                    icon={Ruler}
+                    title="What is a scorer?"
+                    description="A scorer defines how model outputs are graded. It can check for accuracy, relevance, tone, safety, or any custom criteria you set."
+                  />
+                  <EmptyStateTip
+                    icon={Settings2}
+                    title="Built-in and custom scorers"
+                    description="Use pre-built scorers for common checks like exact match or similarity, or write your own scoring logic for domain-specific needs."
+                  />
+                  <EmptyStateTip
+                    icon={BarChart3}
+                    title="Compare across runs"
+                    description="Apply the same scorers across different experiments to track how model quality changes over time or between configurations."
+                  />
+                </EmptyState>
               </TableCell>
             </TableRow>
           </TableBody>

--- a/Clients/src/presentation/components/Table/TasksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/TasksTable/index.tsx
@@ -16,8 +16,9 @@ import {
 import { useCallback, useMemo, useState, useEffect } from "react";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { EmptyState } from "../../EmptyState";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
 import TablePaginationActions from "../../TablePagination";
-import { ChevronsUpDown, ChevronUp, ChevronDown, ListTodo } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, ListTodo, UserPlus, Tag, Link2 } from "lucide-react";
 import { CustomSelect } from "../../CustomSelect";
 import IconButtonComponent from "../../IconButton";
 import Chip from "../../Chip";
@@ -603,9 +604,25 @@ const TasksTable: React.FC<ITasksTableProps> = ({
       {!sortedTasks || sortedTasks.length === 0 ? (
         <EmptyState
           icon={ListTodo}
-          message="No tasks yet. Create a task to start tracking your work."
+          message="No tasks yet. Tasks help you track action items across your governance program."
           showBorder
-        />
+        >
+          <EmptyStateTip
+            icon={UserPlus}
+            title="Assign tasks to team members"
+            description="Each task can be assigned to a workspace member with a priority and due date. They'll be notified when assigned."
+          />
+          <EmptyStateTip
+            icon={Tag}
+            title="Use priorities to stay organized"
+            description="Set priorities (low, medium, high, urgent) and group tasks by status, assignee, or due date to track progress."
+          />
+          <EmptyStateTip
+            icon={Link2}
+            title="Link tasks to controls or risks"
+            description="Associate tasks with specific controls, risks, or other resources to maintain traceability for auditors."
+          />
+        </EmptyState>
       ) : (
         <TableContainer>
           <Table sx={singleTheme.tableStyles.primary.frame}>

--- a/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
+++ b/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
@@ -16,10 +16,11 @@ import { useCallback, useMemo, useState, useEffect } from "react";
 import IconButton from "../../IconButton";
 import ViewRelationshipsButton from "../../ViewRelationshipsButton";
 import { EmptyState } from "../../EmptyState";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
 import TablePaginationActions from "../../TablePagination";
-import { ChevronsUpDown, ChevronUp, ChevronDown, Building2 } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, Building2, ShieldCheck, FileSearch, AlertCircle } from "lucide-react";
 import VendorRisksDialog from "../../VendorRisksDialog";
 import allowedRoles from "../../../../application/constants/permissions";
 import { useAuth } from "../../../../application/hooks/useAuth";
@@ -546,9 +547,25 @@ const TableWithPlaceholder: React.FC<ITableWithPlaceholderProps> = ({
       {!sortedVendors || sortedVendors.length === 0 ? (
         <EmptyState
           icon={Building2}
-          message="There is currently no data in this table."
+          message="No vendors registered yet. Track third-party AI providers and assess their risk."
           showBorder
-        />
+        >
+          <EmptyStateTip
+            icon={ShieldCheck}
+            title="Assess vendor risk tiers"
+            description="Classify each vendor as low, medium, or high risk based on data access, system criticality, and contractual protections."
+          />
+          <EmptyStateTip
+            icon={FileSearch}
+            title="Track contracts and assessments"
+            description="Record contract dates and last assessment dates. Keep track of when renewals and reassessments are due."
+          />
+          <EmptyStateTip
+            icon={AlertCircle}
+            title="Common AI vendors to register"
+            description="OpenAI, Anthropic, Google Cloud AI, AWS Bedrock, Microsoft Azure AI, Hugging Face, and any custom ML service providers you use."
+          />
+        </EmptyState>
       ) : (
         <TableContainer>
           <Table sx={singleTheme.tableStyles.primary.frame}>

--- a/Clients/src/presentation/pages/AIDetection/HistoryPage.tsx
+++ b/Clients/src/presentation/pages/AIDetection/HistoryPage.tsx
@@ -27,9 +27,10 @@ import {
 } from "@mui/material";
 import Chip from "../../components/Chip";
 import Alert from "../../components/Alert";
-import { Trash2, ChevronsUpDown, Clock, ChevronUp, ChevronDown, Scan as ScanIcon } from "lucide-react";
+import { Trash2, ChevronsUpDown, Clock, ChevronUp, ChevronDown, Scan as ScanIcon, GitBranch, Search, BarChart3 } from "lucide-react";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import TablePaginationActions from "../../components/TablePagination";
 import singleTheme from "../../themes/v1SingleTheme";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
@@ -687,9 +688,25 @@ export default function HistoryPage() {
       >
         <EmptyState
           icon={ScanIcon}
-          message="No scans yet. Start your first scan to detect AI/ML libraries in a repository."
+          message="No scans yet. Scan your repositories to detect AI and ML libraries."
           showBorder
-        />
+        >
+          <EmptyStateTip
+            icon={GitBranch}
+            title="Add a repository first"
+            description="Go to the Repositories tab and add a GitHub repository URL. Once added, you can run scans to detect AI/ML usage."
+          />
+          <EmptyStateTip
+            icon={Search}
+            title="What gets detected?"
+            description="AI/ML libraries (TensorFlow, PyTorch, scikit-learn), LLM SDKs (OpenAI, Anthropic), model files, ML pipelines, and containerized AI workloads."
+          />
+          <EmptyStateTip
+            icon={BarChart3}
+            title="Track changes over time"
+            description="Each scan creates a snapshot. Compare scans to see what AI components were added, removed, or changed across your codebase."
+          />
+        </EmptyState>
       </PageHeaderExtended>
     );
   }

--- a/Clients/src/presentation/pages/AIDetection/RepositoriesPage.tsx
+++ b/Clients/src/presentation/pages/AIDetection/RepositoriesPage.tsx
@@ -28,10 +28,11 @@ import Chip from "../../components/Chip";
 import Alert from "../../components/Alert";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import TablePaginationActions from "../../components/TablePagination";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
-import { Play, Pencil, Trash2, Loader2, GitBranch } from "lucide-react";
+import { Play, Pencil, Trash2, Loader2, GitBranch, Github, Shield, RefreshCw } from "lucide-react";
 import axios from "axios";
 import {
   getRepositories,
@@ -418,8 +419,24 @@ export default function RepositoriesPage() {
                   <TableCell colSpan={TABLE_COLUMNS.length} sx={{ p: 0, border: 0 }}>
                     <EmptyState
                       icon={GitBranch}
-                      message="No repositories added yet. Click 'Add repository' to start monitoring."
-                    />
+                      message="No repositories added yet. Add a repository to start detecting AI components."
+                    >
+                      <EmptyStateTip
+                        icon={Github}
+                        title="Connect your GitHub repositories"
+                        description="Paste a GitHub repository URL and the system will scan its codebase for AI/ML libraries, model files, and inference endpoints."
+                      />
+                      <EmptyStateTip
+                        icon={Shield}
+                        title="Detect shadow AI"
+                        description="Find undocumented AI usage in your codebase. Identify libraries and models that haven't been registered in your AI inventory."
+                      />
+                      <EmptyStateTip
+                        icon={RefreshCw}
+                        title="Schedule recurring scans"
+                        description="Set up automatic scans to run on a schedule. Get notified when new AI components are detected in your repositories."
+                      />
+                    </EmptyState>
                   </TableCell>
                 </TableRow>
               ) : (

--- a/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
+++ b/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
@@ -13,10 +13,11 @@ import {
   Box,
   useTheme,
 } from "@mui/material";
-import { ChevronsUpDown, ChevronUp, ChevronDown, AlertTriangle, Bot } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, AlertTriangle, Bot, RefreshCw, Eye, ShieldCheck } from "lucide-react";
 import IconButton from "../../components/IconButton";
 import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import Chip from "../../components/Chip";
 import TablePaginationActions from "../../components/TablePagination";
 import { singleTheme } from "../../themes";
@@ -160,7 +161,25 @@ const AgentTable: React.FC<AgentTableProps> = ({
   }
 
   if (!sortedData || sortedData.length === 0) {
-    return <EmptyState icon={Bot} message="No agents found. Trigger a sync or add one manually." />;
+    return (
+      <EmptyState icon={Bot} message="No agents discovered yet. Sync your infrastructure to detect AI agents.">
+        <EmptyStateTip
+          icon={RefreshCw}
+          title="Trigger a sync"
+          description="Click 'Sync' to scan your connected infrastructure for autonomous AI agents, chatbots, and automated pipelines."
+        />
+        <EmptyStateTip
+          icon={Eye}
+          title="What gets discovered?"
+          description="LLM-based chatbots, autonomous coding agents, automated decision systems, ML inference endpoints, and workflow automation tools."
+        />
+        <EmptyStateTip
+          icon={ShieldCheck}
+          title="Govern discovered agents"
+          description="Once discovered, classify agents by risk level, assign owners, and link them to your compliance controls and risk register."
+        />
+      </EmptyState>
+    );
   }
 
   const tableHeader = (

--- a/Clients/src/presentation/pages/ApprovalWorkflows/ApprovalWorkflowsTable.tsx
+++ b/Clients/src/presentation/pages/ApprovalWorkflows/ApprovalWorkflowsTable.tsx
@@ -41,12 +41,13 @@ import { useState, useCallback, useEffect } from "react";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 dayjs.extend(utc);
-import { ChevronsUpDown, ChevronUp, ChevronDown, ClipboardCheck } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, ClipboardCheck, Send, UserCheck, MessageSquare } from "lucide-react";
 import { ApprovalWorkflowModel } from "../../../domain/models/Common/approvalWorkflow/approvalWorkflow.model";
 import TablePaginationActions from "../../components/TablePagination";
 import { entities } from "./arrays";
 import { TABLE_COLUMNS } from "./arrays";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 
 const cellStyle = singleTheme.tableStyles.primary.body.cell;
 
@@ -197,7 +198,25 @@ const ApprovalWorkflowsTable: React.FC<ApprovalWorkflowTableProps> = ({
 
     // Return early with just EmptyState if no data (consistent with other tables)
     if (!sortedData || sortedData.length === 0) {
-        return <EmptyState icon={ClipboardCheck} message="There is currently no data in this table." />;
+        return (
+            <EmptyState icon={ClipboardCheck} message="No approval workflows yet. Define review and sign-off chains for your governance process.">
+                <EmptyStateTip
+                    icon={Send}
+                    title="Create approval workflows"
+                    description="Define multi-step review chains that run automatically when controls, evidence, or policies need sign-off."
+                />
+                <EmptyStateTip
+                    icon={UserCheck}
+                    title="Assign reviewers"
+                    description="Add team members as reviewers at each step. They'll be notified when items reach their review stage."
+                />
+                <EmptyStateTip
+                    icon={MessageSquare}
+                    title="Track feedback and comments"
+                    description="Reviewers can approve, reject, or request changes with detailed comments. The full audit trail is preserved."
+                />
+            </EmptyState>
+        );
     }
 
     return (

--- a/Clients/src/presentation/pages/Automations/components/AutomationHistory/index.tsx
+++ b/Clients/src/presentation/pages/Automations/components/AutomationHistory/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import EmptyStateTip from "../../../../components/EmptyState/EmptyStateTip";
 import {
   Box,
   Typography,
@@ -15,7 +16,7 @@ import {
   useTheme,
   TableFooter,
 } from '@mui/material';
-import { ChevronDown, ChevronRight, Clock, CheckCircle, XCircle, AlertCircle, Timer, ArrowRight, History } from 'lucide-react';
+import { ChevronDown, ChevronRight, Clock, CheckCircle, XCircle, AlertCircle, Timer, ArrowRight, History, Play, AlertTriangle, RotateCcw } from 'lucide-react';
 import Chip from '../../../../components/Chip';
 import { getAutomationHistory, getAutomationStats, type AutomationExecutionLog } from '../../../../../application/repository/automations.repository';
 import TablePaginationActions from '../../../../components/TablePagination';
@@ -286,7 +287,23 @@ const AutomationHistory: React.FC<AutomationHistoryProps> = ({ automationId }) =
 
       {/* Execution History Table */}
       {logs.length === 0 ? (
-        <EmptyState message="No execution history yet" icon={History} />
+        <EmptyState message="No execution history yet." icon={History}>
+          <EmptyStateTip
+            icon={Play}
+            title="How automations run"
+            description="When an automation triggers (on schedule, via webhook, or manually), its execution is recorded here with status and duration."
+          />
+          <EmptyStateTip
+            icon={AlertTriangle}
+            title="Track failures"
+            description="Failed executions show error details. Use this to diagnose issues with automation steps, API connections, or data formatting."
+          />
+          <EmptyStateTip
+            icon={RotateCcw}
+            title="Re-run past executions"
+            description="Click on any past execution to view its details. You can re-trigger automations manually from the automation settings."
+          />
+        </EmptyState>
       ) : (
         <Stack spacing={0}>
           <TableContainer sx={{ overflowX: 'auto' }}>

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -14,10 +14,11 @@ import {
   TableContainer,
   Box,
 } from "@mui/material";
-import { Trash2, Eye, ChevronsUpDown, ChevronUp, ChevronDown, Scale } from "lucide-react";
+import { Trash2, Eye, ChevronsUpDown, ChevronUp, ChevronDown, Scale, Users, BarChart3, FileText } from "lucide-react";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import SearchBox from "../../components/Search/SearchBox";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { PageHeader } from "../../components/Layout/PageHeader";
 import HelperIcon from "../../components/HelperIcon";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
@@ -227,9 +228,25 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
       ) : sortedAudits.length === 0 ? (
         <EmptyState
           icon={Scale}
-          message="No bias audits yet. Create your first bias audit to get started."
+          message="No bias audits yet. Audit your models for fairness across demographic groups."
           showBorder
-        />
+        >
+          <EmptyStateTip
+            icon={Users}
+            title="Define demographic groups"
+            description="Specify which groups to test: gender, age, ethnicity, language, or custom categories relevant to your application."
+          />
+          <EmptyStateTip
+            icon={BarChart3}
+            title="Measure disparate impact"
+            description="The audit calculates performance differences across groups. See pass rates, accuracy gaps, and statistical significance scores."
+          />
+          <EmptyStateTip
+            icon={FileText}
+            title="Generate audit reports"
+            description="Export detailed bias audit reports for compliance documentation. Results can be attached as evidence to your governance framework."
+          />
+        </EmptyState>
       ) : (
         <TableContainer sx={{ overflowX: "auto" }}>
           <Table sx={singleTheme.tableStyles.primary.frame}>

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectsList.tsx
@@ -18,7 +18,7 @@ import {
   Menu,
   MenuItem,
 } from "@mui/material";
-import { Plus, FileSearch, MessageSquare, Bot, ChevronsUpDown, ChevronUp, ChevronDown, MoreVertical, FlaskConical } from "lucide-react";
+import { Plus, FileSearch, MessageSquare, Bot, ChevronsUpDown, ChevronUp, ChevronDown, MoreVertical, FlaskConical, Target, Layers, TrendingUp } from "lucide-react";
 import { PageHeader } from "../../components/Layout/PageHeader";
 import SelectableCard from "../../components/SelectableCard";
 import { CustomizableButton } from "../../components/button/customizable-button";
@@ -26,6 +26,7 @@ import StandardModal from "../../components/Modals/StandardModal";
 import Field from "../../components/Inputs/Field";
 import Alert from "../../components/Alert";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
 import TablePaginationActions from "../../components/TablePagination";
 import SearchBox from "../../components/Search/SearchBox";
@@ -502,11 +503,31 @@ export default function ProjectsList() {
           icon={FlaskConical}
           message={
             projects.length === 0
-              ? "No projects yet. Create your first project to start evaluating LLMs."
+              ? "No evaluation projects yet. Create a project to start benchmarking your LLM applications."
               : "No projects match your search or filter criteria."
           }
           showBorder
-        />
+        >
+          {projects.length === 0 && (
+            <>
+              <EmptyStateTip
+                icon={Target}
+                title="What is an eval project?"
+                description="A project groups related evaluations for a single LLM application. Define test suites, scoring criteria, and track quality over time."
+              />
+              <EmptyStateTip
+                icon={Layers}
+                title="Compare models side by side"
+                description="Run the same test suite across different models or prompts. The arena view shows head-to-head comparisons with automated scoring."
+              />
+              <EmptyStateTip
+                icon={TrendingUp}
+                title="Track quality over releases"
+                description="Re-run evaluations after each deployment. Monitor regression and improvement trends with historical score charts."
+              />
+            </>
+          )}
+        </EmptyState>
       ) : (
         <TableContainer>
           <Table sx={singleTheme.tableStyles.primary.frame}>

--- a/Clients/src/presentation/pages/IncidentManagement/IncidentTable.tsx
+++ b/Clients/src/presentation/pages/IncidentManagement/IncidentTable.tsx
@@ -16,8 +16,9 @@ import {
 } from "@mui/material";
 import TablePaginationActions from "../../components/TablePagination";
 import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
-import { ChevronsUpDown, ChevronUp, ChevronDown, AlertTriangle } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, AlertTriangle, FileWarning, ClipboardList, Bell } from "lucide-react";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import Chip from "../../components/Chip";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -492,7 +493,25 @@ const IncidentTable: React.FC<IncidentTableProps> = ({
   }
 
   if (!sortedData || sortedData.length === 0) {
-    return <EmptyState icon={AlertTriangle} message="No incidents reported. Incidents will appear here when logged." />;
+    return (
+      <EmptyState icon={AlertTriangle} message="No incidents reported yet. Track and manage AI-related incidents to maintain compliance.">
+        <EmptyStateTip
+          icon={FileWarning}
+          title="What counts as an incident?"
+          description="Any unintended AI behavior, data breach, biased output, system outage, or safety concern. Log them early, even if minor."
+        />
+        <EmptyStateTip
+          icon={ClipboardList}
+          title="Document root cause and response"
+          description="Record what happened, why it happened, the impact, and what corrective actions were taken. This builds your incident response history."
+        />
+        <EmptyStateTip
+          icon={Bell}
+          title="Assign owners and track resolution"
+          description="Assign each incident to a responsible person and track it through to resolution. A clear ownership chain speeds up response times."
+        />
+      </EmptyState>
+    );
   }
 
   return (

--- a/Clients/src/presentation/pages/ModelInventory/DatasetTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/DatasetTable.tsx
@@ -21,7 +21,8 @@ import singleTheme from "../../themes/v1SingleTheme";
 import CustomIconButton from "../../components/IconButton";
 import allowedRoles from "../../../application/constants/permissions";
 import { useAuth } from "../../../application/hooks/useAuth";
-import { ChevronsUpDown, ChevronUp, ChevronDown, Database } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, Database, FileSpreadsheet, Tag, Link2 } from "lucide-react";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { EmptyState } from "../../components/EmptyState";
 import {
   DatasetTableProps,
@@ -255,7 +256,23 @@ const DatasetTable: React.FC<DatasetTableProps> = ({
         icon={Database}
         message="No datasets found. Add a dataset to start tracking your AI training and validation data."
         showBorder={true}
-      />
+      >
+        <EmptyStateTip
+          icon={FileSpreadsheet}
+          title="What to document"
+          description="Record dataset name, source, size, format, and the date it was collected or last updated. Include any preprocessing steps applied."
+        />
+        <EmptyStateTip
+          icon={Tag}
+          title="Label data quality"
+          description="Note whether the dataset has been reviewed for bias, completeness, and accuracy. Track any known quality issues or limitations."
+        />
+        <EmptyStateTip
+          icon={Link2}
+          title="Link to models"
+          description="Connect each dataset to the models that use it for training or validation. This creates traceability for audits and impact analysis."
+        />
+      </EmptyState>
     );
   }
 

--- a/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
@@ -17,13 +17,14 @@ import {
 } from "@mui/material";
 import TablePaginationActions from "../../components/TablePagination";
 import CustomIconButton from "../../components/IconButton";
-import { ChevronsUpDown, ChevronUp, ChevronDown, FileCheck } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, FileCheck, FolderOpen, Shield, Clock } from "lucide-react";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { displayFormattedDate } from "../../tools/isoDateToString";
 import { User } from "../../../domain/types/User";
 import { getAllEntities } from "../../../application/repository/entity.repository";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { FileIcon } from "../../components/FileIcon";
 import {
   loadingContainerStyle,
@@ -461,7 +462,23 @@ const EvidenceHubTable: React.FC<EvidenceHubTableProps> = ({
         ) : (
           <TableRow>
             <TableCell colSpan={visibleTableColumns.length} align="center">
-              <EmptyState message="No evidence found." icon={FileCheck} />
+              <EmptyState message="No evidence yet. Upload documents that prove compliance with each requirement." icon={FileCheck}>
+                <EmptyStateTip
+                  icon={FolderOpen}
+                  title="Organize by control category"
+                  description="Group evidence by the controls they support. This makes audit preparation faster and keeps your evidence library structured."
+                />
+                <EmptyStateTip
+                  icon={Shield}
+                  title="What counts as evidence?"
+                  description="Policies, meeting minutes, configuration screenshots, training records, risk assessments, vendor agreements, and change logs."
+                />
+                <EmptyStateTip
+                  icon={Clock}
+                  title="Track expiry dates"
+                  description="Set expiry dates on evidence so you're reminded to update or re-certify documents before they become stale."
+                />
+              </EmptyState>
             </TableCell>
           </TableRow>
         )}

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -24,10 +24,11 @@ import PluginSlot from "../../components/PluginSlot";
 import { PLUGIN_SLOTS } from "../../../domain/constants/pluginSlots";
 import allowedRoles from "../../../application/constants/permissions";
 import { useAuth } from "../../../application/hooks/useAuth";
-import { ChevronsUpDown, ChevronUp, ChevronDown, Cpu } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, Cpu, Layers, BarChart3, Link2 } from "lucide-react";
 
 const SelectorVertical = (props: any) => <ChevronsUpDown size={16} {...props} />;
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { ModelInventoryTableProps } from "../../../domain/interfaces/i.modelInventory";
 import { getAllEntities } from "../../../application/repository/entity.repository";
 import { User } from "../../../domain/types/User";
@@ -675,7 +676,25 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
   }
 
   if (!data || data.length === 0) {
-    return <EmptyState icon={Cpu} message="No models found." />;
+    return (
+      <EmptyState icon={Cpu} message="No models registered yet. Maintain a complete inventory of all AI models your organization uses.">
+        <EmptyStateTip
+          icon={Layers}
+          title="What counts as a model?"
+          description="Any machine learning model, large language model, computer vision system, or automated decision-making tool. Include both internal and third-party models."
+        />
+        <EmptyStateTip
+          icon={BarChart3}
+          title="Track model status"
+          description="Record each model's status: approved, restricted, pending, blocked, or rejected. This gives auditors visibility into your governance coverage."
+        />
+        <EmptyStateTip
+          icon={Link2}
+          title="Link to vendors and risks"
+          description="Connect each model to its provider and associated risks. This creates a full traceability map for your audit."
+        />
+      </EmptyState>
+    );
   }
 
   return (

--- a/Clients/src/presentation/pages/Plugins/index.tsx
+++ b/Clients/src/presentation/pages/Plugins/index.tsx
@@ -2,7 +2,8 @@ import React, { useState, useCallback, useMemo, Suspense } from "react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { Box, Stack, Typography, Collapse, useTheme } from "@mui/material";
 import { TabContext, TabPanel } from "@mui/lab";
-import { ChevronDown, Puzzle } from "lucide-react";
+import { ChevronDown, Puzzle, Download, Settings2, Shield } from "lucide-react";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
 import TabBar from "../../components/TabBar";
 import PluginCard from "../../components/PluginCard";
@@ -410,7 +411,23 @@ const Plugins: React.FC = () => {
                 icon={Puzzle}
                 message="No plugins installed yet. Visit the marketplace to install plugins."
                 showBorder={true}
-              />
+              >
+                <EmptyStateTip
+                  icon={Download}
+                  title="Browse the marketplace"
+                  description="The marketplace tab above lists available plugins for frameworks (SOC 2, GDPR, HIPAA), integrations (Slack, Jira), and more."
+                />
+                <EmptyStateTip
+                  icon={Settings2}
+                  title="Configure after install"
+                  description="Once installed, each plugin appears here with a manage button. Configure API keys, mappings, and preferences from there."
+                />
+                <EmptyStateTip
+                  icon={Shield}
+                  title="Framework plugins"
+                  description="Framework plugins add new compliance trackers and assessment templates. Install one to extend your governance coverage."
+                />
+              </EmptyState>
             ) : (
               <Box sx={pluginCardsGridThreeColumn}>
                 {installedPlugins.map((plugin) => (

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -11,11 +11,15 @@ import {
   CirclePlus as AddCircleOutlineIcon,
   FolderOpen,
   FileText,
+  Sparkles,
+  Shield,
+  Link2,
 } from "lucide-react";
 import PolicyTable from "../../components/Policies/PolicyTable";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { deletePolicy } from "../../../application/repository/policy.repository";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { SearchBox } from "../../components/Search";
 import { handleAlert } from "../../../application/tools/alertUtils";
 import Alert from "../../components/Alert";
@@ -601,10 +605,30 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
               message={
                 searchTerm
                   ? "No matching policies found."
-                  : "There is currently no data in this table."
+                  : "No policies yet. Policies define the rules your organization follows for AI governance."
               }
               imageAlt="No policies available"
-            />
+            >
+              {!searchTerm && (
+                <>
+                  <EmptyStateTip
+                    icon={Sparkles}
+                    title="Create from templates"
+                    description="Start with a blank policy or use one of the built-in templates. Fill in the details for your organization and publish when ready."
+                  />
+                  <EmptyStateTip
+                    icon={Shield}
+                    title="Link policies to controls"
+                    description="Each policy can be mapped to specific compliance controls, creating an audit trail showing which policies address which requirements."
+                  />
+                  <EmptyStateTip
+                    icon={Link2}
+                    title="Common policies to start with"
+                    description="AI Ethics Policy, Data Governance Policy, AI Risk Management Policy, Incident Response Policy, and Third-Party AI Vendor Policy."
+                  />
+                </>
+              )}
+            </EmptyState>
           ) : (
             <GroupedTableView
               groupedData={groupedPolicies}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyTemplates.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyTemplates.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { Box, Stack, TableRow, TableCell } from "@mui/material";
-import { FileText } from "lucide-react";
+import { FileText, Copy, Filter, BookOpen } from "lucide-react";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { EmptyState } from "../../components/EmptyState";
 import policyTemplates from "../../../application/data/PolicyTemplates.json";
 import { PolicyTemplatesProps } from "../../types/interfaces/i.policy";
@@ -159,7 +160,23 @@ const PolicyTemplates: React.FC<PolicyTemplatesProps> = ({
 
       {/* Table */}
       {filteredPolicyTemplates.length === 0 ? (
-        <EmptyState icon={FileText} message="No policy templates found" />
+        <EmptyState icon={FileText} message="No policy templates found.">
+          <EmptyStateTip
+            icon={Copy}
+            title="What are policy templates?"
+            description="Pre-built policy documents covering common AI governance topics. Copy a template, customize it for your organization, and publish."
+          />
+          <EmptyStateTip
+            icon={Filter}
+            title="Filter by framework"
+            description="Templates are grouped by framework (EU AI Act, ISO 42001, etc.). Use the search bar to find templates relevant to your compliance needs."
+          />
+          <EmptyStateTip
+            icon={BookOpen}
+            title="Build your own"
+            description="If no template fits, create a policy from scratch in the policies tab. You can always come back here for reference."
+          />
+        </EmptyState>
       ) : (
         <GroupedTableView
           groupedData={groupedTemplates}

--- a/Clients/src/presentation/pages/ProjectView/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Stack, Tab, Typography, useTheme } from "@mui/material";
-import { LayoutDashboard, AlertTriangle, Settings, History, ClipboardCheck, FolderOpen } from "lucide-react";
+import { LayoutDashboard, AlertTriangle, Settings, History, ClipboardCheck, FolderOpen, PlusCircle, Shield, FileText } from "lucide-react";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { PageBreadcrumbs } from "../../components/breadcrumbs/PageBreadcrumbs";
 import React, { useEffect } from "react";
 import TabContext from "@mui/lab/TabContext";
@@ -99,7 +100,23 @@ const ProjectView = () => {
       {noProject ? (
         //no project found template
         <Box sx={noProjectContainerStyle}>
-          <EmptyState icon={FolderOpen} message="No projects found. Create a new project to start with." />
+          <EmptyState icon={FolderOpen} message="No projects found. Create a new project to start with.">
+            <EmptyStateTip
+              icon={PlusCircle}
+              title="Create your first project"
+              description="A project represents an AI system or use case you're governing. Click 'New project' to set one up with a name, description, and framework."
+            />
+            <EmptyStateTip
+              icon={Shield}
+              title="Assign a framework"
+              description="Each project can be linked to one or more compliance frameworks (EU AI Act, ISO 42001, etc.) to track controls and assessments."
+            />
+            <EmptyStateTip
+              icon={FileText}
+              title="What goes in a project?"
+              description="Risks, policies, evidence, model inventory, vendors, and training records. Everything needed for a complete governance audit trail."
+            />
+          </EmptyState>
           {/* new project button */}
           <Button
             variant="contained"

--- a/Clients/src/presentation/pages/SettingsPage/AuditLedger/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/AuditLedger/index.tsx
@@ -22,7 +22,11 @@ import {
   ShieldQuestion,
   ChevronsUpDown,
   ClipboardList,
+  FileSearch,
+  Lock,
+  Filter,
 } from "lucide-react";
+import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import SearchBox from "../../../components/Search/SearchBox";
 import Select from "../../../components/Inputs/Select";
@@ -299,7 +303,23 @@ export default function AuditLedger() {
               icon={ClipboardList}
               message="No audit ledger entries found."
               showBorder
-            />
+            >
+              <EmptyStateTip
+                icon={FileSearch}
+                title="What gets logged?"
+                description="Every create, update, and delete action across your workspace is recorded here with a timestamp, user, and entity reference."
+              />
+              <EmptyStateTip
+                icon={Lock}
+                title="Immutable records"
+                description="Audit entries can't be edited or deleted. They provide a tamper-proof trail for compliance audits and internal reviews."
+              />
+              <EmptyStateTip
+                icon={Filter}
+                title="Filter and export"
+                description="Use the filters above to narrow entries by action type, user, or entity. Export filtered results for audit reporting."
+              />
+            </EmptyState>
           ) : (
               <TableContainer sx={singleTheme.tableStyles.primary.frame}>
                 <Table>

--- a/Clients/src/presentation/pages/ShadowAI/AIToolsPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/AIToolsPage.tsx
@@ -29,6 +29,9 @@ import {
   ArrowLeft,
   Bot,
   Radar,
+  Wifi,
+  ShieldAlert,
+  Tags,
 } from "lucide-react";
 import { PROVIDER_ICONS, VENDOR_ICON_MAP } from "../../components/ProviderIcons";
 import {
@@ -44,6 +47,7 @@ import {
 import singleTheme from "../../themes/v1SingleTheme";
 import { palette } from "../../themes/palette";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import Select from "../../components/Inputs/Select";
 import { DashboardHeaderCard } from "../../components/Cards/DashboardHeaderCard";
@@ -454,9 +458,25 @@ export default function AIToolsPage() {
       ) : tools.length === 0 ? (
         <EmptyState
           icon={Radar}
-          message="No AI tools detected yet. Connect a data source to start monitoring."
+          message="No AI tools detected yet. Connect a data source to monitor AI tool usage."
           showBorder
-        />
+        >
+          <EmptyStateTip
+            icon={Wifi}
+            title="Connect data sources"
+            description="Add the AI tools your organization uses or has detected. Track which tools are in use and who has access to them."
+          />
+          <EmptyStateTip
+            icon={ShieldAlert}
+            title="Identify unauthorized tools"
+            description="Discover AI tools being used without IT approval. Flag tools that may expose sensitive data or violate company policy."
+          />
+          <EmptyStateTip
+            icon={Tags}
+            title="Categorize and govern"
+            description="Classify detected tools as approved, under review, or blocked. Set policies per tool and notify users of compliance requirements."
+          />
+        </EmptyState>
       ) : (
         <TableContainer sx={singleTheme.tableStyles.primary.frame}>
           <Table>

--- a/Clients/src/presentation/pages/ShadowAI/RulesPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/RulesPage.tsx
@@ -30,7 +30,7 @@ const Alert = React.lazy(() => import("../../components/Alert"));
 import Toggle from "../../components/Inputs/Toggle";
 import Chip from "../../components/Chip";
 import TabContext from "@mui/lab/TabContext";
-import { Trash2, Info, ShieldCheck, Bell } from "lucide-react";
+import { Trash2, Info, ShieldCheck, Bell, Zap, Mail, Filter } from "lucide-react";
 import TabBar from "../../components/TabBar";
 import TablePaginationActions from "../../components/TablePagination";
 import singleTheme from "../../themes/v1SingleTheme";
@@ -48,6 +48,7 @@ import {
   ShadowAiTriggerType,
 } from "../../../domain/interfaces/i.shadowAi";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import StandardModal from "../../components/Modals/StandardModal";
 import Field from "../../components/Inputs/Field";
@@ -394,9 +395,25 @@ export default function RulesPage() {
         rules.length === 0 ? (
           <EmptyState
             icon={ShieldCheck}
-            message="No rules configured yet. Create a rule to get alerted about Shadow AI activity."
+            message="No rules configured yet. Create rules to automate alerts and enforce AI usage policies."
             showBorder
-          />
+          >
+            <EmptyStateTip
+              icon={Zap}
+              title="Trigger-based alerts"
+              description="Set rules that fire when specific conditions are met: new tool detected, usage threshold exceeded, or data sensitivity flags triggered."
+            />
+            <EmptyStateTip
+              icon={Mail}
+              title="Notify the right people"
+              description="Route alerts to security teams, managers, or compliance officers. Each rule can have different notification recipients."
+            />
+            <EmptyStateTip
+              icon={Filter}
+              title="Common rules to start with"
+              description="Alert on first use of any new AI tool, flag tools accessing sensitive data, notify when usage exceeds a set threshold per department."
+            />
+          </EmptyState>
         ) : (
           <Stack gap="12px">
             {rules.map((rule) => (

--- a/Clients/src/presentation/pages/ShadowAI/UserActivityPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/UserActivityPage.tsx
@@ -23,7 +23,7 @@ import {
   useTheme,
 } from "@mui/material";
 import TabContext from "@mui/lab/TabContext";
-import { ArrowLeft, Mail, Building2, Users } from "lucide-react";
+import { ArrowLeft, Mail, Building2, Users, Activity, TrendingUp } from "lucide-react";
 import TabBar from "../../components/TabBar";
 import TablePaginationActions from "../../components/TablePagination";
 import singleTheme from "../../themes/v1SingleTheme";
@@ -39,6 +39,7 @@ import {
   ShadowAiDepartmentActivity,
 } from "../../../domain/interfaces/i.shadowAi";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
 import { DashboardHeaderCard } from "../../components/Cards/DashboardHeaderCard";
 import {
@@ -370,9 +371,25 @@ export default function UserActivityPage() {
       ) : !hasData ? (
         <EmptyState
           icon={Users}
-          message="No user activity detected yet."
+          message="No user activity detected yet. Activity will appear here once monitoring is connected."
           showBorder
-        />
+        >
+          <EmptyStateTip
+            icon={Activity}
+            title="What gets tracked?"
+            description="User sessions, tool access frequency, and department-level usage patterns for AI tools."
+          />
+          <EmptyStateTip
+            icon={Building2}
+            title="Department-level insights"
+            description="See which departments have the highest AI tool usage. Identify teams that may need governance training or tool approvals."
+          />
+          <EmptyStateTip
+            icon={TrendingUp}
+            title="Spot usage trends"
+            description="Monitor adoption curves and usage spikes. Correlate activity with policy changes or new tool introductions."
+          />
+        </EmptyState>
       ) : viewMode === "users" ? (
         <TableContainer sx={singleTheme.tableStyles.primary.frame}>
           <Table>

--- a/Clients/src/presentation/pages/Tasks/DeadlineView.tsx
+++ b/Clients/src/presentation/pages/Tasks/DeadlineView.tsx
@@ -7,7 +7,8 @@ import {
   Collapse,
   IconButton,
 } from "@mui/material";
-import { ChevronDown, ChevronRight, Calendar, AlertTriangle, CalendarCheck } from "lucide-react";
+import { ChevronDown, ChevronRight, Calendar, AlertTriangle, CalendarCheck, ListChecks, Clock, Users } from "lucide-react";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { TaskModel } from "../../../domain/models/Common/task/task.model";
 import { TaskStatus } from "../../../domain/enums/task.enum";
 import TasksTable from "../../components/Table/TasksTable";
@@ -216,7 +217,23 @@ const DeadlineView: React.FC<DeadlineViewProps> = ({
         icon={CalendarCheck}
         message="No upcoming deadlines. All tasks are completed or have no due dates."
         showBorder
-      />
+      >
+        <EmptyStateTip
+          icon={ListChecks}
+          title="How deadlines work"
+          description="Tasks with due dates appear here grouped by urgency: overdue, due today, this week, and later. Complete or update tasks to clear them."
+        />
+        <EmptyStateTip
+          icon={Clock}
+          title="Set due dates on tasks"
+          description="Open any task and set a due date. It will automatically appear in the correct deadline group on this view."
+        />
+        <EmptyStateTip
+          icon={Users}
+          title="Assign owners"
+          description="Tasks assigned to team members show up in their personal task list. Use the 'My tasks only' toggle on the list view to filter."
+        />
+      </EmptyState>
     );
   }
 

--- a/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
@@ -18,8 +18,9 @@ import "../../components/Table/index.css";
 import singleTheme from "../../themes/v1SingleTheme";
 import CustomIconButton from "../../components/IconButton";
 import allowedRoles from "../../../application/constants/permissions";
-import { ChevronsUpDown, ChevronUp, ChevronDown, GraduationCap } from "lucide-react";
+import { ChevronsUpDown, ChevronUp, ChevronDown, GraduationCap, Users, Calendar, Award } from "lucide-react";
 import { EmptyState } from "../../components/EmptyState";
+import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { useAuth } from "../../../application/hooks/useAuth";
 import {
   getPaginationRowCount,
@@ -483,7 +484,25 @@ const TrainingTable: React.FC<TrainingTableProps> = ({
   }
 
   if (!data || data.length === 0) {
-    return <EmptyState icon={GraduationCap} message="No training records found." />;
+    return (
+      <EmptyState icon={GraduationCap} message="No training records yet. Track AI governance training for your team.">
+        <EmptyStateTip
+          icon={Users}
+          title="Assign training to team members"
+          description="Each record tracks who completed what training, when, and their score. This creates an audit trail for competency requirements."
+        />
+        <EmptyStateTip
+          icon={Calendar}
+          title="Set renewal dates"
+          description="Some certifications and training expire. Record renewal dates so you can keep track of upcoming expirations."
+        />
+        <EmptyStateTip
+          icon={Award}
+          title="Common training topics"
+          description="AI ethics, data privacy, responsible AI use, bias awareness, incident reporting procedures, and framework-specific requirements."
+        />
+      </EmptyState>
+    );
   }
 
   return (

--- a/Clients/src/presentation/pages/WatchTower/Loggings/index.tsx
+++ b/Clients/src/presentation/pages/WatchTower/Loggings/index.tsx
@@ -10,7 +10,8 @@ import { useState, useEffect, useMemo } from "react";
 import { getAllLogs } from "../../../../application/repository/logs.repository";
 import LogsTable from "../../../components/Table/LogsTable";
 import { EmptyState } from "../../../components/EmptyState";
-import { RefreshCw as RefreshIcon, ScrollText } from "lucide-react";
+import { RefreshCw as RefreshIcon, ScrollText, Activity, AlertCircle, Search } from "lucide-react";
+import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
 import SearchBox from "../../../components/Search/SearchBox";
 import Select from "../../../components/Inputs/Select";
 
@@ -225,7 +226,23 @@ const WatchTowerLogs = () => {
       {filteredLogs.length > 0 ? (
         <LogsTable data={filteredLogs} isLoading={isLoading} paginated={true} />
       ) : !error ? (
-        <EmptyState icon={ScrollText} message="There are currently no logs available." />
+        <EmptyState icon={ScrollText} message="There are currently no logs available.">
+          <EmptyStateTip
+            icon={Activity}
+            title="What appears here"
+            description="System events, API calls, and background job results are logged automatically. Logs appear as your workspace generates activity."
+          />
+          <EmptyStateTip
+            icon={AlertCircle}
+            title="Monitor for issues"
+            description="Watch for error-level entries that may indicate failed operations, authentication problems, or service disruptions."
+          />
+          <EmptyStateTip
+            icon={Search}
+            title="Search and filter"
+            description="Use the search bar and level filters above to find specific log entries. Filter by severity to focus on warnings or errors."
+          />
+        </EmptyState>
       ) : null}
     </Stack>
   );


### PR DESCRIPTION
## Summary
- New `EmptyStateTip` collapsible accordion component with colored icon badges (green, blue, amber cycling), smooth 200ms open/close animation, and 13px body text
- Added contextual tips to 22 empty state pages: Policies, Risks, Incidents, Approvals, Evidence Hub, Model Inventory (models + datasets), Training, Tasks, Agents, Vendors, AI Detection (history + repositories), LLM Evals (projects, bias audits, datasets, scorers, models), and Shadow AI (tools, rules, user activity)
- Equal 48px spacing above illustration and below last accordion
- Dark/light mode toggle in sidebar drawer now closes the drawer after switching

## Test plan
- [ ] Visit each page with no data and confirm 3 collapsible tips appear
- [ ] Click tips to expand/collapse and verify smooth animation
- [ ] Verify icon colors cycle: green, blue, amber per tip group
- [ ] Check spacing is symmetric (equal above icon and below last tip)
- [ ] Confirm accordion backgrounds stay neutral when expanded
- [ ] Test in dark mode (tips should be readable, icons visible)
- [ ] Toggle dark/light mode from sidebar drawer and confirm it closes