### PR TITLE
fix(ai-gateway): guardrail catalog enable button not reflecting enabled state

### DIFF
--- a/Clients/src/presentation/pages/AIGateway/Guardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Guardrails/index.tsx
@@ -182,7 +182,7 @@ export default function GuardrailsPage() {
   const loadRules = useCallback(async () => {
     try {
       const res = await apiServices.get<Record<string, any>>("/ai-gateway/guardrails");
-      setRules(res?.data?.data || []);
+      setRules(res?.data?.rules || res?.data?.data || []);
     } catch {
       // Silently handle
     } finally {


### PR DESCRIPTION
## Summary
- Fixed guardrail catalog "Enable" button never updating to "Enabled" after activation
- Root cause: `loadRules()` read `res.data.data` but the API returns `{ rules: [...] }`, so rules were always an empty array and the catalog could never match existing rules
- Also cleaned up 13 duplicate PII rules in the database that were created by repeated Enable clicks while the bug was present

## Test plan
- [ ] Open AI Gateway > Guardrails > PII detection
- [ ] Click "Add from catalog"
- [ ] Verify already-enabled rules show "Enabled" text instead of "Enable" button
- [ ] Click "Enable" on a new rule and verify it switches to "Enabled" without page reload
- [ ] Verify the PII detection list on the main page shows all configured rules