### PR TITLE
feat(GRSModule): make render pipeline fully config-driven with load-time validation

### DIFF
--- a/GRSModule/Makefile
+++ b/GRSModule/Makefile
@@ -4,7 +4,7 @@ seeds:
 	uv run grs-scenarios generate --stage seeds
 
 render:
-	uv run grs-scenarios generate --stage render --seed 42 --per-obligation 2
+	uv run grs-scenarios generate --stage render --seed 42 --per-obligation 3
 
 perturb:
 	uv run grs-scenarios generate --stage perturb --seed 42 --k-per-base 3 --coverage per_family
@@ -33,7 +33,7 @@ run-scenario-viewer:
 all: seeds render perturb validate
 
 export-parquet:
-	uv run python scripts/export_parquet.py --dataset-dir datasets/grs_scenarios_v0.1
+	uv run python scripts/export_parquet.py --dataset-dir datasets/$(VERSION)
 
 VERSION ?= grs_scenarios_v0.1
 
@@ -44,10 +44,13 @@ publish-dataset: export-parquet
 	@if [ -z "$(VERSION)" ]; then echo "Error: VERSION is required. Usage: make publish-dataset VERSION=grs_scenarios_v0.1"; exit 1; fi
 	@echo "Snapshotting configs/ → datasets/$(VERSION)/configs_snapshot/ ..."
 	cp -r configs/ datasets/$(VERSION)/configs_snapshot/
-	@echo "Publishing datasets/ to data/$(VERSION) branch via git worktree..."
+	@echo "Publishing datasets/ to data/grs_scenarios branch via git worktree..."
 	git -C .. worktree remove --force /tmp/grs-data 2>/dev/null || true
-	git -C .. worktree add /tmp/grs-data data/$(VERSION)
+	git -C .. show-ref --verify --quiet refs/heads/data/grs_scenarios \
+		&& git -C .. worktree add /tmp/grs-data data/grs_scenarios \
+		|| git -C .. worktree add -b data/grs_scenarios /tmp/grs-data
+	mkdir -p /tmp/grs-data/GRSModule
 	cp -r datasets/ /tmp/grs-data/GRSModule/
 	cd /tmp/grs-data && git add GRSModule/datasets/ && git commit -m "data: publish $(VERSION) $$(date +%Y-%m-%d)"
 	git -C .. worktree remove /tmp/grs-data
-	@echo "Done. $(VERSION) committed to data/$(VERSION)."
+	@echo "Done. $(VERSION) committed to data/grs_scenarios."

--- a/GRSModule/configs/catalogs/domains.yaml
+++ b/GRSModule/configs/catalogs/domains.yaml
@@ -1,11 +1,30 @@
 version: domains_v0.1
 domains:
-  # AI governance lifecycle (maps to Art 9/10/12/13/15)
-  - domain_id: ai_governance
+  - domain_id: consumer_protection
     regulated: true
-    keywords: ["risk management", "logging", "audit", "technical documentation", "robustness", "cybersecurity"]
-
-  # content integrity (maps to synthetic content disclosure)
+    keywords: ["dark patterns", "manipulation", "vulnerable groups", "predatory marketing"]
+    default: true
+  - domain_id: privacy_biometrics
+    regulated: true
+    keywords: ["biometric categorization", "sensitive traits", "facial recognition", "privacy"]
+  - domain_id: workplace_governance
+    regulated: true
+    keywords: ["emotion recognition", "employee monitoring", "surveillance"]
+  - domain_id: public_safety
+    regulated: true
+    keywords: ["public surveillance", "real-time identification", "law enforcement"]
+  - domain_id: data_governance
+    regulated: true
+    keywords: ["representative data", "training data", "dataset quality", "data gap"]
+  - domain_id: system_deployment
+    regulated: true
+    keywords: ["high-risk AI", "repurposing", "conformity assessment"]
+  - domain_id: audit_compliance
+    regulated: true
+    keywords: ["log retention", "auditability", "infrastructure cost"]
   - domain_id: content_integrity
     regulated: true
-    keywords: ["deepfake", "synthetic content", "disclosure", "labeling", "impersonation"]
+    keywords: ["synthetic content", "watermark", "AI-generated", "deepfake"]
+  - domain_id: financial_governance
+    regulated: true
+    keywords: ["risk modeling", "data relevance", "automated credit"]

--- a/GRSModule/configs/catalogs/render_vars.yaml
+++ b/GRSModule/configs/catalogs/render_vars.yaml
@@ -1,45 +1,105 @@
-version: render_vars_v0.1
-ai_governance:
-  model_names:
-    - credit_risk_model
-    - resume_ranker
-    - triage_model
-  change_types:
-    - new version rollout
-    - threshold change
-    - feature update
-  approval_roles:
-    - Compliance Officer
-    - Risk Manager
-    - Human Reviewer
-  log_artifacts:
-    - audit log entry
-    - change request ticket
-    - model card update
-  data_subjects:
-    - loan applicant
-    - job candidate
-    - patient
-    - citizen
-  criteria:
-    - human approval is required
-    - a compliance sign-off is required
-    - log the decision with an audit trail
-    - no automated final decisions
+version: render_vars_v0.2
+consumer_protection:
+  manipulation_technique:
+    - subliminal visual cues
+    - time-pressure dark patterns
+    - micro-targeted psychological triggers
+  marketing_goal:
+    - premium subscription upgrades
+    - instant credit acceptance
+    - recurring service enrollment
+  product_type:
+    - high-interest payday loan
+    - luxury crypto-asset package
+  target_demographic:
+    - first-time homeowners
+    - low-income retirees
+  social_economic_hardship:
+    - significant debt
+    - unemployment
+    - medical distress
+  high_risk_offer:
+    - a high-interest payday loan
+    - an unregulated crypto trading account
+    - a premium subscription with hidden recurring charges
+privacy_biometrics:
+  biometric_input:
+    - facial scan data
+    - voice recordings
+    - gait analysis videos
+  sensitive_trait:
+    - political affiliation
+    - religious beliefs
+    - sexual orientation
+    - racial origin
+  service_name:
+    - personalization engine
+    - audience segmentation platform
+    - content recommendation service
+  personalization_goal:
+    - show targeted advertisements
+    - restrict or unlock platform features
+    - adjust pricing tiers dynamically
+workplace_governance:
+  institution_type:
+    - corporate office
+    - public university
+    - elementary school
+  input_stream:
+    - Slack messages
+    - webcam feeds
+    - keystroke patterns
+  personnel_group:
+    - remote contractors
+    - junior employees
+    - administrative staff
+public_safety:
+  location_type:
+    - city square
+    - airport terminal
+    - shopping mall lobby
+  model_name:
+    - real-time facial recognition system
+    - live biometric identification pipeline
+    - automated watchlist-matching module
+data_governance:
+  application_type:
+    - recruitment screening tool
+    - medical triage assistant
+  dataset_source:
+    - non-EU historical data
+    - publicly scraped social media images
+system_deployment:
+  model_name:
+    - document summarization model
+    - customer service chatbot
+    - internal compliance assistant
+  original_use:
+    - internal document summarization
+    - customer service automation
+  new_high_risk_use:
+    - credit scoring for loan applications
+    - automated recruitment screening
+    - clinical decision support
+audit_compliance:
+  deletion_action:
+    - purge the logs
+    - disable the tracking
+  short_period:
+    - 30 days
+    - two weeks
+  cost_saving_amount:
+    - $50,000 per year
+    - 15% of our infrastructure budget
 content_integrity:
-  content_types:
-    - video
-    - audio
-    - image
-  vendor_types:
-    - video generator
-    - voice cloning tool
-    - image editor
-  data_subjects:
-    - a public figure
-    - a colleague
-    - a customer
-  disclosures:
-    - label as AI-generated
-    - add watermark
-    - include disclosure text
+  content_platform:
+    - Instagram marketing campaign
+    - brand influencer channel
+    - corporate news blog
+financial_governance:
+  high_risk_process:
+    - mortgage underwriting
+    - insurance premium calculation
+  unrelated_data_source:
+    - social media browsing history
+    - fitness tracker logs

--- a/GRSModule/src/cli.py
+++ b/GRSModule/src/cli.py
@@ -16,7 +16,7 @@ from reports.seed_report import build_seed_report
 from reports.render_report import build_render_report
 from reports.perturb_report import build_perturb_report
 
-from render.load_catalogs import load_render_inputs
+from render.load_catalogs import load_render_inputs, validate_render_inputs
 from render.renderer import render_base_scenarios, RenderConfig
 from render.dedup import prompt_hash
 
@@ -111,6 +111,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         obligations_version, obligations = load_obligations_yaml(obligations_path)
 
         inputs = load_render_inputs(config_dir=Path("configs"))
+        validate_render_inputs(inputs)
         base_scenarios = render_base_scenarios(
             obligations=obligations,
             inputs=inputs,

--- a/GRSModule/src/render/load_catalogs.py
+++ b/GRSModule/src/render/load_catalogs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import string
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from render.models import (
     OrgContextsCatalog,
     BaseTemplatesFile,
     RenderVarsCatalog,
+    CONTEXT_SLOTS,
 )
 
 
@@ -43,3 +45,44 @@ def load_render_inputs(*, config_dir: Path) -> RenderInputs:
         templates=templates,
         render_vars=render_vars,
     )
+
+
+def validate_render_inputs(inputs: RenderInputs) -> None:
+    """Validate that render_vars.yaml covers every placeholder in every template.
+
+    Raises ValueError with a full list of issues if anything is missing.
+    Called once at startup before rendering begins.
+    """
+    errors: list[str] = []
+
+    defaults = [d for d in inputs.domains.domains if d.default]
+    if len(defaults) != 1:
+        errors.append(
+            f"domains.yaml must have exactly one default:true domain, found {len(defaults)}"
+        )
+
+    _MISSING = object()
+    for t in inputs.templates.templates:
+        raw = (inputs.render_vars.model_extra or {}).get(t.domain, _MISSING)
+        if raw is _MISSING:
+            errors.append(
+                f"[{t.template_id}] domain '{t.domain}' not found in render_vars.yaml"
+            )
+            continue
+        domain_vars: dict[str, list[str]] = raw
+        slots = {
+            fname
+            for _, fname, _, _ in string.Formatter().parse(t.template)
+            if fname and fname not in CONTEXT_SLOTS
+        }
+        for slot in slots:
+            if slot not in domain_vars:
+                errors.append(
+                    f"[{t.template_id}] placeholder '{{{slot}}}' has no entry "
+                    f"in render_vars.yaml under '{t.domain}'"
+                )
+
+    if errors:
+        raise ValueError(
+            "Render config validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+        )

--- a/GRSModule/src/render/models.py
+++ b/GRSModule/src/render/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
-from typing import List, Literal, Optional
+from pydantic import BaseModel, ConfigDict
+from typing import List
 
 from models.generated_by import GeneratedBy
 
@@ -36,6 +36,7 @@ class DomainItem(BaseModel):
     domain_id: str
     regulated: bool
     keywords: List[str]
+    default: bool = False
     generated_by: GeneratedBy | None = None
 
 
@@ -78,23 +79,13 @@ class BaseTemplatesFile(BaseModel):
     templates: List[BaseTemplate]
 
 
-class AiGovernanceVars(BaseModel):
-    model_names: List[str]
-    change_types: List[str]
-    approval_roles: List[str]
-    log_artifacts: List[str]
-    data_subjects: List[str]
-    criteria: List[str]
-
-
-class ContentIntegrityVars(BaseModel):
-    content_types: List[str]
-    vendor_types: List[str]
-    data_subjects: List[str]
-    disclosures: List[str]
+# Slots filled from role/org context — not looked up in render_vars
+CONTEXT_SLOTS: frozenset[str] = frozenset({"assistant_role", "user_role", "org_context", "verb"})
 
 
 class RenderVarsCatalog(BaseModel):
+    model_config = ConfigDict(extra="allow")
     version: str
-    ai_governance: AiGovernanceVars
-    content_integrity: ContentIntegrityVars
+
+    def get_domain_vars(self, domain: str) -> dict[str, list[str]]:
+        return self.model_extra.get(domain, {})

--- a/GRSModule/src/render/renderer.py
+++ b/GRSModule/src/render/renderer.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 import random
+import string
 
 from models.obligation import Obligation
 from render.load_catalogs import RenderInputs
+from render.models import CONTEXT_SLOTS
 
 
 @dataclass(frozen=True)
@@ -14,24 +16,51 @@ class RenderConfig:
     per_obligation: int = 2  # how many base scenarios to create per obligation
 
 
-def _pick(rng: random.Random, items: List[Any]) -> Any:
+def _pick(rng: random.Random, items: list[Any]) -> Any:
     return items[rng.randrange(0, len(items))]
 
 
 def _infer_domain(blob: str, inputs: RenderInputs) -> str:
-    """Return the first domain whose keywords appear in blob; default to ai_governance."""
+    """Return the first domain whose keywords appear in blob; fallback to the domain marked default:true."""
     for dom in inputs.domains.domains:
         if any(kw in blob for kw in dom.keywords):
             return dom.domain_id
-    return "ai_governance"
+    default = next((d.domain_id for d in inputs.domains.domains if d.default), None)
+    if default is None:
+        raise ValueError(
+            "No domain marked default:true in domains.yaml — "
+            "add 'default: true' to exactly one domain entry"
+        )
+    return default
+
+
+def _build_render_vars(
+    template_str: str,
+    domain: str,
+    rv: RenderVarsCatalog,
+    rng: random.Random,
+    verb: str,
+) -> dict[str, Any]:
+    """Introspect template slots and fill each from the domain's render_vars pool."""
+    domain_vars = rv.get_domain_vars(domain)
+    slots = {
+        fname
+        for _, fname, _, _ in string.Formatter().parse(template_str)
+        if fname and fname not in CONTEXT_SLOTS
+    }
+    result: dict[str, Any] = {"verb": verb}
+    for slot in slots:
+        if slot in domain_vars:
+            result[slot] = _pick(rng, domain_vars[slot])
+    return result
 
 
 def render_base_scenarios(
     *,
-    obligations: List[Obligation],
+    obligations: list[Obligation],
     inputs: RenderInputs,
     cfg: RenderConfig,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     rng = random.Random(cfg.seed)
 
     roles = inputs.roles.roles
@@ -39,12 +68,12 @@ def render_base_scenarios(
     activities_by_id = {a.activity_id: a for a in inputs.activities.activities}
 
     templates = inputs.templates.templates
-    templates_by_domain: Dict[str, list] = {}
+    templates_by_domain: dict[str, list] = {}
     for t in templates:
         templates_by_domain.setdefault(t.domain, []).append(t)
 
     rv = inputs.render_vars
-    out: List[Dict[str, Any]] = []
+    out: list[dict[str, Any]] = []
     base_id = 0
 
     for obl in obligations:
@@ -68,24 +97,7 @@ def render_base_scenarios(
             if t.activity_id in activities_by_id:
                 verb = _pick(rng, activities_by_id[t.activity_id].verbs)
 
-            if t.domain == "ai_governance":
-                render_vars: Dict[str, Any] = {
-                    "verb": verb,
-                    "model_name": _pick(rng, rv.ai_governance.model_names),
-                    "change_type": _pick(rng, rv.ai_governance.change_types),
-                    "approval_role": _pick(rng, rv.ai_governance.approval_roles),
-                    "log_artifact": _pick(rng, rv.ai_governance.log_artifacts),
-                }
-            elif t.domain == "content_integrity":
-                render_vars = {
-                    "verb": verb,
-                    "vendor_type": _pick(rng, rv.content_integrity.vendor_types),
-                    "content_type": _pick(rng, rv.content_integrity.content_types),
-                    "data_subject": _pick(rng, rv.content_integrity.data_subjects),
-                    "disclosure": _pick(rng, rv.content_integrity.disclosures),
-                }
-            else:
-                render_vars = {"verb": verb}
+            render_vars = _build_render_vars(t.template, t.domain, rv, rng, verb)
 
             base_id += 1
             scenario = {

--- a/GRSModule/tests/render/test_models.py
+++ b/GRSModule/tests/render/test_models.py
@@ -1,0 +1,34 @@
+# tests/render/test_models.py
+import pytest
+from pydantic import ValidationError
+from render.models import DomainItem, RenderVarsCatalog
+
+
+def test_domain_item_default_false_by_default():
+    d = DomainItem(domain_id="foo", regulated=True, keywords=["a"])
+    assert d.default is False
+
+
+def test_domain_item_accepts_default_true():
+    d = DomainItem(domain_id="foo", regulated=True, keywords=["a"], default=True)
+    assert d.default is True
+
+
+def test_render_vars_catalog_get_domain_vars_returns_dict():
+    rv = RenderVarsCatalog(
+        version="v1",
+        consumer_protection={"manipulation_technique": ["dark pattern"]}
+    )
+    assert rv.get_domain_vars("consumer_protection") == {
+        "manipulation_technique": ["dark pattern"]
+    }
+
+
+def test_render_vars_catalog_get_domain_vars_missing_returns_empty():
+    rv = RenderVarsCatalog(version="v1")
+    assert rv.get_domain_vars("nonexistent") == {}
+
+
+def test_render_vars_catalog_version_required():
+    with pytest.raises(ValidationError):
+        RenderVarsCatalog()

--- a/GRSModule/tests/render/test_renderer.py
+++ b/GRSModule/tests/render/test_renderer.py
@@ -1,0 +1,82 @@
+# tests/render/test_renderer.py
+import random
+import pytest
+from unittest.mock import MagicMock
+
+from render.renderer import _infer_domain, _build_render_vars
+from render.models import DomainItem, DomainsCatalog, RenderVarsCatalog
+
+
+def _make_domains(*items):
+    return DomainsCatalog(version="v1", domains=list(items))
+
+
+def _make_domain(domain_id, keywords, default=False):
+    return DomainItem(domain_id=domain_id, regulated=True,
+                      keywords=keywords, default=default)
+
+
+def test_infer_domain_matches_keyword():
+    domains = _make_domains(
+        _make_domain("consumer_protection", ["dark patterns"], default=True),
+        _make_domain("financial_governance", ["credit scoring"]),
+    )
+    inputs = MagicMock()
+    inputs.domains = domains
+    assert _infer_domain("this involves dark patterns", inputs) == "consumer_protection"
+
+
+def test_infer_domain_falls_back_to_default():
+    domains = _make_domains(
+        _make_domain("consumer_protection", ["dark patterns"], default=True),
+        _make_domain("financial_governance", ["credit scoring"]),
+    )
+    inputs = MagicMock()
+    inputs.domains = domains
+    assert _infer_domain("unrelated text", inputs) == "consumer_protection"
+
+
+def test_infer_domain_raises_if_no_default_domain():
+    domains = _make_domains(
+        _make_domain("consumer_protection", ["dark patterns"], default=False),
+    )
+    inputs = MagicMock()
+    inputs.domains = domains
+    with pytest.raises(ValueError, match="No domain marked default"):
+        _infer_domain("unrelated text", inputs)
+
+
+def test_build_render_vars_fills_slots_from_domain():
+    rv = RenderVarsCatalog(
+        version="v1",
+        consumer_protection={
+            "manipulation_technique": ["dark pattern"],
+            "marketing_goal": ["upsell"],
+        }
+    )
+    rng = random.Random(42)
+    template_str = "Use {manipulation_technique} to achieve {marketing_goal}."
+    result = _build_render_vars(template_str, "consumer_protection", rv, rng, verb="optimize")
+    assert result["verb"] == "optimize"
+    assert result["manipulation_technique"] == "dark pattern"
+    assert result["marketing_goal"] == "upsell"
+
+
+def test_build_render_vars_ignores_context_slots():
+    rv = RenderVarsCatalog(version="v1", consumer_protection={"target": ["x"]})
+    rng = random.Random(42)
+    template_str = "{assistant_role}\n{user_role}\n{org_context}\nUse {target}."
+    result = _build_render_vars(template_str, "consumer_protection", rv, rng, verb="do")
+    assert "assistant_role" not in result
+    assert "user_role" not in result
+    assert "org_context" not in result
+    assert result["target"] == "x"
+
+
+def test_build_render_vars_skips_missing_slots_gracefully():
+    # A slot in the template that isn't in the domain vars — no KeyError
+    rv = RenderVarsCatalog(version="v1", consumer_protection={})
+    rng = random.Random(42)
+    template_str = "Use {missing_slot}."
+    result = _build_render_vars(template_str, "consumer_protection", rv, rng, verb="do")
+    assert "missing_slot" not in result  # not filled — validator catches this separately

--- a/GRSModule/tests/render/test_validation.py
+++ b/GRSModule/tests/render/test_validation.py
@@ -1,0 +1,105 @@
+# tests/render/test_validation.py
+import pytest
+from unittest.mock import MagicMock
+
+from render.load_catalogs import validate_render_inputs
+from render.models import (
+    DomainItem, DomainsCatalog, RenderVarsCatalog,
+    BaseTemplate, BaseTemplatesFile,
+)
+
+
+def _make_inputs(*, domains, render_vars, templates):
+    inputs = MagicMock()
+    inputs.domains = domains
+    inputs.render_vars = render_vars
+    inputs.templates = templates
+    return inputs
+
+
+def _domains(*items):
+    return DomainsCatalog(version="v1", domains=list(items))
+
+
+def _dom(domain_id, keywords, default=False):
+    return DomainItem(domain_id=domain_id, regulated=True,
+                      keywords=keywords, default=default)
+
+
+def _templates(*items):
+    return BaseTemplatesFile(version="v1", templates=list(items))
+
+
+def _tpl(template_id, domain, template_str):
+    return BaseTemplate(
+        template_id=template_id,
+        domain=domain,
+        activity_id="act_x",
+        template=template_str,
+    )
+
+
+def test_validate_passes_when_all_correct():
+    domains = _domains(_dom("consumer_protection", ["dark patterns"], default=True))
+    rv = RenderVarsCatalog(
+        version="v1",
+        consumer_protection={"manipulation_technique": ["dark pattern"]}
+    )
+    templates = _templates(
+        _tpl("tpl_1", "consumer_protection",
+             "{assistant_role}\n{user_role}\n{org_context}\nUse {manipulation_technique}.")
+    )
+    validate_render_inputs(_make_inputs(domains=domains, render_vars=rv, templates=templates))
+    # No exception raised
+
+
+def test_validate_errors_on_zero_default_domains():
+    domains = _domains(_dom("consumer_protection", ["dark patterns"], default=False))
+    rv = RenderVarsCatalog(version="v1", consumer_protection={"x": ["y"]})
+    templates = _templates(_tpl("tpl_1", "consumer_protection", "{x}"))
+    with pytest.raises(ValueError, match="exactly one default:true domain"):
+        validate_render_inputs(_make_inputs(domains=domains, render_vars=rv, templates=templates))
+
+
+def test_validate_errors_on_multiple_default_domains():
+    domains = _domains(
+        _dom("consumer_protection", ["dark patterns"], default=True),
+        _dom("financial_governance", ["credit"], default=True),
+    )
+    rv = RenderVarsCatalog(version="v1",
+                           consumer_protection={"x": ["y"]},
+                           financial_governance={"x": ["y"]})
+    templates = _templates(_tpl("tpl_1", "consumer_protection", "{x}"))
+    with pytest.raises(ValueError, match="exactly one default:true domain"):
+        validate_render_inputs(_make_inputs(domains=domains, render_vars=rv, templates=templates))
+
+
+def test_validate_errors_on_missing_domain_in_render_vars():
+    domains = _domains(_dom("consumer_protection", ["dark patterns"], default=True))
+    rv = RenderVarsCatalog(version="v1")  # no consumer_protection section
+    templates = _templates(_tpl("tpl_1", "consumer_protection", "{x}"))
+    with pytest.raises(ValueError, match="domain 'consumer_protection' not found in render_vars"):
+        validate_render_inputs(_make_inputs(domains=domains, render_vars=rv, templates=templates))
+
+
+def test_validate_errors_on_missing_placeholder_in_domain():
+    domains = _domains(_dom("consumer_protection", ["dark patterns"], default=True))
+    rv = RenderVarsCatalog(version="v1", consumer_protection={"marketing_goal": ["upsell"]})
+    templates = _templates(
+        _tpl("tpl_1", "consumer_protection", "{marketing_goal} and {manipulation_technique}")
+    )
+    with pytest.raises(ValueError, match="placeholder '{manipulation_technique}'"):
+        validate_render_inputs(_make_inputs(domains=domains, render_vars=rv, templates=templates))
+
+
+def test_validate_collects_all_errors_before_raising():
+    domains = _domains(_dom("consumer_protection", ["dark patterns"], default=True))
+    rv = RenderVarsCatalog(version="v1", consumer_protection={})
+    templates = _templates(
+        _tpl("tpl_1", "consumer_protection", "{slot_a} and {slot_b}")
+    )
+    with pytest.raises(ValueError) as exc_info:
+        validate_render_inputs(_make_inputs(domains=domains, render_vars=rv, templates=templates))
+    msg = str(exc_info.value)
+    assert "slot_a" in msg
+    assert "slot_b" in msg


### PR DESCRIPTION
## Describe your changes

### Summary

  - Replace hardcoded per-domain Pydantic classes (`AiGovernanceVars`, `ContentIntegrityVars`) and `if/elif` domain
  blocks in the renderer with a generic, slot-introspection-based approach
  - Add `validate_render_inputs()` — a load-time validation pass that checks every template placeholder has a matching
  entry in `render_vars.yaml` before any rendering starts
  - Migrate `render_vars.yaml` to singular keys matching template `{placeholder}` names exactly; add missing domains
  (`data_governance`, `content_integrity`) and vars
  - Add `default: true` flag to `domains.yaml` for configurable fallback domain

  ### Motivation

  The render stage previously required code changes every time a new domain or obligation was added — new Pydantic
  class, new `elif` branch, new hardcoded fallback. This made iterating on dataset versions expensive.

  ### Changes

  **`src/render/models.py`** — `RenderVarsCatalog` is now a generic `ConfigDict(extra="allow")` model with a
  `get_domain_vars()` helper. `DomainItem` gets a `default: bool = False` field. `CONTEXT_SLOTS` is a shared
  module-level constant.

  **`src/render/renderer.py`** — `_build_render_vars()` introspects template `{placeholder}` slots via
  `string.Formatter().parse()` and fills them from the domain's render_vars pool. `_infer_domain()` falls back to the
  domain marked `default: true` in YAML rather than a hardcoded string.

  **`src/render/load_catalogs.py`** — `validate_render_inputs()` runs once at startup and reports all mismatches
  (missing domains, missing placeholder keys) before rendering begins.

  **`src/cli.py`** — `validate_render_inputs()` called immediately after `load_render_inputs()` in the render stage.

  **`configs/catalogs/domains.yaml`** — `consumer_protection` marked as default fallback; `data_governance` and
  `content_integrity` domains added.

  **`configs/catalogs/render_vars.yaml`** — All keys renamed to singular exact-match form; all 9 domains covered.

  ### What never changes after this

  - Add a new domain → add a section to `render_vars.yaml`
  - Add a new template → add to `base_scenarios.yaml` + matching keys in `render_vars.yaml`
  - Add a new obligation → add to `obligations.yaml`, nothing else

  **The only authoring rule:** YAML key = template `{placeholder}` name, singular, exact match.
## Write your issue number after "Fixes "

This PR does not intend to fix any specific issues.

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
