### PR TITLE
fix(dashboard): redirect to overview after deleting demo data

### DIFF
--- a/Clients/src/presentation/containers/Dashboard/index.tsx
+++ b/Clients/src/presentation/containers/Dashboard/index.tsx
@@ -234,8 +234,8 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
 
         setShowToastNotification(false);
 
-        // Reload the page to refresh all dashboard metrics
-        window.location.reload();
+        // Navigate to overview to avoid 404s on deleted entity pages
+        window.location.href = "/overview";
       } else {
         setShowToastNotification(false);
         logEngine({


### PR DESCRIPTION
## Summary
- After deleting demo data, the page now redirects to `/overview` instead of reloading the current URL
- Fixes 404 errors when the user was on a page referencing a deleted entity (e.g. `/project-view?projectId=5`)

## Test plan
- [ ] Create demo data
- [ ] Navigate to the demo project view page
- [ ] Delete demo data
- [ ] Verify the page redirects to `/overview` instead of showing a 404