### PR TITLE
Feat(ai-gateway): Add model/provider access controls on virtual keys

### DIFF
--- a/AIGateway/src/crud/virtual_keys.py
+++ b/AIGateway/src/crud/virtual_keys.py
@@ -26,6 +26,10 @@ async def get_all_virtual_keys(org_id: int) -> list[dict]:
                     vk.key_prefix,
                     vk.name,
                     vk.allowed_endpoint_ids,
+                    vk.allowed_models,
+                    vk.blocked_models,
+                    vk.allowed_providers,
+                    vk.blocked_providers,
                     vk.max_budget_usd,
                     vk.current_spend_usd,
                     vk.rate_limit_rpm,
@@ -67,6 +71,16 @@ async def create_virtual_key(org_id: int, data: dict) -> Optional[dict]:
     rate_limit_rpm = data.get("rate_limit_rpm")
     name = data.get("name")
 
+    def _to_text_array(lst):
+        if lst and len(lst) > 0:
+            return "{" + ",".join(f'"{v}"' for v in lst) + "}"
+        return "{}"
+
+    allowed_models = _to_text_array(data.get("allowed_models"))
+    blocked_models = _to_text_array(data.get("blocked_models"))
+    allowed_providers = _to_text_array(data.get("allowed_providers"))
+    blocked_providers = _to_text_array(data.get("blocked_providers"))
+
     async with get_db() as db:
         result = await db.execute(
             text("""
@@ -76,6 +90,10 @@ async def create_virtual_key(org_id: int, data: dict) -> Optional[dict]:
                     key_prefix,
                     name,
                     allowed_endpoint_ids,
+                    allowed_models,
+                    blocked_models,
+                    allowed_providers,
+                    blocked_providers,
                     max_budget_usd,
                     rate_limit_rpm,
                     metadata,
@@ -87,6 +105,10 @@ async def create_virtual_key(org_id: int, data: dict) -> Optional[dict]:
                     :key_prefix,
                     :name,
                     :allowed_endpoint_ids::int[],
+                    :allowed_models::text[],
+                    :blocked_models::text[],
+                    :allowed_providers::text[],
+                    :blocked_providers::text[],
                     :max_budget_usd,
                     :rate_limit_rpm,
                     :metadata::jsonb,
@@ -98,6 +120,10 @@ async def create_virtual_key(org_id: int, data: dict) -> Optional[dict]:
                     key_prefix,
                     name,
                     allowed_endpoint_ids,
+                    allowed_models,
+                    blocked_models,
+                    allowed_providers,
+                    blocked_providers,
                     max_budget_usd,
                     current_spend_usd,
                     rate_limit_rpm,
@@ -115,6 +141,10 @@ async def create_virtual_key(org_id: int, data: dict) -> Optional[dict]:
                 "key_prefix": key_data["prefix"],
                 "name": name,
                 "allowed_endpoint_ids": array_literal,
+                "allowed_models": allowed_models,
+                "blocked_models": blocked_models,
+                "allowed_providers": allowed_providers,
+                "blocked_providers": blocked_providers,
                 "max_budget_usd": max_budget_usd,
                 "rate_limit_rpm": rate_limit_rpm,
                 "metadata": metadata_json,
@@ -149,6 +179,16 @@ async def update_virtual_key(org_id: int, key_id: int, data: dict) -> Optional[d
         set_clauses.append("allowed_endpoint_ids = :allowed_endpoint_ids::int[]")
         params["allowed_endpoint_ids"] = array_literal
 
+    def _to_text_array(lst):
+        if lst and len(lst) > 0:
+            return "{" + ",".join(f'"{v}"' for v in lst) + "}"
+        return "{}"
+
+    for field in ("allowed_models", "blocked_models", "allowed_providers", "blocked_providers"):
+        if field in data:
+            set_clauses.append(f"{field} = :{field}::text[]")
+            params[field] = _to_text_array(data[field])
+
     if "max_budget_usd" in data:
         set_clauses.append("max_budget_usd = :max_budget_usd")
         params["max_budget_usd"] = data["max_budget_usd"]
@@ -181,6 +221,10 @@ async def update_virtual_key(org_id: int, key_id: int, data: dict) -> Optional[d
             key_prefix,
             name,
             allowed_endpoint_ids,
+            allowed_models,
+            blocked_models,
+            allowed_providers,
+            blocked_providers,
             max_budget_usd,
             current_spend_usd,
             rate_limit_rpm,

--- a/AIGateway/src/database/migrations/versions/a0003_add_virtual_key_model_provider_acls.py
+++ b/AIGateway/src/database/migrations/versions/a0003_add_virtual_key_model_provider_acls.py
@@ -1,0 +1,42 @@
+"""Add model/provider access control columns to virtual keys.
+
+Revision ID: a0003
+Revises: a0002
+Create Date: 2026-03-28
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a0003"
+down_revision: Union[str, None] = "a0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add allowed/blocked models and providers columns to ai_gateway_virtual_keys."""
+    op.execute("SET search_path TO verifywise")
+
+    op.execute("""
+        ALTER TABLE ai_gateway_virtual_keys
+        ADD COLUMN IF NOT EXISTS allowed_models TEXT[] DEFAULT '{}',
+        ADD COLUMN IF NOT EXISTS blocked_models TEXT[] DEFAULT '{}',
+        ADD COLUMN IF NOT EXISTS allowed_providers TEXT[] DEFAULT '{}',
+        ADD COLUMN IF NOT EXISTS blocked_providers TEXT[] DEFAULT '{}'
+    """)
+
+
+def downgrade() -> None:
+    """Remove model/provider access control columns."""
+    op.execute("SET search_path TO verifywise")
+
+    op.execute("""
+        ALTER TABLE ai_gateway_virtual_keys
+        DROP COLUMN IF EXISTS allowed_models,
+        DROP COLUMN IF EXISTS blocked_models,
+        DROP COLUMN IF EXISTS allowed_providers,
+        DROP COLUMN IF EXISTS blocked_providers
+    """)

--- a/AIGateway/src/routers/proxy.py
+++ b/AIGateway/src/routers/proxy.py
@@ -26,6 +26,7 @@ from services.proxy_service import (
     authenticate_virtual_key,
     resolve_endpoint_for_key,
     resolve_endpoint_by_id,
+    enforce_model_provider_acls,
     check_org_budget,
     reconcile_budget,
     enforce_rate_limits,
@@ -89,6 +90,12 @@ async def proxy_chat(request: Request, body: ProxyChatRequest):
         )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+    # Model/provider access control
+    try:
+        enforce_model_provider_acls(vk, endpoint)
+    except ValueError as e:
+        raise HTTPException(status_code=403, detail=str(e))
 
     # Rate limit: per-endpoint + per-key
     await enforce_rate_limits(endpoint, vk)
@@ -325,6 +332,12 @@ async def proxy_embeddings(request: Request, body: ProxyEmbeddingRequest):
         )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+    # Model/provider access control
+    try:
+        enforce_model_provider_acls(vk, endpoint)
+    except ValueError as e:
+        raise HTTPException(status_code=403, detail=str(e))
 
     # Rate limit
     await enforce_rate_limits(endpoint, vk)

--- a/AIGateway/src/routers/virtual_keys.py
+++ b/AIGateway/src/routers/virtual_keys.py
@@ -70,12 +70,33 @@ async def create_key(request: Request):
                 detail="expires_at must be a valid ISO 8601 datetime string",
             )
 
+    # Validate model/provider ACL fields
+    acl_fields = {}
+    for field in ("allowed_models", "blocked_models", "allowed_providers", "blocked_providers"):
+        value = body.get(field)
+        if value is not None:
+            if not isinstance(value, list):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"{field} must be an array",
+                )
+            if not all(isinstance(v, str) for v in value):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"{field} must be an array of strings",
+                )
+            acl_fields[field] = value
+
     org_id = get_org_id(request)
     user_id = get_user_id(request)
 
     data = {
         "name": name,
         "allowed_endpoint_ids": body.get("allowed_endpoint_ids") or [],
+        "allowed_models": acl_fields.get("allowed_models", []),
+        "blocked_models": acl_fields.get("blocked_models", []),
+        "allowed_providers": acl_fields.get("allowed_providers", []),
+        "blocked_providers": acl_fields.get("blocked_providers", []),
         "max_budget_usd": body.get("max_budget_usd"),
         "rate_limit_rpm": body.get("rate_limit_rpm"),
         "metadata": body.get("metadata"),
@@ -171,6 +192,22 @@ async def update_key(key_id: int, request: Request):
                 detail="rate_limit_rpm must be an integer",
             )
         updates["rate_limit_rpm"] = value
+
+    # model/provider ACLs
+    for field in ("allowed_models", "blocked_models", "allowed_providers", "blocked_providers"):
+        if field in body:
+            value = body[field]
+            if value is not None and not isinstance(value, list):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"{field} must be an array",
+                )
+            if value is not None and not all(isinstance(v, str) for v in value):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"{field} must be an array of strings",
+                )
+            updates[field] = value if value is not None else []
 
     # metadata
     if "metadata" in body:

--- a/AIGateway/src/services/proxy_service.py
+++ b/AIGateway/src/services/proxy_service.py
@@ -56,6 +56,8 @@ async def authenticate_virtual_key(bearer_token: str) -> dict:
         result = await db.execute(
             text("""
                 SELECT id, organization_id, name, allowed_endpoint_ids,
+                       allowed_models, blocked_models,
+                       allowed_providers, blocked_providers,
                        max_budget_usd, current_spend_usd, rate_limit_rpm,
                        is_active, revoked_at, expires_at
                 FROM ai_gateway_virtual_keys
@@ -76,6 +78,44 @@ async def authenticate_virtual_key(bearer_token: str) -> dict:
             if float(row["current_spend_usd"]) >= float(row["max_budget_usd"]):
                 raise ValueError("Virtual key budget exhausted")
         return dict(row)
+
+
+# ─── Model / Provider ACL Enforcement ────────────────────────────────────────
+
+def _matches_acl(value: str, patterns: list[str]) -> bool:
+    """Check if a value matches any pattern in the list. Supports trailing wildcard (e.g. 'gpt-4o*')."""
+    for pattern in patterns:
+        if pattern.endswith("*"):
+            if value.startswith(pattern[:-1]):
+                return True
+        elif value == pattern:
+            return True
+    return False
+
+
+def enforce_model_provider_acls(vk: dict, endpoint: dict):
+    """
+    Check virtual key model/provider ACLs against the resolved endpoint.
+    Raises ValueError if the request is denied.
+    """
+    provider = endpoint.get("provider", "")
+    model = endpoint.get("model", "")
+
+    allowed_providers = vk.get("allowed_providers") or []
+    if allowed_providers and not _matches_acl(provider, allowed_providers):
+        raise ValueError(f"Virtual key does not allow provider: {provider}")
+
+    blocked_providers = vk.get("blocked_providers") or []
+    if blocked_providers and _matches_acl(provider, blocked_providers):
+        raise ValueError(f"Virtual key blocks provider: {provider}")
+
+    allowed_models = vk.get("allowed_models") or []
+    if allowed_models and not _matches_acl(model, allowed_models):
+        raise ValueError(f"Virtual key does not allow model: {model}")
+
+    blocked_models = vk.get("blocked_models") or []
+    if blocked_models and _matches_acl(model, blocked_models):
+        raise ValueError(f"Virtual key blocks model: {model}")
 
 
 # ─── Endpoint Resolution ─────────────────────────────────────────────────────

--- a/Clients/src/presentation/pages/AIGateway/VirtualKeys/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/VirtualKeys/index.tsx
@@ -31,6 +31,10 @@ interface CreateVirtualKeyPayload {
   max_budget_usd?: number;
   rate_limit_rpm?: number;
   expires_at?: string;
+  allowed_models?: string[];
+  blocked_models?: string[];
+  allowed_providers?: string[];
+  blocked_providers?: string[];
 }
 
 interface VirtualKey {
@@ -38,6 +42,10 @@ interface VirtualKey {
   key_prefix: string;
   name: string;
   allowed_endpoint_ids: number[];
+  allowed_models: string[];
+  blocked_models: string[];
+  allowed_providers: string[];
+  blocked_providers: string[];
   max_budget_usd: number | null;
   current_spend_usd: number;
   rate_limit_rpm: number | null;
@@ -62,6 +70,10 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
     max_budget_usd: "",
     rate_limit_rpm: "",
     expires_at: "",
+    allowed_models: "",
+    blocked_models: "",
+    allowed_providers: "",
+    blocked_providers: "",
   });
   const [createError, setCreateError] = useState("");
   const [createSubmitting, setCreateSubmitting] = useState(false);
@@ -115,10 +127,16 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
       if (createForm.rate_limit_rpm) payload.rate_limit_rpm = Number(createForm.rate_limit_rpm);
       if (createForm.expires_at) payload.expires_at = new Date(createForm.expires_at).toISOString();
 
+      const parseList = (v: string) => v.split(",").map((s) => s.trim()).filter(Boolean);
+      if (createForm.allowed_models.trim()) payload.allowed_models = parseList(createForm.allowed_models);
+      if (createForm.blocked_models.trim()) payload.blocked_models = parseList(createForm.blocked_models);
+      if (createForm.allowed_providers.trim()) payload.allowed_providers = parseList(createForm.allowed_providers);
+      if (createForm.blocked_providers.trim()) payload.blocked_providers = parseList(createForm.blocked_providers);
+
       const res = await apiServices.post<Record<string, any>>("/ai-gateway/virtual-keys", payload);
       const created = res?.data?.data;
       setIsCreateOpen(false);
-      setCreateForm({ name: "", max_budget_usd: "", rate_limit_rpm: "", expires_at: "" });
+      setCreateForm({ name: "", max_budget_usd: "", rate_limit_rpm: "", expires_at: "", allowed_models: "", blocked_models: "", allowed_providers: "", blocked_providers: "" });
 
       if (created?.plain_key) {
         setNewKey(created.plain_key);
@@ -173,7 +191,7 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
       text="Create key"
       icon={<CirclePlus size={14} strokeWidth={1.5} />}
       onClick={() => {
-        setCreateForm({ name: "", max_budget_usd: "", rate_limit_rpm: "", expires_at: "" });
+        setCreateForm({ name: "", max_budget_usd: "", rate_limit_rpm: "", expires_at: "", allowed_models: "", blocked_models: "", allowed_providers: "", blocked_providers: "" });
         setCreateError("");
         setIsCreateOpen(true);
       }}
@@ -275,6 +293,18 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
                               {key.rate_limit_rpm} RPM
                             </Typography>
                           )}
+                          {key.allowed_models?.length > 0 && (
+                            <Chip label={`models: ${key.allowed_models.join(", ")}`} size="small" uppercase={false} />
+                          )}
+                          {key.blocked_models?.length > 0 && (
+                            <Chip label={`blocked: ${key.blocked_models.join(", ")}`} size="small" uppercase={false} />
+                          )}
+                          {key.allowed_providers?.length > 0 && (
+                            <Chip label={`providers: ${key.allowed_providers.join(", ")}`} size="small" uppercase={false} />
+                          )}
+                          {key.blocked_providers?.length > 0 && (
+                            <Chip label={`blocked providers: ${key.blocked_providers.join(", ")}`} size="small" uppercase={false} />
+                          )}
                           <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
                             by {key.created_by_name} &middot; {displayFormattedDate(key.created_at)}
                           </Typography>
@@ -367,6 +397,30 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
             placeholder="e.g., 60 (leave empty for no limit)"
             value={createForm.rate_limit_rpm}
             onChange={(e) => setCreateForm((p) => ({ ...p, rate_limit_rpm: e.target.value }))}
+          />
+          <Field
+            label="Allowed models"
+            placeholder="e.g., gpt-4o-mini, claude-haiku* (comma-separated, leave empty for all)"
+            value={createForm.allowed_models}
+            onChange={(e) => setCreateForm((p) => ({ ...p, allowed_models: e.target.value }))}
+          />
+          <Field
+            label="Blocked models"
+            placeholder="e.g., gpt-4o, claude-opus* (comma-separated)"
+            value={createForm.blocked_models}
+            onChange={(e) => setCreateForm((p) => ({ ...p, blocked_models: e.target.value }))}
+          />
+          <Field
+            label="Allowed providers"
+            placeholder="e.g., openai, anthropic (comma-separated, leave empty for all)"
+            value={createForm.allowed_providers}
+            onChange={(e) => setCreateForm((p) => ({ ...p, allowed_providers: e.target.value }))}
+          />
+          <Field
+            label="Blocked providers"
+            placeholder="e.g., openrouter (comma-separated)"
+            value={createForm.blocked_providers}
+            onChange={(e) => setCreateForm((p) => ({ ...p, blocked_providers: e.target.value }))}
           />
           <DatePicker
             label="Expiry date"


### PR DESCRIPTION
## Describe your changes

- Adds 4 new fields to virtual keys — allowed_models, blocked_models, allowed_providers, blocked_providers — enabling admins to restrict which models and providers a key can access
- Enforces ACLs at proxy time with 403 responses, supporting wildcard patterns (e.g. claude-haiku*)
- Includes frontend fields in the create modal and ACL chips on key cards

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
