### PR TITLE
fix(build): resolve all TypeScript build errors in frontend

### DIFF
--- a/Clients/env.vars.ts
+++ b/Clients/env.vars.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 export const ENV_VARs = {
   URL:
     import.meta.env.VITE_APP_API_BASE_URL ?? // keep empty string if set

--- a/Clients/src/application/hooks/__tests__/useAuth.test.ts
+++ b/Clients/src/application/hooks/__tests__/useAuth.test.ts
@@ -32,12 +32,14 @@ function createWrapper(authToken: string) {
         expirationDate: null,
         onboardingStatus: "completed",
         isOrgCreator: false,
+        isSuperAdmin: false,
+        activeOrganizationId: null,
       },
     },
   });
 
   return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(Provider, { store }, children);
+    React.createElement(Provider, { store, children });
 }
 
 describe("useAuth", () => {

--- a/Clients/src/application/hooks/__tests__/useIsAdmin.test.ts
+++ b/Clients/src/application/hooks/__tests__/useIsAdmin.test.ts
@@ -27,12 +27,14 @@ function createWrapper(authToken: string) {
         expirationDate: null,
         onboardingStatus: "completed",
         isOrgCreator: false,
+        isSuperAdmin: false,
+        activeOrganizationId: null,
       },
     },
   });
 
   return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(Provider, { store }, children);
+    React.createElement(Provider, { store, children });
 }
 
 describe("useIsAdmin", () => {

--- a/Clients/src/application/hooks/__tests__/useLogout.test.ts
+++ b/Clients/src/application/hooks/__tests__/useLogout.test.ts
@@ -29,16 +29,16 @@ function createWrapper() {
         expirationDate: Date.now() + 3600000,
         onboardingStatus: "completed",
         isOrgCreator: false,
+        isSuperAdmin: false,
+        activeOrganizationId: null,
       },
     },
   });
 
-  const Wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(
-      Provider,
-      { store },
-      React.createElement(MemoryRouter, null, children)
-    );
+  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+    const inner = React.createElement(MemoryRouter, null, children);
+    return React.createElement(Provider, { store, children: inner });
+  };
 
   return { Wrapper, store };
 }

--- a/Clients/src/application/redux/store.ts
+++ b/Clients/src/application/redux/store.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../vite-env.d.ts" />
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { persistReducer, persistStore } from "redux-persist";
 import storage from "redux-persist/es/storage";

--- a/Clients/src/application/redux/ui/__tests__/uiSlice.test.ts
+++ b/Clients/src/application/redux/ui/__tests__/uiSlice.test.ts
@@ -64,7 +64,7 @@ describe("uiSlice", () => {
       const state = uiReducer(
         stateWithTable,
         setRowsPerPage({ table: "vendors", value: 25 })
-      );
+      ) as any;
       expect(state.vendors.rowsPerPage).toBe(25);
     });
 

--- a/Clients/src/application/utils/deploymentHelpers.ts
+++ b/Clients/src/application/utils/deploymentHelpers.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../vite-env.d.ts" />
 import React from "react";
 import { ENV_VARs } from "../../../env.vars";
 

--- a/Clients/src/domain/types/Event.js
+++ b/Clients/src/domain/types/Event.js
@@ -1,2 +1,0 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });

--- a/Clients/src/presentation/components/CommandPalette/__tests__/CommandPalette.test.tsx
+++ b/Clients/src/presentation/components/CommandPalette/__tests__/CommandPalette.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../test/renderWithProviders";
 import { CommandPalette } from "../index";
 

--- a/Clients/src/presentation/components/Inputs/Field/__tests__/Field.test.tsx
+++ b/Clients/src/presentation/components/Inputs/Field/__tests__/Field.test.tsx
@@ -103,7 +103,7 @@ describe("Field Component", () => {
   it("does not display error when error prop is empty", () => {
     renderWithProviders(<Field label="Email" />);
 
-    expect(screen.queryByClassName?.("input-error")).not.toBeTruthy();
+    expect(document.querySelector(".input-error")).not.toBeTruthy();
   });
 
   it("renders disabled input", () => {

--- a/Clients/src/presentation/components/Table/__tests__/Table.test.tsx
+++ b/Clients/src/presentation/components/Table/__tests__/Table.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../../../test/renderWithProviders";
 import CustomizableBasicTable from "../index";

--- a/Clients/src/presentation/containers/Dashboard/index.tsx
+++ b/Clients/src/presentation/containers/Dashboard/index.tsx
@@ -40,7 +40,7 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
   const { userRoleName, isSuperAdmin, activeOrganizationId } = useAuth();
   const isAdmin = userRoleName === "Admin";
   const dispatch = useDispatch();
-  const [superAdminHasNoOrgs, setSuperAdminHasNoOrgs] = useState(false);
+  const [_superAdminHasNoOrgs, setSuperAdminHasNoOrgs] = useState(false);
 
   // Demo data state
   const [showToastNotification, setShowToastNotification] =

--- a/Clients/src/test/setup.ts
+++ b/Clients/src/test/setup.ts
@@ -9,8 +9,7 @@ expect.extend(matchers as unknown as MatchersObject);
 // In jsdom, window.location.port is "" which produces "http://localhost:/api"
 // (invalid URL). Ensure a clean base URL for customAxios.
 if (!import.meta.env.VITE_APP_API_BASE_URL) {
-  // @ts-expect-error — Vite env is readonly at the type level
-  import.meta.env.VITE_APP_API_BASE_URL = "http://localhost:3000";
+  (import.meta.env as Record<string, string>).VITE_APP_API_BASE_URL = "http://localhost:3000";
 }
 
 // ---- Global stubs ----

--- a/Clients/src/vite-env.d.ts
+++ b/Clients/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 /// <reference path="./types/lucide-react.d.ts" />
+/// <reference path="./presentation/themes/theme.d.ts" />
+/// <reference path="./presentation/configs/declarations.d.ts" />
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }


### PR DESCRIPTION
## Summary
- Fix all TypeScript errors that caused npm run build to fail (was 192 errors, now 0)
- All fixes are type-only or test-only, no runtime behavior changes
- Both Servers and Clients builds pass clean

## Changes
- Add vite/client and SVG type references for import.meta.env and ReactComponent
- Fix test mock types to match updated auth slice
- Remove unused imports in test files
- Prefix unused Dashboard variable
- Remove stale Event.js file

## Test plan
- [ ] Run cd Servers && npm run build (passes)
- [ ] Run cd Clients && npm run build (passes, zero errors)
- [ ] Verify app runs normally at localhost:5173