### PR TITLE
fix(ui): scan page cleanup and restore layout spacing

### DIFF
--- a/Clients/src/presentation/components/Layout/PageHeaderExtended.tsx
+++ b/Clients/src/presentation/components/Layout/PageHeaderExtended.tsx
@@ -68,7 +68,7 @@ export function PageHeaderExtended({
                     {loadingToast}
 
                     {(tipBoxEntity || summaryCards) && (
-                        <Stack gap="18px" sx={{ mt: "18px" }}>
+                        <Stack gap="18px" sx={{ mt: "18px", mb: summaryCards ? "16px" : 0 }}>
                             {tipBoxEntity && <TipBox entityName={tipBoxEntity} />}
                             {summaryCards && (
                                 <Box
@@ -80,7 +80,9 @@ export function PageHeaderExtended({
                             )}
                         </Stack>
                     )}
-                    {children}
+                    <Stack gap="16px">
+                        {children}
+                    </Stack>
                 </>
             )}
         </Stack>

--- a/Clients/src/presentation/pages/AIDetection/ScanPage.tsx
+++ b/Clients/src/presentation/pages/AIDetection/ScanPage.tsx
@@ -310,8 +310,8 @@ export default function ScanPage() {
       }
     >
 
-      {/* Statistics Cards - 6 cards in 3x2 grid (only show if there are scans) */}
-      {!isCheckingActive && scanState === "idle" && !statsLoading && stats && stats.total_scans > 0 && (
+      {/* Statistics Cards - 6 cards in 3x2 grid */}
+      {!isCheckingActive && scanState === "idle" && !statsLoading && stats && (
         <Box
           sx={{
             display: "grid",
@@ -397,10 +397,7 @@ export default function ScanPage() {
       {!isCheckingActive && scanState === "idle" && (
         <Box
           sx={{
-            backgroundColor: palette.background.main,
-            border: `1px solid ${palette.border.dark}`,
-            borderRadius: "4px",
-            p: 2,
+            pt: "16px",
           }}
         >
           {/* Repository URL section */}
@@ -456,7 +453,7 @@ export default function ScanPage() {
                   </InputAdornment>
                 ),
               }}
-              sx={{ mb: 0 }}
+              sx={{ mb: 0, maxWidth: "480px" }}
             />
           </Box>
 


### PR DESCRIPTION
## Summary
- Remove card border/background around scan form on AI Detection scan page
- Add 16px padding above Repository URL block
- Narrow the repository URL input field (max-width 480px)
- Show stat cards regardless of scan count
- Restore 16px gap between children in PageHeaderExtended (was lost when outer Stack was set to gap=0 for alert layout fix)
- Add conditional bottom margin after summary cards

## Test plan
- [ ] Check `/ai-detection/scan` — no card around form, narrower input, stats visible with 0 scans
- [ ] Check `/ai-incident-managements` — spacing between cards, filter row, and table is 16px
- [ ] Check `/vendors` and `/policies` — no extra spacing between description and tab bar
- [ ] Check `/risk-management` — summary cards have 16px gap before filter row