### PR TITLE
fix(onboarding): mark onboarding completed after demo data insertion

### DIFF
--- a/Servers/controllers/autoDriver.ctrl.ts
+++ b/Servers/controllers/autoDriver.ctrl.ts
@@ -6,6 +6,7 @@ import {
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import logger, { logStructured } from "../utils/logger/fileLogger";
 import { logEvent } from "../utils/logger/dbLogger";
+import { sequelize } from "../database/db";
 
 export async function postAutoDriver(req: Request, res: Response) {
   logStructured(
@@ -18,6 +19,12 @@ export async function postAutoDriver(req: Request, res: Response) {
 
   try {
     await insertMockData(req.organizationId!, req.organizationId!, req.userId!);
+
+    // Mark onboarding as completed so the setup modal doesn't show again
+    await sequelize.query(
+      `UPDATE organizations SET onboarding_status = 'completed' WHERE id = :organizationId`,
+      { replacements: { organizationId: req.organizationId! } }
+    );
 
     logStructured(
       "successful",


### PR DESCRIPTION
## Summary
- After demo data is seeded via the auto-driver, the setup modal ("Welcome to VerifyWise") still appeared because `onboarding_status` remained `pending` in the organizations table
- Added a query to set `onboarding_status = 'completed'` after `insertMockData` succeeds in `autoDriver.ctrl.ts`

## Test plan
- [ ] Deploy fresh instance with demo data seeded
- [ ] Log in as org creator
- [ ] Verify the "Welcome to VerifyWise" setup modal does NOT appear
- [ ] Verify clicking "Add demo data" on a truly fresh org (no pre-seeded data) still works correctly