### PR TITLE
Inline validation replaced with generic hook on New policy

### DIFF
--- a/Clients/src/presentation/components/Policies/PolicyForm.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyForm.tsx
@@ -32,6 +32,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
   setFormData,
   tags,
   errors,
+  clearFieldError,
 }) => {
   const theme = useTheme();
   const { users } = useUsers();
@@ -43,8 +44,9 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
           ...prevValues,
           [prop]: newValue,
         }));
+        clearFieldError(prop);
       },
-    []
+    [clearFieldError]
   );
 
   const handleDateChange = useCallback((newDate: Dayjs | null) => {
@@ -53,8 +55,9 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
         ...prevValues,
         nextReviewDate: newDate ? newDate.toISOString() : "",
       }));
+      clearFieldError("nextReviewDate");
     }
-  }, []);
+  }, [clearFieldError]);
 
   const autocompleteSlotProps = {
     paper: {
@@ -88,9 +91,10 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
           label="Policy title"
           width="100%"
           value={formData.title ?? ""}
-          onChange={(e) =>
-            setFormData((prev) => ({ ...prev, title: e.target.value }))
-          }
+          onChange={(e) => {
+            setFormData((prev) => ({ ...prev, title: e.target.value }));
+            clearFieldError("title");
+          }}
           error={errors.title}
           sx={{
             backgroundColor: `${background.main}`,
@@ -306,6 +310,7 @@ const PolicyForm: React.FC<PolicyFormProps> = ({
             const statusValue = e.target.value;
             if (typeof statusValue === "string") {
               setFormData((prev) => ({ ...prev, status: statusValue }));
+              clearFieldError("status");
             }
           }}
           items={statuses.map((s) => ({ _id: s, name: s }))}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -112,6 +112,7 @@ import { User } from "../../../domain/types/User";
 import { PolicyFormData, PolicyFormErrors } from "../../types/interfaces/i.policy";
 import { PolicyManagerModel } from "../../../domain/models/Common/policy/policyManager.model";
 import { checkStringValidation } from "../../../application/validations/stringValidation";
+import { useFormValidation } from "../../../application/hooks/useFormValidation";
 import { store } from "../../../application/redux/store";
 import policyTemplates from "../../../application/data/PolicyTemplates.json";
 import { PageBreadcrumbs } from "../../components/breadcrumbs/PageBreadcrumbs";
@@ -452,7 +453,7 @@ export default function PolicyEditorPage() {
   const docxInputRef = useRef<HTMLInputElement>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
-  const [errors, setErrors] = useState<PolicyFormErrors>({});
+  const [serverErrors, setServerErrors] = useState<PolicyFormErrors>({});
   const [toolbarState, setToolbarState] = useState(defaultToolbarState);
   const [currentBlockType, setCurrentBlockType] = useState<string>("p");
   const imageInputRef = useRef<HTMLInputElement>(null);
@@ -468,6 +469,41 @@ export default function PolicyEditorPage() {
   const [searchText, setSearchText] = useState("");
   const [replaceText, setReplaceText] = useState("");
   const [searchMatchCount, setSearchMatchCount] = useState(0);
+
+  const validators = useMemo(
+    () => ({
+      title: (v: unknown) => {
+        const r = checkStringValidation("Policy title", v as string, 1, 64);
+        return r.accepted ? "" : r.message;
+      },
+      status: (v: unknown) => (!v ? "Status is required." : ""),
+      tags: (v: unknown) => {
+        const t = v as string[];
+        return t.filter((tag) => tag.trim() !== "").length === 0
+          ? "At least one tag is required."
+          : "";
+      },
+      nextReviewDate: (v: unknown) => {
+        const r = checkStringValidation("Next review date", (v as string) || "", 1);
+        return r.accepted ? "" : r.message;
+      },
+      assignedReviewers: (v: unknown) => {
+        const reviewers = v as PolicyFormData["assignedReviewers"];
+        return reviewers.filter((u) => u.id !== undefined).length === 0
+          ? "At least one reviewer is required."
+          : "";
+      },
+    }),
+    []
+  );
+
+  const { errors: validationErrors, validateAll, resetErrors } =
+    useFormValidation<PolicyFormData>(validators);
+
+  const displayErrors = useMemo(
+    () => ({ ...validationErrors, ...serverErrors }),
+    [validationErrors, serverErrors]
+  );
 
   const [formData, setFormData] = useState<PolicyFormData>({
     title: "",
@@ -1170,39 +1206,15 @@ export default function PolicyEditorPage() {
     },
   ];
 
-  // ── Validation ────────────────────────────────────────────────────
-  const validateForm = (): boolean => {
-    const newErrors: PolicyFormErrors = {};
-
-    const titleCheck = checkStringValidation("Policy title", formData.title, 1, 64);
-    if (!titleCheck.accepted) newErrors.title = titleCheck.message;
-    if (!formData.status) newErrors.status = "Status is required";
-
-    if (formData.tags.filter((t) => t.trim() !== "").length === 0)
-      newErrors.tags = "At least one tag is required";
-
-    const dateCheck = checkStringValidation(
-      "Next review date",
-      formData.nextReviewDate || "",
-      1
-    );
-    if (!dateCheck.accepted) newErrors.nextReviewDate = dateCheck.message;
-
-    if (formData.assignedReviewers.filter((u) => u.id !== undefined).length === 0)
-      newErrors.assignedReviewers = "At least one reviewer is required";
-
-    setErrors(newErrors);
-    if (Object.keys(newErrors).length > 0) {
-      formRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-      setValidationSnackbar(true);
-      return false;
-    }
-    return true;
-  };
-
   // ── Save ──────────────────────────────────────────────────────────
   const save = async () => {
-    if (!validateForm()) return;
+    setServerErrors({});
+    resetErrors();
+    if (!validateAll(formData)) {
+      formRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      setValidationSnackbar(true);
+      return;
+    }
     setIsSaving(true);
 
     const html = editor?.getHTML() || "";
@@ -1241,19 +1253,19 @@ export default function PolicyEditorPage() {
         err?.originalError?.response || err?.response?.data || err?.response;
 
       if (errorData?.errors) {
-        const serverErrors: PolicyFormErrors = {};
+        const apiErrors: PolicyFormErrors = {};
         errorData.errors.forEach((error: any) => {
-          if (error.field === "title") serverErrors.title = error.message;
-          else if (error.field === "status") serverErrors.status = error.message;
-          else if (error.field === "tags") serverErrors.tags = error.message;
+          if (error.field === "title") apiErrors.title = error.message;
+          else if (error.field === "status") apiErrors.status = error.message;
+          else if (error.field === "tags") apiErrors.tags = error.message;
           else if (error.field === "content_html")
-            serverErrors.content = error.message;
+            apiErrors.content = error.message;
           else if (error.field === "next_review_date")
-            serverErrors.nextReviewDate = error.message;
+            apiErrors.nextReviewDate = error.message;
           else if (error.field === "assigned_reviewer_ids")
-            serverErrors.assignedReviewers = error.message;
+            apiErrors.assignedReviewers = error.message;
         });
-        setErrors(serverErrors);
+        setServerErrors(apiErrors);
       }
     }
   };
@@ -1727,8 +1739,8 @@ export default function PolicyEditorPage() {
             formData={formData}
             setFormData={setFormData}
             tags={tags}
-            errors={errors}
-            setErrors={setErrors}
+            errors={displayErrors}
+            setErrors={() => {}}
           />
         </Box>
 
@@ -2263,13 +2275,13 @@ export default function PolicyEditorPage() {
             `}</style>
           </Box>
 
-          {errors.content && (
+          {displayErrors.content && (
             <Typography
               component="span"
               color={theme.palette.status?.error?.text || theme.palette.error.main}
               sx={{ opacity: 0.8, fontSize: 11, mt: 1 }}
             >
-              {errors.content}
+              {displayErrors.content}
             </Typography>
           )}
 

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -497,7 +497,7 @@ export default function PolicyEditorPage() {
     []
   );
 
-  const { errors: validationErrors, validateAll, resetErrors } =
+  const { errors: validationErrors, validateAll, resetErrors, clearFieldError } =
     useFormValidation<PolicyFormData>(validators);
 
   const displayErrors = useMemo(
@@ -1740,7 +1740,7 @@ export default function PolicyEditorPage() {
             setFormData={setFormData}
             tags={tags}
             errors={displayErrors}
-            setErrors={() => {}}
+            clearFieldError={clearFieldError}
           />
         </Box>
 

--- a/Clients/src/presentation/types/interfaces/i.policy.ts
+++ b/Clients/src/presentation/types/interfaces/i.policy.ts
@@ -48,7 +48,7 @@ export interface PolicyFormProps {
   setFormData: React.Dispatch<React.SetStateAction<import("../../../domain/interfaces/i.policy").PolicyFormData>>;
   tags: string[];
   errors: import("../../../domain/interfaces/i.policy").PolicyFormErrors;
-  setErrors: React.Dispatch<React.SetStateAction<import("../../../domain/interfaces/i.policy").PolicyFormErrors>>;
+  clearFieldError: (field: keyof import("../../../domain/interfaces/i.policy").PolicyFormData) => void;
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

A reusable generic useFormValidation hook has been integrated into the "New Policy" modal, replacing the previous custom validation logic.

## Write your issue number after "Fixes "

Fixes #3660 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="800" height="400" alt="Screenshot 2026-04-02 at 7 16 49 PM" src="https://github.com/user-attachments/assets/db771597-de77-40eb-aba7-5134208cece3" />
