### PR TITLE
Changed the import in store.ts:3 from redux-persist/lib/storage (CJS) to redux-persist/es/storage (ESM)

### DIFF
--- a/Clients/src/application/redux/store.ts
+++ b/Clients/src/application/redux/store.ts
@@ -1,6 +1,6 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { persistReducer, persistStore } from "redux-persist";
-import storage from "redux-persist/lib/storage";
+import storage from "redux-persist/es/storage";
 import uiSlice from "./ui/uiSlice";
 import authReducer from "./auth/authSlice";
 import fileReducer from "./file/fileSlice";


### PR DESCRIPTION
## Changed the import in store.ts:3 from redux-persist/lib/storage (CJS) to redux-persist/es/storage (ESM), which fixes the `storage.getItem` is not a function error caused by Vite 8's changed CJS interop behavior.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
