### PR TITLE
Agent modal inline validation was replaced with the generic hook

### DIFF
--- a/Clients/src/presentation/components/Modals/AgentDiscovery/ManualAgentModal.tsx
+++ b/Clients/src/presentation/components/Modals/AgentDiscovery/ManualAgentModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Drawer,
   Stack,
@@ -14,6 +14,8 @@ import { CustomizableButton } from "../../button/customizable-button";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import { AgentPrimitiveRow } from "../../../../domain/interfaces/i.agentDiscovery";
+import { useFormValidation } from "../../../../application/hooks/useFormValidation";
+import { checkStringValidation } from "../../../../application/validations/stringValidation";
 
 interface ManualAgentModalProps {
   isOpen: boolean;
@@ -48,7 +50,19 @@ const ManualAgentModal: React.FC<ManualAgentModalProps> = ({
     owner_id: "",
     notes: "",
   });
-  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const validators = useMemo(
+    () => ({
+      display_name: (v: unknown) => {
+        const r = checkStringValidation("Display name", v as string, 1, 256);
+        return r.accepted ? "" : r.message;
+      },
+      primitive_type: (v: unknown) => (!v ? "Type is required." : ""),
+    }),
+    []
+  );
+  const { errors, validateAll, clearFieldError, resetErrors } =
+    useFormValidation<typeof formData>(validators);
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -82,23 +96,11 @@ const ManualAgentModal: React.FC<ManualAgentModalProps> = ({
   const handleClose = () => {
     setIsOpen(false);
     setFormData({ display_name: "", primitive_type: "", owner_id: "", notes: "" });
-    setErrors({});
-  };
-
-  const validate = (): boolean => {
-    const newErrors: Record<string, string> = {};
-    if (!formData.display_name.trim()) {
-      newErrors.display_name = "Display name is required";
-    }
-    if (!formData.primitive_type) {
-      newErrors.primitive_type = "Type is required";
-    }
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+    resetErrors();
   };
 
   const handleSubmit = async () => {
-    if (!validate()) return;
+    if (!validateAll(formData)) return;
 
     setIsSubmitting(true);
     try {
@@ -154,9 +156,10 @@ const ManualAgentModal: React.FC<ManualAgentModalProps> = ({
           label="Display name"
           placeholder="e.g. Sales Assistant Bot"
           value={formData.display_name}
-          onChange={(e) =>
-            setFormData((prev) => ({ ...prev, display_name: e.target.value }))
-          }
+          onChange={(e) => {
+            setFormData((prev) => ({ ...prev, display_name: e.target.value }));
+            clearFieldError("display_name");
+          }}
           isRequired
           error={errors.display_name}
         />
@@ -169,12 +172,13 @@ const ManualAgentModal: React.FC<ManualAgentModalProps> = ({
           items={PRIMITIVE_TYPES}
           isRequired
           error={errors.primitive_type}
-          onChange={(e) =>
+          onChange={(e) => {
             setFormData((prev) => ({
               ...prev,
               primitive_type: e.target.value as string,
-            }))
-          }
+            }));
+            clearFieldError("primitive_type");
+          }}
         />
 
         <SelectComponent


### PR DESCRIPTION
## Describe your changes

A reusable generic useFormValidation hook has been integrated into the "Add agent" modal, replacing the previous custom validation logic.

## Write your issue number after "Fixes "

Fixes #3619 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="700" height="400" alt="Screenshot 2026-03-27 at 6 28 45 PM" src="https://github.com/user-attachments/assets/87a52cb9-a7d0-4d51-9da4-f6c88b1b9b31" />
