### PR TITLE
Upgrade all framework editors to full Tiptap toolbar, fix ISO 27001 bugs

### DIFF
--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -597,7 +597,7 @@ const VWISO42001AnnexDrawerDialog = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 600,
+          width: 780,
           margin: 0,
           "& .MuiDrawer-paper": {
             margin: 0,
@@ -608,7 +608,7 @@ const VWISO42001AnnexDrawerDialog = ({
       >
         <Stack
           sx={{
-            width: 600,
+            width: 780,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -629,7 +629,7 @@ const VWISO42001AnnexDrawerDialog = ({
       open={open}
       onClose={onClose}
       sx={{
-        width: 600,
+        width: 780,
         margin: 0,
         "& .MuiDrawer-paper": {
           margin: 0,
@@ -641,12 +641,12 @@ const VWISO42001AnnexDrawerDialog = ({
       <Stack
         className="vw-iso-42001-annex-drawer-dialog-content"
         sx={{
-          width: 600,
+          width: 780,
         }}
       >
         <Stack
           sx={{
-            width: 600,
+            width: 780,
             padding: "15px 20px",
             display: "flex",
             flexDirection: "row",
@@ -777,8 +777,6 @@ const VWISO42001AnnexDrawerDialog = ({
                   height="120px"
                 />
               </Stack>
-
-              <Divider sx={{ my: 2 }} />
 
               {/* Status & Assignments Section */}
               <Stack
@@ -1344,7 +1342,6 @@ const VWISO42001AnnexDrawerDialog = ({
           <Alert {...alert} isToast={true} onClick={() => setAlert(null)} />
         )}
 
-        <Divider />
         <Stack
           className="vw-iso-42001-annex-drawer-dialog-footer"
           sx={{

--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -597,7 +597,7 @@ const VWISO42001AnnexDrawerDialog = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 780,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
             margin: 0,
@@ -608,7 +608,7 @@ const VWISO42001AnnexDrawerDialog = ({
       >
         <Stack
           sx={{
-            width: 780,
+            width: 850,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -629,7 +629,7 @@ const VWISO42001AnnexDrawerDialog = ({
       open={open}
       onClose={onClose}
       sx={{
-        width: 780,
+        width: 850,
         margin: 0,
         "& .MuiDrawer-paper": {
           margin: 0,
@@ -641,12 +641,12 @@ const VWISO42001AnnexDrawerDialog = ({
       <Stack
         className="vw-iso-42001-annex-drawer-dialog-content"
         sx={{
-          width: 780,
+          width: 850,
         }}
       >
         <Stack
           sx={{
-            width: 780,
+            width: 850,
             padding: "15px 20px",
             display: "flex",
             flexDirection: "row",

--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import Checkbox from "../../Inputs/Checkbox";
 import Field from "../../Inputs/Field";
+import RichTextEditor from "../../RichTextEditor";
 import { inputStyles } from "../ClauseDrawerDialog";
 import DatePicker from "../../Inputs/Datepicker";
 import Select from "../../Inputs/Select";
@@ -763,23 +764,17 @@ const VWISO42001AnnexDrawerDialog = ({
                 }}
               >
                 <Typography fontSize={13} sx={{ marginBottom: "5px" }}>
-                  Implementation Description:
+                  Implementation description:
                 </Typography>
-                <Field
-                  type="description"
-                  value={formData.implementation_description}
-                  onChange={(e) =>
-                    handleFieldChange("implementation_description", e.target.value)
+                <RichTextEditor
+                  toolbar="full"
+                  initialContent={formData.implementation_description}
+                  onContentChange={(content) =>
+                    handleFieldChange("implementation_description", content)
                   }
-                  disabled={!formData.is_applicable || isEditingDisabled}
-                  sx={{
-                    cursor: !formData.is_applicable ? "not-allowed" : "text",
-                    "& .field field-decription field-input MuiInputBase-root MuiInputBase-input":
-                      {
-                        height: "73px",
-                      },
-                  }}
-                  placeholder="Describe how this requirement is implemented"
+                  placeholder="Describe how this requirement is implemented..."
+                  isEditable={formData.is_applicable && !isEditingDisabled}
+                  height="120px"
                 />
               </Stack>
 

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -676,7 +676,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
       <Drawer open={open} onClose={onClose} anchor="right">
         <Stack
           sx={{
-            width: 780,
+            width: 850,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -701,10 +701,10 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 780,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
-            width: 780,
+            width: 850,
             margin: 0,
             borderRadius: 0,
             overflowX: "hidden",
@@ -715,7 +715,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
       >
         <Stack
           className="iso42001-clause-drawer-dialog-content"
-          sx={{ width: 780 }}
+          sx={{ width: 850 }}
         >
           {/* HEADER */}
           <Stack

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -676,7 +676,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
       <Drawer open={open} onClose={onClose} anchor="right">
         <Stack
           sx={{
-            width: 600,
+            width: 780,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -701,10 +701,10 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 600,
+          width: 780,
           margin: 0,
           "& .MuiDrawer-paper": {
-            width: 600,
+            width: 780,
             margin: 0,
             borderRadius: 0,
             overflowX: "hidden",
@@ -715,7 +715,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
       >
         <Stack
           className="iso42001-clause-drawer-dialog-content"
-          sx={{ width: 600 }}
+          sx={{ width: 780 }}
         >
           {/* HEADER */}
           <Stack
@@ -867,8 +867,6 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
                   />
                 </Stack>
               </Stack>
-
-              <Divider sx={{ my: 2 }} />
 
               {/* Status & Assignments */}
               <Stack gap="24px">
@@ -1511,8 +1509,6 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
               </Suspense>
             </TabPanel>
           </TabContext>
-
-          <Divider />
 
           {/* FOOTER - SAVE BUTTON */}
           <Stack

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -38,6 +38,7 @@ import dayjs, { Dayjs } from "dayjs";
 
 // Inputs & UI Components
 import Field from "../../Inputs/Field";
+import RichTextEditor from "../../RichTextEditor";
 import Select from "../../Inputs/Select";
 import DatePicker from "../../Inputs/Datepicker";
 import TabBar from "../../TabBar";
@@ -851,17 +852,18 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
                   <Typography fontSize={13} sx={{ marginBottom: "5px" }}>
                     Implementation description:
                   </Typography>
-                  <Field
-                    type="description"
-                    value={formData.implementation_description}
-                    onChange={(e) =>
+                  <RichTextEditor
+                    toolbar="full"
+                    initialContent={formData.implementation_description}
+                    onContentChange={(content) =>
                       handleFieldChange(
                         "implementation_description",
-                        e.target.value
+                        content
                       )
                     }
                     placeholder="Describe how this requirement is implemented..."
-                    disabled={isEditingDisabled}
+                    isEditable={!isEditingDisabled}
+                    height="120px"
                   />
                 </Stack>
               </Stack>

--- a/Clients/src/presentation/components/Drawer/EUAIActQuestionDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/EUAIActQuestionDrawerDialog/index.tsx
@@ -870,7 +870,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 600,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
             margin: 0,
@@ -881,7 +881,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
       >
         <Stack
           sx={{
-            width: 600,
+            width: 850,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -906,10 +906,10 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 600,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
-            width: 600,
+            width: 850,
             margin: 0,
             borderRadius: 0,
             overflowX: "hidden",
@@ -919,7 +919,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
       >
         <Stack
           className="eu-ai-act-question-drawer-dialog-content"
-          sx={{ width: 600 }}
+          sx={{ width: 850 }}
         >
           {/* HEADER */}
           <Stack
@@ -1077,6 +1077,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
                     Answer:
                   </Typography>
                   <RichTextEditor
+                    toolbar="full"
                     key={`answer-editor-${displayQuestion?.answer_id}-${editorKey}`}
                     onContentChange={handleAnswerChange}
                     initialContent={formData.answer}
@@ -1096,8 +1097,6 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
                   />
                 </Stack>
               </Stack>
-
-              <Divider sx={{ my: 2 }} />
 
               {/* Status */}
               <Stack gap="24px">
@@ -1692,8 +1691,6 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
               </Suspense>
             </TabPanel>
           </TabContext>
-
-          <Divider />
 
           {/* FOOTER - SAVE BUTTON */}
           <Stack

--- a/Clients/src/presentation/components/Drawer/EUAIActQuestionDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/EUAIActQuestionDrawerDialog/index.tsx
@@ -1099,7 +1099,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
               </Stack>
 
               {/* Status */}
-              <Stack gap="24px">
+              <Stack gap="24px" sx={{ mt: "8px" }}>
                 <Select
                   id="status"
                   label="Status:"

--- a/Clients/src/presentation/components/Drawer/EUAIActQuestionDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/EUAIActQuestionDrawerDialog/index.tsx
@@ -919,7 +919,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
       >
         <Stack
           className="eu-ai-act-question-drawer-dialog-content"
-          sx={{ width: 850 }}
+          sx={{ width: 850, minHeight: "100vh" }}
         >
           {/* HEADER */}
           <Stack

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -675,7 +675,7 @@ const VWISO27001AnnexDrawerDialog = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 600,
+          width: 780,
           margin: 0,
           "& .MuiDrawer-paper": {
             margin: 0,
@@ -686,7 +686,7 @@ const VWISO27001AnnexDrawerDialog = ({
       >
         <Stack
           sx={{
-            width: 600,
+            width: 780,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -707,7 +707,7 @@ const VWISO27001AnnexDrawerDialog = ({
       open={open}
       onClose={onClose}
       sx={{
-        width: 600,
+        width: 780,
         margin: 0,
         "& .MuiDrawer-paper": {
           margin: 0,
@@ -718,11 +718,11 @@ const VWISO27001AnnexDrawerDialog = ({
     >
       <Stack
         className="vw-iso-27001-annex-drawer-dialog-content"
-        sx={{ width: 600 }}
+        sx={{ width: 780 }}
       >
         <Stack
           sx={{
-            width: 600,
+            width: 780,
             padding: "15px 20px",
             display: "flex",
             flexDirection: "row",
@@ -1565,7 +1565,6 @@ const VWISO27001AnnexDrawerDialog = ({
           <Alert {...alert} isToast={true} onClick={() => setAlert(null)} />
         )}
 
-        <Divider />
         <Stack
           className="vw-iso-27001-annex-drawer-dialog-footer"
           sx={{

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -21,6 +21,7 @@ import {
   Eye as ViewIcon,
 } from "lucide-react";
 import Field from "../../Inputs/Field";
+import RichTextEditor from "../../RichTextEditor";
 import { inputStyles } from "../ClauseDrawerDialog";
 import DatePicker from "../../Inputs/Datepicker";
 import Select from "../../Inputs/Select";
@@ -839,26 +840,20 @@ const VWISO27001AnnexDrawerDialog = ({
 
               <Stack>
                 <Typography fontSize={13} sx={{ marginBottom: "5px" }}>
-                  Implementation Description:
+                  Implementation description:
                 </Typography>
-                <Field
-                  type="description"
-                  value={formData.implementation_description}
-                  onChange={(e) =>
+                <RichTextEditor
+                  toolbar="full"
+                  initialContent={formData.implementation_description}
+                  onContentChange={(content) =>
                     handleFieldChange(
                       "implementation_description",
-                      e.target.value
+                      content
                     )
                   }
-                  disabled={isEditingDisabled}
-                  sx={{
-                    cursor: "text",
-                    "& .field field-decription field-input MuiInputBase-root MuiInputBase-input":
-                      {
-                        height: "73px",
-                      },
-                  }}
-                  placeholder="Describe how this requirement is implemented"
+                  placeholder="Describe how this requirement is implemented..."
+                  isEditable={!isEditingDisabled}
+                  height="120px"
                 />
               </Stack>
             </Stack>

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -675,7 +675,7 @@ const VWISO27001AnnexDrawerDialog = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 780,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
             margin: 0,
@@ -686,7 +686,7 @@ const VWISO27001AnnexDrawerDialog = ({
       >
         <Stack
           sx={{
-            width: 780,
+            width: 850,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -707,7 +707,7 @@ const VWISO27001AnnexDrawerDialog = ({
       open={open}
       onClose={onClose}
       sx={{
-        width: 780,
+        width: 850,
         margin: 0,
         "& .MuiDrawer-paper": {
           margin: 0,
@@ -718,11 +718,11 @@ const VWISO27001AnnexDrawerDialog = ({
     >
       <Stack
         className="vw-iso-27001-annex-drawer-dialog-content"
-        sx={{ width: 780 }}
+        sx={{ width: 850 }}
       >
         <Stack
           sx={{
-            width: 780,
+            width: 850,
             padding: "15px 20px",
             display: "flex",
             flexDirection: "row",

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -78,7 +78,7 @@ interface ISO27001SubClauseData {
 interface ISO27001ClauseRef {
   id?: number;
   title?: string;
-  arrangement?: number;
+  order_no?: number;
   clause_no?: number;
 }
 
@@ -824,7 +824,7 @@ const VWISO27001ClauseDrawerDialog = ({
             }}
           >
             <Typography fontSize={15} fontWeight={700}>
-              {clause?.arrangement + "." + (index + 1)} {displayData?.title}
+              {clause?.order_no + "." + (index + 1)} {displayData?.title}
             </Typography>
             <CloseIcon
               size={20}

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -22,6 +22,7 @@ import {
   Eye as ViewIcon,
 } from "lucide-react";
 import Field from "../../Inputs/Field";
+import RichTextEditor from "../../RichTextEditor";
 import { FileData } from "../../../../domain/types/File";
 import Select from "../../Inputs/Select";
 import DatePicker from "../../Inputs/Datepicker";
@@ -936,26 +937,20 @@ const VWISO27001ClauseDrawerDialog = ({
                 {/* Implementation Description */}
                 <Stack>
                   <Typography fontSize={13} sx={{ marginBottom: "5px" }}>
-                    Implementation Description:
+                    Implementation description:
                   </Typography>
-                  <Field
-                    type="description"
-                    value={formData.implementation_description}
-                    onChange={(e) =>
+                  <RichTextEditor
+                    toolbar="full"
+                    initialContent={formData.implementation_description}
+                    onContentChange={(content) =>
                       handleFieldChange(
                         "implementation_description",
-                        e.target.value
+                        content
                       )
                     }
-                    sx={{
-                      cursor: "text",
-                      "& .field field-decription field-input MuiInputBase-root MuiInputBase-input":
-                        {
-                          height: "73px",
-                        },
-                    }}
-                    placeholder="Describe how this requirement is implemented"
-                    disabled={isEditingDisabled}
+                    placeholder="Describe how this requirement is implemented..."
+                    isEditable={!isEditingDisabled}
+                    height="120px"
                   />
                 </Stack>
               </Stack>

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -764,7 +764,7 @@ const VWISO27001ClauseDrawerDialog = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 780,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
             margin: 0,
@@ -775,7 +775,7 @@ const VWISO27001ClauseDrawerDialog = ({
       >
         <Stack
           sx={{
-            width: 780,
+            width: 850,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -796,10 +796,10 @@ const VWISO27001ClauseDrawerDialog = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 780,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
-            width: 780,
+            width: 850,
             margin: 0,
             borderRadius: 0,
             overflowX: "hidden",
@@ -810,12 +810,12 @@ const VWISO27001ClauseDrawerDialog = ({
         <Stack
           className="vw-iso-27001-clause-drawer-dialog-content"
           sx={{
-            width: 780,
+            width: 850,
           }}
         >
           <Stack
             sx={{
-              width: 780,
+              width: 850,
               padding: "15px 20px",
               display: "flex",
               flexDirection: "row",

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -764,7 +764,7 @@ const VWISO27001ClauseDrawerDialog = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 600,
+          width: 780,
           margin: 0,
           "& .MuiDrawer-paper": {
             margin: 0,
@@ -775,7 +775,7 @@ const VWISO27001ClauseDrawerDialog = ({
       >
         <Stack
           sx={{
-            width: 600,
+            width: 780,
             height: "100%",
             display: "flex",
             justifyContent: "center",
@@ -796,10 +796,10 @@ const VWISO27001ClauseDrawerDialog = ({
         open={open}
         onClose={onClose}
         sx={{
-          width: 600,
+          width: 780,
           margin: 0,
           "& .MuiDrawer-paper": {
-            width: 600,
+            width: 780,
             margin: 0,
             borderRadius: 0,
             overflowX: "hidden",
@@ -810,12 +810,12 @@ const VWISO27001ClauseDrawerDialog = ({
         <Stack
           className="vw-iso-27001-clause-drawer-dialog-content"
           sx={{
-            width: 600,
+            width: 780,
           }}
         >
           <Stack
             sx={{
-              width: 600,
+              width: 780,
               padding: "15px 20px",
               display: "flex",
               flexDirection: "row",
@@ -954,8 +954,6 @@ const VWISO27001ClauseDrawerDialog = ({
                   />
                 </Stack>
               </Stack>
-
-              <Divider sx={{ my: 2 }} />
 
               <Stack gap={"24px"}>
                 <Select
@@ -1620,7 +1618,6 @@ const VWISO27001ClauseDrawerDialog = ({
               </Suspense>
             </TabPanel>
           </TabContext>
-          <Divider />
           <Stack
             className="vw-iso-27001-clause-drawer-dialog-footer"
             sx={{

--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -9,6 +9,7 @@ import { Divider, Drawer, Typography } from "@mui/material";
 import { X as CloseIcon, Save as SaveIcon, Trash2 as DeleteIcon, Eye as ViewIcon, Download as DownloadIcon, FileText as FileIcon } from "lucide-react";
 
 import Field from "../../Inputs/Field";
+import RichTextEditor from "../../RichTextEditor";
 import Select from "../../Inputs/Select";
 import DatePicker from "../../Inputs/Datepicker";
 import ChipInput from "../../Inputs/ChipInput";
@@ -623,24 +624,18 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                       <Typography fontSize={13} sx={{ marginBottom: "5px" }}>
                         Implementation description:
                       </Typography>
-                      <Field
-                        type="description"
-                        value={formData.implementation_description}
-                        onChange={(e) =>
+                      <RichTextEditor
+                        toolbar="full"
+                        initialContent={formData.implementation_description}
+                        onContentChange={(content) =>
                           handleFieldChange(
                             "implementation_description",
-                            e.target.value
+                            content
                           )
                         }
-                        sx={{
-                          cursor: "text",
-                          "& .field field-decription field-input MuiInputBase-root MuiInputBase-input":
-                            {
-                              height: "73px",
-                            },
-                        }}
                         placeholder="Enter implementation details and how this subcategory is being addressed..."
-                        disabled={isEditingDisabled}
+                        isEditable={!isEditingDisabled}
+                        height="120px"
                       />
                     </Stack>
                   </Stack>

--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -533,10 +533,10 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
           }
         }}
         sx={{
-          width: 600,
+          width: 780,
           margin: 0,
           "& .MuiDrawer-paper": {
-            width: 600,
+            width: 780,
             margin: 0,
             borderRadius: 0,
             overflowX: "hidden",
@@ -547,14 +547,14 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
         <Stack
           className="nist-ai-rmf-drawer-dialog-content"
           sx={{
-            width: 600,
+            width: 780,
           }}
         >
           {/* Loading State */}
           {isLoading && (
             <Stack
               sx={{
-                width: 600,
+                width: 780,
                 height: "100%",
                 display: "flex",
                 justifyContent: "center",
@@ -639,8 +639,6 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                       />
                     </Stack>
                   </Stack>
-
-                  <Divider />
 
                   {/* Status Assignment Section */}
                   <Stack padding="15px 20px" gap="24px">
@@ -1279,8 +1277,6 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                   />
                 </Suspense>
               )}
-
-              <Divider />
 
               {/* Footer */}
               <Stack

--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -533,10 +533,10 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
           }
         }}
         sx={{
-          width: 780,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
-            width: 780,
+            width: 850,
             margin: 0,
             borderRadius: 0,
             overflowX: "hidden",
@@ -547,14 +547,14 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
         <Stack
           className="nist-ai-rmf-drawer-dialog-content"
           sx={{
-            width: 780,
+            width: 850,
           }}
         >
           {/* Loading State */}
           {isLoading && (
             <Stack
               sx={{
-                width: 780,
+                width: 850,
                 height: "100%",
                 display: "flex",
                 justifyContent: "center",

--- a/Clients/src/presentation/components/Modals/ComplianceFeedback/ComplianceFeedback.tsx
+++ b/Clients/src/presentation/components/Modals/ComplianceFeedback/ComplianceFeedback.tsx
@@ -110,6 +110,7 @@ const AuditorFeedback: React.FC<IAuditorFeedbackProps> = ({
           </Typography>
 
           <RichTextEditor
+            toolbar="full"
             initialContent={feedback}
             onContentChange={handleContentChange}
             isEditable={!readOnly}

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -1212,18 +1212,19 @@ const NewControlPane = ({
                       <Typography fontSize={13} sx={{ marginBottom: "5px" }}>
                         Implementation description:
                       </Typography>
-                      <Field
-                        type="description"
-                        value={currentFormData.implementation_details}
-                        onChange={(e) =>
+                      <RichTextEditor
+                        toolbar="full"
+                        initialContent={currentFormData.implementation_details}
+                        onContentChange={(content) =>
                           updateSubcontrolField(
                             currentSubcontrol.id!,
                             "implementation_details",
-                            e.target.value
+                            content
                           )
                         }
                         placeholder="Describe how this requirement is implemented..."
-                        disabled={isEditingDisabled}
+                        isEditable={!isEditingDisabled}
+                        height="120px"
                       />
                     </Stack>
 

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -1228,8 +1228,6 @@ const NewControlPane = ({
                       />
                     </Stack>
 
-                    <Divider sx={{ my: 2 }} />
-
                     {/* Status & Assignments */}
                     <Stack gap="24px">
                       <Select
@@ -1354,8 +1352,6 @@ const NewControlPane = ({
                         disabled={isEditingDisabled}
                       />
                     </Stack>
-
-                    <Divider sx={{ my: 2 }} />
 
                     {/* Evidence Description */}
                     <Stack>

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -1046,10 +1046,10 @@ const NewControlPane = ({
         open={isOpen}
         onClose={handleClose}
         sx={{
-          width: 600,
+          width: 850,
           margin: 0,
           "& .MuiDrawer-paper": {
-            width: 600,
+            width: 850,
             margin: 0,
             borderRadius: 0,
             overflowX: "hidden",
@@ -1363,6 +1363,7 @@ const NewControlPane = ({
                         Evidence:
                       </Typography>
                       <RichTextEditor
+                        toolbar="full"
                         key={`evidence-${currentSubcontrol.id}`}
                         initialContent={currentFormData.evidence_description}
                         onContentChange={(content: string) =>
@@ -1383,6 +1384,7 @@ const NewControlPane = ({
                         Auditor feedback:
                       </Typography>
                       <RichTextEditor
+                        toolbar="full"
                         key={`feedback-${currentSubcontrol.id}`}
                         initialContent={currentFormData.feedback_description}
                         onContentChange={(content: string) =>

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -1196,7 +1196,7 @@ const NewControlPane = ({
 
               {/* INNER TABS - SECTIONS */}
               <TabContext value={activeTab}>
-                <Box sx={{ padding: "0 20px" }}>
+                <Box>
                   <TabBar
                     tabs={innerTabs}
                     activeTab={activeTab}
@@ -1206,7 +1206,7 @@ const NewControlPane = ({
 
                 {/* TAB 1: DETAILS */}
                 <TabPanel value="details" sx={{ padding: 0 }}>
-                  <Stack padding="15px 20px" gap="15px">
+                  <Stack padding="15px 0" gap="15px">
                     {/* Implementation Details */}
                     <Stack>
                       <Typography fontSize={13} sx={{ marginBottom: "5px" }}>
@@ -1398,7 +1398,7 @@ const NewControlPane = ({
                 </TabPanel>
 
                 {/* TAB 2: EVIDENCES */}
-                <TabPanel value="evidences" sx={{ padding: "15px 20px" }}>
+                <TabPanel value="evidences" sx={{ padding: "15px 0" }}>
                   <Stack spacing={3}>
                     {/* Evidence Files Section */}
                     {/* SECTION 1: EVIDENCE FILES */}
@@ -2187,7 +2187,7 @@ const NewControlPane = ({
                 </TabPanel>
 
                 {/* TAB 3: CROSS MAPPINGS */}
-                <TabPanel value="cross-mappings" sx={{ padding: "15px 20px" }}>
+                <TabPanel value="cross-mappings" sx={{ padding: "15px 0" }}>
                   <Stack spacing={3}>
                     <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                       Linked risks
@@ -2402,7 +2402,7 @@ const NewControlPane = ({
                 )}
 
                 {/* TAB 4: NOTES */}
-                <TabPanel value="notes" sx={{ padding: "15px 20px" }}>
+                <TabPanel value="notes" sx={{ padding: "15px 0" }}>
                   <Suspense fallback={<CircularProgress size={24} />}>
                     <NotesTab
                       attachedTo="EU_AI_ACT_SUBCONTROL"

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -2,38 +2,87 @@ import React, { useEffect, useState } from "react";
 import { Box, Tooltip, IconButton, Stack, useTheme } from "@mui/material";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { Bold, Italic, List, ListOrdered } from "lucide-react";
+import Table from "@tiptap/extension-table";
+import { TableRow } from "@tiptap/extension-table";
+import { TableCell } from "@tiptap/extension-table";
+import { TableHeader } from "@tiptap/extension-table";
+import Underline from "@tiptap/extension-underline";
+import Link from "@tiptap/extension-link";
+import Placeholder from "@tiptap/extension-placeholder";
+import {
+  Bold,
+  Italic,
+  List,
+  ListOrdered,
+  Underline as UnderlineIcon,
+  Table as TableIcon,
+  Link as LinkIcon,
+  Trash2,
+  Plus,
+  Minus,
+} from "lucide-react";
 import "./index.css";
 import { IRichTextEditorProps } from "../../types/interfaces/i.editor";
 
-const FormatBold = () => <Bold size={20} />;
-const FormatItalic = () => <Italic size={20} />;
-const FormatListBulleted = () => <List size={20} />;
-const FormatListNumbered = () => <ListOrdered size={20} />;
+const ICON_SIZE = 18;
+
+interface ToolbarItem {
+  title: string;
+  icon: React.ReactNode;
+  action: string;
+  isActive?: boolean;
+}
 
 const RichTextEditor: React.FC<IRichTextEditorProps> = ({
   onContentChange,
   headerSx,
   initialContent = "",
   isEditable = true,
+  toolbar = "basic",
+  height = "90px",
+  placeholder,
 }) => {
   const theme = useTheme();
   const [activeList, setActiveList] = useState<"bulleted" | "numbered" | null>(
     null
   );
 
+  const isFull = toolbar === "full";
+
+  const extensions = [
+    StarterKit,
+    ...(isFull
+      ? [
+          Table.configure({ resizable: true }),
+          TableRow,
+          TableCell,
+          TableHeader,
+          Underline,
+          Link.configure({ openOnClick: false }),
+          ...(placeholder
+            ? [Placeholder.configure({ placeholder })]
+            : []),
+        ]
+      : placeholder
+        ? [Placeholder.configure({ placeholder })]
+        : []),
+  ];
+
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions,
     content: initialContent,
     autofocus: false,
     immediatelyRender: true,
     editable: isEditable,
-    onUpdate: ({ editor }: { editor: NonNullable<ReturnType<typeof useEditor>> }) => {
+    onUpdate: ({
+      editor,
+    }: {
+      editor: NonNullable<ReturnType<typeof useEditor>>;
+    }) => {
       onContentChange?.(editor.getHTML());
     },
   });
 
-  // Update editable state when isEditable prop changes
   useEffect(() => {
     if (editor) {
       editor.setEditable(isEditable);
@@ -49,13 +98,10 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
   const applyFormatting = (type: string) => {
     if (!editor) return;
 
-    const toggleFormatting: { [key: string]: () => void } = {
+    const actions: Record<string, () => void> = {
       bold: () => editor.chain().focus().toggleBold().run(),
       italic: () => editor.chain().focus().toggleItalic().run(),
-      uppercase: () =>
-        editor.commands.setContent(editor.getText().toUpperCase()),
-      lowercase: () =>
-        editor.commands.setContent(editor.getText().toLowerCase()),
+      underline: () => editor.chain().focus().toggleUnderline().run(),
       bullets: () => {
         editor.chain().focus().toggleBulletList().run();
         setActiveList((prev) => (prev === "bulleted" ? null : "bulleted"));
@@ -64,10 +110,92 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
         editor.chain().focus().toggleOrderedList().run();
         setActiveList((prev) => (prev === "numbered" ? null : "numbered"));
       },
+      table: () =>
+        editor
+          .chain()
+          .focus()
+          .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+          .run(),
+      addColumn: () => editor.chain().focus().addColumnAfter().run(),
+      removeColumn: () => editor.chain().focus().deleteColumn().run(),
+      addRow: () => editor.chain().focus().addRowAfter().run(),
+      removeRow: () => editor.chain().focus().deleteRow().run(),
+      deleteTable: () => editor.chain().focus().deleteTable().run(),
+      link: () => {
+        const url = window.prompt("Enter URL:");
+        if (url) {
+          editor.chain().focus().setLink({ href: url }).run();
+        }
+      },
     };
 
-    toggleFormatting[type]();
+    actions[type]?.();
   };
+
+  const basicItems: ToolbarItem[] = [
+    { title: "Bold", icon: <Bold size={ICON_SIZE} />, action: "bold" },
+    { title: "Italic", icon: <Italic size={ICON_SIZE} />, action: "italic" },
+    {
+      title: "Bullet list",
+      icon: <List size={ICON_SIZE} />,
+      action: "bullets",
+      isActive: activeList === "bulleted",
+    },
+    {
+      title: "Numbered list",
+      icon: <ListOrdered size={ICON_SIZE} />,
+      action: "numbers",
+      isActive: activeList === "numbered",
+    },
+  ];
+
+  const fullItems: ToolbarItem[] = [
+    ...basicItems,
+    {
+      title: "Underline",
+      icon: <UnderlineIcon size={ICON_SIZE} />,
+      action: "underline",
+    },
+    {
+      title: "Insert table",
+      icon: <TableIcon size={ICON_SIZE} />,
+      action: "table",
+    },
+    { title: "Link", icon: <LinkIcon size={ICON_SIZE} />, action: "link" },
+  ];
+
+  // Show table manipulation buttons when cursor is inside a table
+  const isInTable = editor?.isActive("table") ?? false;
+  const tableActions: ToolbarItem[] = isInTable
+    ? [
+        {
+          title: "Add column",
+          icon: <Plus size={14} />,
+          action: "addColumn",
+        },
+        {
+          title: "Remove column",
+          icon: <Minus size={14} />,
+          action: "removeColumn",
+        },
+        { title: "Add row", icon: <Plus size={14} />, action: "addRow" },
+        {
+          title: "Remove row",
+          icon: <Minus size={14} />,
+          action: "removeRow",
+        },
+        {
+          title: "Delete table",
+          icon: <Trash2 size={14} />,
+          action: "deleteTable",
+        },
+      ]
+    : [];
+
+  const toolbarItems = [
+    ...(isFull ? fullItems : basicItems),
+    ...tableActions,
+  ];
 
   return (
     <Stack>
@@ -75,37 +203,23 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
       <Box
         sx={{
           display: "flex",
-          border: "1px solid",
-          borderColor: "#c4c4c4",
+          flexWrap: "wrap",
+          border: "1px solid #d0d5dd",
           borderBottom: "none",
-          borderRadius: theme.shape.borderRadius,
+          borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
           ...headerSx,
         }}
       >
-        {[
-          { title: "Bold", icon: <FormatBold />, action: "bold" },
-          { title: "Italic", icon: <FormatItalic />, action: "italic" },
-          { title: "Bullets", icon: <FormatListBulleted />, action: "bullets" },
-          { title: "Numbers", icon: <FormatListNumbered />, action: "numbers" },
-        ].map(({ title, icon, action }) => (
-          <Tooltip
-            key={action}
-            title={title}
-            aria-label={title}
-            sx={{ fontSize: 13 }}
-          >
+        {toolbarItems.map(({ title, icon, action, isActive }) => (
+          <Tooltip key={action} title={title} sx={{ fontSize: 13 }}>
             {!isEditable ? (
               <span style={{ display: "inline-block" }}>
                 <IconButton
                   onClick={() => applyFormatting(action)}
                   disableRipple
-                  color={
-                    (action === "bullets" && activeList === "bulleted") ||
-                    (action === "numbers" && activeList === "numbered")
-                      ? "primary"
-                      : "default"
-                  }
-                  disabled={!isEditable}
+                  size="small"
+                  color={isActive ? "primary" : "default"}
+                  disabled
                 >
                   {icon}
                 </IconButton>
@@ -114,13 +228,8 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
               <IconButton
                 onClick={() => applyFormatting(action)}
                 disableRipple
-                color={
-                  (action === "bullets" && activeList === "bulleted") ||
-                  (action === "numbers" && activeList === "numbered")
-                    ? "primary"
-                    : "default"
-                }
-                disabled={!isEditable}
+                size="small"
+                color={isActive ? "primary" : "default"}
               >
                 {icon}
               </IconButton>
@@ -135,31 +244,56 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
           className="custom-tip-tap-editor"
           editor={editor}
           style={{
-            border: "1px solid #c4c4c4",
-            height: "90px", // Set height of the editor container
+            border: "1px solid #d0d5dd",
+            minHeight: height,
             overflowY: "auto",
             padding: "8px",
             paddingTop: "0px",
             borderTop: "none",
+            borderRadius: `0 0 ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px`,
             marginBottom: "5px",
             outline: "none",
-            display: "flex", // Allow flex behavior
-            alignItems: "flex-start", // Align content at the top
+            display: "flex",
+            alignItems: "flex-start",
           }}
-          disabled={!isEditable} // Disable editing
+          disabled={!isEditable}
         />
       </Stack>
 
       <style>
         {`
           .ProseMirror {
-         flex: 1; /* Allow content to grow naturally */
-        outline: none !important;
-        box-shadow: none !important;
-        white-space: pre-wrap;
+            flex: 1;
+            outline: none !important;
+            box-shadow: none !important;
+            white-space: pre-wrap;
           }
           .custom-tip-tap-editor .ProseMirror p {
             margin: 0;
+          }
+          .custom-tip-tap-editor .ProseMirror table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 8px 0;
+          }
+          .custom-tip-tap-editor .ProseMirror th,
+          .custom-tip-tap-editor .ProseMirror td {
+            border: 1px solid #d0d5dd;
+            padding: 6px 8px;
+            font-size: 13px;
+            min-width: 60px;
+          }
+          .custom-tip-tap-editor .ProseMirror th {
+            background-color: #f3f4f6;
+            font-weight: 600;
+          }
+          .custom-tip-tap-editor .ProseMirror .is-empty::before {
+            content: attr(data-placeholder);
+            color: #98A2B3;
+            pointer-events: none;
+            float: left;
+            height: 0;
+            font-size: 13px;
           }
         `}
       </style>

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -2,13 +2,13 @@ import React, { useEffect, useState } from "react";
 import { Box, Tooltip, IconButton, Stack, useTheme } from "@mui/material";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Table from "@tiptap/extension-table";
+import { Table } from "@tiptap/extension-table";
 import { TableRow } from "@tiptap/extension-table";
 import { TableCell } from "@tiptap/extension-table";
 import { TableHeader } from "@tiptap/extension-table";
-import Underline from "@tiptap/extension-underline";
-import Link from "@tiptap/extension-link";
-import Placeholder from "@tiptap/extension-placeholder";
+import { Underline } from "@tiptap/extension-underline";
+import { Link } from "@tiptap/extension-link";
+import { Placeholder } from "@tiptap/extension-placeholder";
 import {
   Bold,
   Italic,

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from "react";
-import { Box, Tooltip, IconButton, Stack, useTheme } from "@mui/material";
+import { Box, Tooltip, IconButton, Stack, useTheme, Select as MuiSelect, MenuItem } from "@mui/material";
 import { useEditor, EditorContent } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
@@ -317,6 +317,39 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
           ...headerSx,
         }}
       >
+        {/* Heading selector — only in full toolbar */}
+        {isFull && editor && (
+          <>
+            <MuiSelect
+              size="small"
+              value={
+                editor.isActive("heading", { level: 1 }) ? "h1" :
+                editor.isActive("heading", { level: 2 }) ? "h2" :
+                editor.isActive("heading", { level: 3 }) ? "h3" : "p"
+              }
+              onChange={(e) => {
+                const val = e.target.value;
+                if (val === "p") editor.chain().focus().setParagraph().run();
+                else if (val === "h1") editor.chain().focus().toggleHeading({ level: 1 }).run();
+                else if (val === "h2") editor.chain().focus().toggleHeading({ level: 2 }).run();
+                else if (val === "h3") editor.chain().focus().toggleHeading({ level: 3 }).run();
+              }}
+              disabled={!isEditable}
+              sx={{
+                height: "28px",
+                fontSize: 12,
+                minWidth: 90,
+                "& .MuiSelect-select": { py: "4px" },
+              }}
+            >
+              <MenuItem value="p" sx={{ fontSize: 12 }}>Text</MenuItem>
+              <MenuItem value="h1" sx={{ fontSize: 12 }}>Header 1</MenuItem>
+              <MenuItem value="h2" sx={{ fontSize: 12 }}>Header 2</MenuItem>
+              <MenuItem value="h3" sx={{ fontSize: 12 }}>Header 3</MenuItem>
+            </MuiSelect>
+            <Box sx={{ width: "1px", height: "28px", backgroundColor: borderPalette.light, mx: "2px", alignSelf: "center" }} />
+          </>
+        )}
         {allItems.map(({ key, title, icon, action, isActive, dividerAfter }) => (
           <React.Fragment key={key}>
             <Tooltip title={title}>

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useCallback } from "react";
 import { Box, Tooltip, IconButton, Stack, useTheme } from "@mui/material";
-import { useEditor, EditorContent, BubbleMenu } from "@tiptap/react";
-import { StarterKit } from "@tiptap/starter-kit";
+import { useEditor, EditorContent } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react/menus";
+import StarterKit from "@tiptap/starter-kit";
 import { Table } from "@tiptap/extension-table";
 import { TableRow } from "@tiptap/extension-table";
 import { TableCell } from "@tiptap/extension-table";

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback } from "react";
 import { Box, Tooltip, IconButton, Stack, useTheme } from "@mui/material";
-import { useEditor, EditorContent } from "@tiptap/react";
+import { useEditor, EditorContent, BubbleMenu } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { Table } from "@tiptap/extension-table";
 import { TableRow } from "@tiptap/extension-table";
@@ -20,8 +20,10 @@ import {
   Undo2,
   Redo2,
   Strikethrough,
-  Minus,
   Plus,
+  X,
+  Rows3,
+  Columns3,
   Trash2,
 } from "lucide-react";
 import "./index.css";
@@ -209,50 +211,7 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
         ]
       : [];
 
-  // Table context actions (only when cursor is inside a table)
-  const isInTable = editor?.isActive("table") ?? false;
-  const tableActions: ToolbarItem[] =
-    isInTable && editor
-      ? [
-          {
-            key: "addCol",
-            title: "Add column",
-            icon: <Plus size={14} />,
-            action: () =>
-              run(() => editor.chain().focus().addColumnAfter().run()),
-          },
-          {
-            key: "delCol",
-            title: "Delete column",
-            icon: <Minus size={14} />,
-            action: () =>
-              run(() => editor.chain().focus().deleteColumn().run()),
-          },
-          {
-            key: "addRow",
-            title: "Add row",
-            icon: <Plus size={14} />,
-            action: () =>
-              run(() => editor.chain().focus().addRowAfter().run()),
-          },
-          {
-            key: "delRow",
-            title: "Delete row",
-            icon: <Minus size={14} />,
-            action: () =>
-              run(() => editor.chain().focus().deleteRow().run()),
-          },
-          {
-            key: "delTable",
-            title: "Delete table",
-            icon: <Trash2 size={14} />,
-            action: () =>
-              run(() => editor.chain().focus().deleteTable().run()),
-          },
-        ]
-      : [];
-
-  const allItems = [...basicItems, ...fullExtras, ...tableActions];
+  const allItems = [...basicItems, ...fullExtras];
 
   return (
     <Stack className="vw-rich-text-editor">
@@ -327,6 +286,59 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
           fontSize: "13px",
         }}
       />
+
+      {/* Floating table toolbar — appears when cursor is inside a table */}
+      {editor && isFull && (
+        <BubbleMenu
+          editor={editor}
+          pluginKey="tableMenu"
+          shouldShow={({ editor: e }) => e.isActive("table")}
+          updateDelay={100}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              gap: "2px",
+              p: "4px",
+              alignItems: "center",
+              backgroundColor: theme.palette.background.default,
+              border: `1px solid ${borderPalette.dark}`,
+              borderRadius: "6px",
+              boxShadow: "0 4px 12px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.08)",
+            }}
+          >
+            {[
+              { key: "addRowBefore", title: "Add row above", icon: <Plus size={14} />, action: () => editor.chain().focus().addRowBefore().run() },
+              { key: "addRowAfter", title: "Add row below", icon: <Rows3 size={14} />, action: () => editor.chain().focus().addRowAfter().run() },
+              { key: "deleteRow", title: "Delete row", icon: <X size={14} />, action: () => editor.chain().focus().deleteRow().run(), separator: true },
+              { key: "addColBefore", title: "Add column left", icon: <Plus size={14} />, action: () => editor.chain().focus().addColumnBefore().run() },
+              { key: "addColAfter", title: "Add column right", icon: <Columns3 size={14} />, action: () => editor.chain().focus().addColumnAfter().run() },
+              { key: "deleteCol", title: "Delete column", icon: <X size={14} />, action: () => editor.chain().focus().deleteColumn().run(), separator: true },
+              { key: "deleteTable", title: "Delete table", icon: <Trash2 size={14} />, action: () => editor.chain().focus().deleteTable().run(), danger: true },
+            ].map(({ key, title, icon, action, separator, danger }: { key: string; title: string; icon: React.ReactNode; action: () => void; separator?: boolean; danger?: boolean }) => (
+              <React.Fragment key={key}>
+                <Tooltip title={title} placement="top" arrow>
+                  <IconButton
+                    onMouseDown={(e) => { e.preventDefault(); action(); }}
+                    size="small"
+                    sx={{
+                      padding: "5px",
+                      borderRadius: "4px",
+                      color: danger ? "#dc2626" : "#374151",
+                      "&:hover": { backgroundColor: danger ? "#fef2f2" : theme.palette.action.hover },
+                    }}
+                  >
+                    {icon}
+                  </IconButton>
+                </Tooltip>
+                {separator && (
+                  <Box sx={{ width: "1px", height: "20px", backgroundColor: borderPalette.light, mx: "2px" }} />
+                )}
+              </React.Fragment>
+            ))}
+          </Box>
+        </BubbleMenu>
+      )}
 
       <style>
         {`

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -10,6 +10,10 @@ import { TableHeader } from "@tiptap/extension-table";
 import { Underline } from "@tiptap/extension-underline";
 import { Link } from "@tiptap/extension-link";
 import { Placeholder } from "@tiptap/extension-placeholder";
+import { Highlight } from "@tiptap/extension-highlight";
+import { TextAlign } from "@tiptap/extension-text-align";
+import { Subscript } from "@tiptap/extension-subscript";
+import { Superscript } from "@tiptap/extension-superscript";
 import {
   Bold,
   Italic,
@@ -26,6 +30,15 @@ import {
   Rows3,
   Columns3,
   Trash2,
+  Superscript as SuperscriptIcon,
+  Subscript as SubscriptIcon,
+  Highlighter,
+  Code,
+  Quote,
+  Minus,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
 } from "lucide-react";
 import "./index.css";
 import { IRichTextEditorProps } from "../../types/interfaces/i.editor";
@@ -55,7 +68,7 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
   const isFull = toolbar === "full";
 
   const extensions = [
-    StarterKit,
+    StarterKit.configure({ heading: { levels: [1, 2, 3] } }),
     ...(isFull
       ? [
           Table.configure({ resizable: true }),
@@ -64,6 +77,10 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
           TableHeader,
           Underline,
           Link.configure({ openOnClick: false }),
+          Highlight,
+          TextAlign.configure({ types: ["heading", "paragraph"] }),
+          Subscript,
+          Superscript,
         ]
       : []),
     ...(placeholder
@@ -173,20 +190,77 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
             action: () =>
               run(() => editor.chain().focus().toggleUnderline().run()),
             isActive: editor.isActive("underline"),
+          },
+          {
+            key: "superscript",
+            title: "Superscript",
+            icon: <SuperscriptIcon size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().toggleSuperscript().run()),
+            isActive: editor.isActive("superscript"),
+          },
+          {
+            key: "subscript",
+            title: "Subscript",
+            icon: <SubscriptIcon size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().toggleSubscript().run()),
+            isActive: editor.isActive("subscript"),
+          },
+          {
+            key: "highlight",
+            title: "Highlight",
+            icon: <Highlighter size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().toggleHighlight().run()),
+            isActive: editor.isActive("highlight"),
+          },
+          {
+            key: "code",
+            title: "Code block",
+            icon: <Code size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().toggleCodeBlock().run()),
+            isActive: editor.isActive("codeBlock"),
             dividerAfter: true,
           },
           {
-            key: "table",
-            title: "Insert table",
-            icon: <TableIcon size={ICON_SIZE} />,
+            key: "blockquote",
+            title: "Blockquote",
+            icon: <Quote size={ICON_SIZE} />,
             action: () =>
-              run(() =>
-                editor
-                  .chain()
-                  .focus()
-                  .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
-                  .run()
-              ),
+              run(() => editor.chain().focus().toggleBlockquote().run()),
+            isActive: editor.isActive("blockquote"),
+          },
+          {
+            key: "hr",
+            title: "Horizontal rule",
+            icon: <Minus size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().setHorizontalRule().run()),
+            dividerAfter: true,
+          },
+          {
+            key: "align-left",
+            title: "Align left",
+            icon: <AlignLeft size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().setTextAlign("left").run()),
+          },
+          {
+            key: "align-center",
+            title: "Align center",
+            icon: <AlignCenter size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().setTextAlign("center").run()),
+          },
+          {
+            key: "align-right",
+            title: "Align right",
+            icon: <AlignRight size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().setTextAlign("right").run()),
+            dividerAfter: true,
           },
           {
             key: "link",
@@ -208,6 +282,19 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
                 }
               }),
             isActive: editor.isActive("link"),
+          },
+          {
+            key: "table",
+            title: "Insert table",
+            icon: <TableIcon size={ICON_SIZE} />,
+            action: () =>
+              run(() =>
+                editor
+                  .chain()
+                  .focus()
+                  .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+                  .run()
+              ),
           },
         ]
       : [];

--- a/Clients/src/presentation/components/RichTextEditor/index.tsx
+++ b/Clients/src/presentation/components/RichTextEditor/index.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useCallback } from "react";
 import { Box, Tooltip, IconButton, Stack, useTheme } from "@mui/material";
 import { useEditor, EditorContent } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { Table } from "@tiptap/extension-table";
 import { TableRow } from "@tiptap/extension-table";
 import { TableCell } from "@tiptap/extension-table";
@@ -17,20 +17,26 @@ import {
   Underline as UnderlineIcon,
   Table as TableIcon,
   Link as LinkIcon,
-  Trash2,
-  Plus,
+  Undo2,
+  Redo2,
+  Strikethrough,
   Minus,
+  Plus,
+  Trash2,
 } from "lucide-react";
 import "./index.css";
 import { IRichTextEditorProps } from "../../types/interfaces/i.editor";
+import { border as borderPalette } from "../../themes/palette";
 
-const ICON_SIZE = 18;
+const ICON_SIZE = 16;
 
 interface ToolbarItem {
+  key: string;
   title: string;
   icon: React.ReactNode;
-  action: string;
+  action: () => void;
   isActive?: boolean;
+  dividerAfter?: boolean;
 }
 
 const RichTextEditor: React.FC<IRichTextEditorProps> = ({
@@ -43,10 +49,6 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
   placeholder,
 }) => {
   const theme = useTheme();
-  const [activeList, setActiveList] = useState<"bulleted" | "numbered" | null>(
-    null
-  );
-
   const isFull = toolbar === "full";
 
   const extensions = [
@@ -59,13 +61,11 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
           TableHeader,
           Underline,
           Link.configure({ openOnClick: false }),
-          ...(placeholder
-            ? [Placeholder.configure({ placeholder })]
-            : []),
         ]
-      : placeholder
-        ? [Placeholder.configure({ placeholder })]
-        : []),
+      : []),
+    ...(placeholder
+      ? [Placeholder.configure({ placeholder, showOnlyWhenEditable: true, showOnlyCurrent: true })]
+      : []),
   ];
 
   const editor = useEditor({
@@ -95,205 +95,284 @@ const RichTextEditor: React.FC<IRichTextEditorProps> = ({
     };
   }, [editor]);
 
-  const applyFormatting = (type: string) => {
-    if (!editor) return;
-
-    const actions: Record<string, () => void> = {
-      bold: () => editor.chain().focus().toggleBold().run(),
-      italic: () => editor.chain().focus().toggleItalic().run(),
-      underline: () => editor.chain().focus().toggleUnderline().run(),
-      bullets: () => {
-        editor.chain().focus().toggleBulletList().run();
-        setActiveList((prev) => (prev === "bulleted" ? null : "bulleted"));
-      },
-      numbers: () => {
-        editor.chain().focus().toggleOrderedList().run();
-        setActiveList((prev) => (prev === "numbered" ? null : "numbered"));
-      },
-      table: () =>
-        editor
-          .chain()
-          .focus()
-          .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
-          .run(),
-      addColumn: () => editor.chain().focus().addColumnAfter().run(),
-      removeColumn: () => editor.chain().focus().deleteColumn().run(),
-      addRow: () => editor.chain().focus().addRowAfter().run(),
-      removeRow: () => editor.chain().focus().deleteRow().run(),
-      deleteTable: () => editor.chain().focus().deleteTable().run(),
-      link: () => {
-        const url = window.prompt("Enter URL:");
-        if (url) {
-          editor.chain().focus().setLink({ href: url }).run();
-        }
-      },
-    };
-
-    actions[type]?.();
-  };
-
-  const basicItems: ToolbarItem[] = [
-    { title: "Bold", icon: <Bold size={ICON_SIZE} />, action: "bold" },
-    { title: "Italic", icon: <Italic size={ICON_SIZE} />, action: "italic" },
-    {
-      title: "Bullet list",
-      icon: <List size={ICON_SIZE} />,
-      action: "bullets",
-      isActive: activeList === "bulleted",
+  const run = useCallback(
+    (fn: () => void) => {
+      if (!editor || !isEditable) return;
+      fn();
     },
-    {
-      title: "Numbered list",
-      icon: <ListOrdered size={ICON_SIZE} />,
-      action: "numbers",
-      isActive: activeList === "numbered",
-    },
-  ];
+    [editor, isEditable]
+  );
 
-  const fullItems: ToolbarItem[] = [
-    ...basicItems,
-    {
-      title: "Underline",
-      icon: <UnderlineIcon size={ICON_SIZE} />,
-      action: "underline",
-    },
-    {
-      title: "Insert table",
-      icon: <TableIcon size={ICON_SIZE} />,
-      action: "table",
-    },
-    { title: "Link", icon: <LinkIcon size={ICON_SIZE} />, action: "link" },
-  ];
-
-  // Show table manipulation buttons when cursor is inside a table
-  const isInTable = editor?.isActive("table") ?? false;
-  const tableActions: ToolbarItem[] = isInTable
+  // Build toolbar items based on variant
+  const basicItems: ToolbarItem[] = editor
     ? [
         {
-          title: "Add column",
-          icon: <Plus size={14} />,
-          action: "addColumn",
+          key: "undo",
+          title: "Undo",
+          icon: <Undo2 size={ICON_SIZE} />,
+          action: () => run(() => editor.chain().focus().undo().run()),
         },
         {
-          title: "Remove column",
-          icon: <Minus size={14} />,
-          action: "removeColumn",
-        },
-        { title: "Add row", icon: <Plus size={14} />, action: "addRow" },
-        {
-          title: "Remove row",
-          icon: <Minus size={14} />,
-          action: "removeRow",
+          key: "redo",
+          title: "Redo",
+          icon: <Redo2 size={ICON_SIZE} />,
+          action: () => run(() => editor.chain().focus().redo().run()),
+          dividerAfter: true,
         },
         {
-          title: "Delete table",
-          icon: <Trash2 size={14} />,
-          action: "deleteTable",
+          key: "bold",
+          title: "Bold",
+          icon: <Bold size={ICON_SIZE} />,
+          action: () => run(() => editor.chain().focus().toggleBold().run()),
+          isActive: editor.isActive("bold"),
+        },
+        {
+          key: "italic",
+          title: "Italic",
+          icon: <Italic size={ICON_SIZE} />,
+          action: () => run(() => editor.chain().focus().toggleItalic().run()),
+          isActive: editor.isActive("italic"),
+        },
+        {
+          key: "strike",
+          title: "Strikethrough",
+          icon: <Strikethrough size={ICON_SIZE} />,
+          action: () => run(() => editor.chain().focus().toggleStrike().run()),
+          isActive: editor.isActive("strike"),
+          dividerAfter: true,
+        },
+        {
+          key: "ul",
+          title: "Bullet list",
+          icon: <List size={ICON_SIZE} />,
+          action: () =>
+            run(() => editor.chain().focus().toggleBulletList().run()),
+          isActive: editor.isActive("bulletList"),
+        },
+        {
+          key: "ol",
+          title: "Numbered list",
+          icon: <ListOrdered size={ICON_SIZE} />,
+          action: () =>
+            run(() => editor.chain().focus().toggleOrderedList().run()),
+          isActive: editor.isActive("orderedList"),
         },
       ]
     : [];
 
-  const toolbarItems = [
-    ...(isFull ? fullItems : basicItems),
-    ...tableActions,
-  ];
+  const fullExtras: ToolbarItem[] =
+    editor && isFull
+      ? [
+          {
+            key: "underline",
+            title: "Underline",
+            icon: <UnderlineIcon size={ICON_SIZE} />,
+            action: () =>
+              run(() => editor.chain().focus().toggleUnderline().run()),
+            isActive: editor.isActive("underline"),
+            dividerAfter: true,
+          },
+          {
+            key: "table",
+            title: "Insert table",
+            icon: <TableIcon size={ICON_SIZE} />,
+            action: () =>
+              run(() =>
+                editor
+                  .chain()
+                  .focus()
+                  .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+                  .run()
+              ),
+          },
+          {
+            key: "link",
+            title: editor.isActive("link") ? "Remove link" : "Insert link",
+            icon: <LinkIcon size={ICON_SIZE} />,
+            action: () =>
+              run(() => {
+                if (editor.isActive("link")) {
+                  editor.chain().focus().unsetLink().run();
+                  return;
+                }
+                const url = window.prompt("Enter URL:");
+                if (url) {
+                  editor
+                    .chain()
+                    .focus()
+                    .setLink({ href: url })
+                    .run();
+                }
+              }),
+            isActive: editor.isActive("link"),
+          },
+        ]
+      : [];
+
+  // Table context actions (only when cursor is inside a table)
+  const isInTable = editor?.isActive("table") ?? false;
+  const tableActions: ToolbarItem[] =
+    isInTable && editor
+      ? [
+          {
+            key: "addCol",
+            title: "Add column",
+            icon: <Plus size={14} />,
+            action: () =>
+              run(() => editor.chain().focus().addColumnAfter().run()),
+          },
+          {
+            key: "delCol",
+            title: "Delete column",
+            icon: <Minus size={14} />,
+            action: () =>
+              run(() => editor.chain().focus().deleteColumn().run()),
+          },
+          {
+            key: "addRow",
+            title: "Add row",
+            icon: <Plus size={14} />,
+            action: () =>
+              run(() => editor.chain().focus().addRowAfter().run()),
+          },
+          {
+            key: "delRow",
+            title: "Delete row",
+            icon: <Minus size={14} />,
+            action: () =>
+              run(() => editor.chain().focus().deleteRow().run()),
+          },
+          {
+            key: "delTable",
+            title: "Delete table",
+            icon: <Trash2 size={14} />,
+            action: () =>
+              run(() => editor.chain().focus().deleteTable().run()),
+          },
+        ]
+      : [];
+
+  const allItems = [...basicItems, ...fullExtras, ...tableActions];
 
   return (
-    <Stack>
-      {/* Toolbar */}
+    <Stack className="vw-rich-text-editor">
+      {/* Toolbar — matches Policy Editor design */}
       <Box
         sx={{
           display: "flex",
           flexWrap: "wrap",
-          border: "1px solid #d0d5dd",
+          gap: "2px",
+          padding: "4px",
+          border: `1px solid ${borderPalette.dark}`,
           borderBottom: "none",
           borderRadius: `${theme.shape.borderRadius}px ${theme.shape.borderRadius}px 0 0`,
+          backgroundColor: theme.palette.background.default,
           ...headerSx,
         }}
       >
-        {toolbarItems.map(({ title, icon, action, isActive }) => (
-          <Tooltip key={action} title={title} sx={{ fontSize: 13 }}>
-            {!isEditable ? (
-              <span style={{ display: "inline-block" }}>
+        {allItems.map(({ key, title, icon, action, isActive, dividerAfter }) => (
+          <React.Fragment key={key}>
+            <Tooltip title={title}>
+              <span>
                 <IconButton
-                  onClick={() => applyFormatting(action)}
-                  disableRipple
+                  onClick={action}
                   size="small"
-                  color={isActive ? "primary" : "default"}
-                  disabled
+                  disabled={!isEditable}
+                  sx={{
+                    padding: "6px",
+                    borderRadius: "3px",
+                    backgroundColor: isActive
+                      ? "#E0F7FA"
+                      : "transparent",
+                    border: "1px solid",
+                    borderColor: isActive
+                      ? theme.palette.primary.main
+                      : "transparent",
+                    "&:hover": {
+                      backgroundColor: theme.palette.action.hover,
+                    },
+                  }}
                 >
                   {icon}
                 </IconButton>
               </span>
-            ) : (
-              <IconButton
-                onClick={() => applyFormatting(action)}
-                disableRipple
-                size="small"
-                color={isActive ? "primary" : "default"}
-              >
-                {icon}
-              </IconButton>
+            </Tooltip>
+            {dividerAfter && (
+              <Box
+                sx={{
+                  width: "1px",
+                  height: "28px",
+                  backgroundColor: borderPalette.light,
+                  mx: "2px",
+                  alignSelf: "center",
+                }}
+              />
             )}
-          </Tooltip>
+          </React.Fragment>
         ))}
       </Box>
 
-      {/* Tiptap Editor */}
-      <Stack>
-        <EditorContent
-          className="custom-tip-tap-editor"
-          editor={editor}
-          style={{
-            border: "1px solid #d0d5dd",
-            minHeight: height,
-            overflowY: "auto",
-            padding: "8px",
-            paddingTop: "0px",
-            borderTop: "none",
-            borderRadius: `0 0 ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px`,
-            marginBottom: "5px",
-            outline: "none",
-            display: "flex",
-            alignItems: "flex-start",
-          }}
-          disabled={!isEditable}
-        />
-      </Stack>
+      {/* Editor content */}
+      <EditorContent
+        className="vw-tiptap-content"
+        editor={editor}
+        style={{
+          border: `1px solid ${borderPalette.dark}`,
+          minHeight: height,
+          overflowY: "auto",
+          padding: "8px 12px",
+          borderTop: "none",
+          borderRadius: `0 0 ${theme.shape.borderRadius}px ${theme.shape.borderRadius}px`,
+          outline: "none",
+          fontSize: "13px",
+        }}
+      />
 
       <style>
         {`
-          .ProseMirror {
-            flex: 1;
+          .vw-tiptap-content .ProseMirror {
             outline: none !important;
             box-shadow: none !important;
-            white-space: pre-wrap;
+            min-height: ${height};
           }
-          .custom-tip-tap-editor .ProseMirror p {
-            margin: 0;
-          }
-          .custom-tip-tap-editor .ProseMirror table {
-            border-collapse: collapse;
-            width: 100%;
-            margin: 8px 0;
-          }
-          .custom-tip-tap-editor .ProseMirror th,
-          .custom-tip-tap-editor .ProseMirror td {
-            border: 1px solid #d0d5dd;
-            padding: 6px 8px;
+          .vw-tiptap-content .ProseMirror p {
+            margin: 4px 0;
             font-size: 13px;
-            min-width: 60px;
+            line-height: 1.5;
           }
-          .custom-tip-tap-editor .ProseMirror th {
-            background-color: #f3f4f6;
-            font-weight: 600;
-          }
-          .custom-tip-tap-editor .ProseMirror .is-empty::before {
+          .vw-tiptap-content .ProseMirror p.is-editor-empty:first-child::before {
             content: attr(data-placeholder);
             color: #98A2B3;
             pointer-events: none;
             float: left;
             height: 0;
             font-size: 13px;
+          }
+          .vw-tiptap-content .ProseMirror table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 8px 0;
+          }
+          .vw-tiptap-content .ProseMirror th,
+          .vw-tiptap-content .ProseMirror td {
+            border: 1px solid ${borderPalette.dark};
+            padding: 6px 8px;
+            font-size: 13px;
+            min-width: 60px;
+          }
+          .vw-tiptap-content .ProseMirror th {
+            background-color: #f3f4f6;
+            font-weight: 600;
+          }
+          .vw-tiptap-content .ProseMirror ul,
+          .vw-tiptap-content .ProseMirror ol {
+            padding-left: 20px;
+            margin: 4px 0;
+            font-size: 13px;
+          }
+          .vw-tiptap-content .ProseMirror a {
+            color: #13715B;
+            text-decoration: underline;
           }
         `}
       </style>

--- a/Clients/src/presentation/components/VWQuestion/index.tsx
+++ b/Clients/src/presentation/components/VWQuestion/index.tsx
@@ -282,6 +282,7 @@ const QuestionFrame = ({
         </Stack>
       </Box>
       <RichTextEditor
+        toolbar="full"
         key={question.question_id || "default"}
         onContentChange={handleContentChange}
         headerSx={{

--- a/Clients/src/presentation/pages/Assessment/NewAssessment/AssessmentQuestions/AssessmentQuestions.tsx
+++ b/Clients/src/presentation/pages/Assessment/NewAssessment/AssessmentQuestions/AssessmentQuestions.tsx
@@ -122,6 +122,7 @@ const AssessmentQuestions = ({
               </Box>
 
               <RichTextEditor
+                toolbar="full"
                 key={`${assessmentsValues[activeTab].id}-${subtopic.id}-${question.id}`}
                 onContentChange={(content: string) => {
                   const cleanedContent =

--- a/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
@@ -157,7 +157,7 @@ const ISO27001Annex = ({
 
     if (annexes) {
       annexes.forEach((annex: any) => {
-        const controls = annex.annexControls || [];
+        const controls = annex.annexcontrols || [];
         const filteredControls = filterControls(controls);
         counts[annex.id ?? 0] = filteredControls.length;
       });
@@ -197,7 +197,7 @@ const ISO27001Annex = ({
     const annex = annexes.find((a: any) => a.id === Number(activeAnnexId));
     if (annex) {
       handleAccordionChange(annex.id)(new Event("click") as any, true);
-      const annexControl = annex.annexControls?.find(
+      const annexControl = annex.annexcontrols?.find(
         (ac: any) => ac.id === Number(activeAnnexControlId),
       );
       if (annexControl) {
@@ -406,7 +406,7 @@ const ISO27001Annex = ({
                     </AccordionSummary>
                   <AccordionDetails sx={{ padding: 0 }}>
                     {(() => {
-                      const controls = annex.annexControls || [];
+                      const controls = annex.annexcontrols || [];
 
                       // Use shared filtering function
                       const filteredControls = filterControls(controls);

--- a/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Annex/index.tsx
@@ -157,7 +157,7 @@ const ISO27001Annex = ({
 
     if (annexes) {
       annexes.forEach((annex: any) => {
-        const controls = annex.annexcontrols || [];
+        const controls = annex.annexControls || [];
         const filteredControls = filterControls(controls);
         counts[annex.id ?? 0] = filteredControls.length;
       });
@@ -197,7 +197,7 @@ const ISO27001Annex = ({
     const annex = annexes.find((a: any) => a.id === Number(activeAnnexId));
     if (annex) {
       handleAccordionChange(annex.id)(new Event("click") as any, true);
-      const annexControl = annex.annexcontrols?.find(
+      const annexControl = annex.annexControls?.find(
         (ac: any) => ac.id === Number(activeAnnexControlId),
       );
       if (annexControl) {
@@ -406,7 +406,7 @@ const ISO27001Annex = ({
                     </AccordionSummary>
                   <AccordionDetails sx={{ padding: 0 }}>
                     {(() => {
-                      const controls = annex.annexcontrols || [];
+                      const controls = annex.annexControls || [];
 
                       // Use shared filtering function
                       const filteredControls = filterControls(controls);

--- a/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
+++ b/Clients/src/presentation/pages/Framework/ISO27001/Clause/index.tsx
@@ -345,7 +345,7 @@ const ISO27001Clause = ({
               )}
             >
               <Typography fontSize={13}>
-                {clause.arrangement + "." + (index + 1)}{" "}
+                {clause.order_no + "." + (index + 1)}{" "}
                 {subClause.title ?? "Untitled"}
               </Typography>
               <StatusDropdown
@@ -453,7 +453,7 @@ const ISO27001Clause = ({
                     style={styles.expandIcon(expanded === clause.id) as React.CSSProperties}
                   />
                   <Typography sx={{ paddingLeft: "2.5px", fontSize: 13 }}>
-                    {clause.arrangement} {clause.title}
+                    {clause.order_no} {clause.title}
                   </Typography>
                   {hasActiveFilters && count !== undefined && (
                     <Box component="span" sx={{

--- a/Clients/src/presentation/types/interfaces/i.editor.ts
+++ b/Clients/src/presentation/types/interfaces/i.editor.ts
@@ -6,6 +6,12 @@ export interface IRichTextEditorProps {
   bodySx?: object;
   initialContent?: string;
   isEditable?: boolean;
+  /** "basic" = bold/italic/lists, "full" = adds table, underline, link */
+  toolbar?: "basic" | "full";
+  /** Override editor height (default "90px") */
+  height?: string;
+  /** Placeholder text */
+  placeholder?: string;
 }
 
 export interface IAuditorFeedbackProps {

--- a/Servers/database/migrations/20260318031606-fix-duplicate-iso27001-annex-structs.js
+++ b/Servers/database/migrations/20260318031606-fix-duplicate-iso27001-annex-structs.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Remove duplicate annex_struct_iso27001 records that have no
+ * annexcontrols_struct_iso27001 children. These orphans were
+ * created by a double-insert in the seed migration and cause
+ * "No matching controls" in the ISO 27001 annexes UI.
+ */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DELETE FROM verifywise.annex_struct_iso27001
+      WHERE id NOT IN (
+        SELECT DISTINCT annex_id FROM verifywise.annexcontrols_struct_iso27001
+      )
+    `);
+  },
+
+  async down() {
+    // No-op: the deleted rows were duplicates with no children
+  }
+};


### PR DESCRIPTION
## Summary

### Rich text editor upgrade
- Rebuild RichTextEditor component to match Policy Editor design: active state highlights, divider separators, heading selector (Text/H1/H2/H3)
- Full toolbar: Undo, Redo, Bold, Italic, Strikethrough, Bullet list, Numbered list, Underline, Superscript, Subscript, Highlight, Code block, Blockquote, Horizontal rule, Align left/center/right, Link, Table
- Floating BubbleMenu for table actions (add/delete row/column, delete table) — appears when cursor is inside a table
- Replace plain text Field with RichTextEditor for implementation_details in all 6 framework components (ISO 42001/27001 clauses + annexes, NIST AI RMF, EU AI Act controls)
- Add toolbar="full" to all existing RichTextEditor instances (evidence, feedback, assessments, compliance feedback)

### Drawer improvements
- Widen all framework drawers from 600px to 850px for toolbar fit
- Remove excess horizontal dividers (before Status, before Save, before Evidence)
- Fix double padding in EU AI Act controls sidebar
- Fix Save button positioning in EU AI Act assessments drawer

### ISO 27001 bug fixes
- Fix "undefined.1 Understanding the organization..." — clause.arrangement replaced with clause.order_no (column doesn't exist in clauses_struct_iso27001)
- Fix "No matching controls" in annexes — duplicate annex_struct_iso27001 records (IDs 1-4 orphans, IDs 5-8 with actual controls). Migration removes orphans.
- Fix annexControls case mismatch in drawer header

## Test plan
- [ ] ISO 42001 → Clauses → click clause → full Tiptap toolbar with heading selector
- [ ] ISO 42001 → Annexes → click annex → same toolbar
- [ ] ISO 27001 → Clauses → clause numbers show correctly (no "undefined")
- [ ] ISO 27001 → Annexes → controls appear when clicking annex rows
- [ ] NIST AI RMF → click subcategory → full toolbar
- [ ] EU AI Act → Controls → click subcontrol → full toolbar, no excess padding
- [ ] EU AI Act → Assessments → click question → full toolbar, Save at bottom
- [ ] Insert table → floating toolbar appears inside table
- [ ] Existing plain text content renders correctly after upgrade