### PR TITLE
fix(ai-gateway): validate API keys before saving — format check + live provider verification

### DIFF
--- a/Clients/src/application/utils/apiKeyValidation.ts
+++ b/Clients/src/application/utils/apiKeyValidation.ts
@@ -16,7 +16,7 @@ const PROVIDER_KEY_PATTERNS: Record<string, { pattern: RegExp; description: stri
     description: 'Anthropic keys start with "sk-ant-" (e.g. "sk-ant-api03-...")',
   },
   gemini: {
-    pattern: /^AIza[a-zA-Z0-9_-]{34,}$/,
+    pattern: /^AIza[a-zA-Z0-9_-]{35,}$/,
     description: 'Google Gemini keys start with "AIza"',
   },
   xai: {

--- a/Clients/src/application/utils/apiKeyValidation.ts
+++ b/Clients/src/application/utils/apiKeyValidation.ts
@@ -1,0 +1,49 @@
+/**
+ * Client-side API key format validation for AI Gateway provider keys.
+ * Patterns mirror those in Servers/utils/evaluationLlmApiKey.utils.ts.
+ *
+ * Returns null if the key is valid (or the provider has no known pattern).
+ * Returns an error message string if the key is invalid.
+ */
+
+const PROVIDER_KEY_PATTERNS: Record<string, { pattern: RegExp; description: string }> = {
+  openai: {
+    pattern: /^sk-(proj-)?[a-zA-Z0-9_-]{20,}$/,
+    description: 'OpenAI keys start with "sk-" or "sk-proj-" followed by 20+ characters',
+  },
+  anthropic: {
+    pattern: /^sk-ant-(api\d+-)?[a-zA-Z0-9_-]{20,}$/,
+    description: 'Anthropic keys start with "sk-ant-" (e.g. "sk-ant-api03-...")',
+  },
+  gemini: {
+    pattern: /^AIza[a-zA-Z0-9_-]{34,}$/,
+    description: 'Google Gemini keys start with "AIza"',
+  },
+  xai: {
+    pattern: /^xai-[a-zA-Z0-9_-]{20,}$/,
+    description: 'xAI keys start with "xai-"',
+  },
+  mistral: {
+    pattern: /^[a-zA-Z0-9]{32,}$/,
+    description: 'Mistral keys are alphanumeric strings of 32+ characters',
+  },
+  openrouter: {
+    pattern: /^sk-or-v1-[a-zA-Z0-9]{40,}$/,
+    description: 'OpenRouter keys start with "sk-or-v1-"',
+  },
+};
+
+/**
+ * Validate the format of a provider API key.
+ * @returns null if valid (or no pattern exists for this provider), error message if invalid.
+ */
+export function validateApiKeyFormat(provider: string, apiKey: string): string | null {
+  const config = PROVIDER_KEY_PATTERNS[provider.toLowerCase()];
+  if (!config) return null; // no pattern → skip format validation
+
+  const trimmed = apiKey.trim();
+  if (!config.pattern.test(trimmed)) {
+    return `Invalid ${provider} API key format. ${config.description}.`;
+  }
+  return null;
+}

--- a/Clients/src/application/utils/apiKeyValidation.ts
+++ b/Clients/src/application/utils/apiKeyValidation.ts
@@ -1,6 +1,6 @@
 /**
  * Client-side API key format validation for AI Gateway provider keys.
- * Patterns mirror those in Servers/utils/evaluationLlmApiKey.utils.ts.
+ * Patterns are consistent with those used in the broader VerifyWise codebase.
  *
  * Returns null if the key is valid (or the provider has no known pattern).
  * Returns an error message string if the key is invalid.

--- a/Clients/src/application/utils/tests/apiKeyValidation.test.ts
+++ b/Clients/src/application/utils/tests/apiKeyValidation.test.ts
@@ -29,7 +29,7 @@ describe("validateApiKeyFormat", () => {
 
   // Google / Gemini
   it("accepts a valid Google Gemini key for gemini provider", () => {
-    expect(validateApiKeyFormat("gemini", "AIzaABCDEFGHIJKLMNOPQRSTUVWXYZ12345678")).toBeNull();
+    expect(validateApiKeyFormat("gemini", "AIzaABCDEFGHIJKLMNOPQRSTUVWXYZ123456789")).toBeNull();
   });
 
   it("rejects a Gemini key without AIza prefix", () => {

--- a/Clients/src/application/utils/tests/apiKeyValidation.test.ts
+++ b/Clients/src/application/utils/tests/apiKeyValidation.test.ts
@@ -1,0 +1,77 @@
+import { validateApiKeyFormat } from "../apiKeyValidation";
+
+describe("validateApiKeyFormat", () => {
+  // OpenAI
+  it("accepts a valid sk- OpenAI key", () => {
+    expect(validateApiKeyFormat("openai", "sk-abcdefghijklmnopqrst")).toBeNull();
+  });
+
+  it("accepts a valid sk-proj- OpenAI key", () => {
+    expect(validateApiKeyFormat("openai", "sk-proj-abcdefghijklmnopqrst")).toBeNull();
+  });
+
+  it("rejects a truncated OpenAI key", () => {
+    expect(validateApiKeyFormat("openai", "sk-short")).not.toBeNull();
+  });
+
+  it("rejects a half-pasted OpenAI key without prefix", () => {
+    expect(validateApiKeyFormat("openai", "abcdefghijklmnopqrstuvwxyz")).not.toBeNull();
+  });
+
+  // Anthropic
+  it("accepts a valid Anthropic key", () => {
+    expect(validateApiKeyFormat("anthropic", "sk-ant-api03-abcdefghijklmnopqrstu")).toBeNull();
+  });
+
+  it("rejects an Anthropic key missing the sk-ant- prefix", () => {
+    expect(validateApiKeyFormat("anthropic", "sk-abcdefghijklmnopqrstu")).not.toBeNull();
+  });
+
+  // Google / Gemini
+  it("accepts a valid Google Gemini key for gemini provider", () => {
+    expect(validateApiKeyFormat("gemini", "AIzaABCDEFGHIJKLMNOPQRSTUVWXYZ12345678")).toBeNull();
+  });
+
+  it("rejects a Gemini key without AIza prefix", () => {
+    expect(validateApiKeyFormat("gemini", "badkeyABCDEFGHIJKLMNOPQRSTUVWXYZ12345678")).not.toBeNull();
+  });
+
+  // xAI
+  it("accepts a valid xAI key", () => {
+    expect(validateApiKeyFormat("xai", "xai-abcdefghijklmnopqrstu")).toBeNull();
+  });
+
+  it("rejects an xAI key without xai- prefix", () => {
+    expect(validateApiKeyFormat("xai", "notxai-abcdefghijklmno")).not.toBeNull();
+  });
+
+  // Mistral
+  it("accepts a valid Mistral key (32+ alphanum chars)", () => {
+    expect(validateApiKeyFormat("mistral", "abcdefghijklmnopqrstuvwxyz123456")).toBeNull();
+  });
+
+  it("rejects a short Mistral key", () => {
+    expect(validateApiKeyFormat("mistral", "tooshort")).not.toBeNull();
+  });
+
+  // OpenRouter
+  it("accepts a valid OpenRouter key", () => {
+    expect(validateApiKeyFormat("openrouter", "sk-or-v1-" + "a".repeat(40))).toBeNull();
+  });
+
+  it("rejects an OpenRouter key with wrong prefix", () => {
+    expect(validateApiKeyFormat("openrouter", "sk-" + "a".repeat(40))).not.toBeNull();
+  });
+
+  // Unknown / unvalidated providers
+  it("returns null for unknown providers (bedrock, azure, cohere)", () => {
+    expect(validateApiKeyFormat("bedrock", "any-key-format")).toBeNull();
+    expect(validateApiKeyFormat("azure", "any-key-format")).toBeNull();
+    expect(validateApiKeyFormat("cohere", "any-key-format")).toBeNull();
+  });
+
+  // Whitespace trimming
+  it("accepts a key with leading/trailing whitespace by trimming it", () => {
+    expect(validateApiKeyFormat("openai", "  sk-abcdefghijklmnopqrst  ")).toBeNull();
+  });
+});

--- a/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
@@ -12,6 +12,7 @@ import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtende
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, ProviderIcon, TOP_PROVIDERS } from "../shared";
+import { validateApiKeyFormat } from "../../../../application/utils/apiKeyValidation";
 
 const TOP_IDS = new Set(TOP_PROVIDERS.map((p) => p._id));
 
@@ -104,9 +105,32 @@ export default function AIGatewaySettingsPage() {
       setKeyError("All fields are required");
       return;
     }
+
+    // 1. Client-side format check (instant feedback)
+    const formatError = validateApiKeyFormat(keyForm.provider, keyForm.api_key);
+    if (formatError) {
+      setKeyError(formatError);
+      return;
+    }
+
     setKeySubmitting(true);
     setKeyError("");
+
     try {
+      // 2. Live verification — call the provider's API
+      const verifyRes = await apiServices.post("/ai-gateway/keys/verify", {
+        provider: keyForm.provider,
+        apiKey: keyForm.api_key,
+      });
+      // verifyApiKey uses raw res.json() so valid is at the top level (verifyRes.data.valid)
+      const { valid, message } = verifyRes?.data || {};
+
+      if (valid === false) {
+        setKeyError(message || "API key is invalid. Please check it and try again.");
+        return;
+      }
+
+      // 3. Save
       await apiServices.post("/ai-gateway/keys", keyForm);
       setIsKeyModalOpen(false);
       setKeyForm({ key_name: "", provider: "", api_key: "" });

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx
@@ -36,7 +36,7 @@ import {
   WARNING_TEXT,
   KEY_DISPLAY_BG,
 } from "../shared";
-import { validateApiKeyFormat } from "../../../../../application/utils/apiKeyValidation";
+import { validateApiKeyFormat } from "../../../../application/utils/apiKeyValidation";
 
 // Spinner keyframes for loading state
 const spinKeyframes = `@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`;

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx
@@ -36,6 +36,7 @@ import {
   WARNING_TEXT,
   KEY_DISPLAY_BG,
 } from "../shared";
+import { validateApiKeyFormat } from "../../../../../application/utils/apiKeyValidation";
 
 // Spinner keyframes for loading state
 const spinKeyframes = `@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`;
@@ -360,9 +361,32 @@ export default function OnboardingOverlay({ onGetStarted, setupStatus, onStepCom
       setKeyError("All fields are required");
       return;
     }
+
+    // 1. Client-side format check
+    const formatError = validateApiKeyFormat(keyForm.provider, keyForm.api_key);
+    if (formatError) {
+      setKeyError(formatError);
+      return;
+    }
+
     setKeySubmitting(true);
     setKeyError("");
+
     try {
+      // 2. Live verification
+      const verifyRes = await apiServices.post("/ai-gateway/keys/verify", {
+        provider: keyForm.provider,
+        apiKey: keyForm.api_key,
+      });
+      // verifyApiKey uses raw res.json() — valid is at verifyRes.data.valid (not nested in data.data)
+      const { valid, message } = verifyRes?.data || {};
+
+      if (valid === false) {
+        setKeyError(message || "API key is invalid. Please check it and try again.");
+        return;
+      }
+
+      // 3. Save — preserve the original success path exactly
       await apiServices.post("/ai-gateway/keys", keyForm);
       closeModal();
       onStepCompleted();

--- a/Servers/controllers/aiGateway.ctrl.ts
+++ b/Servers/controllers/aiGateway.ctrl.ts
@@ -216,7 +216,7 @@ export async function verifyApiKey(req: Request, res: Response) {
         headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01" },
       },
       gemini: {
-        url: `https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`,
+        url: `https://generativelanguage.googleapis.com/v1/models?key=${encodeURIComponent(apiKey)}`,
         headers: {},
       },
       xai: {

--- a/Servers/controllers/aiGateway.ctrl.ts
+++ b/Servers/controllers/aiGateway.ctrl.ts
@@ -193,6 +193,83 @@ export async function deleteApiKey(req: Request, res: Response) {
   }
 }
 
+export async function verifyApiKey(req: Request, res: Response) {
+  const fn = "verifyApiKey";
+  try {
+    const { provider, apiKey } = req.body;
+
+    if (!provider) {
+      return res.status(400).json({ success: false, valid: false, message: "provider is required" });
+    }
+    if (!apiKey) {
+      return res.status(400).json({ success: false, valid: false, message: "apiKey is required" });
+    }
+
+    // Provider verification endpoints. gemini maps to Google's API.
+    const endpoints: Record<string, { url: string; headers: Record<string, string> }> = {
+      openai: {
+        url: "https://api.openai.com/v1/models",
+        headers: { Authorization: `Bearer ${apiKey}` },
+      },
+      anthropic: {
+        url: "https://api.anthropic.com/v1/models",
+        headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01" },
+      },
+      gemini: {
+        url: `https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`,
+        headers: {},
+      },
+      xai: {
+        url: "https://api.x.ai/v1/models",
+        headers: { Authorization: `Bearer ${apiKey}` },
+      },
+      mistral: {
+        url: "https://api.mistral.ai/v1/models",
+        headers: { Authorization: `Bearer ${apiKey}` },
+      },
+      openrouter: {
+        url: "https://openrouter.ai/api/v1/auth/key",
+        headers: { Authorization: `Bearer ${apiKey}` },
+      },
+    };
+
+    const config = endpoints[provider];
+    if (!config) {
+      // bedrock, azure, together_ai, cohere, etc. — no simple verification endpoint
+      return res.status(200).json({ success: true, valid: true, message: "Provider not configured for verification, assuming valid" });
+    }
+
+    try {
+      const response = await fetch(config.url, {
+        method: "GET",
+        headers: { ...config.headers, "Content-Type": "application/json" },
+      });
+
+      if (response.ok) {
+        return res.status(200).json({ success: true, valid: true, message: "API key verified successfully" });
+      } else if (response.status === 401 || response.status === 403) {
+        return res.status(200).json({ success: true, valid: false, message: "Invalid API key — authentication failed" });
+      } else if (response.status === 400) {
+        let errorMsg = "Invalid API key";
+        try {
+          const data = await response.json();
+          errorMsg = data?.error?.message || data?.message || errorMsg;
+        } catch { /* ignore */ }
+        return res.status(200).json({ success: true, valid: false, message: errorMsg });
+      } else if (response.status === 429) {
+        return res.status(200).json({ success: true, valid: true, message: "Rate limited — key appears valid" });
+      } else {
+        return res.status(200).json({ success: true, valid: true, message: "Could not verify key, assuming valid" });
+      }
+    } catch {
+      return res.status(200).json({ success: true, valid: true, message: "Network error during verification, assuming valid" });
+    }
+  } catch (error: any) {
+    logStructured("error", "failed to verify gateway API key", fn, fileName);
+    return res.status(500).json({ success: false, valid: false, message: "Internal server error" });
+  }
+}
+
 // ─── Endpoints ───────────────────────────────────────────────────────────────
 
 export async function getEndpoints(req: Request, res: Response) {

--- a/Servers/routes/aiGateway.route.ts
+++ b/Servers/routes/aiGateway.route.ts
@@ -68,7 +68,7 @@ router.use(authenticateJWT);
 // API Key management — Admin only for create/update/delete
 router.get("/keys", getApiKeys);
 router.post("/keys", authorize(["Admin"]), createApiKey);
-router.post("/keys/verify", authorize(["Admin"]), verifyApiKey);
+router.post("/keys/verify", generalApiLimiter, authorize(["Admin"]), verifyApiKey);
 router.patch("/keys/:id", authorize(["Admin"]), updateApiKey);
 router.delete("/keys/:id", authorize(["Admin"]), deleteApiKey);
 

--- a/Servers/routes/aiGateway.route.ts
+++ b/Servers/routes/aiGateway.route.ts
@@ -10,6 +10,7 @@ import {
   createApiKey,
   updateApiKey,
   deleteApiKey,
+  verifyApiKey,
   // Endpoints
   getEndpoints,
   getEndpoint,
@@ -67,6 +68,7 @@ router.use(authenticateJWT);
 // API Key management — Admin only for create/update/delete
 router.get("/keys", getApiKeys);
 router.post("/keys", authorize(["Admin"]), createApiKey);
+router.post("/keys/verify", authorize(["Admin"]), verifyApiKey);
 router.patch("/keys/:id", authorize(["Admin"]), updateApiKey);
 router.delete("/keys/:id", authorize(["Admin"]), deleteApiKey);
 

--- a/Servers/tests/aiGatewayKeyVerification.test.ts
+++ b/Servers/tests/aiGatewayKeyVerification.test.ts
@@ -1,0 +1,99 @@
+import { Request, Response } from "express";
+
+// Mock global fetch before importing controller
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Import after mock setup
+import { verifyApiKey } from "../controllers/aiGateway.ctrl";
+
+function makeReq(body: object): Partial<Request> {
+  return { body };
+}
+
+function makeRes(): { status: jest.Mock; json: jest.Mock; statusCode: number } {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("verifyApiKey", () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it("returns 400 when provider is missing", async () => {
+    const req = makeReq({ apiKey: "sk-abc" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ valid: false }));
+  });
+
+  it("returns 400 when apiKey is missing", async () => {
+    const req = makeReq({ provider: "openai" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ valid: false }));
+  });
+
+  it("returns valid: true when provider API returns 200", async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+    const req = makeReq({ provider: "openai", apiKey: "sk-abc123" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ valid: true }));
+  });
+
+  it("returns valid: false when provider API returns 401", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({}) });
+    const req = makeReq({ provider: "openai", apiKey: "sk-bad" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ valid: false }));
+  });
+
+  it("returns valid: false when provider API returns 403", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 403, json: async () => ({}) });
+    const req = makeReq({ provider: "anthropic", apiKey: "sk-ant-bad" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ valid: false }));
+  });
+
+  it("assumes valid when provider API returns 429 (rate limited)", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 429, json: async () => ({}) });
+    const req = makeReq({ provider: "mistral", apiKey: "somekey123" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ valid: true }));
+  });
+
+  it("maps gemini provider to Google verification endpoint", async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+    const req = makeReq({ provider: "gemini", apiKey: "AIzaABCDEFGHIJKLMN1234567890123456789" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    const calledUrl: string = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain("generativelanguage.googleapis.com");
+  });
+
+  it("assumes valid for unknown providers (bedrock, azure, etc.)", async () => {
+    const req = makeReq({ provider: "bedrock", apiKey: "some-aws-key" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ valid: true }));
+  });
+
+  it("assumes valid when fetch throws a network error", async () => {
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+    const req = makeReq({ provider: "openai", apiKey: "sk-abc" });
+    const res = makeRes();
+    await verifyApiKey(req as Request, res as unknown as Response);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ valid: true }));
+  });
+});


### PR DESCRIPTION
## Describe your changes

### Summary

  - API keys added in the AI Gateway (Settings page and onboarding flow) were accepted without any validation, allowing
  truncated or invalid keys to be stored silently
  - Added client-side format validation (regex) for 6 providers: OpenAI, Anthropic, Google Gemini, xAI, Mistral,
  OpenRouter
  - Added a new `POST /ai-gateway/keys/verify` backend endpoint that makes a live test call to the provider's API before
   saving
  - Applied the same fix to both "Add key" entry points: Settings page and the onboarding overlay

### Validation flow (both UI entry points)

  1. Empty-field check (unchanged)
  2. **Format check** — instant regex, no network call (e.g. `sk-abc` → immediate error)
  3. **Live verify** — `POST /ai-gateway/keys/verify` calls the provider's models endpoint; 401/403 = rejected,
  429/network error = assumed valid
  4. **Save** — only reached if both pass

  Providers without a known API verification endpoint (Bedrock, Azure, Together AI, Cohere, etc.) skip steps 2–3 and are
   saved directly.

### Changes

  - `Servers/controllers/aiGateway.ctrl.ts` — new `verifyApiKey` export
  - `Servers/routes/aiGateway.route.ts` — `POST /ai-gateway/keys/verify` (rate-limited, Admin only, registered before
  `PATCH /keys/:id`)
  - `Servers/tests/aiGatewayKeyVerification.test.ts` — 9 Jest tests
  - `Clients/src/application/utils/apiKeyValidation.ts` — `validateApiKeyFormat` utility
  - `Clients/src/application/utils/tests/apiKeyValidation.test.ts` — 16 Vitest tests
  - `Clients/src/presentation/pages/AIGateway/Settings/index.tsx` — wired validation into `handleCreateKey`
  - `Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx` — same

## Write your issue number after "Fixes "

This PR does not intend to fix any specific issues.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
