### PR TITLE
Add reusable VWCharts components and migrate all Recharts charts

### DIFF
--- a/Clients/src/presentation/components/Charts/VWCharts.tsx
+++ b/Clients/src/presentation/components/Charts/VWCharts.tsx
@@ -371,7 +371,7 @@ export const VWDonutChart: React.FC<VWDonutChartProps> = ({
           </Typography>
         </Box>
       )}
-    </ChartWrapper>
+    </Box>
   );
 };
 

--- a/Clients/src/presentation/components/Charts/VWCharts.tsx
+++ b/Clients/src/presentation/components/Charts/VWCharts.tsx
@@ -51,13 +51,20 @@ export const vwTooltipStyle: React.CSSProperties = {
   backgroundColor: palette.background.main,
 };
 
-/** Suppress blue focus outlines on all Recharts SVG elements */
-const noOutlineSx = {
-  "& *": { outline: "none !important" },
-  "& *:focus": { outline: "none !important" },
-  "& svg": { outline: "none !important" },
-  "& svg *": { outline: "none !important" },
-};
+/** Inline style to suppress blue focus outlines on Recharts SVG elements */
+const noOutlineStyle: React.CSSProperties = { outline: "none" };
+
+/** Wrapper that suppresses focus outlines on all chart children */
+const ChartWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Box
+    sx={{
+      "& *:focus": { outline: "none !important" },
+      "& svg *:focus": { outline: "none !important" },
+    }}
+  >
+    {children}
+  </Box>
+);
 
 /** Default axis tick style */
 const axisTick = { fontSize: 11, fill: palette.text.tertiary };
@@ -135,8 +142,8 @@ export const VWBarChart: React.FC<VWBarChartProps> = ({
 }) => {
   const isVertical = layout === "vertical";
   return (
-    <Box sx={noOutlineSx}>
-    <ResponsiveContainer width="100%" height={height}>
+    <ChartWrapper>
+    <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
       <BarChart data={data} layout={layout} margin={margin} barCategoryGap={barCategoryGap}>
         <CartesianGrid
           strokeDasharray="3 3"
@@ -201,7 +208,7 @@ export const VWBarChart: React.FC<VWBarChartProps> = ({
         ))}
       </BarChart>
     </ResponsiveContainer>
-    </Box>
+    </ChartWrapper>
   );
 };
 
@@ -244,8 +251,8 @@ export const VWAreaChart: React.FC<VWAreaChartProps> = ({
   margin,
   gradientOpacity = 0.12,
 }) => (
-  <Box sx={noOutlineSx}>
-  <ResponsiveContainer width="100%" height={height}>
+  <ChartWrapper>
+  <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
     <AreaChart data={data} margin={margin}>
       <defs>
         {series.map((s) => (
@@ -291,7 +298,7 @@ export const VWAreaChart: React.FC<VWAreaChartProps> = ({
       ))}
     </AreaChart>
   </ResponsiveContainer>
-  </Box>
+  </ChartWrapper>
 );
 
 // ─── VWDonutChart ───────────────────────────────────────────────────────────
@@ -326,8 +333,8 @@ export const VWDonutChart: React.FC<VWDonutChartProps> = ({
 }) => {
   const computedOuter = outerRadius || Math.floor(size / 2) - 5;
   return (
-    <Box sx={{ position: "relative", width: size, height: size, ...noOutlineSx }}>
-      <ResponsiveContainer width="100%" height="100%">
+    <Box sx={{ position: "relative", width: size, height: size, "& *:focus": { outline: "none !important" }, "& svg *:focus": { outline: "none !important" } }}>
+      <ResponsiveContainer width="100%" height="100%" style={noOutlineStyle}>
         <PieChart>
           <Pie
             data={data}
@@ -364,7 +371,7 @@ export const VWDonutChart: React.FC<VWDonutChartProps> = ({
           </Typography>
         </Box>
       )}
-    </Box>
+    </ChartWrapper>
   );
 };
 
@@ -414,8 +421,8 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
   const Legend = showLegend ? require("recharts").Legend : null;
 
   return (
-    <Box sx={noOutlineSx}>
-    <ResponsiveContainer width="100%" height={height}>
+    <ChartWrapper>
+    <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
       <LineChart data={data} margin={margin}>
         <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
         <XAxis
@@ -459,6 +466,6 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
         ))}
       </LineChart>
     </ResponsiveContainer>
-    </Box>
+    </ChartWrapper>
   );
 };

--- a/Clients/src/presentation/components/Charts/VWCharts.tsx
+++ b/Clients/src/presentation/components/Charts/VWCharts.tsx
@@ -58,6 +58,7 @@ const noOutlineStyle: React.CSSProperties = { outline: "none" };
 const ChartWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <Box
     sx={{
+      width: "100%",
       "& *:focus": { outline: "none !important" },
       "& svg *:focus": { outline: "none !important" },
     }}

--- a/Clients/src/presentation/components/Charts/VWCharts.tsx
+++ b/Clients/src/presentation/components/Charts/VWCharts.tsx
@@ -51,6 +51,14 @@ export const vwTooltipStyle: React.CSSProperties = {
   backgroundColor: palette.background.main,
 };
 
+/** Suppress blue focus outlines on all Recharts SVG elements */
+const noOutlineSx = {
+  "& *": { outline: "none !important" },
+  "& *:focus": { outline: "none !important" },
+  "& svg": { outline: "none !important" },
+  "& svg *": { outline: "none !important" },
+};
+
 /** Default axis tick style */
 const axisTick = { fontSize: 11, fill: palette.text.tertiary };
 const axisTickDisabled = { fontSize: 11, fill: palette.text.disabled };
@@ -127,7 +135,8 @@ export const VWBarChart: React.FC<VWBarChartProps> = ({
 }) => {
   const isVertical = layout === "vertical";
   return (
-    <ResponsiveContainer width="100%" height={height} style={{ outline: "none" }}>
+    <Box sx={noOutlineSx}>
+    <ResponsiveContainer width="100%" height={height}>
       <BarChart data={data} layout={layout} margin={margin} barCategoryGap={barCategoryGap}>
         <CartesianGrid
           strokeDasharray="3 3"
@@ -192,6 +201,7 @@ export const VWBarChart: React.FC<VWBarChartProps> = ({
         ))}
       </BarChart>
     </ResponsiveContainer>
+    </Box>
   );
 };
 
@@ -234,7 +244,8 @@ export const VWAreaChart: React.FC<VWAreaChartProps> = ({
   margin,
   gradientOpacity = 0.12,
 }) => (
-  <ResponsiveContainer width="100%" height={height} style={{ outline: "none" }}>
+  <Box sx={noOutlineSx}>
+  <ResponsiveContainer width="100%" height={height}>
     <AreaChart data={data} margin={margin}>
       <defs>
         {series.map((s) => (
@@ -280,6 +291,7 @@ export const VWAreaChart: React.FC<VWAreaChartProps> = ({
       ))}
     </AreaChart>
   </ResponsiveContainer>
+  </Box>
 );
 
 // ─── VWDonutChart ───────────────────────────────────────────────────────────
@@ -314,8 +326,8 @@ export const VWDonutChart: React.FC<VWDonutChartProps> = ({
 }) => {
   const computedOuter = outerRadius || Math.floor(size / 2) - 5;
   return (
-    <Box sx={{ position: "relative", width: size, height: size }}>
-      <ResponsiveContainer width="100%" height="100%" style={{ outline: "none" }}>
+    <Box sx={{ position: "relative", width: size, height: size, ...noOutlineSx }}>
+      <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Pie
             data={data}
@@ -402,7 +414,8 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
   const Legend = showLegend ? require("recharts").Legend : null;
 
   return (
-    <ResponsiveContainer width="100%" height={height} style={{ outline: "none" }}>
+    <Box sx={noOutlineSx}>
+    <ResponsiveContainer width="100%" height={height}>
       <LineChart data={data} margin={margin}>
         <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
         <XAxis
@@ -446,5 +459,6 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
         ))}
       </LineChart>
     </ResponsiveContainer>
+    </Box>
   );
 };

--- a/Clients/src/presentation/components/Charts/VWCharts.tsx
+++ b/Clients/src/presentation/components/Charts/VWCharts.tsx
@@ -54,8 +54,8 @@ export const vwTooltipStyle: React.CSSProperties = {
 /** Inline style to suppress blue focus outlines on Recharts SVG elements */
 const noOutlineStyle: React.CSSProperties = { outline: "none" };
 
-/** Wrapper that suppresses focus outlines on all chart children */
-const ChartWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+/** Wrapper that suppresses focus outlines on all chart children. Export for custom charts. */
+export const ChartOutlineWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <Box
     sx={{
       width: "100%",
@@ -143,7 +143,7 @@ export const VWBarChart: React.FC<VWBarChartProps> = ({
 }) => {
   const isVertical = layout === "vertical";
   return (
-    <ChartWrapper>
+    <ChartOutlineWrapper>
     <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
       <BarChart data={data} layout={layout} margin={margin} barCategoryGap={barCategoryGap}>
         <CartesianGrid
@@ -209,7 +209,7 @@ export const VWBarChart: React.FC<VWBarChartProps> = ({
         ))}
       </BarChart>
     </ResponsiveContainer>
-    </ChartWrapper>
+    </ChartOutlineWrapper>
   );
 };
 
@@ -252,7 +252,7 @@ export const VWAreaChart: React.FC<VWAreaChartProps> = ({
   margin,
   gradientOpacity = 0.12,
 }) => (
-  <ChartWrapper>
+  <ChartOutlineWrapper>
   <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
     <AreaChart data={data} margin={margin}>
       <defs>
@@ -299,7 +299,7 @@ export const VWAreaChart: React.FC<VWAreaChartProps> = ({
       ))}
     </AreaChart>
   </ResponsiveContainer>
-  </ChartWrapper>
+  </ChartOutlineWrapper>
 );
 
 // ─── VWDonutChart ───────────────────────────────────────────────────────────
@@ -422,7 +422,7 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
   const Legend = showLegend ? require("recharts").Legend : null;
 
   return (
-    <ChartWrapper>
+    <ChartOutlineWrapper>
     <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
       <LineChart data={data} margin={margin}>
         <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
@@ -467,6 +467,6 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
         ))}
       </LineChart>
     </ResponsiveContainer>
-    </ChartWrapper>
+    </ChartOutlineWrapper>
   );
 };

--- a/Clients/src/presentation/pages/EvalsDashboard/components/PerformanceChart.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/components/PerformanceChart.tsx
@@ -3,7 +3,7 @@ import { Box, Typography } from "@mui/material";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import { getAllExperiments, type Experiment } from "../../../../application/repository/deepEval.repository";
 import { palette } from "../../../themes/palette";
-import { vwTooltipStyle } from "../../../components/Charts/VWCharts";
+import { vwTooltipStyle, ChartOutlineWrapper } from "../../../components/Charts/VWCharts";
 
 export type TimeRange = "7d" | "30d" | "100d" | "all";
 
@@ -295,12 +295,7 @@ export default function PerformanceChart({ projectId, timeRange }: PerformanceCh
   };
 
   return (
-    <Box sx={{ width: "100%" }}>
-    <Box sx={{
-      width: "100%",
-      "& *": { outline: "none !important" },
-      "& *:focus": { outline: "none !important" },
-    }}>
+    <ChartOutlineWrapper>
         <ResponsiveContainer key={`rc-${projectId}-${data.length}-${activeMetrics.join(",")}-${timeRange}`} width="100%" height={Math.max(dynamicHeight, 220)} debounce={1}>
         <LineChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 20 }}>
           <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
@@ -357,8 +352,7 @@ export default function PerformanceChart({ projectId, timeRange }: PerformanceCh
           })}
         </LineChart>
       </ResponsiveContainer>
-      </Box>
-    </Box>
+    </ChartOutlineWrapper>
   );
 }
 

--- a/Clients/src/presentation/pages/EvalsDashboard/components/PerformanceChart.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/components/PerformanceChart.tsx
@@ -3,6 +3,7 @@ import { Box, Typography } from "@mui/material";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import { getAllExperiments, type Experiment } from "../../../../application/repository/deepEval.repository";
 import { palette } from "../../../themes/palette";
+import { vwTooltipStyle } from "../../../components/Charts/VWCharts";
 
 export type TimeRange = "7d" | "30d" | "100d" | "all";
 
@@ -248,11 +249,7 @@ export default function PerformanceChart({ projectId, timeRange }: PerformanceCh
     return (
       <Box
         sx={{
-          backgroundColor: palette.background.main,
-          border: `1px solid ${palette.border.light}`,
-          borderRadius: "8px",
-          boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
-          padding: "12px",
+          ...vwTooltipStyle,
           minWidth: "180px",
         }}
       >

--- a/Clients/src/presentation/pages/ShadowAI/InsightsPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/InsightsPage.tsx
@@ -14,23 +14,12 @@ import {
   SelectChangeEvent,
 } from "@mui/material";
 import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-} from "recharts";
-import {
   AppWindow,
   Users,
   AlertTriangle,
   Building2,
 } from "lucide-react";
+import { VWBarChart, VWDonutChart, vwTooltipStyle } from "../../components/Charts/VWCharts";
 import {
   getInsightsSummary,
   getToolsByEvents,
@@ -205,32 +194,16 @@ export default function InsightsPage() {
               <Skeleton variant="rectangular" height={250} sx={{ borderRadius: "4px" }} />
             ) : departments.length > 0 ? (
               <Stack direction="row" alignItems="center" justifyContent="center" gap="24px">
-                <Box sx={{ width: 200, height: 200 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <PieChart>
-                      <Pie
-                        data={departments}
-                        dataKey="user_count"
-                        nameKey="department"
-                        cx="50%"
-                        cy="50%"
-                        outerRadius={90}
-                        innerRadius={0}
-                      >
-                        {departments.map((_dept, index) => (
-                          <Cell
-                            key={index}
-                            fill={DEPT_COLORS[index % DEPT_COLORS.length]}
-                          />
-                        ))}
-                      </Pie>
-                      <Tooltip
-                        contentStyle={{ fontSize: 12, borderRadius: 4 }}
-                        formatter={(value) => [String(value), ""]}
-                      />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </Box>
+                <VWDonutChart
+                  data={departments}
+                  dataKey="user_count"
+                  nameKey="department"
+                  colors={DEPT_COLORS}
+                  size={200}
+                  innerRadius={0}
+                  outerRadius={90}
+                  tooltipFormatter={(value) => [String(value), ""]}
+                />
                 <Stack gap="8px">
                   {departments.map((dept, index) => (
                     <Stack key={dept.department} direction="row" alignItems="center" gap="8px">
@@ -264,46 +237,16 @@ export default function InsightsPage() {
               <Skeleton variant="rectangular" height={260} sx={{ borderRadius: "4px" }} />
             ) : toolsByEvents.length > 0 ? (
               <>
-                <ResponsiveContainer width="100%" height={260}>
-                  <BarChart
-                    data={toolsByEvents}
-                    layout="vertical"
-                    margin={{ left: 8, right: 24, top: 8, bottom: 8 }}
-                    barCategoryGap="20%"
-                  >
-                    <CartesianGrid strokeDasharray="3 3" stroke={palette.background.hover} horizontal={false} />
-                    <XAxis
-                      type="number"
-                      tick={{ fontSize: 11, fill: palette.text.disabled }}
-                      axisLine={{ stroke: palette.border.light }}
-                      tickLine={false}
-                    />
-                    <YAxis
-                      type="category"
-                      dataKey="tool_name"
-                      tick={{ fontSize: 12, fill: palette.text.secondary }}
-                      width={90}
-                      axisLine={false}
-                      tickLine={false}
-                    />
-                    <Tooltip
-                      contentStyle={{
-                        fontSize: 12,
-                        borderRadius: 6,
-                        border: `1px solid ${palette.border.light}`,
-                        boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
-                      }}
-                      formatter={(value) => [typeof value === "number" ? value.toLocaleString() : String(value), "Events"]}
-                      cursor={{ fill: "rgba(19, 113, 91, 0.04)" }}
-                    />
-                    <Bar
-                      dataKey="event_count"
-                      fill={palette.brand.primary}
-                      radius={[0, 4, 4, 0]}
-                      maxBarSize={28}
-                    />
-                  </BarChart>
-                </ResponsiveContainer>
+                <VWBarChart
+                  data={toolsByEvents}
+                  series={[{ dataKey: "event_count" }]}
+                  categoryKey="tool_name"
+                  layout="vertical"
+                  height={260}
+                  barCategoryGap="20%"
+                  hideHorizontalGrid
+                  tooltipFormatter={(value) => [typeof value === "number" ? value.toLocaleString() : String(value), "Events"]}
+                />
                 <VWLink
                   onClick={() => navigate("/shadow-ai/tools")}
                   showIcon={false}
@@ -322,46 +265,16 @@ export default function InsightsPage() {
             {loading ? (
               <Skeleton variant="rectangular" height={260} sx={{ borderRadius: "4px" }} />
             ) : toolsByUsers.length > 0 ? (
-              <ResponsiveContainer width="100%" height={260}>
-                <BarChart
-                  data={toolsByUsers}
-                  layout="vertical"
-                  margin={{ left: 8, right: 24, top: 8, bottom: 8 }}
-                  barCategoryGap="20%"
-                >
-                  <CartesianGrid strokeDasharray="3 3" stroke={palette.background.hover} horizontal={false} />
-                  <XAxis
-                    type="number"
-                    tick={{ fontSize: 11, fill: palette.text.disabled }}
-                    axisLine={{ stroke: palette.border.light }}
-                    tickLine={false}
-                  />
-                  <YAxis
-                    type="category"
-                    dataKey="tool_name"
-                    tick={{ fontSize: 12, fill: palette.text.secondary }}
-                    width={90}
-                    axisLine={false}
-                    tickLine={false}
-                  />
-                  <Tooltip
-                    contentStyle={{
-                      fontSize: 12,
-                      borderRadius: 6,
-                      border: `1px solid ${palette.border.light}`,
-                      boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
-                    }}
-                    formatter={(value) => [typeof value === "number" ? value.toLocaleString() : String(value), "Users"]}
-                    cursor={{ fill: "rgba(19, 113, 91, 0.04)" }}
-                  />
-                  <Bar
-                    dataKey="user_count"
-                    fill={palette.brand.primary}
-                    radius={[0, 4, 4, 0]}
-                    maxBarSize={28}
-                  />
-                </BarChart>
-              </ResponsiveContainer>
+              <VWBarChart
+                data={toolsByUsers}
+                series={[{ dataKey: "user_count" }]}
+                categoryKey="tool_name"
+                layout="vertical"
+                height={260}
+                barCategoryGap="20%"
+                hideHorizontalGrid
+                tooltipFormatter={(value) => [typeof value === "number" ? value.toLocaleString() : String(value), "Users"]}
+              />
             ) : (
               <NoChartData />
             )}

--- a/Clients/src/presentation/pages/ShadowAI/InsightsPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/InsightsPage.tsx
@@ -202,7 +202,7 @@ export default function InsightsPage() {
                   size={200}
                   innerRadius={0}
                   outerRadius={90}
-                  tooltipFormatter={(value) => [String(value), ""]}
+                  tooltipFormatter={(value, name) => [String(value), name]}
                 />
                 <Stack gap="8px">
                   {departments.map((dept, index) => (


### PR DESCRIPTION
## Summary

- Add `VWCharts.tsx` with 4 reusable chart components (`VWBarChart`, `VWAreaChart`, `VWDonutChart`, `VWLineChart`) + shared utilities (`vwTooltipStyle`, `VWGradient`, `ChartOutlineWrapper`)
- Migrate Shadow AI InsightsPage: 2 bar charts → `VWBarChart`, 1 pie chart → `VWDonutChart` (90 lines removed)
- Migrate LLM Evals PerformanceChart: `ChartOutlineWrapper` + `vwTooltipStyle` (kept custom tooltip/legend)
- All Recharts charts now use consistent styling — palette axes, gradient fills, rounded tooltips, no blue focus outlines

## What this enables

Any new chart built with `VWBarChart`, `VWAreaChart`, `VWDonutChart`, or `VWLineChart` automatically gets consistent VerifyWise styling. ~30 lines of boilerplate eliminated per chart.

## Test plan

- [ ] Shadow AI → Insights: verify bar charts render with data, tooltips show values
- [ ] Shadow AI → Insights: verify pie chart tooltips show department names (not empty labels)
- [ ] Shadow AI → Insights: click on bars/pie slices — no blue focus outlines
- [ ] LLM Evals → select a project with experiments → verify performance chart renders
- [ ] Check no TypeScript errors: `cd Clients && npx tsc --noEmit`