### PR TITLE
Migrate all MUI X-Charts to Recharts, convert CSS bars, fix UI issues

### DIFF
--- a/Clients/src/presentation/components/AdvisorChat/ChartRenderer.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/ChartRenderer.tsx
@@ -1,6 +1,18 @@
-import { FC, memo, useMemo } from 'react';
-import { Box, Typography, Paper, useTheme, Theme } from '@mui/material';
-import { BarChart, PieChart, LineChart } from '@mui/x-charts';
+import { FC, memo } from 'react';
+import { Box, Typography, Paper, useTheme } from '@mui/material';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+} from 'recharts';
+import { VWDonutChart, vwTooltipStyle } from '../Charts/VWCharts';
+import palette from '../../themes/palette';
 
 interface ChartData {
   type: 'bar' | 'pie' | 'table' | 'donut' | 'line';
@@ -18,33 +30,23 @@ interface ChartRendererProps {
   chartData: ChartData;
 }
 
-// Create tooltip styles with theme
-const createTooltipSlotProps = (theme: Theme) => ({
-  tooltip: {
-    sx: {
-      '& .MuiChartsTooltip-table': {
-        fontSize: theme.typography.body2.fontSize,
-      },
-      '& .MuiChartsTooltip-cell': {
-        fontSize: theme.typography.body2.fontSize,
-      },
-      '& .MuiChartsTooltip-labelCell': {
-        fontSize: theme.typography.body2.fontSize,
-      },
-      '& .MuiChartsTooltip-valueCell': {
-        fontSize: theme.typography.body2.fontSize,
-      },
-      '& .MuiChartsTooltip-mark': {
-        width: 10,
-        height: 10,
-      },
-    },
-  },
-});
+/** Default chart palette colors to use when item.color is not provided */
+const DEFAULT_CHART_COLORS: string[] = [
+  palette.brand.primary,
+  '#3B82F6',
+  '#F59E0B',
+  '#EA580C',
+  '#8B5CF6',
+  '#EC4899',
+  '#10B981',
+  '#6B7280',
+];
+
+const axisTick = { fontSize: 11, fill: palette.text.tertiary };
+const axisLine = { stroke: palette.border.light };
 
 const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
   const theme = useTheme();
-  const tooltipSlotProps = useMemo(() => createTooltipSlotProps(theme), [theme]);
   const size = 200;
 
   // Return null if no chart data at all
@@ -72,99 +74,120 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
   }
 
   const renderChart = () => {
-    // Only compute labels/values if data exists
-    const labels = hasValidData ? data.map(item => item.label) : [];
-    const dataValues = hasValidData ? data.map(item => item.value) : [];
-
     switch (type) {
-      case 'line':
+      case 'line': {
         // Line chart for timeseries data with series
         if (hasValidSeries) {
+          // Transform series + xAxisLabels into Recharts-compatible data array
+          const lineData = xAxisLabels!.map((label, i) => {
+            const point: Record<string, string | number> = { label };
+            series!.forEach(s => {
+              point[s.label] = s.data[i] ?? 0;
+            });
+            return point;
+          });
+
           return (
-            <LineChart
-              xAxis={[{
-                scaleType: 'point',
-                data: xAxisLabels,
-              }]}
-              series={series!.map(s => ({
-                data: s.data,
-                label: s.label,
-                curve: 'linear',
-              }))}
-              height={250}
-              width={300}
-              margin={{ left: 0, right: 20, top: 20, bottom: 0 }}
-              slotProps={tooltipSlotProps}
-            />
+            <ResponsiveContainer width={300} height={250}>
+              <LineChart data={lineData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
+                <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />
+                <YAxis tick={axisTick} tickLine={false} axisLine={axisLine} />
+                <Tooltip contentStyle={vwTooltipStyle} />
+                {series!.map((s, i) => (
+                  <Line
+                    key={s.label}
+                    type="linear"
+                    dataKey={s.label}
+                    stroke={DEFAULT_CHART_COLORS[i % DEFAULT_CHART_COLORS.length]}
+                    strokeWidth={1.5}
+                    dot={{ r: 3 }}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
           );
         }
+
         // Fallback for simple line chart using data array
         if (!hasValidData) return null;
+        const simpleLineData = data.map(item => ({ label: item.label, value: item.value }));
         return (
-          <LineChart
-            xAxis={[{ scaleType: 'point', data: labels }]}
-            series={[{ data: dataValues, curve: 'linear' }]}
-            height={250}
-            width={320}
-            margin={{ left: 0, right: 20, top: 20, bottom: 0 }}
-            slotProps={tooltipSlotProps}
-          />
+          <ResponsiveContainer width={320} height={250}>
+            <LineChart data={simpleLineData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
+              <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />
+              <YAxis tick={axisTick} tickLine={false} axisLine={axisLine} />
+              <Tooltip contentStyle={vwTooltipStyle} />
+              <Line
+                type="linear"
+                dataKey="value"
+                stroke={palette.brand.primary}
+                strokeWidth={1.5}
+                dot={{ r: 3 }}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
         );
+      }
 
-      case 'bar':
+      case 'bar': {
+        const barChartData = data.map(item => ({ label: item.label, value: item.value }));
         return (
-          <BarChart
-            xAxis={[{ scaleType: 'band', data: labels }]}
-            series={[{ data: dataValues }]}
-            height={size}
-            width={300}
-            margin={{ left: 0, right: 20, top: 20 }}
-            slotProps={tooltipSlotProps}
-          />
+          <ResponsiveContainer width={300} height={size}>
+            <BarChart data={barChartData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
+              <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />
+              <YAxis tick={axisTick} tickLine={false} axisLine={axisLine} />
+              <Tooltip contentStyle={vwTooltipStyle} />
+              <Bar
+                dataKey="value"
+                fill={palette.brand.primary}
+                radius={[4, 4, 0, 0]}
+                maxBarSize={28}
+              />
+            </BarChart>
+          </ResponsiveContainer>
         );
+      }
 
-      case 'pie':
+      case 'pie': {
+        const pieData = data.map(item => ({ name: item.label, value: item.value }));
+        const pieColors = data.map(
+          (item, i) => item.color || DEFAULT_CHART_COLORS[i % DEFAULT_CHART_COLORS.length]
+        );
         return (
-          <PieChart
-            series={[
-              {
-                data: data.map((item, index) => ({
-                  id: index,
-                  value: item.value,
-                  label: item.label,
-                  color: item.color,
-                })),
-                faded: { innerRadius: 30, additionalRadius: -30 },
-              },
-            ]}
-            width={size}
-            height={size}
-            slotProps={tooltipSlotProps}
+          <VWDonutChart
+            data={pieData}
+            dataKey="value"
+            nameKey="name"
+            colors={pieColors}
+            size={size}
+            innerRadius={0}
+            outerRadius={Math.floor(size / 2) - 5}
           />
         );
+      }
 
-      case 'donut':
+      case 'donut': {
+        const donutData = data.map(item => ({ name: item.label, value: item.value }));
+        const donutColors = data.map(
+          (item, i) => item.color || DEFAULT_CHART_COLORS[i % DEFAULT_CHART_COLORS.length]
+        );
         return (
-          <PieChart
-            series={[
-              {
-                data: data.map((item, index) => ({
-                  id: index,
-                  value: item.value,
-                  label: item.label,
-                  color: item.color,
-                })),
-                innerRadius: size * 0.35,
-                outerRadius: size * 0.45,
-                paddingAngle: 2,
-                cornerRadius: 2,
-              },
-            ]}
-            width={size}
-            height={size}
-            slotProps={tooltipSlotProps}
+          <VWDonutChart
+            data={donutData}
+            dataKey="value"
+            nameKey="name"
+            colors={donutColors}
+            size={size}
+            innerRadius={Math.floor(size * 0.35)}
+            outerRadius={Math.floor(size * 0.45)}
           />
         );
+      }
 
       case 'table':
         return (

--- a/Clients/src/presentation/components/AdvisorChat/ChartRenderer.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/ChartRenderer.tsx
@@ -11,14 +11,13 @@ import {
   LineChart,
   Line,
 } from 'recharts';
-import { VWDonutChart, vwTooltipStyle } from '../Charts/VWCharts';
-import palette from '../../themes/palette';
+import { VWDonutChart, vwTooltipStyle, axisTick, axisLine, gridStroke } from '../Charts/VWCharts';
+import palette, { chart as chartPalette } from '../../themes/palette';
 
 interface ChartData {
   type: 'bar' | 'pie' | 'table' | 'donut' | 'line';
   data: {label: string, value: number, color?: string}[] ;
   title: string;
-  // For line charts with multiple series (timeseries data)
   series?: Array<{
     label: string;
     data: number[];
@@ -29,21 +28,6 @@ interface ChartData {
 interface ChartRendererProps {
   chartData: ChartData;
 }
-
-/** Default chart palette colors to use when item.color is not provided */
-const DEFAULT_CHART_COLORS: string[] = [
-  palette.brand.primary,
-  '#3B82F6',
-  '#F59E0B',
-  '#EA580C',
-  '#8B5CF6',
-  '#EC4899',
-  '#10B981',
-  '#6B7280',
-];
-
-const axisTick = { fontSize: 11, fill: palette.text.tertiary };
-const axisLine = { stroke: palette.border.light };
 
 const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
   const theme = useTheme();
@@ -90,7 +74,7 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
           return (
             <ResponsiveContainer width={300} height={250}>
               <LineChart data={lineData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
+                <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
                 <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />
                 <YAxis tick={axisTick} tickLine={false} axisLine={axisLine} />
                 <Tooltip contentStyle={vwTooltipStyle} />
@@ -99,7 +83,7 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
                     key={s.label}
                     type="linear"
                     dataKey={s.label}
-                    stroke={DEFAULT_CHART_COLORS[i % DEFAULT_CHART_COLORS.length]}
+                    stroke={chartPalette[i % chartPalette.length]}
                     strokeWidth={1.5}
                     dot={{ r: 3 }}
                     isAnimationActive={false}
@@ -116,7 +100,7 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
         return (
           <ResponsiveContainer width={320} height={250}>
             <LineChart data={simpleLineData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
+              <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
               <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />
               <YAxis tick={axisTick} tickLine={false} axisLine={axisLine} />
               <Tooltip contentStyle={vwTooltipStyle} />
@@ -138,7 +122,7 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
         return (
           <ResponsiveContainer width={300} height={size}>
             <BarChart data={barChartData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
+              <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
               <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />
               <YAxis tick={axisTick} tickLine={false} axisLine={axisLine} />
               <Tooltip contentStyle={vwTooltipStyle} />
@@ -153,38 +137,22 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
         );
       }
 
-      case 'pie': {
-        const pieData = data.map(item => ({ name: item.label, value: item.value }));
-        const pieColors = data.map(
-          (item, i) => item.color || DEFAULT_CHART_COLORS[i % DEFAULT_CHART_COLORS.length]
-        );
-        return (
-          <VWDonutChart
-            data={pieData}
-            dataKey="value"
-            nameKey="name"
-            colors={pieColors}
-            size={size}
-            innerRadius={0}
-            outerRadius={Math.floor(size / 2) - 5}
-          />
-        );
-      }
-
+      case 'pie':
       case 'donut': {
-        const donutData = data.map(item => ({ name: item.label, value: item.value }));
-        const donutColors = data.map(
-          (item, i) => item.color || DEFAULT_CHART_COLORS[i % DEFAULT_CHART_COLORS.length]
+        const isPie = type === 'pie';
+        const chartData = data.map(item => ({ name: item.label, value: item.value }));
+        const colors = data.map(
+          (item, i) => item.color || chartPalette[i % chartPalette.length]
         );
         return (
           <VWDonutChart
-            data={donutData}
+            data={chartData}
             dataKey="value"
             nameKey="name"
-            colors={donutColors}
+            colors={colors}
             size={size}
-            innerRadius={Math.floor(size * 0.35)}
-            outerRadius={Math.floor(size * 0.45)}
+            innerRadius={isPie ? 0 : Math.floor(size * 0.35)}
+            outerRadius={isPie ? Math.floor(size / 2) - 5 : Math.floor(size * 0.45)}
           />
         );
       }

--- a/Clients/src/presentation/components/Cards/DashboardCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/DashboardCard/index.tsx
@@ -35,8 +35,8 @@ export function DashboardCard({
         transition: "all 0.2s ease",
         "&:hover": navigateTo
           ? {
-              background: `linear-gradient(135deg, ${background.accent} 0%, #f1f5f9 100%)`,
-              borderColor: `${text.muted}`,
+              background: `linear-gradient(135deg, ${background.accent} 0%, ${background.gradientStop} 100%)`,
+              borderColor: `${borderPalette.light}`,
             }
           : {},
       }}

--- a/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
@@ -54,8 +54,8 @@ export function TaskRadarCard({
         cursor: "pointer",
         transition: "all 0.2s ease",
         "&:hover": {
-          background: `linear-gradient(135deg, ${background.accent} 0%, #f1f5f9 100%)`,
-          borderColor: text.muted,
+          background: `linear-gradient(135deg, ${background.accent} 0%, ${background.gradientStop} 100%)`,
+          borderColor: borderPalette.light,
         },
       }}
       onMouseEnter={() => setIsHovered(true)}

--- a/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
@@ -72,32 +72,47 @@ export function TaskRadarCard({
         />
       </Stack>
 
-      <Stack
-        direction="row"
-        justifyContent="space-around"
-        alignItems="flex-end"
-        sx={{ height: barHeight + 40, flex: 1 }}
-      >
-        {items.map((item) => (
-          <Stack key={item.label} alignItems="center" gap={0.5}>
-            <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#1F2937" }}>
-              {item.value}
-            </Typography>
-            <Box
-              sx={{
-                width: 40,
-                height: (item.value / max) * barHeight || 4,
-                backgroundColor: item.color,
-                borderRadius: "4px 4px 0 0",
-                minHeight: 4,
-              }}
-            />
-            <Typography sx={{ fontSize: 11, color: `${text.icon}`, textAlign: "center" }}>
-              {item.label}
-            </Typography>
-          </Stack>
+      <Box sx={{ position: "relative", flex: 1 }}>
+        {/* Dashed grid lines */}
+        {[0, 1, 2, 3].map((i) => (
+          <Box
+            key={i}
+            sx={{
+              position: "absolute",
+              top: i * (barHeight / 4),
+              left: 0,
+              right: 0,
+              borderTop: `1px dashed ${borderPalette.light}`,
+            }}
+          />
         ))}
-      </Stack>
+        <Stack
+          direction="row"
+          justifyContent="space-around"
+          alignItems="flex-end"
+          sx={{ height: barHeight + 40 }}
+        >
+          {items.map((item) => (
+            <Stack key={item.label} alignItems="center" gap="4px">
+              <Typography sx={{ fontSize: 13, fontWeight: 600, color: text.primary }}>
+                {item.value}
+              </Typography>
+              <Box
+                sx={{
+                  width: 40,
+                  height: (item.value / max) * barHeight || 4,
+                  backgroundColor: item.color,
+                  borderRadius: "4px 4px 0 0",
+                  minHeight: 4,
+                }}
+              />
+              <Typography sx={{ fontSize: 11, color: text.icon, textAlign: "center" }}>
+                {item.label}
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      </Box>
     </Stack>
   );
 }

--- a/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
@@ -1,7 +1,18 @@
 import { useState } from "react";
-import { Box, Stack, Typography } from "@mui/material";
+import { Stack, Typography } from "@mui/material";
 import { ChevronRight } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+  ResponsiveContainer,
+} from "recharts";
+import { vwTooltipStyle, ChartOutlineWrapper } from "../../Charts/VWCharts";
 import { text, background, border as borderPalette } from "../../../themes/palette";
 
 interface TaskRadarCardProps {
@@ -10,6 +21,12 @@ interface TaskRadarCardProps {
   upcoming: number;
 }
 
+const BAR_COLORS: Record<string, string> = {
+  Overdue: "#EF4444",
+  "Due soon": "#F59E0B",
+  Upcoming: "#10B981",
+};
+
 export function TaskRadarCard({
   overdue,
   due,
@@ -17,13 +34,11 @@ export function TaskRadarCard({
 }: TaskRadarCardProps) {
   const navigate = useNavigate();
   const [isHovered, setIsHovered] = useState(false);
-  const max = Math.max(overdue, due, upcoming, 1);
-  const barHeight = 80;
 
-  const items = [
-    { label: "Overdue", value: overdue, color: "#EF4444" },
-    { label: "Due soon", value: due, color: "#F59E0B" },
-    { label: "Upcoming", value: upcoming, color: "#10B981" },
+  const chartData = [
+    { name: "Overdue", value: overdue },
+    { name: "Due soon", value: due },
+    { name: "Upcoming", value: upcoming },
   ];
 
   return (
@@ -40,7 +55,7 @@ export function TaskRadarCard({
         transition: "all 0.2s ease",
         "&:hover": {
           background: `linear-gradient(135deg, ${background.accent} 0%, #f1f5f9 100%)`,
-          borderColor: `${text.muted}`,
+          borderColor: text.muted,
         },
       }}
       onMouseEnter={() => setIsHovered(true)}
@@ -51,13 +66,13 @@ export function TaskRadarCard({
         direction="row"
         justifyContent="space-between"
         alignItems="center"
-        mb="16px"
+        mb="8px"
       >
         <Typography
           sx={{
             fontSize: 14,
             fontWeight: 600,
-            color: "#1F2937",
+            color: text.primary,
           }}
         >
           Task radar
@@ -67,52 +82,36 @@ export function TaskRadarCard({
           style={{
             opacity: isHovered ? 1 : 0.3,
             transition: "opacity 0.2s ease",
-            color: `${text.icon}`,
+            color: text.icon,
           }}
         />
       </Stack>
 
-      <Box sx={{ position: "relative", flex: 1 }}>
-        {/* Dashed grid lines */}
-        {[0, 1, 2, 3].map((i) => (
-          <Box
-            key={i}
-            sx={{
-              position: "absolute",
-              top: i * (barHeight / 4),
-              left: 0,
-              right: 0,
-              borderTop: `1px dashed ${borderPalette.light}`,
-            }}
-          />
-        ))}
-        <Stack
-          direction="row"
-          justifyContent="space-around"
-          alignItems="flex-end"
-          sx={{ height: barHeight + 40 }}
-        >
-          {items.map((item) => (
-            <Stack key={item.label} alignItems="center" gap="4px">
-              <Typography sx={{ fontSize: 13, fontWeight: 600, color: text.primary }}>
-                {item.value}
-              </Typography>
-              <Box
-                sx={{
-                  width: 40,
-                  height: (item.value / max) * barHeight || 4,
-                  backgroundColor: item.color,
-                  borderRadius: "4px 4px 0 0",
-                  minHeight: 4,
-                }}
-              />
-              <Typography sx={{ fontSize: 11, color: text.icon, textAlign: "center" }}>
-                {item.label}
-              </Typography>
-            </Stack>
-          ))}
-        </Stack>
-      </Box>
+      <ChartOutlineWrapper>
+        <ResponsiveContainer width="100%" height={130}>
+          <BarChart data={chartData} margin={{ top: 8, right: 0, bottom: 0, left: -24 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke={borderPalette.light} vertical={false} />
+            <XAxis
+              dataKey="name"
+              tick={{ fontSize: 11, fill: text.icon }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: text.tertiary }}
+              tickLine={false}
+              axisLine={false}
+              allowDecimals={false}
+            />
+            <Tooltip contentStyle={vwTooltipStyle} formatter={(value: number) => [value, ""]} />
+            <Bar dataKey="value" radius={[4, 4, 0, 0]} maxBarSize={40}>
+              {chartData.map((entry) => (
+                <Cell key={entry.name} fill={BAR_COLORS[entry.name]} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartOutlineWrapper>
     </Stack>
   );
 }

--- a/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
@@ -103,7 +103,7 @@ export function TaskRadarCard({
               axisLine={false}
               allowDecimals={false}
             />
-            <Tooltip contentStyle={vwTooltipStyle} formatter={(value: number) => [value, ""]} />
+            <Tooltip contentStyle={vwTooltipStyle} />
             <Bar dataKey="value" radius={[4, 4, 0, 0]} maxBarSize={40}>
               {chartData.map((entry) => (
                 <Cell key={entry.name} fill={BAR_COLORS[entry.name]} />

--- a/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
@@ -187,17 +187,11 @@ export function ModelInventoryHistoryChart({
           categoryKey="date"
           height={height}
           showLegend={true}
-          margin={{ top: 10, right: 30, bottom: 30, left: 70 }}
+          margin={{ top: 10, right: 16, bottom: 10, left: 0 }}
           yAxisProps={{
             domain: [0, maxValue > 0 ? Math.ceil(maxValue * 1.15) : 10],
             tickFormatter: (v: number) => v.toString(),
-            label: {
-              value: "Count",
-              angle: -90,
-              position: "insideLeft",
-              offset: -50,
-              style: { fontSize: 13, fill: text.secondary },
-            },
+            width: 35,
           }}
         />
       </Stack>

--- a/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { Typography, Stack, Box } from "@mui/material";
-import { LineChart } from "@mui/x-charts/LineChart";
+import { Typography, Stack } from "@mui/material";
 import { getModelInventoryTimeseries } from "../../../application/repository/modelInventoryHistory.repository";
 import { ModelInventoryStatus } from "../../../domain/enums/modelInventory.enum";
 import { ButtonToggle } from "../button-toggle";
@@ -8,6 +7,7 @@ import CustomizableSkeleton from "../Skeletons";
 import { TrendingUp } from "lucide-react";
 import { EmptyState } from "../EmptyState";
 import { text, background, border as borderPalette } from "../../themes/palette";
+import { VWLineChart } from "./VWCharts";
 
 interface ModelInventoryHistoryChartProps {
   parameter?: string;
@@ -16,10 +16,10 @@ interface ModelInventoryHistoryChartProps {
 }
 
 const STATUS_COLORS: Record<string, string> = {
-  [ModelInventoryStatus.APPROVED]: "#10B981", // Emerald green
-  [ModelInventoryStatus.PENDING]: "#F59E0B", // Amber
-  [ModelInventoryStatus.RESTRICTED]: "#EF4444", // Red
-  [ModelInventoryStatus.BLOCKED]: "#DC2626", // Dark red
+  [ModelInventoryStatus.APPROVED]: "#10B981",
+  [ModelInventoryStatus.PENDING]: "#F59E0B",
+  [ModelInventoryStatus.RESTRICTED]: "#EF4444",
+  [ModelInventoryStatus.BLOCKED]: "#DC2626",
 };
 
 const TIMEFRAME_OPTIONS = [
@@ -37,10 +37,9 @@ export function ModelInventoryHistoryChart({
 }: ModelInventoryHistoryChartProps) {
   const storageKey = "analytics_timeframe_model";
 
-  // Initialize timeframe from localStorage or default
   const [timeframe, setTimeframe] = useState<string>(() => {
     const stored = localStorage.getItem(storageKey);
-    if (stored && TIMEFRAME_OPTIONS.some(opt => opt.value === stored)) {
+    if (stored && TIMEFRAME_OPTIONS.some((opt) => opt.value === stored)) {
       return stored;
     }
     return "1month";
@@ -48,9 +47,10 @@ export function ModelInventoryHistoryChart({
 
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [timeseriesData, setTimeseriesData] = useState<{ timestamp: string; data: Record<string, number> }[]>([]);
+  const [timeseriesData, setTimeseriesData] = useState<
+    { timestamp: string; data: Record<string, number> }[]
+  >([]);
 
-  // Persist timeframe to localStorage whenever it changes
   useEffect(() => {
     localStorage.setItem(storageKey, timeframe);
   }, [timeframe]);
@@ -65,7 +65,8 @@ export function ModelInventoryHistoryChart({
       }
     } catch (err: unknown) {
       console.error("Error fetching timeseries data:", err);
-      const message = err instanceof Error ? err.message : "Failed to load chart data";
+      const message =
+        err instanceof Error ? err.message : "Failed to load chart data";
       setError(message);
     } finally {
       setLoading(false);
@@ -80,34 +81,45 @@ export function ModelInventoryHistoryChart({
     setTimeframe(newTimeframe);
   };
 
-  // Prepare data for the chart
+  // Build Recharts-compatible flat data array and series config
   const prepareChartData = () => {
     if (!timeseriesData || timeseriesData.length === 0) {
-      return { timestamps: [], series: [], maxValue: 0 };
+      return { chartData: [], series: [], maxValue: 0 };
     }
 
-    const timestamps = timeseriesData.map((point) => new Date(point.timestamp));
-
-    // Get all unique status values
     const statusValues = Object.values(ModelInventoryStatus);
+
+    // Merge parallel arrays into a single array of objects for Recharts
+    const chartData = timeseriesData.map((point) => {
+      const date = new Date(point.timestamp);
+      const label = new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+      }).format(date);
+      const entry: Record<string, string | number> = { date: label };
+      statusValues.forEach((status) => {
+        entry[status] = point.data[status] || 0;
+      });
+      return entry;
+    });
+
     const series = statusValues.map((status) => ({
-      label: status,
-      data: timeseriesData.map((point) => point.data[status] || 0),
-      color: STATUS_COLORS[status] || `${text.disabled}`,
-      curve: "monotoneX" as const,
-      showMark: false,
+      dataKey: status,
+      name: status,
+      color: STATUS_COLORS[status] || text.disabled,
+      strokeWidth: 2,
+      dot: false as const,
     }));
 
-    // Calculate max value across all series for proper y-axis scaling
     const maxValue = Math.max(
-      ...series.flatMap((s) => s.data),
+      ...timeseriesData.flatMap((point) => Object.values(point.data)),
       0
     );
 
-    return { timestamps, series, maxValue };
+    return { chartData, series, maxValue };
   };
 
-  const { timestamps, series, maxValue } = prepareChartData();
+  const { chartData, series, maxValue } = prepareChartData();
 
   if (loading) {
     return (
@@ -177,75 +189,25 @@ export function ModelInventoryHistoryChart({
           />
         </Stack>
 
-        <Stack sx={{ width: "100%", mt: 2 }}>
-          <Box sx={{ position: "relative" }}>
-            <LineChart
-              xAxis={[
-                {
-                  data: timestamps,
-                  scaleType: "time",
-                  valueFormatter: (date) => {
-                    return new Intl.DateTimeFormat("en-US", {
-                      month: "short",
-                      day: "numeric",
-                    }).format(date);
-                  },
-                  tickLabelStyle: {
-                    fontSize: 12,
-                    fill: `${text.tertiary}`,
-                  },
-                },
-              ]}
-              yAxis={[
-                {
-                  label: "Count",
-                  min: 0,
-                  max: maxValue > 0 ? Math.ceil(maxValue * 1.15) : 10,
-                  tickMinStep: 1,
-                  valueFormatter: (value: number) => value.toString(),
-                  labelStyle: {
-                    fontSize: 13,
-                    fill: `${text.secondary}`,
-                  },
-                  tickLabelStyle: {
-                    fontSize: 12,
-                    fill: `${text.tertiary}`,
-                  },
-                },
-              ]}
-              series={series}
-              height={height}
-              margin={{ top: 10, right: 30, bottom: 30, left: 70 }}
-              slotProps={{
-                legend: {
-                  direction: "horizontal",
-                  position: { vertical: "bottom", horizontal: "center" },
-                },
-              }}
-              grid={{
-                vertical: true,
-                horizontal: true,
-              }}
-              sx={{
-                "& .MuiLineElement-root": {
-                  strokeWidth: 3,
-                },
-                "& .MuiChartsGrid-line": {
-                  stroke: `${borderPalette.light}`,
-                  strokeWidth: 1,
-                },
-                "& .MuiChartsAxis-line": {
-                  stroke: `${borderPalette.dark}`,
-                  strokeWidth: 1.5,
-                },
-                "& .MuiChartsAxis-tick": {
-                  stroke: `${borderPalette.dark}`,
-                },
-              }}
-            />
-
-          </Box>
-        </Stack>
+        <VWLineChart
+          data={chartData}
+          series={series}
+          categoryKey="date"
+          height={height}
+          showLegend={true}
+          margin={{ top: 10, right: 30, bottom: 30, left: 70 }}
+          yAxisProps={{
+            domain: [0, maxValue > 0 ? Math.ceil(maxValue * 1.15) : 10],
+            tickFormatter: (v: number) => v.toString(),
+            label: {
+              value: "Count",
+              angle: -90,
+              position: "insideLeft",
+              offset: -50,
+              style: { fontSize: 13, fill: text.secondary },
+            },
+          }}
+        />
       </Stack>
     </Stack>
   );

--- a/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/ModelInventoryHistoryChart.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Typography, Stack } from "@mui/material";
 import { getModelInventoryTimeseries } from "../../../application/repository/modelInventoryHistory.repository";
 import { ModelInventoryStatus } from "../../../domain/enums/modelInventory.enum";
@@ -11,7 +11,6 @@ import { VWLineChart } from "./VWCharts";
 
 interface ModelInventoryHistoryChartProps {
   parameter?: string;
-  title?: string;
   height?: number;
 }
 
@@ -82,21 +81,16 @@ export function ModelInventoryHistoryChart({
   };
 
   // Build Recharts-compatible flat data array and series config
-  const prepareChartData = () => {
+  const { chartData, series, maxValue } = useMemo(() => {
     if (!timeseriesData || timeseriesData.length === 0) {
       return { chartData: [], series: [], maxValue: 0 };
     }
 
     const statusValues = Object.values(ModelInventoryStatus);
+    const fmt = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" });
 
-    // Merge parallel arrays into a single array of objects for Recharts
     const chartData = timeseriesData.map((point) => {
-      const date = new Date(point.timestamp);
-      const label = new Intl.DateTimeFormat("en-US", {
-        month: "short",
-        day: "numeric",
-      }).format(date);
-      const entry: Record<string, string | number> = { date: label };
+      const entry: Record<string, string | number> = { date: fmt.format(new Date(point.timestamp)) };
       statusValues.forEach((status) => {
         entry[status] = point.data[status] || 0;
       });
@@ -117,9 +111,7 @@ export function ModelInventoryHistoryChart({
     );
 
     return { chartData, series, maxValue };
-  };
-
-  const { chartData, series, maxValue } = prepareChartData();
+  }, [timeseriesData, parameter]);
 
   if (loading) {
     return (

--- a/Clients/src/presentation/components/Charts/NewMetricsCards.tsx
+++ b/Clients/src/presentation/components/Charts/NewMetricsCards.tsx
@@ -52,7 +52,7 @@ function MetricBarChart({ data, height = 130 }: MetricBarChartProps) {
             axisLine={false}
             allowDecimals={false}
           />
-          <Tooltip contentStyle={vwTooltipStyle} formatter={(value: number) => [value, ""]} />
+          <Tooltip contentStyle={vwTooltipStyle} />
           <Bar dataKey="value" radius={[4, 4, 0, 0]} maxBarSize={36}>
             {data.map((entry) => (
               <Cell key={entry.name} fill={entry.color} />

--- a/Clients/src/presentation/components/Charts/NewMetricsCards.tsx
+++ b/Clients/src/presentation/components/Charts/NewMetricsCards.tsx
@@ -1,6 +1,18 @@
 import { Box, Stack, Typography, LinearProgress } from "@mui/material";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+  ResponsiveContainer,
+} from "recharts";
 import { StatusDonutChart } from "./StatusDonutChart";
+import { vwTooltipStyle, ChartOutlineWrapper } from "./VWCharts";
 import { DASHBOARD_COLORS, TEXT_STYLES } from "../../styles/colors";
+import { border as borderPalette } from "../../themes/palette";
 
 const C = DASHBOARD_COLORS;
 
@@ -16,38 +28,43 @@ function LegendItem({ label, value, color }: { label: string; value: number; col
   );
 }
 
-// Shared vertical bar component
-interface VerticalBarProps {
-  label: string;
-  value: number;
-  color: string;
-  max: number;
-  barHeight: number;
-  barWidth?: number;
-  labelSize?: number;
+// Shared Recharts bar chart for dashboard metric cards
+interface MetricBarChartProps {
+  data: { name: string; value: number; color: string }[];
+  height?: number;
 }
 
-function VerticalBar({ label, value, color, max, barHeight, barWidth = 40, labelSize = 11 }: VerticalBarProps) {
+function MetricBarChart({ data, height = 130 }: MetricBarChartProps) {
   return (
-    <Stack alignItems="center" gap={0.5}>
-      <Typography sx={TEXT_STYLES.value}>{value}</Typography>
-      <Box
-        sx={{
-          width: barWidth,
-          height: (value / max) * barHeight || 4,
-          backgroundColor: color,
-          borderRadius: "4px 4px 0 0",
-          minHeight: 4,
-        }}
-      />
-      <Typography sx={{ fontSize: labelSize, color: C.textSecondary, textAlign: "center" }}>
-        {label}
-      </Typography>
-    </Stack>
+    <ChartOutlineWrapper>
+      <ResponsiveContainer width="100%" height={height}>
+        <BarChart data={data} margin={{ top: 8, right: 0, bottom: 0, left: -24 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke={borderPalette.light} vertical={false} />
+          <XAxis
+            dataKey="name"
+            tick={{ fontSize: 10, fill: C.textSecondary }}
+            tickLine={false}
+            axisLine={false}
+          />
+          <YAxis
+            tick={{ fontSize: 10, fill: C.textSecondary }}
+            tickLine={false}
+            axisLine={false}
+            allowDecimals={false}
+          />
+          <Tooltip contentStyle={vwTooltipStyle} formatter={(value: number) => [value, ""]} />
+          <Bar dataKey="value" radius={[4, 4, 0, 0]} maxBarSize={36}>
+            {data.map((entry) => (
+              <Cell key={entry.name} fill={entry.color} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartOutlineWrapper>
   );
 }
 
-// Training Completion Card - Progress bar style
+// Training Completion Card - Bar chart
 interface TrainingCompletionProps {
   total: number;
   distribution: { planned: number; inProgress: number; completed: number };
@@ -56,23 +73,14 @@ interface TrainingCompletionProps {
 }
 
 export function TrainingCompletionCard({ distribution }: TrainingCompletionProps) {
-  const max = Math.max(distribution.completed, distribution.inProgress, distribution.planned, 1);
-  const barHeight = 80;
-
-  const items = [
-    { label: "Planned", value: distribution.planned, color: C.draft },
-    { label: "In progress", value: distribution.inProgress, color: C.inProgress },
-    { label: "Completed", value: distribution.completed, color: C.completed },
+  const data = [
+    { name: "Planned", value: distribution.planned, color: C.draft },
+    { name: "In progress", value: distribution.inProgress, color: C.inProgress },
+    { name: "Completed", value: distribution.completed, color: C.completed },
   ];
 
-  return (
-    <Stack direction="row" justifyContent="space-around" alignItems="flex-end" sx={{ height: barHeight + 40 }}>
-      {items.map((item) => (
-        <VerticalBar key={item.label} {...item} max={max} barHeight={barHeight} />
-      ))}
-    </Stack>
-  );
-};
+  return <MetricBarChart data={data} />;
+}
 
 // Policy Status Card - Donut with legend
 interface PolicyStatusProps {
@@ -101,40 +109,31 @@ export function PolicyStatusCard({ total, distribution }: PolicyStatusProps) {
       <Box sx={{ pt: "8px" }}>
         <StatusDonutChart data={data} total={total} size={100} />
       </Box>
-      <Stack gap={0.5} sx={{ pt: "8px" }}>
+      <Stack gap="4px" sx={{ pt: "8px" }}>
         {data.map((item) => (
           <LegendItem key={item.label} {...item} />
         ))}
       </Stack>
     </Stack>
   );
-};
+}
 
-// Incident Status Card - Vertical bars
+// Incident Status Card - Bar chart
 interface IncidentStatusProps {
   total: number;
   distribution: { open: number; investigating: number; mitigated: number; closed: number };
 }
 
 export function IncidentStatusCard({ distribution }: IncidentStatusProps) {
-  const max = Math.max(distribution.open, distribution.investigating, distribution.mitigated, distribution.closed, 1);
-  const barHeight = 80;
-
-  const items = [
-    { label: "Open", value: distribution.open, color: C.open },
-    { label: "Investigating", value: distribution.investigating, color: C.investigating },
-    { label: "Mitigated", value: distribution.mitigated, color: C.mitigated },
-    { label: "Closed", value: distribution.closed, color: C.closed },
+  const data = [
+    { name: "Open", value: distribution.open, color: C.open },
+    { name: "Investigating", value: distribution.investigating, color: C.investigating },
+    { name: "Mitigated", value: distribution.mitigated, color: C.mitigated },
+    { name: "Closed", value: distribution.closed, color: C.closed },
   ];
 
-  return (
-    <Stack direction="row" justifyContent="space-around" alignItems="flex-end" sx={{ height: barHeight + 40 }}>
-      {items.map((item) => (
-        <VerticalBar key={item.label} {...item} max={max} barHeight={barHeight} barWidth={32} labelSize={10} />
-      ))}
-    </Stack>
-  );
-};
+  return <MetricBarChart data={data} />;
+}
 
 // Evidence Coverage Card - Progress with counts
 interface EvidenceCoverageProps {
@@ -154,7 +153,7 @@ export function EvidenceCoverageCard({
 }: EvidenceCoverageProps) {
   return (
   <Box>
-    <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+    <Stack direction="row" justifyContent="space-between" alignItems="center" mb="16px">
       <Typography sx={TEXT_STYLES.percentage}>{coveragePercentage}%</Typography>
       <Typography sx={{ fontSize: 12, color: C.textSecondary }}>model coverage</Typography>
     </Stack>
@@ -208,11 +207,11 @@ export function ModelLifecycleCard({ total, distribution }: ModelLifecycleProps)
       <Box sx={{ pt: "8px" }}>
         <StatusDonutChart data={data} total={total} size={100} />
       </Box>
-      <Stack gap={0.5} sx={{ pt: "8px" }}>
+      <Stack gap="4px" sx={{ pt: "8px" }}>
         {data.map((item) => (
           <LegendItem key={item.label} {...item} />
         ))}
       </Stack>
     </Stack>
   );
-};
+}

--- a/Clients/src/presentation/components/Charts/PortfolioTrendChart.tsx
+++ b/Clients/src/presentation/components/Charts/PortfolioTrendChart.tsx
@@ -73,7 +73,7 @@ export function PortfolioTrendChart({
       categoryKey="label"
       height={height}
       showLegend={true}
-      margin={{ left: 60, right: 20, top: 20, bottom: 30 }}
+      margin={{ left: 8, right: 16, top: 10, bottom: 10 }}
       legendFormatter={(value: string) => value}
     />
   );

--- a/Clients/src/presentation/components/Charts/PortfolioTrendChart.tsx
+++ b/Clients/src/presentation/components/Charts/PortfolioTrendChart.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
-import { Box, Stack, Typography } from "@mui/material";
-import { LineChart } from "@mui/x-charts/LineChart";
+import { Stack, Typography } from "@mui/material";
 import { DASHBOARD_COLORS } from "../../styles/colors";
 import type { IPortfolioSnapshot } from "../../../domain/interfaces/i.quantitativeRisk";
+import { VWLineChart } from "./VWCharts";
 
 const C = DASHBOARD_COLORS;
 
@@ -11,23 +11,41 @@ interface PortfolioTrendChartProps {
   height?: number;
 }
 
-export function PortfolioTrendChart({ snapshots, height = 200 }: PortfolioTrendChartProps) {
+export function PortfolioTrendChart({
+  snapshots,
+  height = 200,
+}: PortfolioTrendChartProps) {
   const sorted = useMemo(
-    () => [...snapshots].sort((a, b) => new Date(a.snapshot_date).getTime() - new Date(b.snapshot_date).getTime()),
+    () =>
+      [...snapshots].sort(
+        (a, b) =>
+          new Date(a.snapshot_date).getTime() -
+          new Date(b.snapshot_date).getTime()
+      ),
     [snapshots]
   );
 
-  const xLabels = useMemo(() => sorted.map((s) => {
-    const d = new Date(s.snapshot_date);
-    return `${d.getMonth() + 1}/${d.getDate()}`;
-  }), [sorted]);
-
-  const aleData = useMemo(() => sorted.map((s) => s.total_ale), [sorted]);
-  const residualData = useMemo(() => sorted.map((s) => s.total_residual_ale), [sorted]);
+  // Merge xLabels + both series into a single data array for Recharts
+  const chartData = useMemo(
+    () =>
+      sorted.map((s) => {
+        const d = new Date(s.snapshot_date);
+        return {
+          label: `${d.getMonth() + 1}/${d.getDate()}`,
+          "Total ALE": s.total_ale,
+          "Residual ALE": s.total_residual_ale,
+        };
+      }),
+    [sorted]
+  );
 
   if (snapshots.length === 0) {
     return (
-      <Stack alignItems="center" justifyContent="center" sx={{ height, opacity: 0.5 }}>
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        sx={{ height, opacity: 0.5 }}
+      >
         <Typography sx={{ fontSize: 13, color: C.textSecondary }}>
           No trend data available yet
         </Typography>
@@ -36,35 +54,27 @@ export function PortfolioTrendChart({ snapshots, height = 200 }: PortfolioTrendC
   }
 
   return (
-    <Box sx={{ width: "100%", height }}>
-      <LineChart
-        xAxis={[{ data: xLabels, scaleType: "point" }]}
-        series={[
-          {
-            data: aleData,
-            label: "Total ALE",
-            color: C.critical,
-            showMark: false,
-          },
-          {
-            data: residualData,
-            label: "Residual ALE",
-            color: C.medium,
-            showMark: false,
-          },
-        ]}
-        height={height}
-        margin={{ left: 60, right: 20, top: 20, bottom: 30 }}
-        slotProps={{
-          legend: {
-            direction: "row",
-            position: { vertical: "top", horizontal: "right" },
-            itemMarkWidth: 10,
-            itemMarkHeight: 10,
-            labelStyle: { fontSize: 11 },
-          },
-        }}
-      />
-    </Box>
+    <VWLineChart
+      data={chartData}
+      series={[
+        {
+          dataKey: "Total ALE",
+          name: "Total ALE",
+          color: C.critical,
+          dot: false,
+        },
+        {
+          dataKey: "Residual ALE",
+          name: "Residual ALE",
+          color: C.medium,
+          dot: false,
+        },
+      ]}
+      categoryKey="label"
+      height={height}
+      showLegend={true}
+      margin={{ left: 60, right: 20, top: 20, bottom: 30 }}
+      legendFormatter={(value: string) => value}
+    />
   );
 }

--- a/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Typography, Stack } from "@mui/material";
 import { getRiskTimeseries } from "../../../application/repository/riskHistory.repository";
 import { ButtonToggle } from "../button-toggle";
@@ -10,7 +10,6 @@ import { VWLineChart } from "./VWCharts";
 
 interface RiskHistoryChartProps {
   parameter?: string;
-  title?: string;
   height?: number;
 }
 
@@ -125,12 +124,13 @@ export function RiskHistoryChart({
   };
 
   // Build Recharts-compatible flat data array and series config
-  const prepareChartData = () => {
+  const { chartData, series, maxValue } = useMemo(() => {
     if (!timeseriesData || timeseriesData.length === 0) {
       return { chartData: [], series: [], maxValue: 0 };
     }
 
     const colorMap = getColorMap(parameter);
+    const fmt = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" });
 
     // Collect all unique value keys across all timestamps
     const allValues = new Set<string>();
@@ -142,12 +142,7 @@ export function RiskHistoryChart({
 
     // Merge parallel arrays into a single array of objects for Recharts
     const chartData = timeseriesData.map((point) => {
-      const date = new Date(point.timestamp);
-      const label = new Intl.DateTimeFormat("en-US", {
-        month: "short",
-        day: "numeric",
-      }).format(date);
-      const entry: Record<string, string | number> = { date: label };
+      const entry: Record<string, string | number> = { date: fmt.format(new Date(point.timestamp)) };
       valueKeys.forEach((key) => {
         entry[key] = point.data[key] || 0;
       });
@@ -168,9 +163,7 @@ export function RiskHistoryChart({
     );
 
     return { chartData, series, maxValue };
-  };
-
-  const { chartData, series, maxValue } = prepareChartData();
+  }, [timeseriesData, parameter]);
 
   if (loading) {
     return (

--- a/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
-import { Typography, Stack, Box } from "@mui/material";
-import { LineChart } from "@mui/x-charts/LineChart";
+import { Typography, Stack } from "@mui/material";
 import { getRiskTimeseries } from "../../../application/repository/riskHistory.repository";
 import { ButtonToggle } from "../button-toggle";
 import CustomizableSkeleton from "../Skeletons";
 import { TrendingUp } from "lucide-react";
 import { EmptyState } from "../EmptyState";
 import { text, background, border as borderPalette } from "../../themes/palette";
+import { VWLineChart } from "./VWCharts";
 
 interface RiskHistoryChartProps {
   parameter?: string;
@@ -16,38 +16,38 @@ interface RiskHistoryChartProps {
 
 // Color schemes for different risk parameters
 const SEVERITY_COLORS: Record<string, string> = {
-  "Negligible": "#10B981", // Green
-  "Minor": "#84CC16", // Light green
-  "Moderate": "#F59E0B", // Amber
-  "Major": "#F97316", // Orange
-  "Catastrophic": "#DC2626", // Dark red
+  "Negligible": "#10B981",
+  "Minor": "#84CC16",
+  "Moderate": "#F59E0B",
+  "Major": "#F97316",
+  "Catastrophic": "#DC2626",
 };
 
 const LIKELIHOOD_COLORS: Record<string, string> = {
-  "Rare": "#10B981", // Green
-  "Unlikely": "#84CC16", // Light green
-  "Possible": "#F59E0B", // Amber
-  "Likely": "#F97316", // Orange
-  "Almost Certain": "#DC2626", // Dark red
+  "Rare": "#10B981",
+  "Unlikely": "#84CC16",
+  "Possible": "#F59E0B",
+  "Likely": "#F97316",
+  "Almost Certain": "#DC2626",
 };
 
 const MITIGATION_STATUS_COLORS: Record<string, string> = {
-  "Not Started": "#94A3B8", // Gray
-  "In Progress": "#3B82F6", // Blue
-  "Completed": "#10B981", // Green
-  "On Hold": "#F59E0B", // Amber
-  "Deferred": "#8B5CF6", // Purple
-  "Canceled": "#EF4444", // Red
-  "Requires review": "#F97316", // Orange
+  "Not Started": "#94A3B8",
+  "In Progress": "#3B82F6",
+  "Completed": "#10B981",
+  "On Hold": "#F59E0B",
+  "Deferred": "#8B5CF6",
+  "Canceled": "#EF4444",
+  "Requires review": "#F97316",
 };
 
 const RISK_LEVEL_COLORS: Record<string, string> = {
-  "No risk": "#10B981", // Green
-  "Very low risk": "#84CC16", // Light green
-  "Low risk": "#FCD34D", // Yellow
-  "Medium risk": "#F59E0B", // Amber
-  "High risk": "#F97316", // Orange
-  "Very high risk": "#DC2626", // Dark red
+  "No risk": "#10B981",
+  "Very low risk": "#84CC16",
+  "Low risk": "#FCD34D",
+  "Medium risk": "#F59E0B",
+  "High risk": "#F97316",
+  "Very high risk": "#DC2626",
 };
 
 const TIMEFRAME_OPTIONS = [
@@ -59,7 +59,6 @@ const TIMEFRAME_OPTIONS = [
   { value: "1year", label: "1 Year" },
 ];
 
-// Get color map based on parameter
 const getColorMap = (parameter: string): Record<string, string> => {
   switch (parameter) {
     case "severity":
@@ -81,10 +80,9 @@ export function RiskHistoryChart({
 }: RiskHistoryChartProps) {
   const storageKey = "analytics_timeframe_risk";
 
-  // Initialize timeframe from localStorage or default
   const [timeframe, setTimeframe] = useState<string>(() => {
     const stored = localStorage.getItem(storageKey);
-    if (stored && TIMEFRAME_OPTIONS.some(opt => opt.value === stored)) {
+    if (stored && TIMEFRAME_OPTIONS.some((opt) => opt.value === stored)) {
       return stored;
     }
     return "1month";
@@ -92,9 +90,10 @@ export function RiskHistoryChart({
 
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [timeseriesData, setTimeseriesData] = useState<{ timestamp: string; data: Record<string, number> }[]>([]);
+  const [timeseriesData, setTimeseriesData] = useState<
+    { timestamp: string; data: Record<string, number> }[]
+  >([]);
 
-  // Persist timeframe to localStorage whenever it changes
   useEffect(() => {
     localStorage.setItem(storageKey, timeframe);
   }, [timeframe]);
@@ -109,7 +108,8 @@ export function RiskHistoryChart({
       }
     } catch (err: unknown) {
       console.error("Error fetching timeseries data:", err);
-      const message = err instanceof Error ? err.message : "Failed to load chart data";
+      const message =
+        err instanceof Error ? err.message : "Failed to load chart data";
       setError(message);
     } finally {
       setLoading(false);
@@ -124,40 +124,53 @@ export function RiskHistoryChart({
     setTimeframe(newTimeframe);
   };
 
-  // Prepare data for the chart
+  // Build Recharts-compatible flat data array and series config
   const prepareChartData = () => {
     if (!timeseriesData || timeseriesData.length === 0) {
-      return { timestamps: [], series: [], maxValue: 0 };
+      return { chartData: [], series: [], maxValue: 0 };
     }
 
-    const timestamps = timeseriesData.map((point) => new Date(point.timestamp));
     const colorMap = getColorMap(parameter);
 
-    // Get all unique values from the data
+    // Collect all unique value keys across all timestamps
     const allValues = new Set<string>();
     timeseriesData.forEach((point) => {
       Object.keys(point.data).forEach((key) => allValues.add(key));
     });
 
-    // Create series for each value
-    const series = Array.from(allValues).map((value) => ({
-      label: value,
-      data: timeseriesData.map((point) => point.data[value] || 0),
-      color: colorMap[value] || `${text.disabled}`,
-      curve: "monotoneX" as const,
-      showMark: false,
+    const valueKeys = Array.from(allValues);
+
+    // Merge parallel arrays into a single array of objects for Recharts
+    const chartData = timeseriesData.map((point) => {
+      const date = new Date(point.timestamp);
+      const label = new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+      }).format(date);
+      const entry: Record<string, string | number> = { date: label };
+      valueKeys.forEach((key) => {
+        entry[key] = point.data[key] || 0;
+      });
+      return entry;
+    });
+
+    const series = valueKeys.map((value) => ({
+      dataKey: value,
+      name: value,
+      color: colorMap[value] || text.disabled,
+      strokeWidth: 2,
+      dot: false as const,
     }));
 
-    // Calculate max value across all series for proper y-axis scaling
     const maxValue = Math.max(
-      ...series.flatMap((s) => s.data),
+      ...timeseriesData.flatMap((point) => Object.values(point.data)),
       0
     );
 
-    return { timestamps, series, maxValue };
+    return { chartData, series, maxValue };
   };
 
-  const { timestamps, series, maxValue } = prepareChartData();
+  const { chartData, series, maxValue } = prepareChartData();
 
   if (loading) {
     return (
@@ -227,74 +240,25 @@ export function RiskHistoryChart({
           />
         </Stack>
 
-        <Stack sx={{ width: "100%", mt: 2 }}>
-          <Box sx={{ position: "relative" }}>
-            <LineChart
-              xAxis={[
-                {
-                  data: timestamps,
-                  scaleType: "time",
-                  valueFormatter: (date) => {
-                    return new Intl.DateTimeFormat("en-US", {
-                      month: "short",
-                      day: "numeric",
-                    }).format(date);
-                  },
-                  tickLabelStyle: {
-                    fontSize: 12,
-                    fill: `${text.tertiary}`,
-                  },
-                },
-              ]}
-              yAxis={[
-                {
-                  label: "Count",
-                  min: 0,
-                  max: maxValue > 0 ? Math.ceil(maxValue * 1.15) : 10,
-                  tickMinStep: 1,
-                  valueFormatter: (value: number) => value.toString(),
-                  labelStyle: {
-                    fontSize: 13,
-                    fill: `${text.secondary}`,
-                  },
-                  tickLabelStyle: {
-                    fontSize: 12,
-                    fill: `${text.tertiary}`,
-                  },
-                },
-              ]}
-              series={series}
-              height={height}
-              margin={{ top: 10, right: 30, bottom: 30, left: 70 }}
-              slotProps={{
-                legend: {
-                  direction: "horizontal",
-                  position: { vertical: "bottom", horizontal: "center" },
-                },
-              }}
-              grid={{
-                vertical: true,
-                horizontal: true,
-              }}
-              sx={{
-                "& .MuiLineElement-root": {
-                  strokeWidth: 3,
-                },
-                "& .MuiChartsGrid-line": {
-                  stroke: `${borderPalette.light}`,
-                  strokeWidth: 1,
-                },
-                "& .MuiChartsAxis-line": {
-                  stroke: `${borderPalette.dark}`,
-                  strokeWidth: 1.5,
-                },
-                "& .MuiChartsAxis-tick": {
-                  stroke: `${borderPalette.dark}`,
-                },
-              }}
-            />
-          </Box>
-        </Stack>
+        <VWLineChart
+          data={chartData}
+          series={series}
+          categoryKey="date"
+          height={height}
+          showLegend={true}
+          margin={{ top: 10, right: 30, bottom: 30, left: 70 }}
+          yAxisProps={{
+            domain: [0, maxValue > 0 ? Math.ceil(maxValue * 1.15) : 10],
+            tickFormatter: (v: number) => v.toString(),
+            label: {
+              value: "Count",
+              angle: -90,
+              position: "insideLeft",
+              offset: -50,
+              style: { fontSize: 13, fill: text.secondary },
+            },
+          }}
+        />
       </Stack>
     </Stack>
   );

--- a/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
+++ b/Clients/src/presentation/components/Charts/RiskHistoryChart.tsx
@@ -239,17 +239,11 @@ export function RiskHistoryChart({
           categoryKey="date"
           height={height}
           showLegend={true}
-          margin={{ top: 10, right: 30, bottom: 30, left: 70 }}
+          margin={{ top: 10, right: 16, bottom: 10, left: 0 }}
           yAxisProps={{
             domain: [0, maxValue > 0 ? Math.ceil(maxValue * 1.15) : 10],
             tickFormatter: (v: number) => v.toString(),
-            label: {
-              value: "Count",
-              angle: -90,
-              position: "insideLeft",
-              offset: -50,
-              style: { fontSize: 13, fill: text.secondary },
-            },
+            width: 35,
           }}
         />
       </Stack>

--- a/Clients/src/presentation/components/Charts/StatusDonutChart.tsx
+++ b/Clients/src/presentation/components/Charts/StatusDonutChart.tsx
@@ -112,7 +112,7 @@ export function StatusDonutChart({
             sx={{
               fontWeight: 600,
               fontSize: "16px",
-              color: "#1F2937",
+              color: text.primary,
             }}
           >
             {total}

--- a/Clients/src/presentation/components/Charts/StatusDonutChart.tsx
+++ b/Clients/src/presentation/components/Charts/StatusDonutChart.tsx
@@ -92,7 +92,6 @@ export function StatusDonutChart({
           alignItems: "center",
           justifyContent: "center",
           pointerEvents: "none",
-          zIndex: 2,
         }}
       >
         <Box

--- a/Clients/src/presentation/components/Charts/StatusDonutChart.tsx
+++ b/Clients/src/presentation/components/Charts/StatusDonutChart.tsx
@@ -92,6 +92,7 @@ export function StatusDonutChart({
           alignItems: "center",
           justifyContent: "center",
           pointerEvents: "none",
+          zIndex: 1,
         }}
       >
         <Box

--- a/Clients/src/presentation/components/Charts/StatusDonutChart.tsx
+++ b/Clients/src/presentation/components/Charts/StatusDonutChart.tsx
@@ -1,7 +1,7 @@
-import { PieChart } from "@mui/x-charts";
 import { Box, Typography } from "@mui/material";
 import { StatusDonutChartProps } from "../../types/interfaces/i.chart";
 import { text, background, status } from "../../themes/palette";
+import { VWDonutChart } from "./VWCharts";
 
 export function StatusDonutChart({
   data,
@@ -39,6 +39,16 @@ export function StatusDonutChart({
     );
   }
 
+  // VWDonutChart expects data with a single dataKey and a parallel colors array
+  const chartData = filteredData.map((item) => ({
+    value: item.value,
+    label: item.label,
+  }));
+  const colors = filteredData.map((item) => item.color);
+
+  const innerRadius = Math.round(size * 0.28);
+  const outerRadius = Math.round(size * 0.48);
+
   return (
     <Box
       sx={{
@@ -61,51 +71,14 @@ export function StatusDonutChart({
           boxShadow: "inset 0 2px 4px rgba(0,0,0,0.1)",
         }}
       />
-      <PieChart
-        series={[
-          {
-            data: filteredData.map((item, index) => ({
-              id: index,
-              value: item.value,
-              label: item.label,
-              color: item.color,
-            })),
-            innerRadius: size * 0.28,
-            outerRadius: size * 0.48,
-            paddingAngle: 1,
-            cornerRadius: 3,
-          },
-        ]}
-        width={size}
-        height={size}
-        slotProps={{
-          tooltip: {
-            sx: {
-              "& .MuiChartsTooltip-root": {
-                fontSize: "13px !important",
-              },
-              "& .MuiChartsTooltip-table": {
-                fontSize: "13px !important",
-              },
-              "& .MuiChartsTooltip-cell": {
-                fontSize: "13px !important",
-              },
-              "& .MuiChartsTooltip-labelCell": {
-                fontSize: "13px !important",
-              },
-              "& .MuiChartsTooltip-valueCell": {
-                fontSize: "13px !important",
-              },
-            },
-          },
-        }}
-        sx={{
-          "& .MuiChartsLegend-root": {
-            display: "none !important",
-          },
-          position: "relative",
-          zIndex: 1,
-        }}
+      <VWDonutChart
+        data={chartData}
+        dataKey="value"
+        nameKey="label"
+        colors={colors}
+        size={size}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
       />
       {/* Center circle with total */}
       <Box

--- a/Clients/src/presentation/components/Charts/VWCharts.tsx
+++ b/Clients/src/presentation/components/Charts/VWCharts.tsx
@@ -35,6 +35,7 @@ import {
   Area,
   LineChart,
   Line,
+  Legend,
   TooltipProps,
 } from "recharts";
 import palette from "../../themes/palette";
@@ -67,11 +68,11 @@ export const ChartOutlineWrapper: React.FC<{ children: React.ReactNode }> = ({ c
   </Box>
 );
 
-/** Default axis tick style */
-const axisTick = { fontSize: 11, fill: palette.text.tertiary };
-const axisTickDisabled = { fontSize: 11, fill: palette.text.disabled };
-const axisLine = { stroke: palette.border.light };
-const gridStroke = palette.border.light;
+/** Default axis tick style — exported for custom charts */
+export const axisTick = { fontSize: 11, fill: palette.text.tertiary };
+export const axisTickDisabled = { fontSize: 11, fill: palette.text.disabled };
+export const axisLine = { stroke: palette.border.light };
+export const gridStroke = palette.border.light;
 
 // ─── VWGradient ─────────────────────────────────────────────────────────────
 
@@ -418,9 +419,6 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
   showLegend = false,
   legendFormatter,
 }) => {
-  // Dynamic import to avoid pulling Legend when not needed
-  const Legend = showLegend ? require("recharts").Legend : null;
-
   return (
     <ChartOutlineWrapper>
     <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
@@ -446,7 +444,7 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
         ) : (
           <Tooltip contentStyle={vwTooltipStyle} formatter={tooltipFormatter} />
         )}
-        {showLegend && Legend && (
+        {showLegend && (
           <Legend
             wrapperStyle={{ paddingTop: 12, fontSize: 13 }}
             formatter={legendFormatter}

--- a/Clients/src/presentation/components/Charts/VWCharts.tsx
+++ b/Clients/src/presentation/components/Charts/VWCharts.tsx
@@ -335,7 +335,7 @@ export const VWDonutChart: React.FC<VWDonutChartProps> = ({
 }) => {
   const computedOuter = outerRadius || Math.floor(size / 2) - 5;
   return (
-    <Box sx={{ position: "relative", width: size, height: size, "& *:focus": { outline: "none !important" }, "& svg *:focus": { outline: "none !important" } }}>
+    <Box sx={{ position: "relative", width: size, height: size, "& .recharts-tooltip-wrapper": { zIndex: "10 !important" }, "& *:focus": { outline: "none !important" }, "& svg *:focus": { outline: "none !important" } }}>
       <ResponsiveContainer width="100%" height="100%" style={noOutlineStyle}>
         <PieChart>
           <Pie

--- a/Clients/src/presentation/components/TabBar/index.tsx
+++ b/Clients/src/presentation/components/TabBar/index.tsx
@@ -128,7 +128,7 @@ const TabBar: React.FC<TabBarProps> = ({
   };
 
   return (
-    <Box sx={{ borderBottom: 1, borderColor: "borderPalette.dark" }}>
+    <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
       <TabList
         onChange={handleChange}
         TabIndicatorProps={{ style: { backgroundColor: indicatorColor } }}

--- a/Clients/src/presentation/pages/Framework/Dashboard/StatusBreakdownCard.tsx
+++ b/Clients/src/presentation/pages/Framework/Dashboard/StatusBreakdownCard.tsx
@@ -1,9 +1,9 @@
 import { Box, Typography, Stack, IconButton } from "@mui/material";
-import { PieChart } from "@mui/x-charts/PieChart";
 import { useEffect, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { frameworkDashboardCardStyles } from "./styles";
 import { brand, text, border as borderPalette, status } from "../../../themes/palette";
+import { VWDonutChart } from "../../../components/Charts/VWCharts";
 
 interface FrameworkData {
   frameworkId: number;
@@ -45,6 +45,24 @@ interface StatusData {
   "implemented": number;
   "needs rework": number;
 }
+
+const STATUS_COLORS = [
+  `${text.disabled}`,
+  "#D1D5DB",
+  "#F59E0B",
+  "#3B82F6",
+  `${brand.primary}`,
+  "#EA580C",
+];
+
+const STATUS_LABELS = [
+  "Not started",
+  "Draft",
+  "In progress",
+  "Awaiting review",
+  "Implemented",
+  "Needs rework",
+];
 
 const StatusBreakdownCard = ({ frameworksData }: StatusBreakdownCardProps) => {
   const [clauseStatusData, setClauseStatusData] = useState<Map<number, StatusData>>(new Map());
@@ -128,23 +146,23 @@ const StatusBreakdownCard = ({ frameworksData }: StatusBreakdownCardProps) => {
     if (total === 0) return [];
 
     return [
-      { id: 0, value: data["not started"], label: "Not started", color: `${text.disabled}` },
-      { id: 1, value: data["draft"], label: "Draft", color: "#D1D5DB" },
-      { id: 2, value: data["in progress"], label: "In progress", color: "#F59E0B" },
-      { id: 3, value: data["awaiting review"], label: "Awaiting review", color: "#3B82F6" },
-      { id: 4, value: data["implemented"], label: "Implemented", color: `${brand.primary}` },
-      { id: 5, value: data["needs rework"], label: "Needs rework", color: "#EA580C" },
+      { name: "Not started", value: data["not started"] },
+      { name: "Draft", value: data["draft"] },
+      { name: "In progress", value: data["in progress"] },
+      { name: "Awaiting review", value: data["awaiting review"] },
+      { name: "Implemented", value: data["implemented"] },
+      { name: "Needs rework", value: data["needs rework"] },
     ];
   };
 
   const getAllStatuses = (data: StatusData) => {
     return [
-      { id: 0, value: data["not started"], label: "Not started", color: `${text.disabled}` },
-      { id: 1, value: data["draft"], label: "Draft", color: "#D1D5DB" },
-      { id: 2, value: data["in progress"], label: "In progress", color: "#F59E0B" },
-      { id: 3, value: data["awaiting review"], label: "Awaiting review", color: "#3B82F6" },
-      { id: 4, value: data["implemented"], label: "Implemented", color: `${brand.primary}` },
-      { id: 5, value: data["needs rework"], label: "Needs rework", color: "#EA580C" },
+      { id: 0, value: data["not started"], label: "Not started", color: STATUS_COLORS[0] },
+      { id: 1, value: data["draft"], label: "Draft", color: STATUS_COLORS[1] },
+      { id: 2, value: data["in progress"], label: "In progress", color: STATUS_COLORS[2] },
+      { id: 3, value: data["awaiting review"], label: "Awaiting review", color: STATUS_COLORS[3] },
+      { id: 4, value: data["implemented"], label: "Implemented", color: STATUS_COLORS[4] },
+      { id: 5, value: data["needs rework"], label: "Needs rework", color: STATUS_COLORS[5] },
     ];
   };
 
@@ -292,55 +310,15 @@ const StatusBreakdownCard = ({ frameworksData }: StatusBreakdownCardProps) => {
                 >
                   {/* Donut Chart Column */}
                   <Box sx={{ display: "flex", justifyContent: "center" }}>
-                    <Box sx={{ position: "relative", width: "120px", height: "120px" }}>
-                      <PieChart
-                        series={[
-                          {
-                            data: pieData,
-                            innerRadius: 30,
-                            outerRadius: 48,
-                            paddingAngle: 2,
-                            cornerRadius: 3,
-                            cx: 60,
-                            cy: 60,
-                          },
-                        ]}
-                        width={120}
-                        height={120}
-                        slotProps={{
-                          legend: { hidden: true } as any,
-                        }}
-                        sx={{
-                          "& .MuiChartsLegend-root": {
-                            display: "none !important",
-                          },
-                          "& .MuiChartsTooltip-root": {
-                            fontSize: "13px !important",
-                          },
-                          "& .MuiChartsTooltip-root *": {
-                            fontSize: "13px !important",
-                          },
-                          "& .MuiChartsTooltip-mark": {
-                            fontSize: "13px !important",
-                          },
-                          "& .MuiChartsTooltip-labelCell": {
-                            fontSize: "13px !important",
-                          },
-                          "& .MuiChartsTooltip-valueCell": {
-                            fontSize: "13px !important",
-                          },
-                          "& .MuiChartsTooltip-table": {
-                            fontSize: "13px !important",
-                          },
-                          "& .MuiChartsTooltip-table td": {
-                            fontSize: "13px !important",
-                          },
-                          "& .MuiChartsTooltip-table th": {
-                            fontSize: "13px !important",
-                          },
-                        }}
-                      />
-                    </Box>
+                    <VWDonutChart
+                      data={pieData}
+                      dataKey="value"
+                      nameKey="name"
+                      colors={STATUS_COLORS}
+                      size={120}
+                      innerRadius={30}
+                      outerRadius={48}
+                    />
                   </Box>
 
                   {/* Status Table Column */}
@@ -506,55 +484,15 @@ const StatusBreakdownCard = ({ frameworksData }: StatusBreakdownCardProps) => {
               >
                 {/* Donut Chart Column */}
                 <Box sx={{ display: "flex", justifyContent: "center" }}>
-                  <Box sx={{ position: "relative", width: "120px", height: "120px" }}>
-                    <PieChart
-                      series={[
-                        {
-                          data: pieData,
-                          innerRadius: 30,
-                          outerRadius: 48,
-                          paddingAngle: 2,
-                          cornerRadius: 3,
-                          cx: 60,
-                          cy: 60,
-                        },
-                      ]}
-                      width={120}
-                      height={120}
-                      slotProps={{
-                        legend: { hidden: true } as any,
-                      }}
-                      sx={{
-                        "& .MuiChartsLegend-root": {
-                          display: "none !important",
-                        },
-                        "& .MuiChartsTooltip-root": {
-                          fontSize: "13px !important",
-                        },
-                        "& .MuiChartsTooltip-root *": {
-                          fontSize: "13px !important",
-                        },
-                        "& .MuiChartsTooltip-mark": {
-                          fontSize: "13px !important",
-                        },
-                        "& .MuiChartsTooltip-labelCell": {
-                          fontSize: "13px !important",
-                        },
-                        "& .MuiChartsTooltip-valueCell": {
-                          fontSize: "13px !important",
-                        },
-                        "& .MuiChartsTooltip-table": {
-                          fontSize: "13px !important",
-                        },
-                        "& .MuiChartsTooltip-table td": {
-                          fontSize: "13px !important",
-                        },
-                        "& .MuiChartsTooltip-table th": {
-                          fontSize: "13px !important",
-                        },
-                      }}
-                    />
-                  </Box>
+                  <VWDonutChart
+                    data={pieData}
+                    dataKey="value"
+                    nameKey="name"
+                    colors={STATUS_COLORS}
+                    size={120}
+                    innerRadius={30}
+                    outerRadius={48}
+                  />
                 </Box>
 
                 {/* Status Table Column */}

--- a/Servers/database/migrations/20260317221105-create-agent-discovery-tables.js
+++ b/Servers/database/migrations/20260317221105-create-agent-discovery-tables.js
@@ -1,0 +1,78 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // verifywise.agent_primitives
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS verifywise.agent_primitives (
+        id SERIAL PRIMARY KEY,
+        organization_id INTEGER NOT NULL,
+        source_system VARCHAR(100) NOT NULL DEFAULT 'manual',
+        primitive_type VARCHAR(100) NOT NULL,
+        external_id VARCHAR(500) NOT NULL,
+        display_name VARCHAR(500) NOT NULL,
+        owner_id VARCHAR(255),
+        permissions JSONB NOT NULL DEFAULT '[]',
+        permission_categories JSONB NOT NULL DEFAULT '[]',
+        last_activity TIMESTAMPTZ,
+        metadata JSONB NOT NULL DEFAULT '{}',
+        review_status VARCHAR(50) NOT NULL DEFAULT 'unreviewed',
+        reviewed_by INTEGER,
+        reviewed_at TIMESTAMPTZ,
+        linked_model_inventory_id INTEGER,
+        is_stale BOOLEAN NOT NULL DEFAULT false,
+        is_manual BOOLEAN NOT NULL DEFAULT false,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        UNIQUE (organization_id, source_system, external_id)
+      )
+    `);
+
+    // verifywise.agent_discovery_sync_log
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS verifywise.agent_discovery_sync_log (
+        id SERIAL PRIMARY KEY,
+        organization_id INTEGER NOT NULL,
+        source_system VARCHAR(100) NOT NULL,
+        status VARCHAR(50) NOT NULL DEFAULT 'running',
+        primitives_found INTEGER NOT NULL DEFAULT 0,
+        primitives_created INTEGER NOT NULL DEFAULT 0,
+        primitives_updated INTEGER NOT NULL DEFAULT 0,
+        primitives_stale_flagged INTEGER NOT NULL DEFAULT 0,
+        error_message TEXT,
+        triggered_by VARCHAR(100) NOT NULL DEFAULT 'system',
+        started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        completed_at TIMESTAMPTZ
+      )
+    `);
+
+    // verifywise.agent_audit_log
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS verifywise.agent_audit_log (
+        id SERIAL PRIMARY KEY,
+        organization_id INTEGER NOT NULL,
+        agent_primitive_id INTEGER NOT NULL REFERENCES verifywise.agent_primitives(id) ON DELETE CASCADE,
+        action VARCHAR(100) NOT NULL,
+        field_changed VARCHAR(255),
+        old_value TEXT,
+        new_value TEXT,
+        performed_by INTEGER,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+
+    // Indexes
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS idx_agent_primitives_org ON verifywise.agent_primitives(organization_id);
+      CREATE INDEX IF NOT EXISTS idx_agent_primitives_review ON verifywise.agent_primitives(organization_id, review_status);
+      CREATE INDEX IF NOT EXISTS idx_agent_sync_log_org ON verifywise.agent_discovery_sync_log(organization_id);
+      CREATE INDEX IF NOT EXISTS idx_agent_audit_log_agent ON verifywise.agent_audit_log(agent_primitive_id);
+    `);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query('DROP TABLE IF EXISTS verifywise.agent_audit_log CASCADE');
+    await queryInterface.sequelize.query('DROP TABLE IF EXISTS verifywise.agent_discovery_sync_log CASCADE');
+    await queryInterface.sequelize.query('DROP TABLE IF EXISTS verifywise.agent_primitives CASCADE');
+  }
+};


### PR DESCRIPTION
## Summary

- Migrate all 6 MUI X-Charts files to Recharts/VWCharts — zero `@mui/x-charts` imports remaining
- Convert TaskRadarCard, IncidentStatusCard, TrainingCompletionCard from hand-drawn CSS bars to Recharts BarChart with per-bar colors, dashed grids, and styled tooltips
- Fix donut chart tooltip z-index (was hidden behind center number)
- Fix chart margins (remove "Count" Y-axis label, reduce oversized left margins)
- Fix tooltip showing value on second line (removed empty name formatter)
- Lighten dashboard card hover (use borderPalette.light instead of text.muted)
- Lighten TabBar bottom border (use divider instead of dark border)
- Add missing agent discovery tables migration (agent_primitives, agent_discovery_sync_log, agent_audit_log)
- Export shared chart constants (axisTick, axisLine, gridStroke) from VWCharts
- Memoize prepareChartData in RiskHistoryChart and ModelInventoryHistoryChart
- Remove unused title props, collapse duplicate pie/donut cases in ChartRenderer

## Files changed (12 files, -100 net lines)

| File | Change |
|------|--------|
| RiskHistoryChart | MUI LineChart → VWLineChart, useMemo |
| ModelInventoryHistoryChart | MUI LineChart → VWLineChart, useMemo |
| PortfolioTrendChart | MUI LineChart → VWLineChart |
| StatusDonutChart | MUI PieChart → VWDonutChart, z-index fix |
| StatusBreakdownCard | MUI PieChart → VWDonutChart |
| ChartRenderer | MUI Bar/Pie/Line → Recharts + VWDonutChart |
| NewMetricsCards | CSS bars → Recharts BarChart |
| TaskRadarCard | CSS bars → Recharts BarChart |
| DashboardCard | Lighter hover |
| TabBar | Lighter bottom border |
| VWCharts | Export constants, fix Legend import, z-index |
| Migration | Create agent discovery tables |

## Test plan

- [ ] Dashboard (`/`): TaskRadar, IncidentStatus, TrainingCompletion bar charts render with colored bars and dashed grids
- [ ] Dashboard (`/`): hover on cards shows lighter background
- [ ] Dashboard (`/`): donut chart tooltips appear above center number
- [ ] Dashboard (`/`): bar chart tooltips show name and value on one line
- [ ] Risk management → Analytics tab: line chart renders without "Count" gap
- [ ] Model inventory → Analytics tab: same
- [ ] Framework → select framework → Dashboard: donut charts render
- [ ] Shadow AI → Insights: existing Recharts charts still work
- [ ] Agent Discovery (`/agent-discovery`): page loads without 500 errors
- [ ] TabBar bottom border is lighter across all tabbed pages
- [ ] No `@mui/x-charts` imports: `grep -r "@mui/x-charts" Clients/src/` returns nothing