### PR TITLE
Fix AI Gateway frontend to match Python API response formats

### DIFF
--- a/AIGateway/src/crud/prompts.py
+++ b/AIGateway/src/crud/prompts.py
@@ -495,12 +495,13 @@ async def create_test_dataset(
         result = await db.execute(
             text("""
                 INSERT INTO ai_gateway_prompt_test_datasets
-                    (prompt_id, name, test_cases, created_by, created_at, updated_at)
+                    (organization_id, prompt_id, name, test_cases, created_by, created_at, updated_at)
                 VALUES
-                    (:prompt_id, :name, CAST(:test_cases AS jsonb), :created_by, NOW(), NOW())
+                    (:org_id, :prompt_id, :name, CAST(:test_cases AS jsonb), :created_by, NOW(), NOW())
                 RETURNING *
             """),
             {
+                "org_id": org_id,
                 "prompt_id": prompt_id,
                 "name": name,
                 "test_cases": test_cases_json,

--- a/AIGateway/src/crud/prompts.py
+++ b/AIGateway/src/crud/prompts.py
@@ -297,7 +297,7 @@ async def publish_version(
         await db.execute(
             text("""
                 UPDATE ai_gateway_prompt_versions
-                SET status = 'draft', published_at = NULL, published_by = NULL, updated_at = NOW()
+                SET status = 'draft', published_at = NULL, published_by = NULL
                 WHERE prompt_id = :prompt_id
                   AND EXISTS (
                       SELECT 1 FROM ai_gateway_prompts p
@@ -313,8 +313,7 @@ async def publish_version(
                 UPDATE ai_gateway_prompt_versions
                 SET status = 'published',
                     published_at = NOW(),
-                    published_by = :published_by,
-                    updated_at = NOW()
+                    published_by = :published_by
                 WHERE prompt_id = :prompt_id AND version = :version_number
                   AND EXISTS (
                       SELECT 1 FROM ai_gateway_prompts p

--- a/AIGateway/src/crud/prompts.py
+++ b/AIGateway/src/crud/prompts.py
@@ -201,9 +201,10 @@ async def create_version(
         result = await db.execute(
             text("""
                 INSERT INTO ai_gateway_prompt_versions
-                    (prompt_id, version, content, variables, model, config,
-                     commit_message, created_by, status, created_at, updated_at)
+                    (organization_id, prompt_id, version, content, variables, model, config,
+                     commit_message, created_by, status, created_at)
                 VALUES (
+                    :org_id,
                     :prompt_id,
                     COALESCE(
                         (SELECT MAX(version) FROM ai_gateway_prompt_versions WHERE prompt_id = :prompt_id),
@@ -216,12 +217,12 @@ async def create_version(
                     :commit_message,
                     :created_by,
                     'draft',
-                    NOW(),
                     NOW()
                 )
                 RETURNING *
             """),
             {
+                "org_id": org_id,
                 "prompt_id": prompt_id,
                 "content": content_json,
                 "variables": variables_json,
@@ -400,9 +401,9 @@ async def assign_label(
         result = await db.execute(
             text("""
                 INSERT INTO ai_gateway_prompt_labels
-                    (prompt_id, label_name, version_id, assigned_by, assigned_at)
+                    (organization_id, prompt_id, label_name, version_id, assigned_by, assigned_at)
                 VALUES
-                    (:prompt_id, :label_name, :version_id, :assigned_by, NOW())
+                    (:org_id, :prompt_id, :label_name, :version_id, :assigned_by, NOW())
                 ON CONFLICT (prompt_id, label_name)
                 DO UPDATE SET
                     version_id  = EXCLUDED.version_id,
@@ -411,6 +412,7 @@ async def assign_label(
                 RETURNING *
             """),
             {
+                "org_id": org_id,
                 "prompt_id": prompt_id,
                 "label_name": label_name,
                 "version_id": version_id,

--- a/AIGateway/src/crud/risk.py
+++ b/AIGateway/src/crud/risk.py
@@ -9,7 +9,7 @@ async def get_risk_settings(org_id: int) -> list[dict]:
         result = await db.execute(
             text(
                 "SELECT * FROM ai_gateway_risk_settings "
-                "WHERE org_id = :org_id "
+                "WHERE organization_id = :org_id "
                 "ORDER BY condition_id"
             ),
             {"org_id": org_id},
@@ -33,10 +33,10 @@ async def upsert_risk_setting(
             text(
                 """
                 INSERT INTO ai_gateway_risk_settings
-                    (org_id, condition_id, is_enabled, threshold, severity_override)
+                    (organization_id, condition_id, is_enabled, threshold, severity_override)
                 VALUES
                     (:org_id, :condition_id, :is_enabled, :threshold::jsonb, :severity_override)
-                ON CONFLICT (org_id, condition_id) DO UPDATE SET
+                ON CONFLICT (organization_id, condition_id) DO UPDATE SET
                     is_enabled       = EXCLUDED.is_enabled,
                     threshold        = COALESCE(EXCLUDED.threshold, ai_gateway_risk_settings.threshold),
                     severity_override = COALESCE(EXCLUDED.severity_override, ai_gateway_risk_settings.severity_override),
@@ -81,7 +81,7 @@ async def create_suggestion(
             text(
                 f"""
                 INSERT INTO ai_gateway_risk_suggestions
-                    (org_id, condition_id, title, description, severity,
+                    (organization_id, condition_id, title, description, severity,
                      evidence, compliance_tags, suggested_mitigation, status)
                 VALUES
                     (:org_id, :condition_id, :title, :description, :severity,
@@ -117,7 +117,7 @@ async def get_suggestions(org_id: int, status: Optional[str] = None) -> list[dic
                     u.name AS reviewed_by_name
                 FROM ai_gateway_risk_suggestions s
                 LEFT JOIN users u ON u.id = s.reviewed_by
-                WHERE s.org_id = :org_id
+                WHERE s.organization_id = :org_id
                 {status_clause}
                 ORDER BY s.created_at DESC
                 """
@@ -148,7 +148,7 @@ async def update_suggestion_status(
                     dismiss_reason   = :dismiss_reason,
                     accepted_risk_id = :accepted_risk_id
                 WHERE id = :id
-                  AND org_id = :org_id
+                  AND organization_id = :org_id
                   AND status = 'pending'
                 RETURNING *
                 """
@@ -175,7 +175,7 @@ async def has_pending_suggestion(org_id: int, condition_id: str) -> bool:
                 """
                 SELECT EXISTS (
                     SELECT 1 FROM ai_gateway_risk_suggestions
-                    WHERE org_id = :org_id
+                    WHERE organization_id = :org_id
                       AND condition_id = :condition_id
                       AND status = 'pending'
                 )
@@ -195,7 +195,7 @@ async def get_all_pending_condition_ids(org_id: int) -> set[str]:
                 """
                 SELECT DISTINCT condition_id
                 FROM ai_gateway_risk_suggestions
-                WHERE org_id = :org_id
+                WHERE organization_id = :org_id
                   AND status = 'pending'
                 """
             ),

--- a/AIGateway/src/routers/endpoints.py
+++ b/AIGateway/src/routers/endpoints.py
@@ -113,11 +113,10 @@ async def update_endpoint(endpoint_id: int, request: Request) -> Any:
 
     try:
         await record_endpoint_change(
-            org_id=org_id,
-            user_id=user_id,
+            organization_id=org_id,
             endpoint_id=endpoint_id,
-            before=existing,
-            after=updated,
+            changed_by=user_id,
+            action="updated",
         )
     except Exception:
         logger.exception(

--- a/AIGateway/src/routers/guardrails_crud.py
+++ b/AIGateway/src/routers/guardrails_crud.py
@@ -185,10 +185,10 @@ async def update_guardrail_rule(rule_id: int, request: Request):
 
     # Record change history
     await record_guardrail_change(
-        org_id=org_id,
-        user_id=user_id,
-        rule_id=rule_id,
-        changes=body,
+        organization_id=org_id,
+        guardrail_id=rule_id,
+        changed_by=user_id,
+        action="updated",
     )
 
     # Notify on is_active toggle

--- a/AIGateway/src/routers/spend.py
+++ b/AIGateway/src/routers/spend.py
@@ -31,10 +31,10 @@ _PERIOD_DAYS: dict[str, int] = {
 }
 
 
-def get_date_range(period: str) -> tuple[str, str]:
+def get_date_range(period: str) -> tuple[datetime, datetime]:
     """
     Convert a period string ("1d" | "7d" | "30d" | "90d") to
-    (start_date_iso, end_date_iso) UTC strings.
+    (start_datetime, end_datetime) UTC datetime objects.
 
     Raises HTTPException 400 for unknown periods.
     """
@@ -46,7 +46,7 @@ def get_date_range(period: str) -> tuple[str, str]:
         )
     now = datetime.now(tz=timezone.utc)
     start = now - timedelta(days=days)
-    return start.isoformat(), now.isoformat()
+    return start, now
 
 
 # ---------------------------------------------------------------------------

--- a/AIGateway/src/routers/virtual_keys.py
+++ b/AIGateway/src/routers/virtual_keys.py
@@ -14,8 +14,6 @@ from middlewares.auth import verify_internal_key
 from utils.auth import get_org_id, get_user_id, require_admin
 from utils.notifications import notify_config_change
 
-FRONTEND_URL = "http://localhost:5173"
-
 router = APIRouter(prefix="/virtual-keys", tags=["virtual-keys"])
 
 
@@ -93,13 +91,14 @@ async def create_key(request: Request):
         )
 
     await notify_config_change(
-        org_id=org_id,
-        user_id=user_id,
-        action="created",
-        entity_type="virtual_key",
-        entity_id=record["id"],
-        entity_name=name,
-        frontend_url=FRONTEND_URL,
+        organization_id=org_id,
+        changed_by_user_id=user_id,
+        event={
+            "action": "created",
+            "entity_type": "virtual_key",
+            "entity_id": str(record["id"]),
+            "entity_name": name,
+        },
     )
 
     return {
@@ -210,13 +209,14 @@ async def update_key(key_id: int, request: Request):
         )
 
     await notify_config_change(
-        org_id=org_id,
-        user_id=user_id,
-        action="updated",
-        entity_type="virtual_key",
-        entity_id=key_id,
-        entity_name=record.get("name"),
-        frontend_url=FRONTEND_URL,
+        organization_id=org_id,
+        changed_by_user_id=user_id,
+        event={
+            "action": "updated",
+            "entity_type": "virtual_key",
+            "entity_id": str(key_id),
+            "entity_name": record.get("name", ""),
+        },
     )
 
     return {"status": "success", "data": record}
@@ -242,13 +242,13 @@ async def revoke_key(key_id: int, request: Request):
         )
 
     await notify_config_change(
-        org_id=org_id,
-        user_id=user_id,
-        action="revoked",
-        entity_type="virtual_key",
-        entity_id=key_id,
-        entity_name=None,
-        frontend_url=FRONTEND_URL,
+        organization_id=org_id,
+        changed_by_user_id=user_id,
+        event={
+            "action": "revoked",
+            "entity_type": "virtual_key",
+            "entity_id": str(key_id),
+        },
     )
 
     return {"status": "success", "message": "Virtual key revoked"}
@@ -274,13 +274,13 @@ async def delete_key(key_id: int, request: Request):
         )
 
     await notify_config_change(
-        org_id=org_id,
-        user_id=user_id,
-        action="deleted",
-        entity_type="virtual_key",
-        entity_id=key_id,
-        entity_name=None,
-        frontend_url=FRONTEND_URL,
+        organization_id=org_id,
+        changed_by_user_id=user_id,
+        event={
+            "action": "deleted",
+            "entity_type": "virtual_key",
+            "entity_id": str(key_id),
+        },
     )
 
     return {"status": "success", "message": "Virtual key deleted"}

--- a/AIGateway/src/utils/notifications.py
+++ b/AIGateway/src/utils/notifications.py
@@ -37,15 +37,31 @@ async def _send_notification(payload: dict[str, Any]) -> None:
 
 
 async def notify_config_change(
-    organization_id: int,
-    changed_by_user_id: int,
-    event: dict[str, str],
+    organization_id: Optional[int] = None,
+    changed_by_user_id: Optional[int] = None,
+    event: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
 ) -> None:
-    """Notify admins of a config change (API key, endpoint, guardrail)."""
+    """Notify admins of a config change (API key, endpoint, guardrail).
+
+    Accepts both positional-style and keyword-style arguments to accommodate
+    various callers (virtual_keys, endpoints, guardrails, api_keys, prompts).
+    """
+    org_id = organization_id or kwargs.get("org_id")
+    user_id = changed_by_user_id or kwargs.get("user_id")
+
+    # Build event dict from explicit event param or from kwargs
+    if event is None:
+        event = {}
+        for k in ("action", "entity", "entity_type", "entity_name",
+                   "entity_id", "detail", "payload", "frontend_url"):
+            if k in kwargs:
+                event[k] = kwargs[k]
+
     await _send_notification({
         "type": "config_change",
-        "organization_id": organization_id,
-        "changed_by_user_id": changed_by_user_id,
+        "organization_id": org_id,
+        "changed_by_user_id": user_id,
         "event": event,
     })
 

--- a/Clients/src/application/contexts/AIGatewaySidebar.context.tsx
+++ b/Clients/src/application/contexts/AIGatewaySidebar.context.tsx
@@ -37,11 +37,11 @@ export const AIGatewaySidebarProvider: FC<{ children: ReactNode }> = ({ children
           apiServices.get("/ai-gateway/virtual-keys").catch(() => null),
         ]);
         if (cancelled) return;
-        const endpoints = endpointsRes?.data?.data;
+        const endpoints = endpointsRes?.data?.endpoints;
         if (Array.isArray(endpoints)) {
           setEndpointsCount(endpoints.filter((e: { is_active: boolean }) => e.is_active).length);
         }
-        const prompts = promptsRes?.data?.data;
+        const prompts = promptsRes?.data?.prompts;
         if (Array.isArray(prompts)) {
           setPromptsCount(prompts.length);
         }

--- a/Clients/src/presentation/pages/AIGateway/Endpoints/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Endpoints/index.tsx
@@ -68,9 +68,9 @@ export default function EndpointsPage() {
         apiServices.get("/ai-gateway/guardrails").catch(() => null),
         apiServices.get("/ai-gateway/prompts").catch(() => null),
       ]);
-      setEndpoints(endpointsRes?.data?.data || []);
+      setEndpoints(endpointsRes?.data?.endpoints || []);
       setApiKeys(keysRes?.data?.data || []);
-      setPrompts(promptsRes?.data?.data || []);
+      setPrompts(promptsRes?.data?.prompts || []);
       const allRules = grRes?.data?.data || [];
       setActiveGuardrailCount(allRules.filter((r: any) => r.is_active).length);
     } catch {

--- a/Clients/src/presentation/pages/AIGateway/Endpoints/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Endpoints/index.tsx
@@ -71,7 +71,7 @@ export default function EndpointsPage() {
       setEndpoints(endpointsRes?.data?.endpoints || []);
       setApiKeys(keysRes?.data?.data || []);
       setPrompts(promptsRes?.data?.prompts || []);
-      const allRules = grRes?.data?.data || [];
+      const allRules = grRes?.data?.rules || grRes?.data?.data || [];
       setActiveGuardrailCount(allRules.filter((r: any) => r.is_active).length);
     } catch {
       // Silently handle
@@ -163,7 +163,7 @@ export default function EndpointsPage() {
       setForm({ ...EMPTY_FORM });
       await loadData();
     } catch (err: any) {
-      setFormError(err?.response?.data?.message || `Failed to ${editingId ? "update" : "create"} endpoint`);
+      setFormError(err?.response?.data?.detail || err?.response?.data?.message || `Failed to ${editingId ? "update" : "create"} endpoint`);
     } finally {
       setIsSubmitting(false);
     }

--- a/Clients/src/presentation/pages/AIGateway/Guardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Guardrails/index.tsx
@@ -256,7 +256,7 @@ export default function GuardrailsPage() {
       setCfForm({ name: "", type: "keyword", pattern: "", action: "block" });
       await loadRules();
     } catch (err: any) {
-      setCfError(err?.response?.data?.message || "Failed to create rule");
+      setCfError(err?.response?.data?.detail || err?.response?.data?.message || "Failed to create rule");
     } finally {
       setCfSubmitting(false);
     }
@@ -295,7 +295,7 @@ export default function GuardrailsPage() {
       const res = await apiServices.post("/ai-gateway/guardrails/test", { text: testText });
       setTestResult(res?.data?.data);
     } catch (err: any) {
-      setTestResult({ error: err?.response?.data?.message || "Test failed — is the AI Gateway service running?" });
+      setTestResult({ error: err?.response?.data?.detail || err?.response?.data?.message || "Test failed — is the AI Gateway service running?" });
     } finally {
       setTestLoading(false);
     }

--- a/Clients/src/presentation/pages/AIGateway/Guardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Guardrails/index.tsx
@@ -183,7 +183,7 @@ export default function GuardrailsPage() {
   const loadRules = useCallback(async () => {
     try {
       const res = await apiServices.get("/ai-gateway/guardrails");
-      setRules(res?.data?.data || []);
+      setRules(res?.data?.rules || res?.data?.data || []);
     } catch {
       // Silently handle
     } finally {

--- a/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
@@ -167,10 +167,10 @@ export default function LogsPage() {
   const loadGuardrailLogs = useCallback(async () => {
     setGrLoading(true);
     try {
-      const res = await apiServices.get(`/ai-gateway/guardrails/logs/detail?period=30d&limit=${GR_PAGE_SIZE}&offset=${grPage * GR_PAGE_SIZE}`);
-      const data = res?.data?.data || {};
-      setGrLogs(data.logs || []);
-      setGrTotal(data.total || 0);
+      const res = await apiServices.get(`/ai-gateway/guardrails/logs?limit=${GR_PAGE_SIZE}&offset=${grPage * GR_PAGE_SIZE}`);
+      const data = res?.data || {};
+      setGrLogs(data.logs || data?.data?.logs || []);
+      setGrTotal(data.total || data.logs?.length || 0);
     } catch {
       // Silently handle
     } finally {

--- a/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
@@ -229,7 +229,7 @@ export default function LogsPage() {
       try {
         const qs = buildQuery(p, rpp);
         const res = await apiServices.get(`/ai-gateway/spend/logs?${qs}`);
-        const data = res?.data?.data || {};
+        const data = res?.data || {};
         setLogs(data.rows || []);
         setTotal(data.total || 0);
       } catch {

--- a/Clients/src/presentation/pages/AIGateway/Models/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Models/index.tsx
@@ -102,7 +102,7 @@ export default function ModelsPage() {
   // Filters
   const [search, setSearch] = useState("");
   const [providerFilter, setProviderFilter] = useState("");
-  const [modeFilter, setModeFilter] = useState("chat");
+  const [modeFilter, setModeFilter] = useState("");
   const [featureFilters, setFeatureFilters] = useState<Set<string>>(new Set());
   const [page, setPage] = useState(0);
 
@@ -131,16 +131,24 @@ export default function ModelsPage() {
 
   // Derived: unique providers
   const providers = useMemo(() => {
-    const set = new Set(models.map((m) => m.provider));
+    const set = new Set(cleanModels.map((m) => m.provider));
     return [{ _id: "", name: "All providers" }, ...[...set].sort().map((p) => ({ _id: p, name: p }))];
+  }, [cleanModels]);
+
+  // Filter out LiteLLM's description/sample row
+  const cleanModels = useMemo(() => {
+    return models.filter((m) => {
+      const name = ((m as any).model || m.id || "").toLowerCase();
+      return name !== "sample_spec" && !m.provider?.includes("docs.litellm.ai");
+    });
   }, [models]);
 
   // Filtered + searched models
   const filtered = useMemo(() => {
-    let result = models;
+    let result = cleanModels;
     if (search) {
       const q = search.toLowerCase();
-      result = result.filter((m) => m.id.toLowerCase().includes(q) || m.provider.toLowerCase().includes(q));
+      result = result.filter((m) => (m.model || m.id || "").toLowerCase().includes(q) || m.provider.toLowerCase().includes(q));
     }
     if (providerFilter) result = result.filter((m) => m.provider === providerFilter);
     if (modeFilter) result = result.filter((m) => m.mode === modeFilter);
@@ -148,7 +156,7 @@ export default function ModelsPage() {
       result = result.filter((m) => (m as any)[feat] === true);
     }
     return result;
-  }, [models, search, providerFilter, modeFilter, featureFilters]);
+  }, [cleanModels, search, providerFilter, modeFilter, featureFilters]);
 
   const pageCount = useMemo(() => Math.ceil(filtered.length / PAGE_SIZE), [filtered]);
   const pageModels = useMemo(() => filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE), [filtered, page]);
@@ -208,7 +216,7 @@ export default function ModelsPage() {
   return (
     <PageHeaderExtended
       title="Models"
-      description={<>Browse <strong style={{ color: palette.text.primary }}>{models.length.toLocaleString()}</strong> LLM models across <strong style={{ color: palette.text.primary }}>{providers.length - 1}</strong> providers.</>}
+      description={<>Browse <strong style={{ color: palette.text.primary }}>{cleanModels.length.toLocaleString()}</strong> LLM models across <strong style={{ color: palette.text.primary }}>{providers.length - 1}</strong> providers.</>}
       tipBoxEntity="ai-gateway-models"
       helpArticlePath="ai-gateway/models"
     >
@@ -225,7 +233,7 @@ export default function ModelsPage() {
             <Stack gap="16px">
               {/* Filters */}
               <Stack direction="row" gap="8px" flexWrap="wrap" alignItems="flex-end">
-                <Box sx={{ flex: 1, minWidth: "200px" }}>
+                <Box sx={{ width: "240px", minWidth: "160px" }}>
                   <Field
                     placeholder="Search models..."
                     value={search}
@@ -310,7 +318,7 @@ export default function ModelsPage() {
                   <Stack gap="0px">
                     {pageModels.map((m) => (
                       <Stack
-                        key={m.id}
+                        key={(m as any).model || m.id}
                         direction="row"
                         alignItems="center"
                         sx={{
@@ -430,7 +438,7 @@ export default function ModelsPage() {
                       const costPerReq = inputCostPerReq + outputCostPerReq;
                       return (
                         <Stack
-                          key={m.id}
+                          key={(m as any).model || m.id}
                           direction="row"
                           alignItems="center"
                           sx={{
@@ -531,7 +539,7 @@ export default function ModelsPage() {
                     <Stack gap="4px" sx={{ maxHeight: "200px", overflowY: "auto" }}>
                       {filtered.slice(0, 20).map((m) => (
                         <Stack
-                          key={m.id}
+                          key={(m as any).model || m.id}
                           direction="row"
                           justifyContent="space-between"
                           alignItems="center"
@@ -563,7 +571,7 @@ export default function ModelsPage() {
                       <tr>
                         <th scope="col" style={{ textAlign: "left", padding: "8px", borderBottom: `1px solid ${palette.border.light}`, color: palette.text.tertiary, fontSize: 11, fontWeight: 600, textTransform: "uppercase" as const }}>Feature</th>
                         {compareModels.map((m) => (
-                          <th scope="col" key={m.id} style={{ textAlign: "center", padding: "8px", borderBottom: `1px solid ${palette.border.light}`, fontSize: 11, fontWeight: 600, minWidth: "140px", position: "relative", color: palette.text.tertiary, textTransform: "uppercase" as const }}>
+                          <th scope="col" key={(m as any).model || m.id} style={{ textAlign: "center", padding: "8px", borderBottom: `1px solid ${palette.border.light}`, fontSize: 11, fontWeight: 600, minWidth: "140px", position: "relative", color: palette.text.tertiary, textTransform: "uppercase" as const }}>
                             <span style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: "4px" }}>
                               {m.id}
                               <span
@@ -625,7 +633,7 @@ export default function ModelsPage() {
                               const isBest = bestVal !== null && numVal === bestVal && validNums.length > 1;
 
                               return (
-                                <td key={m.id} style={{
+                                <td key={(m as any).model || m.id} style={{
                                   textAlign: "center", padding: "8px",
                                   borderBottom: `1px solid ${palette.border.light}`,
                                   fontSize: 12,

--- a/Clients/src/presentation/pages/AIGateway/Models/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Models/index.tsx
@@ -34,6 +34,7 @@ import { sectionTitleSx, useCardSx, ProviderIcon } from "../shared";
 
 interface ModelInfo {
   id: string;
+  model?: string;
   provider: string;
   mode: string;
   max_input_tokens: number | null;
@@ -129,19 +130,19 @@ export default function ModelsPage() {
 
   useEffect(() => { loadModels(); }, [loadModels]);
 
+  // Filter out LiteLLM's description/sample row
+  const cleanModels = useMemo(() => {
+    return models.filter((m) => {
+      const name = (m.model || m.id || "").toLowerCase();
+      return name !== "sample_spec" && !m.provider?.includes("docs.litellm.ai");
+    });
+  }, [models]);
+
   // Derived: unique providers
   const providers = useMemo(() => {
     const set = new Set(cleanModels.map((m) => m.provider));
     return [{ _id: "", name: "All providers" }, ...[...set].sort().map((p) => ({ _id: p, name: p }))];
   }, [cleanModels]);
-
-  // Filter out LiteLLM's description/sample row
-  const cleanModels = useMemo(() => {
-    return models.filter((m) => {
-      const name = ((m as any).model || m.id || "").toLowerCase();
-      return name !== "sample_spec" && !m.provider?.includes("docs.litellm.ai");
-    });
-  }, [models]);
 
   // Filtered + searched models
   const filtered = useMemo(() => {
@@ -318,7 +319,7 @@ export default function ModelsPage() {
                   <Stack gap="0px">
                     {pageModels.map((m) => (
                       <Stack
-                        key={(m as any).model || m.id}
+                        key={m.model || m.id}
                         direction="row"
                         alignItems="center"
                         sx={{
@@ -438,7 +439,7 @@ export default function ModelsPage() {
                       const costPerReq = inputCostPerReq + outputCostPerReq;
                       return (
                         <Stack
-                          key={(m as any).model || m.id}
+                          key={m.model || m.id}
                           direction="row"
                           alignItems="center"
                           sx={{
@@ -539,7 +540,7 @@ export default function ModelsPage() {
                     <Stack gap="4px" sx={{ maxHeight: "200px", overflowY: "auto" }}>
                       {filtered.slice(0, 20).map((m) => (
                         <Stack
-                          key={(m as any).model || m.id}
+                          key={m.model || m.id}
                           direction="row"
                           justifyContent="space-between"
                           alignItems="center"
@@ -571,7 +572,7 @@ export default function ModelsPage() {
                       <tr>
                         <th scope="col" style={{ textAlign: "left", padding: "8px", borderBottom: `1px solid ${palette.border.light}`, color: palette.text.tertiary, fontSize: 11, fontWeight: 600, textTransform: "uppercase" as const }}>Feature</th>
                         {compareModels.map((m) => (
-                          <th scope="col" key={(m as any).model || m.id} style={{ textAlign: "center", padding: "8px", borderBottom: `1px solid ${palette.border.light}`, fontSize: 11, fontWeight: 600, minWidth: "140px", position: "relative", color: palette.text.tertiary, textTransform: "uppercase" as const }}>
+                          <th scope="col" key={m.model || m.id} style={{ textAlign: "center", padding: "8px", borderBottom: `1px solid ${palette.border.light}`, fontSize: 11, fontWeight: 600, minWidth: "140px", position: "relative", color: palette.text.tertiary, textTransform: "uppercase" as const }}>
                             <span style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: "4px" }}>
                               {m.id}
                               <span
@@ -633,7 +634,7 @@ export default function ModelsPage() {
                               const isBest = bestVal !== null && numVal === bestVal && validNums.length > 1;
 
                               return (
-                                <td key={(m as any).model || m.id} style={{
+                                <td key={m.model || m.id} style={{
                                   textAlign: "center", padding: "8px",
                                   borderBottom: `1px solid ${palette.border.light}`,
                                   fontSize: 12,

--- a/Clients/src/presentation/pages/AIGateway/Models/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Models/index.tsx
@@ -118,7 +118,7 @@ export default function ModelsPage() {
   const loadModels = useCallback(async () => {
     try {
       const res = await apiServices.get("/ai-gateway/models/catalog");
-      setModels(res?.data?.models || []);
+      setModels(res?.data?.data?.models || res?.data?.models || []);
       setError("");
     } catch {
       setError("Failed to load model catalog. Is the AI Gateway running?");

--- a/Clients/src/presentation/pages/AIGateway/Models/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Models/index.tsx
@@ -118,7 +118,7 @@ export default function ModelsPage() {
   const loadModels = useCallback(async () => {
     try {
       const res = await apiServices.get("/ai-gateway/models/catalog");
-      setModels(res?.data?.data?.models || []);
+      setModels(res?.data?.models || []);
       setError("");
     } catch {
       setError("Failed to load model catalog. Is the AI Gateway running?");

--- a/Clients/src/presentation/pages/AIGateway/Playground/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Playground/index.tsx
@@ -48,7 +48,7 @@ export default function PlaygroundPage() {
     const load = async () => {
       try {
         const res = await apiServices.get("/ai-gateway/endpoints");
-        const eps = (res?.data?.data || []).filter((e: any) => e.is_active);
+        const eps = (res?.data?.endpoints || []).filter((e: any) => e.is_active);
         setEndpoints(eps);
         if (eps.length > 0) {
           setSelectedEndpoint((prev) => prev || eps[0].slug);

--- a/Clients/src/presentation/pages/AIGateway/Prompts/PromptEditor.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/PromptEditor.tsx
@@ -276,11 +276,11 @@ export default function PromptEditorPage() {
         apiServices.get("/ai-gateway/endpoints"),
         apiServices.get(`/ai-gateway/prompts/${id}/labels`),
       ]);
-      setPrompt(promptRes?.data?.data);
-      const vers: Version[] = versionsRes?.data?.data || [];
+      setPrompt(promptRes?.data?.prompt || promptRes?.data?.data);
+      const vers: Version[] = versionsRes?.data?.versions || versionsRes?.data?.data || [];
       setVersions(vers);
       setEndpoints((endpointsRes?.data?.endpoints || []).filter((e: any) => e.is_active));
-      setLabels(labelsRes?.data?.data || []);
+      setLabels(labelsRes?.data?.labels || labelsRes?.data?.data || []);
       if (vers.length > 0) loadVersionIntoEditor(vers[0]);
     } catch { /* silently handle */ }
     finally { setLoading(false); }
@@ -310,7 +310,7 @@ export default function PromptEditorPage() {
         config: Object.keys(config).length > 0 ? config : null,
         commit_message: commitMsg || null,
       });
-      const newVer = res?.data?.data;
+      const newVer = res?.data?.version || res?.data?.data;
       if (newVer) {
         setCurrentVersion(newVer.version);
         setCurrentStatus("draft");
@@ -358,7 +358,7 @@ export default function PromptEditorPage() {
     if (!id) return;
     try {
       const res = await apiServices.post(`/ai-gateway/prompts/${id}/versions/${versionNumber}/publish`);
-      const published = res?.data?.data;
+      const published = res?.data?.version || res?.data?.data;
       if (published) {
         setVersions((prev) =>
           prev.map((v) =>
@@ -404,7 +404,7 @@ export default function PromptEditorPage() {
       });
       // Refresh labels
       const labelsRes = await apiServices.get(`/ai-gateway/prompts/${id}/labels`);
-      setLabels(labelsRes?.data?.data || []);
+      setLabels(labelsRes?.data?.labels || labelsRes?.data?.data || []);
       setIsLabelModalOpen(false);
       setNewLabelName("");
     } catch { /* silently handle */ }

--- a/Clients/src/presentation/pages/AIGateway/Prompts/PromptEditor.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/PromptEditor.tsx
@@ -279,7 +279,7 @@ export default function PromptEditorPage() {
       setPrompt(promptRes?.data?.data);
       const vers: Version[] = versionsRes?.data?.data || [];
       setVersions(vers);
-      setEndpoints((endpointsRes?.data?.data || []).filter((e: any) => e.is_active));
+      setEndpoints((endpointsRes?.data?.endpoints || []).filter((e: any) => e.is_active));
       setLabels(labelsRes?.data?.data || []);
       if (vers.length > 0) loadVersionIntoEditor(vers[0]);
     } catch { /* silently handle */ }

--- a/Clients/src/presentation/pages/AIGateway/Prompts/TestDatasetPanel.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/TestDatasetPanel.tsx
@@ -73,7 +73,7 @@ export default function TestDatasetPanel({
   const loadDatasets = useCallback(async () => {
     try {
       const res = await apiServices.get(`/ai-gateway/prompts/${promptId}/test-datasets`);
-      setDatasets(res?.data?.data || []);
+      setDatasets(res?.data?.test_datasets || res?.data?.data || []);
     } catch { /* silently handle */ }
   }, [promptId]);
 
@@ -128,7 +128,7 @@ export default function TestDatasetPanel({
           name: datasetName,
           test_cases: testCases,
         });
-        const created = res?.data?.data;
+        const created = res?.data?.test_dataset || res?.data?.data;
         if (created) {
           setSelectedDatasetId(created.id);
           setDatasets((prev) => [created, ...prev]);

--- a/Clients/src/presentation/pages/AIGateway/Prompts/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/index.tsx
@@ -61,7 +61,7 @@ export default function PromptsPage() {
   const loadData = useCallback(async () => {
     try {
       const res = await apiServices.get("/ai-gateway/prompts");
-      const promptList: Prompt[] = res?.data?.data || [];
+      const promptList: Prompt[] = res?.data?.prompts || [];
       // Fetch labels for each prompt in parallel
       const labelsRes = await Promise.all(
         promptList.map((p) => apiServices.get(`/ai-gateway/prompts/${p.id}/labels`).catch(() => null))

--- a/Clients/src/presentation/pages/AIGateway/Prompts/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/index.tsx
@@ -67,7 +67,7 @@ export default function PromptsPage() {
         promptList.map((p) => apiServices.get(`/ai-gateway/prompts/${p.id}/labels`).catch(() => null))
       );
       for (let i = 0; i < promptList.length; i++) {
-        promptList[i].labels = labelsRes[i]?.data?.data || [];
+        promptList[i].labels = labelsRes[i]?.data?.labels || labelsRes[i]?.data?.data || [];
       }
       setPrompts(promptList);
     } catch { /* silently handle */ }
@@ -91,13 +91,13 @@ export default function PromptsPage() {
       const res = await apiServices.post("/ai-gateway/prompts", {
         name: form.name, slug: form.slug, description: form.description || null,
       });
-      const created = res?.data?.data;
+      const created = res?.data?.prompt || res?.data?.data;
       setIsCreateOpen(false);
       setForm({ name: "", slug: "", description: "" });
       if (created?.id) navigate(`/ai-gateway/prompts/${created.id}`);
       else loadData();
     } catch (err: any) {
-      setFormError(err?.response?.data?.data || err?.response?.data?.message || "Failed to create prompt");
+      setFormError(err?.response?.data?.detail || err?.response?.data?.message || "Failed to create prompt");
     } finally { setIsSubmitting(false); }
   };
 

--- a/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
@@ -206,11 +206,11 @@ export default function AIGatewaySettingsPage() {
         apiServices.get("/ai-gateway/risk-suggestions").catch(() => null),
       ]);
       if (settingsRes?.data) {
-        setRiskSettings(settingsRes.data);
+        setRiskSettings(settingsRes.data?.settings || settingsRes.data);
         setRiskSettingsDirty(false);
       }
       if (suggestionsRes?.data) {
-        setSuggestions(suggestionsRes.data);
+        setSuggestions(suggestionsRes.data?.suggestions || suggestionsRes.data);
       }
     } catch {
       // Silently handle
@@ -253,7 +253,7 @@ export default function AIGatewaySettingsPage() {
       setKeyForm({ key_name: "", provider: "", api_key: "" });
       await loadData();
     } catch (err: any) {
-      setKeyError(err?.response?.data?.message || "Failed to create API key");
+      setKeyError(err?.response?.data?.detail || err?.response?.data?.message || "Failed to create API key");
     } finally {
       setKeySubmitting(false);
     }
@@ -363,7 +363,7 @@ export default function AIGatewaySettingsPage() {
     setDetectResult("");
     try {
       const res = await apiServices.post("/ai-gateway/risk-suggestions/detect");
-      const count = res?.data?.data?.new_suggestions ?? 0;
+      const count = res?.data?.new_suggestions_count ?? res?.data?.data?.new_suggestions ?? 0;
       setDetectResult(count > 0 ? `${count} new suggestion${count > 1 ? "s" : ""} found` : "No new risks detected");
       await loadRiskData();
       setTimeout(() => setDetectResult(""), 5000);

--- a/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
@@ -770,7 +770,7 @@ export default function AIGatewaySettingsPage() {
                         setSpendPurgeResult("Purging...");
                         try {
                           const res = await apiServices.post("/ai-gateway/spend/logs/purge");
-                          const count = res?.data?.data?.deleted_count || 0;
+                          const count = res?.data?.deleted ?? res?.data?.data?.deleted_count ?? 0;
                           setSpendPurgeResult(count > 0 ? `Deleted ${count} logs` : "No old logs to purge");
                           if (count > 0) await loadData();
                           setTimeout(() => setSpendPurgeResult(""), 3000);

--- a/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
@@ -179,7 +179,7 @@ export default function AIGatewaySettingsPage() {
         
       }
 
-      const gs = gsRes?.data?.data;
+      const gs = gsRes?.data?.settings;
       if (gs) {
         setGuardrailSettings(gs);
         setGsForm({
@@ -205,12 +205,12 @@ export default function AIGatewaySettingsPage() {
         apiServices.get("/ai-gateway/risk-settings").catch(() => null),
         apiServices.get("/ai-gateway/risk-suggestions").catch(() => null),
       ]);
-      if (settingsRes?.data?.data) {
-        setRiskSettings(settingsRes.data.data);
+      if (settingsRes?.data) {
+        setRiskSettings(settingsRes.data);
         setRiskSettingsDirty(false);
       }
-      if (suggestionsRes?.data?.data) {
-        setSuggestions(suggestionsRes.data.data);
+      if (suggestionsRes?.data) {
+        setSuggestions(suggestionsRes.data);
       }
     } catch {
       // Silently handle

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx
@@ -290,7 +290,7 @@ export default function OnboardingOverlay({ onGetStarted, setupStatus, onStepCom
       apiServices.get("/ai-gateway/virtual-keys").catch(() => null),
     ]).then(([epRes, vkRes]) => {
       if (cancelled) return;
-      const endpoints = epRes?.data?.data || [];
+      const endpoints = epRes?.data?.endpoints || [];
       const activeEp = endpoints.find((e: { is_active: boolean }) => e.is_active);
       if (activeEp) setFirstReqSlug(activeEp.slug);
       const vkeys = vkRes?.data?.data || [];

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/OnboardingOverlay.tsx
@@ -388,7 +388,8 @@ export default function OnboardingOverlay({ onGetStarted, setupStatus, onStepCom
       closeModal();
       onStepCompleted();
     } catch (err: unknown) {
-      setKeyError((err as { response?: { data?: { message?: string } } })?.response?.data?.message || "Failed to create API key");
+      const errData = (err as { response?: { data?: { detail?: string; message?: string } } })?.response?.data;
+      setKeyError(errData?.detail || errData?.message || "Failed to create API key");
     } finally {
       setKeySubmitting(false);
     }
@@ -412,7 +413,8 @@ export default function OnboardingOverlay({ onGetStarted, setupStatus, onStepCom
       closeModal();
       onStepCompleted();
     } catch (err: unknown) {
-      setEndpointError((err as { response?: { data?: { message?: string } } })?.response?.data?.message || "Failed to create endpoint");
+      const errData = (err as { response?: { data?: { detail?: string; message?: string } } })?.response?.data;
+      setEndpointError(errData?.detail || errData?.message || "Failed to create endpoint");
     } finally {
       setEndpointSubmitting(false);
     }
@@ -428,14 +430,15 @@ export default function OnboardingOverlay({ onGetStarted, setupStatus, onStepCom
     try {
       const res = await apiServices.post("/ai-gateway/virtual-keys", { name: vkeyName.trim() });
       const created = res?.data?.data;
-      if (created?.key) {
-        setCreatedKey(created.key);
+      if (created?.plain_key) {
+        setCreatedKey(created.plain_key);
         onStepCompleted();
       } else {
         setVkeyError("Key was created but could not be retrieved. Refresh the page.");
       }
     } catch (err: unknown) {
-      setVkeyError((err as { response?: { data?: { message?: string } } })?.response?.data?.message || "Failed to create virtual key");
+      const errData = (err as { response?: { data?: { detail?: string; message?: string } } })?.response?.data;
+      setVkeyError(errData?.detail || errData?.message || "Failed to create virtual key");
     } finally {
       setVkeySubmitting(false);
     }
@@ -454,13 +457,13 @@ export default function OnboardingOverlay({ onGetStarted, setupStatus, onStepCom
         endpoint_slug: firstReqSlug,
         messages: [{ role: "user", content: "Say hello and introduce yourself in one sentence." }],
       });
-      const data = res?.data?.data;
+      const data = res?.data?.data || res?.data;
       const text = data?.choices?.[0]?.message?.content || JSON.stringify(data, null, 2);
       setFirstReqResponse(text);
       onStepCompleted();
     } catch (err: unknown) {
-      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
-      setFirstReqError(msg || "Request failed. Check that your endpoint and API key are configured correctly.");
+      const errData = (err as { response?: { data?: { detail?: string; message?: string } } })?.response?.data;
+      setFirstReqError(errData?.detail || errData?.message || "Request failed. Check that your endpoint and API key are configured correctly.");
     } finally {
       setFirstReqRunning(false);
     }

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -104,7 +104,21 @@ export default function SpendDashboardPage() {
         setData(spendRes?.data || null);
         setByEndpoint(endpointRes?.data?.data || []);
         setByUser(userRes?.data?.data || []);
-        setGuardrailStats(gsRes?.data || null);
+        // Map Python guardrail stats field names to frontend expectations
+        const gs = gsRes?.data || null;
+        if (gs?.summary) {
+          gs.summary.blocked_count = gs.summary.blocked_count ?? gs.summary.blocked ?? 0;
+          gs.summary.masked_count = gs.summary.masked_count ?? gs.summary.masked ?? 0;
+          gs.summary.total_checks = gs.summary.total_checks ?? gs.summary.total ?? 0;
+        }
+        // byType can serve as topDetections (grouped by type + action)
+        if (!gs?.topDetections && gs?.byType) {
+          gs.topDetections = gs.byType.map((d: any) => ({
+            ...d,
+            entity_type: d.entity_type || d.guardrail_type,
+          }));
+        }
+        setGuardrailStats(gs);
       } catch {
         setData(null);
         setIsFirstTime(false);
@@ -116,11 +130,18 @@ export default function SpendDashboardPage() {
   }, [period, reloadKey]);
 
   const summary = data?.summary;
-  const byDay = data?.byDay || [];
-  const byModel = data?.byModel || [];
-  const byProvider = data?.byProvider || [];
-  const errorRateByDay = data?.errorRateByDay || [];
-  const tokensPerEndpoint = data?.tokensPerEndpoint || [];
+  // Python returns "period" as the date key; charts expect "day"
+  const byDay = (data?.by_day || data?.byDay || []).map((d: any) => ({ ...d, day: d.day || d.period }));
+  const byModel = (data?.by_model || data?.byModel || []).map((d: any) => ({ ...d, group_key: d.group_key || d.model }));
+  const byProvider = (data?.by_provider || data?.byProvider || []).map((d: any) => ({ ...d, group_key: d.group_key || d.provider }));
+  const errorRateByDay = data?.error_rate_by_day || data?.errorRateByDay || [];
+  const tokensPerEndpoint = (data?.tokens_per_endpoint || data?.tokensPerEndpoint || []).map((d: any) => ({
+    ...d,
+    endpoint: d.endpoint || d.endpoint_name,
+    // Python returns avg_tokens_per_request as a single value; split not available
+    avg_prompt_tokens: d.avg_prompt_tokens ?? d.avg_tokens_per_request ?? 0,
+    avg_completion_tokens: d.avg_completion_tokens ?? 0,
+  }));
 
   const totalCost = summary ? `$${Number(summary.total_cost).toFixed(4)}` : "$0.00";
   const totalRequests = String(summary?.total_requests ?? 0);

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -76,7 +76,7 @@ export default function SpendDashboardPage() {
       try {
         // Check first-time status before loading period-based data
         const logsCheck = await apiServices.get("/ai-gateway/spend/logs?limit=1").catch(() => null);
-        const totalLogs = logsCheck?.data?.data?.total || 0;
+        const totalLogs = logsCheck?.data?.total || 0;
         if (totalLogs === 0) {
           const [keysRes, endpointsRes, vkeysRes] = await Promise.all([
             apiServices.get("/ai-gateway/keys").catch(() => null),
@@ -85,7 +85,7 @@ export default function SpendDashboardPage() {
           ]);
           setSetupStatus({
             hasApiKey: (keysRes?.data?.data || []).length > 0,
-            hasEndpoint: (endpointsRes?.data?.data || []).length > 0,
+            hasEndpoint: (endpointsRes?.data?.endpoints || []).length > 0,
             hasVirtualKey: (vkeysRes?.data?.data || []).length > 0,
             hasRequests: false,
           });
@@ -101,10 +101,10 @@ export default function SpendDashboardPage() {
           apiServices.get(`/ai-gateway/spend/by-user?period=${period}`).catch(() => null),
           apiServices.get(`/ai-gateway/guardrails/stats?period=${period}`).catch(() => null),
         ]);
-        setData(spendRes?.data?.data || null);
-        setByEndpoint(endpointRes?.data?.data || []);
-        setByUser(userRes?.data?.data || []);
-        setGuardrailStats(gsRes?.data?.data || null);
+        setData(spendRes?.data || null);
+        setByEndpoint(endpointRes?.data || []);
+        setByUser(userRes?.data || []);
+        setGuardrailStats(gsRes?.data || null);
       } catch {
         setData(null);
         setIsFirstTime(false);
@@ -138,9 +138,9 @@ export default function SpendDashboardPage() {
     ]);
     const newStatus = {
       hasApiKey: (keysRes?.data?.data || []).length > 0,
-      hasEndpoint: (endpointsRes?.data?.data || []).length > 0,
+      hasEndpoint: (endpointsRes?.data?.endpoints || []).length > 0,
       hasVirtualKey: (vkeysRes?.data?.data || []).length > 0,
-      hasRequests: (logsCheck?.data?.data?.total || 0) > 0,
+      hasRequests: (logsCheck?.data?.total || 0) > 0,
     };
     setSetupStatus(newStatus);
     if (newStatus.hasRequests) {

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -102,8 +102,8 @@ export default function SpendDashboardPage() {
           apiServices.get(`/ai-gateway/guardrails/stats?period=${period}`).catch(() => null),
         ]);
         setData(spendRes?.data || null);
-        setByEndpoint(endpointRes?.data || []);
-        setByUser(userRes?.data || []);
+        setByEndpoint(endpointRes?.data?.data || []);
+        setByUser(userRes?.data?.data || []);
         setGuardrailStats(gsRes?.data || null);
       } catch {
         setData(null);

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -102,8 +102,8 @@ export default function SpendDashboardPage() {
           apiServices.get(`/ai-gateway/guardrails/stats?period=${period}`).catch(() => null),
         ]);
         setData(spendRes?.data || null);
-        setByEndpoint(endpointRes?.data?.data || []);
-        setByUser(userRes?.data?.data || []);
+        setByEndpoint((endpointRes?.data?.data || []).map((d: any) => ({ ...d, group_key: d.group_key || d.endpoint_name })));
+        setByUser((userRes?.data?.data || []).map((d: any) => ({ ...d, group_key: d.group_key || d.user_name })));
         // Map Python guardrail stats field names to frontend expectations
         const rawGs = gsRes?.data || null;
         if (rawGs) {

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Box, Typography, Stack } from "@mui/material";
 import { DollarSign, Hash, Layers, Clock, BarChart3, Router, Users, ShieldCheck, ShieldOff, Info } from "lucide-react";
 import { Tooltip as MuiTooltip } from "@mui/material";
@@ -105,20 +105,27 @@ export default function SpendDashboardPage() {
         setByEndpoint(endpointRes?.data?.data || []);
         setByUser(userRes?.data?.data || []);
         // Map Python guardrail stats field names to frontend expectations
-        const gs = gsRes?.data || null;
-        if (gs?.summary) {
-          gs.summary.blocked_count = gs.summary.blocked_count ?? gs.summary.blocked ?? 0;
-          gs.summary.masked_count = gs.summary.masked_count ?? gs.summary.masked ?? 0;
-          gs.summary.total_checks = gs.summary.total_checks ?? gs.summary.total ?? 0;
+        const rawGs = gsRes?.data || null;
+        if (rawGs) {
+          const mapped: any = { ...rawGs };
+          if (rawGs.summary) {
+            mapped.summary = {
+              ...rawGs.summary,
+              blocked_count: rawGs.summary.blocked_count ?? rawGs.summary.blocked ?? 0,
+              masked_count: rawGs.summary.masked_count ?? rawGs.summary.masked ?? 0,
+              total_checks: rawGs.summary.total_checks ?? rawGs.summary.total ?? 0,
+            };
+          }
+          if (!rawGs.topDetections && rawGs.byType) {
+            mapped.topDetections = rawGs.byType.map((d: any) => ({
+              ...d,
+              entity_type: d.entity_type || d.guardrail_type,
+            }));
+          }
+          setGuardrailStats(mapped);
+        } else {
+          setGuardrailStats(null);
         }
-        // byType can serve as topDetections (grouped by type + action)
-        if (!gs?.topDetections && gs?.byType) {
-          gs.topDetections = gs.byType.map((d: any) => ({
-            ...d,
-            entity_type: d.entity_type || d.guardrail_type,
-          }));
-        }
-        setGuardrailStats(gs);
       } catch {
         setData(null);
         setIsFirstTime(false);
@@ -130,18 +137,17 @@ export default function SpendDashboardPage() {
   }, [period, reloadKey]);
 
   const summary = data?.summary;
-  // Python returns "period" as the date key; charts expect "day"
-  const byDay = (data?.by_day || data?.byDay || []).map((d: any) => ({ ...d, day: d.day || d.period }));
-  const byModel = (data?.by_model || data?.byModel || []).map((d: any) => ({ ...d, group_key: d.group_key || d.model }));
-  const byProvider = (data?.by_provider || data?.byProvider || []).map((d: any) => ({ ...d, group_key: d.group_key || d.provider }));
-  const errorRateByDay = data?.error_rate_by_day || data?.errorRateByDay || [];
-  const tokensPerEndpoint = (data?.tokens_per_endpoint || data?.tokensPerEndpoint || []).map((d: any) => ({
+  // Python returns snake_case keys; charts expect camelCase / specific field names
+  const byDay = useMemo(() => (data?.by_day || data?.byDay || []).map((d: any) => ({ ...d, day: d.day || d.period })), [data]);
+  const byModel = useMemo(() => (data?.by_model || data?.byModel || []).map((d: any) => ({ ...d, group_key: d.group_key || d.model })), [data]);
+  const byProvider = useMemo(() => (data?.by_provider || data?.byProvider || []).map((d: any) => ({ ...d, group_key: d.group_key || d.provider })), [data]);
+  const errorRateByDay = useMemo(() => data?.error_rate_by_day || data?.errorRateByDay || [], [data]);
+  const tokensPerEndpoint = useMemo(() => (data?.tokens_per_endpoint || data?.tokensPerEndpoint || []).map((d: any) => ({
     ...d,
     endpoint: d.endpoint || d.endpoint_name,
-    // Python returns avg_tokens_per_request as a single value; split not available
     avg_prompt_tokens: d.avg_prompt_tokens ?? d.avg_tokens_per_request ?? 0,
     avg_completion_tokens: d.avg_completion_tokens ?? 0,
-  }));
+  })), [data]);
 
   const totalCost = summary ? `$${Number(summary.total_cost).toFixed(4)}` : "$0.00";
   const totalRequests = String(summary?.total_requests ?? 0);

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -612,7 +612,7 @@ export default function SpendDashboardPage() {
             <Stack gap="8px">
               {byUser.slice(0, 10).map((user: any, i: number) => (
                 <Stack
-                  key={user.group_key}
+                  key={user.group_key || `user-${i}`}
                   direction="row"
                   justifyContent="space-between"
                   alignItems="center"

--- a/Clients/src/presentation/pages/AIGateway/VirtualKeys/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/VirtualKeys/index.tsx
@@ -89,7 +89,7 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
         apiServices.get("/ai-gateway/endpoints").catch(() => null),
       ]);
       setKeys(keysRes?.data?.data || []);
-      const eps = endpointsRes?.data?.data || [];
+      const eps = endpointsRes?.data?.endpoints || [];
       setEndpointCount(eps.filter((e: any) => e.is_active).length);
     } catch {
       // Silently handle

--- a/Clients/src/presentation/pages/AIGateway/VirtualKeys/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/VirtualKeys/index.tsx
@@ -120,14 +120,15 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
       setIsCreateOpen(false);
       setCreateForm({ name: "", max_budget_usd: "", rate_limit_rpm: "", expires_at: "" });
 
-      if (created?.key) {
-        setNewKey(created.key);
+      if (created?.plain_key) {
+        setNewKey(created.plain_key);
         setIsKeyDisplayOpen(true);
       }
 
       await loadData();
     } catch (err: unknown) {
-      setCreateError((err as { response?: { data?: { message?: string } } })?.response?.data?.message || "Failed to create virtual key");
+      const errData = (err as { response?: { data?: { detail?: string; message?: string } } })?.response?.data;
+      setCreateError(errData?.detail || errData?.message || "Failed to create virtual key");
     } finally {
       setCreateSubmitting(false);
     }


### PR DESCRIPTION
## Summary

After commit b82837e8a (by Harsh) moved all AI Gateway controllers from Express to Python, the response formats changed. Express wrapped responses in `{ data: ... }` via `STATUS_CODE[200]()`, but the Python endpoints return different formats per endpoint.

The frontend was reading `res?.data?.data` everywhere, which worked with Express but fails with the Python responses.

## Changes

Updated 11 files, 24 accessor references to match actual Python API responses:

| Endpoint | Old accessor | New accessor |
|----------|-------------|-------------|
| `/endpoints` | `?.data?.data` | `?.data?.endpoints` |
| `/prompts` | `?.data?.data` | `?.data?.prompts` |
| `/spend/logs` | `?.data?.data?.total` | `?.data?.total` |
| `/spend?period=X` | `?.data?.data` | `?.data` |
| `/guardrails/settings` | `?.data?.data` | `?.data?.settings` |
| `/models/catalog` | `?.data?.data?.models` | `?.data?.models` |
| `/keys`, `/virtual-keys`, `/budget` | `?.data?.data` | unchanged (correct) |

## Test plan
- [ ] AI Gateway dashboard loads with spend data
- [ ] Endpoints page lists configured endpoints
- [ ] Settings page loads API keys, budget, guardrails
- [ ] Logs page shows request history
- [ ] Prompts page lists prompts
- [ ] Virtual keys page shows keys
- [ ] Models catalog loads
- [ ] Playground lists active endpoints