### PR TITLE
Fix: Recharts "width(-1) and height(-1)" Console Warnings

### DIFF
--- a/Clients/src/presentation/components/AdvisorChat/ChartRenderer.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/ChartRenderer.tsx
@@ -72,7 +72,7 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
           });
 
           return (
-            <ResponsiveContainer width={300} height={250}>
+            <ResponsiveContainer width={300} height={250} minWidth={0}>
               <LineChart data={lineData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
                 <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />
@@ -98,7 +98,7 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
         if (!hasValidData) return null;
         const simpleLineData = data.map(item => ({ label: item.label, value: item.value }));
         return (
-          <ResponsiveContainer width={320} height={250}>
+          <ResponsiveContainer width={320} height={250} minWidth={0}>
             <LineChart data={simpleLineData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
               <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />
@@ -120,7 +120,7 @@ const ChartRendererComponent: FC<ChartRendererProps> = ({ chartData }) => {
       case 'bar': {
         const barChartData = data.map(item => ({ label: item.label, value: item.value }));
         return (
-          <ResponsiveContainer width={300} height={size}>
+          <ResponsiveContainer width={300} height={size} minWidth={0}>
             <BarChart data={barChartData} margin={{ left: 0, right: 20, top: 20, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
               <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={axisLine} />

--- a/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
+++ b/Clients/src/presentation/components/Cards/TaskRadarCard/index.tsx
@@ -88,7 +88,7 @@ export function TaskRadarCard({
       </Stack>
 
       <ChartOutlineWrapper>
-        <ResponsiveContainer width="100%" height={130}>
+        <ResponsiveContainer width="100%" height={130} minWidth={0}>
           <BarChart data={chartData} margin={{ top: 8, right: 0, bottom: 0, left: -24 }}>
             <CartesianGrid strokeDasharray="3 3" stroke={borderPalette.light} vertical={false} />
             <XAxis

--- a/Clients/src/presentation/components/Charts/NewMetricsCards.tsx
+++ b/Clients/src/presentation/components/Charts/NewMetricsCards.tsx
@@ -37,7 +37,7 @@ interface MetricBarChartProps {
 function MetricBarChart({ data, height = 130 }: MetricBarChartProps) {
   return (
     <ChartOutlineWrapper>
-      <ResponsiveContainer width="100%" height={height}>
+      <ResponsiveContainer width="100%" height={height} minWidth={0}>
         <BarChart data={data} margin={{ top: 8, right: 0, bottom: 0, left: -24 }}>
           <CartesianGrid strokeDasharray="3 3" stroke={borderPalette.light} vertical={false} />
           <XAxis

--- a/Clients/src/presentation/components/Charts/VWCharts.tsx
+++ b/Clients/src/presentation/components/Charts/VWCharts.tsx
@@ -145,7 +145,7 @@ export const VWBarChart: React.FC<VWBarChartProps> = ({
   const isVertical = layout === "vertical";
   return (
     <ChartOutlineWrapper>
-    <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
+    <ResponsiveContainer width="100%" height={height} minWidth={0} style={noOutlineStyle}>
       <BarChart data={data} layout={layout} margin={margin} barCategoryGap={barCategoryGap}>
         <CartesianGrid
           strokeDasharray="3 3"
@@ -254,7 +254,7 @@ export const VWAreaChart: React.FC<VWAreaChartProps> = ({
   gradientOpacity = 0.12,
 }) => (
   <ChartOutlineWrapper>
-  <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
+  <ResponsiveContainer width="100%" height={height} minWidth={0} style={noOutlineStyle}>
     <AreaChart data={data} margin={margin}>
       <defs>
         {series.map((s) => (
@@ -336,7 +336,7 @@ export const VWDonutChart: React.FC<VWDonutChartProps> = ({
   const computedOuter = outerRadius || Math.floor(size / 2) - 5;
   return (
     <Box sx={{ position: "relative", width: size, height: size, "& .recharts-tooltip-wrapper": { zIndex: "10 !important" }, "& *:focus": { outline: "none !important" }, "& svg *:focus": { outline: "none !important" } }}>
-      <ResponsiveContainer width="100%" height="100%" style={noOutlineStyle}>
+      <ResponsiveContainer width={size} height={size} minWidth={0} style={noOutlineStyle}>
         <PieChart>
           <Pie
             data={data}
@@ -421,7 +421,7 @@ export const VWLineChart: React.FC<VWLineChartProps> = ({
 }) => {
   return (
     <ChartOutlineWrapper>
-    <ResponsiveContainer width="100%" height={height} style={noOutlineStyle}>
+    <ResponsiveContainer width="100%" height={height} minWidth={0} style={noOutlineStyle}>
       <LineChart data={data} margin={margin}>
         <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
         <XAxis

--- a/Clients/src/presentation/components/Charts/chartEnhancements.tsx
+++ b/Clients/src/presentation/components/Charts/chartEnhancements.tsx
@@ -204,7 +204,7 @@ export const Sparkline: React.FC<SparklineProps> = ({
   if (!data || data.length < 2) return null;
   const chartData = data.map((v, i) => ({ v, i }));
   return (
-    <ResponsiveContainer width={width} height={height} style={{ outline: "none" }}>
+    <ResponsiveContainer width={width} height={height} minWidth={0} style={{ outline: "none" }}>
       <LineChart data={chartData} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
         <Line
           type="monotone"

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/MockDashboard.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/MockDashboard.tsx
@@ -54,7 +54,7 @@ export default function MockDashboard() {
       <Box sx={cardSx}>
         <Stack gap="12px">
           <Typography sx={sectionTitleSx}>Cost over time</Typography>
-          <ResponsiveContainer width="100%" height={260} style={{ outline: "none" }}>
+          <ResponsiveContainer width="100%" height={260} minWidth={0} style={{ outline: "none" }}>
             <BarChart data={MOCK_BY_DAY}>
               <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
               <XAxis

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -272,7 +272,7 @@ export default function SpendDashboardPage() {
                 <Box sx={{ display: "flex", cursor: "help" }}><Info size={14} color={palette.text.disabled} /></Box>
               </MuiTooltip>
             </Stack>
-            <ResponsiveContainer width="100%" height={260} style={{ outline: "none" }}>
+            <ResponsiveContainer width="100%" height={260} minWidth={0} style={{ outline: "none" }}>
               <BarChart data={byDay}>
                 <defs>
                   <GradientDef id="costBarGradient" color={palette.brand.primary} />
@@ -451,7 +451,7 @@ export default function SpendDashboardPage() {
                     <Box sx={{ display: "flex", cursor: "help" }}><Info size={14} color={palette.text.disabled} /></Box>
                   </MuiTooltip>
                 </Stack>
-                <ResponsiveContainer width="100%" height={180} style={{ outline: "none" }}>
+                <ResponsiveContainer width="100%" height={180} minWidth={0} style={{ outline: "none" }}>
                   <AreaChart data={errorRateByDay}>
                     <defs>
                       <GradientDef id="errorGradient" color={GUARDRAIL_ACTION_COLORS.blocked} />
@@ -488,7 +488,7 @@ export default function SpendDashboardPage() {
                     <Box sx={{ display: "flex", cursor: "help" }}><Info size={14} color={palette.text.disabled} /></Box>
                   </MuiTooltip>
                 </Stack>
-                <ResponsiveContainer width="100%" height={180} style={{ outline: "none" }}>
+                <ResponsiveContainer width="100%" height={180} minWidth={0} style={{ outline: "none" }}>
                   <BarChart data={tokensPerEndpoint} layout="vertical">
                     <CartesianGrid strokeDasharray="3 3" stroke={palette.border.light} />
                     <XAxis
@@ -535,7 +535,7 @@ export default function SpendDashboardPage() {
                 </Stack>
                 <Box sx={{ display: "flex", alignItems: "center", gap: "16px" }}>
                   <Box sx={{ position: "relative", width: 160, height: 160 }}>
-                    <ResponsiveContainer width={160} height={160} style={{ outline: "none" }}>
+                    <ResponsiveContainer width={160} height={160} minWidth={0} style={{ outline: "none" }}>
                       <PieChart>
                         <Pie
                           data={byProvider}
@@ -602,7 +602,7 @@ export default function SpendDashboardPage() {
                     <Typography sx={{ fontSize: 11, color: palette.text.tertiary }}>Masked</Typography>
                   </Stack>
                 </Stack>
-                <ResponsiveContainer width="100%" height={160} style={{ outline: "none" }}>
+                <ResponsiveContainer width="100%" height={160} minWidth={0} style={{ outline: "none" }}>
                   <AreaChart data={guardrailStats?.byDay || []} margin={{ left: 0, right: 0 }}>
                     <defs>
                       <GradientDef id="blockedGradient" color={GUARDRAIL_ACTION_COLORS.blocked} />

--- a/Clients/src/presentation/pages/EvalsDashboard/components/PerformanceChart.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/components/PerformanceChart.tsx
@@ -308,7 +308,7 @@ export default function PerformanceChart({ projectId, timeRange }: PerformanceCh
 
   return (
     <ChartOutlineWrapper>
-        <ResponsiveContainer key={`rc-${projectId}-${data.length}-${activeMetrics.join(",")}-${timeRange}`} width="100%" height={Math.max(dynamicHeight, 220)} debounce={1}>
+        <ResponsiveContainer key={`rc-${projectId}-${data.length}-${activeMetrics.join(",")}-${timeRange}`} width="100%" height={Math.max(dynamicHeight, 220)} minWidth={0} debounce={1}>
         <LineChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 20 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" />
           <XAxis 


### PR DESCRIPTION
# Fix: Recharts "width(-1) and height(-1)" Console Warnings

## Problem

Navigating to the Dashboard and other pages with charts produced repeated console warnings:

```
The width(-1) and height(-1) of chart should be greater than 0
```

This happened because Recharts `ResponsiveContainer` components measure their parent element's dimensions on mount. During initial render — before CSS layout completes (Fade animations, CSS grid calculations) — the measured size minus padding/borders can result in negative values (-1).

All 17 `ResponsiveContainer` instances across the codebase were affected.

## Fix

**For most charts:** Added `minWidth={0}` to every `ResponsiveContainer`. This tells Recharts to clamp to 0 instead of going negative, suppressing the warning while rendering correctly once layout completes.

**For `VWDonutChart` specifically:** The chart used `width="100%" height="100%"` inside a parent `Box` with a known pixel `size` prop. Percentage-based dimensions forced `ResponsiveContainer` to measure the parent, hitting the race condition. Replaced with explicit pixel dimensions (`width={size} height={size}`) to bypass the measurement entirely.

## Files Changed

| File | What changed |
|------|-------------|
| `Charts/VWCharts.tsx` | Added `minWidth={0}` to VWBarChart, VWAreaChart, VWLineChart; used pixel dims for VWDonutChart |
| `Cards/TaskRadarCard/index.tsx` | Added `minWidth={0}` |
| `Charts/NewMetricsCards.tsx` | Added `minWidth={0}` |
| `Charts/chartEnhancements.tsx` | Added `minWidth={0}` to Sparkline |
| `AdvisorChat/ChartRenderer.tsx` | Added `minWidth={0}` to 3 chart renderers |
| `AIGateway/SpendDashboard/MockDashboard.tsx` | Added `minWidth={0}` |
| `AIGateway/SpendDashboard/index.tsx` | Added `minWidth={0}` to 5 charts |
| `EvalsDashboard/components/PerformanceChart.tsx` | Added `minWidth={0}` |


------

Close #3588 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
