### PR TITLE
fix(super-admin): improve super admin panel UX and add user management

### DIFF
--- a/Clients/src/application/constants/roles.ts
+++ b/Clients/src/application/constants/roles.ts
@@ -5,3 +5,19 @@ export const ROLES = {
   4 : "Auditor",
   5 : "Super Admin"
 }
+
+/** Assignable role options (excludes Super Admin) for dropdowns */
+export const ROLE_OPTIONS = [
+  { value: 1, label: "Admin" },
+  { value: 2, label: "Reviewer" },
+  { value: 3, label: "Editor" },
+  { value: 4, label: "Auditor" },
+] as const;
+
+/** Role badge colors for table display */
+export const ROLE_COLORS: Record<string, { bg: string; text: string }> = {
+  Admin: { bg: "#eff6ff", text: "#2563eb" },
+  Reviewer: { bg: "#faf5ff", text: "#9333ea" },
+  Editor: { bg: "#f0fdf4", text: "#16a34a" },
+  Auditor: { bg: "#fefce8", text: "#ca8a04" },
+};

--- a/Clients/src/application/repository/superAdmin.repository.ts
+++ b/Clients/src/application/repository/superAdmin.repository.ts
@@ -47,6 +47,10 @@ export async function updateOrganization(id: number, data: { name?: string; logo
   return apiServices.patch(`/super-admin/organizations/${id}`, data);
 }
 
+export async function getUserCount() {
+  return apiServices.get<ServerResponse<{ count: number }>>("/super-admin/users/count");
+}
+
 export async function getAllUsers() {
   return apiServices.get<ServerResponse<GlobalUser[]>>("/super-admin/users");
 }
@@ -57,6 +61,10 @@ export async function getOrgUsers(orgId: number) {
 
 export async function inviteUserToOrg(orgId: number, data: { email: string; name: string; surname?: string; roleId: number }) {
   return apiServices.post(`/super-admin/organizations/${orgId}/invite`, data);
+}
+
+export async function updateUser(userId: number, data: { name?: string; surname?: string; email?: string; roleId?: number }) {
+  return apiServices.patch(`/super-admin/users/${userId}`, data);
 }
 
 export async function removeUser(userId: number) {

--- a/Clients/src/presentation/components/SuperAdminSidebar/index.tsx
+++ b/Clients/src/presentation/components/SuperAdminSidebar/index.tsx
@@ -1,11 +1,27 @@
-import React from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { Building, Users } from "lucide-react";
 import SidebarShell, { SidebarMenuItem } from "../Sidebar/SidebarShell";
+import { getUserCount } from "../../../application/repository/superAdmin.repository";
 
 const SuperAdminSidebar: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const [userCount, setUserCount] = useState<number>(0);
+
+  const fetchUserCount = useCallback(async () => {
+    try {
+      const response = await getUserCount();
+      const serverData = response.data as any;
+      setUserCount(serverData?.data?.count ?? 0);
+    } catch {
+      // Silently fail — count will show 0
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUserCount();
+  }, [fetchUserCount]);
 
   const topItems: SidebarMenuItem[] = [
     {
@@ -19,6 +35,7 @@ const SuperAdminSidebar: React.FC = () => {
       label: "Users",
       icon: <Users size={16} strokeWidth={1.5} />,
       path: "/super-admin/users",
+      count: userCount,
     },
   ];
 

--- a/Clients/src/presentation/pages/Authentication/Login/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/Login/index.tsx
@@ -175,21 +175,18 @@ const Login: React.FC = () => {
             localStorage.setItem("root_version", __APP_VERSION__);
             logEngine({ type: "info", message: "Super-admin login successful." });
 
-            // Auto-select the first organization so super-admin sees the normal UI
+            // Auto-select the first organization so super-admin can view org data
             try {
               const orgsResponse = await getOrganizations();
               const orgsData = (orgsResponse.data as any)?.data || [];
               if (orgsData.length > 0) {
                 dispatch(setActiveOrganizationId(orgsData[0].id));
-                setIsSubmitting(false);
-                navigate("/");
-                return;
               }
             } catch (err) {
               console.error("Failed to fetch organizations for auto-select:", err);
             }
 
-            // No orgs available — go to super-admin panel to create one
+            // Always go to super-admin panel
             setIsSubmitting(false);
             navigate("/super-admin");
             return;

--- a/Clients/src/presentation/pages/SuperAdmin/AllUsers/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/AllUsers/index.tsx
@@ -15,13 +15,19 @@ import {
   TextField,
   useTheme,
 } from "@mui/material";
-import { Trash2, Users as UsersIcon, Mail, Building, ArrowUp, ArrowDown } from "lucide-react";
+import { UserPlus, Users as UsersIcon, ArrowUp, ArrowDown } from "lucide-react";
 import {
   getAllUsers,
   removeUser,
+  updateUser,
+  getOrganizations,
+  inviteUserToOrg,
   GlobalUser,
+  Organization,
 } from "../../../../application/repository/superAdmin.repository";
+import { ROLE_OPTIONS, ROLE_COLORS } from "../../../../application/constants/roles";
 import StandardModal from "../../../components/Modals/StandardModal";
+import Field from "../../../components/Inputs/Field";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
 import SearchBox from "../../../components/Search/SearchBox";
 import { EmptyState } from "../../../components/EmptyState";
@@ -73,6 +79,269 @@ const DeleteUserModal = ({
   );
 };
 
+const EditUserModal = ({
+  target,
+  onClose,
+  onUpdated,
+}: {
+  target: GlobalUser | null;
+  onClose: () => void;
+  onUpdated: () => void;
+}) => {
+  const [name, setName] = useState("");
+  const [surname, setSurname] = useState("");
+  const [email, setEmail] = useState("");
+  const [roleId, setRoleId] = useState(3);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (target) {
+      setName(target.name);
+      setSurname(target.surname || "");
+      setEmail(target.email);
+      setRoleId(target.role_id);
+      setError("");
+    }
+  }, [target]);
+
+  const handleSubmit = async () => {
+    if (!target) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      await updateUser(target.id, {
+        name: name.trim(),
+        surname: surname.trim(),
+        email: email.trim(),
+        roleId,
+      });
+      onClose();
+      onUpdated();
+    } catch (err: any) {
+      setError(err?.message || "Failed to update user");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const roleSelectItems = ROLE_OPTIONS.map((r) => ({ _id: r.value, name: r.label }));
+
+  return (
+    <StandardModal
+      isOpen={!!target}
+      onClose={onClose}
+      title="Edit user"
+      description={`Edit details for ${target?.name || "user"}`}
+      submitButtonText="Save changes"
+      onSubmit={handleSubmit}
+      isSubmitting={submitting}
+      maxWidth="480px"
+    >
+      <Stack spacing={2}>
+        <Field
+          label="First name"
+          isRequired
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          sx={{ width: "100%" }}
+        />
+        <Field
+          label="Last name"
+          value={surname}
+          onChange={(e) => setSurname(e.target.value)}
+          sx={{ width: "100%" }}
+        />
+        <Field
+          label="Email"
+          isRequired
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          sx={{ width: "100%" }}
+        />
+        <Stack spacing={0.5}>
+          <Typography variant="body2" fontWeight={500}>
+            Organization
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: "text.secondary" }}>
+            {target?.organization_name || "—"}
+          </Typography>
+        </Stack>
+        <Select
+          id="edit-role"
+          label="Role"
+          value={roleId}
+          items={roleSelectItems}
+          onChange={(e: SelectChangeEvent<string | number>) => setRoleId(Number(e.target.value))}
+          getOptionValue={(item: { _id: string | number }) => item._id}
+          sx={{ width: "100%" }}
+        />
+        <Stack spacing={0.5}>
+          <Typography variant="body2" fontWeight={500}>
+            Joined
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: "text.secondary" }}>
+            {target ? new Date(target.created_at).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            }) : "—"}
+          </Typography>
+        </Stack>
+        <Stack spacing={0.5}>
+          <Typography variant="body2" fontWeight={500}>
+            Last login
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: "text.secondary" }}>
+            {target?.last_login
+              ? new Date(target.last_login).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })
+              : "Never"}
+          </Typography>
+        </Stack>
+        {error && (
+          <Typography sx={{ fontSize: 13, color: "#D32F2F" }}>
+            {error}
+          </Typography>
+        )}
+      </Stack>
+    </StandardModal>
+  );
+};
+
+const InviteUserModal = ({
+  isOpen,
+  onClose,
+  onInvited,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onInvited: () => void;
+}) => {
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [surname, setSurname] = useState("");
+  const [roleId, setRoleId] = useState(3);
+  const [orgId, setOrgId] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+
+  useEffect(() => {
+    if (isOpen) {
+      getOrganizations()
+        .then((response) => {
+          const serverData = response.data as any;
+          setOrganizations(serverData?.data || []);
+        })
+        .catch(() => {});
+    }
+  }, [isOpen]);
+
+  const resetForm = () => {
+    setEmail("");
+    setName("");
+    setSurname("");
+    setRoleId(3);
+    setOrgId("");
+    setError("");
+  };
+
+  const handleSubmit = async () => {
+    if (!orgId || !email.trim() || !name.trim()) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      await inviteUserToOrg(parseInt(orgId), {
+        email: email.trim(),
+        name: name.trim(),
+        surname: surname.trim() || undefined,
+        roleId,
+      });
+      resetForm();
+      onClose();
+      onInvited();
+    } catch (err: any) {
+      setError(err?.message || "Failed to invite user");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const orgSelectItems = [
+    { _id: "" as string | number, name: "Select organization" },
+    ...organizations.map((o) => ({ _id: String(o.id) as string | number, name: o.name })),
+  ];
+  const roleSelectItems = ROLE_OPTIONS.map((r) => ({ _id: r.value, name: r.label }));
+
+  return (
+    <StandardModal
+      isOpen={isOpen}
+      onClose={() => { resetForm(); onClose(); }}
+      title="Invite user"
+      description="Send an invitation to a new user"
+      submitButtonText="Send invite"
+      onSubmit={handleSubmit}
+      isSubmitting={submitting}
+      maxWidth="480px"
+    >
+      <Stack spacing={2}>
+        <Select
+          id="invite-org"
+          label="Organization"
+          value={orgId}
+          items={orgSelectItems}
+          onChange={(e: SelectChangeEvent<string | number>) => setOrgId(String(e.target.value))}
+          getOptionValue={(item: { _id: string | number }) => item._id}
+          sx={{ width: "100%" }}
+        />
+        <Field
+          label="Email"
+          isRequired
+          placeholder="user@example.com"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          sx={{ width: "100%" }}
+        />
+        <Field
+          label="First name"
+          isRequired
+          placeholder="First name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          sx={{ width: "100%" }}
+        />
+        <Field
+          label="Last name"
+          placeholder="Last name"
+          value={surname}
+          onChange={(e) => setSurname(e.target.value)}
+          sx={{ width: "100%" }}
+        />
+        <Select
+          id="invite-role"
+          label="Role"
+          value={roleId}
+          items={roleSelectItems}
+          onChange={(e: SelectChangeEvent<string | number>) => setRoleId(Number(e.target.value))}
+          getOptionValue={(item: { _id: string | number }) => item._id}
+          sx={{ width: "100%" }}
+        />
+        {error && (
+          <Typography sx={{ fontSize: 13, color: "#D32F2F" }}>
+            {error}
+          </Typography>
+        )}
+      </Stack>
+    </StandardModal>
+  );
+};
+
 type SortField = "name" | "email" | "organization_name" | "role_name" | "created_at";
 
 const AllUsers = () => {
@@ -85,6 +354,8 @@ const AllUsers = () => {
   const [sortField, setSortField] = useState<SortField>("name");
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const [deleteTarget, setDeleteTarget] = useState<GlobalUser | null>(null);
+  const [editTarget, setEditTarget] = useState<GlobalUser | null>(null);
+  const [inviteOpen, setInviteOpen] = useState(false);
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -119,7 +390,7 @@ const AllUsers = () => {
     ];
   }, [users]);
 
-  const roleOptions = useMemo(() => {
+  const roleFilterOptions = useMemo(() => {
     const roles = [...new Set(users.map((u) => u.role_name).filter(Boolean))].sort();
     return [
       { _id: "all", name: "All Roles" },
@@ -166,13 +437,6 @@ const AllUsers = () => {
     });
   }, [users, searchTerm, filterOrg, filterRole, sortField, sortDirection]);
 
-  const roleColors: Record<string, { bg: string; text: string }> = {
-    Admin: { bg: "#eff6ff", text: "#2563eb" },
-    Reviewer: { bg: "#faf5ff", text: "#9333ea" },
-    Editor: { bg: "#f0fdf4", text: "#16a34a" },
-    Auditor: { bg: "#fefce8", text: "#ca8a04" },
-  };
-
   const tableStyles = singleTheme.tableStyles.primary;
 
   const columns: { field: SortField; label: string }[] = [
@@ -187,8 +451,24 @@ const AllUsers = () => {
     <PageHeaderExtended
       title="Users"
       description="View and manage all users across all organizations."
+      actionButton={
+        <Button
+          variant="contained"
+          disableElevation
+          startIcon={<UserPlus size={14} />}
+          onClick={() => setInviteOpen(true)}
+          sx={{
+            textTransform: "none",
+            height: 34,
+            fontSize: "13px",
+            borderRadius: "4px",
+          }}
+        >
+          Invite user
+        </Button>
+      }
     >
-      <Stack direction="row" alignItems="center" gap={1.5} flexWrap="wrap">
+      <Stack direction="row" alignItems="center" gap="8px" flexWrap="wrap">
         <SearchBox
           placeholder="Search users..."
           value={searchTerm}
@@ -243,17 +523,12 @@ const AllUsers = () => {
         <Select
           id="filter-role"
           value={filterRole}
-          items={roleOptions}
+          items={roleFilterOptions}
           onChange={(e: SelectChangeEvent<string | number>) => setFilterRole(String(e.target.value))}
           getOptionValue={(item: { _id: string | number }) => item._id}
           isFilterApplied={filterRole !== "all"}
           sx={{ width: 150 }}
         />
-        <Typography
-          sx={{ fontSize: "13px", color: "text.secondary", whiteSpace: "nowrap" }}
-        >
-          {filteredUsers.length} user{filteredUsers.length !== 1 ? "s" : ""}
-        </Typography>
       </Stack>
 
       {loading ? (
@@ -305,9 +580,13 @@ const AllUsers = () => {
             </TableHead>
             <TableBody>
               {filteredUsers.map((user) => {
-                const colors = roleColors[user.role_name] || { bg: "#f3f4f6", text: "#6b7280" };
+                const colors = ROLE_COLORS[user.role_name] || { bg: "#f3f4f6", text: "#6b7280" };
                 return (
-                  <TableRow key={user.id} sx={tableStyles.body.row}>
+                  <TableRow
+                    key={user.id}
+                    sx={{ ...tableStyles.body.row, cursor: "pointer" }}
+                    onClick={() => setEditTarget(user)}
+                  >
                     <TableCell sx={tableStyles.body.cell}>
                       <Stack direction="row" alignItems="center" gap={1}>
                         <Box
@@ -333,18 +612,12 @@ const AllUsers = () => {
                       </Stack>
                     </TableCell>
                     <TableCell sx={tableStyles.body.cell}>
-                      <Stack direction="row" alignItems="center" gap={0.5}>
-                        <Mail size={13} color="#6b7280" />
-                        <Typography sx={{ fontSize: 13 }}>{user.email}</Typography>
-                      </Stack>
+                      <Typography sx={{ fontSize: 13 }}>{user.email}</Typography>
                     </TableCell>
                     <TableCell sx={tableStyles.body.cell}>
-                      <Stack direction="row" alignItems="center" gap={0.5}>
-                        <Building size={13} color="#6b7280" />
-                        <Typography sx={{ fontSize: 13 }}>
-                          {user.organization_name ? `${user.organization_name} (org:${user.organization_id})` : "—"}
-                        </Typography>
-                      </Stack>
+                      <Typography sx={{ fontSize: 13 }}>
+                        {user.organization_name ? `${user.organization_name} (org:${user.organization_id})` : "—"}
+                      </Typography>
                     </TableCell>
                     <TableCell sx={tableStyles.body.cell}>
                       <Box
@@ -374,8 +647,7 @@ const AllUsers = () => {
                       <Button
                         size="small"
                         variant="outlined"
-                        startIcon={<Trash2 size={13} />}
-                        onClick={() => setDeleteTarget(user)}
+                        onClick={(e) => { e.stopPropagation(); setDeleteTarget(user); }}
                         sx={{
                           ...tableStyles.body.button,
                           color: "#dc2626",
@@ -402,6 +674,16 @@ const AllUsers = () => {
         target={deleteTarget}
         onClose={() => setDeleteTarget(null)}
         onDeleted={fetchUsers}
+      />
+      <EditUserModal
+        target={editTarget}
+        onClose={() => setEditTarget(null)}
+        onUpdated={fetchUsers}
+      />
+      <InviteUserModal
+        isOpen={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+        onInvited={fetchUsers}
       />
     </PageHeaderExtended>
   );

--- a/Clients/src/presentation/pages/SuperAdmin/Organizations/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/Organizations/index.tsx
@@ -11,7 +11,7 @@ import {
   TableRow,
   Box,
 } from "@mui/material";
-import { Building, Plus, Trash2, Users, ArrowUp, ArrowDown } from "lucide-react";
+import { Building, Plus, ArrowUp, ArrowDown } from "lucide-react";
 import {
   getOrganizations,
   createOrganization,
@@ -280,34 +280,14 @@ const Organizations = () => {
               {filteredOrganizations.map((org) => (
                 <TableRow key={org.id} sx={tableStyles.body.row}>
                   <TableCell sx={tableStyles.body.cell}>
-                    <Stack direction="row" alignItems="center" gap={1}>
-                      <Box
-                        sx={{
-                          width: 28,
-                          height: 28,
-                          borderRadius: "6px",
-                          backgroundColor: "#f0fdf4",
-                          border: "1px solid #bbf7d0",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          flexShrink: 0,
-                        }}
-                      >
-                        <Building size={14} color="#16a34a" />
-                      </Box>
-                      <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
-                        {org.name} (org:{org.id})
-                      </Typography>
-                    </Stack>
+                    <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
+                      {org.name} (org:{org.id})
+                    </Typography>
                   </TableCell>
                   <TableCell sx={tableStyles.body.cell}>
-                    <Stack direction="row" alignItems="center" gap={0.5}>
-                      <Users size={13} color="#6b7280" />
-                      <Typography sx={{ fontSize: 13 }}>
-                        {org.user_count ?? 0}
-                      </Typography>
-                    </Stack>
+                    <Typography sx={{ fontSize: 13 }}>
+                      {org.user_count ?? 0}
+                    </Typography>
                   </TableCell>
                   <TableCell sx={tableStyles.body.cell}>
                     {new Date(org.created_at).toLocaleDateString("en-US", {
@@ -317,22 +297,20 @@ const Organizations = () => {
                     })}
                   </TableCell>
                   <TableCell sx={{ ...tableStyles.body.cell, textAlign: "right" }}>
-                    <Stack direction="row" justifyContent="flex-end" gap={0.5}>
+                    <Stack direction="row" justifyContent="flex-end" gap="8px">
                       <Button
                         size="small"
                         variant="outlined"
-                        startIcon={<Users size={13} />}
                         onClick={() =>
                           navigate(`/super-admin/organizations/${org.id}/users`)
                         }
                         sx={tableStyles.body.button}
                       >
-                        Users
+                        View users
                       </Button>
                       <Button
                         size="small"
                         variant="outlined"
-                        startIcon={<Trash2 size={13} />}
                         onClick={() => setDeleteTarget(org)}
                         sx={{
                           ...tableStyles.body.button,

--- a/Clients/src/presentation/pages/SuperAdmin/Settings/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/Settings/index.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import { useState, type SyntheticEvent } from "react";
 import TabPanel from "@mui/lab/TabPanel";
 import TabContext from "@mui/lab/TabContext";
 import { useNavigate, useParams } from "react-router-dom";
+import { Settings } from "lucide-react";
 import TabBar, { TabItem } from "../../../components/TabBar";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
 import Profile from "../../SettingsPage/Profile";
@@ -12,7 +13,12 @@ export default function SuperAdminSettings() {
   const { tab } = useParams<{ tab?: string }>();
   const [activeTab, setActiveTab] = useState(tab || "profile");
 
-  const handleTabChange = (_: React.SyntheticEvent, newValue: string) => {
+  const breadcrumbItems = [
+    { label: "Settings", icon: <Settings size={14} />, ...(tab ? { path: "/super-admin/settings" } : {}) },
+    ...(tab ? [{ label: tab.charAt(0).toUpperCase() + tab.slice(1) }] : []),
+  ];
+
+  const handleTabChange = (_: SyntheticEvent, newValue: string) => {
     setActiveTab(newValue);
     if (newValue === "profile") navigate("/super-admin/settings");
     else navigate(`/super-admin/settings/${newValue}`);
@@ -20,8 +26,9 @@ export default function SuperAdminSettings() {
 
   return (
     <PageHeaderExtended
-      title="Super Admin Settings"
+      title="Settings"
       description="Manage your super admin profile and security."
+      breadcrumbItems={breadcrumbItems}
     >
       <TabContext value={activeTab}>
         <TabBar

--- a/Clients/src/presentation/pages/SuperAdmin/Users/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/Users/index.tsx
@@ -11,7 +11,7 @@ import {
   TableRow,
   Box,
 } from "@mui/material";
-import { Trash2, UserPlus, Users as UsersIcon, Mail } from "lucide-react";
+import { UserPlus, Users as UsersIcon } from "lucide-react";
 import {
   getOrgUsers,
   inviteUserToOrg,
@@ -24,6 +24,7 @@ import Field from "../../../components/Inputs/Field";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
 import SearchBox from "../../../components/Search/SearchBox";
 import { EmptyState } from "../../../components/EmptyState";
+import { ROLE_OPTIONS, ROLE_COLORS } from "../../../../application/constants/roles";
 import singleTheme from "../../../themes/v1SingleTheme";
 
 const Users = () => {
@@ -114,20 +115,6 @@ const Users = () => {
     }
   };
 
-  const roleOptions = [
-    { value: 1, label: "Admin" },
-    { value: 2, label: "Reviewer" },
-    { value: 3, label: "Editor" },
-    { value: 4, label: "Auditor" },
-  ];
-
-  const roleColors: Record<string, { bg: string; text: string }> = {
-    Admin: { bg: "#eff6ff", text: "#2563eb" },
-    Reviewer: { bg: "#faf5ff", text: "#9333ea" },
-    Editor: { bg: "#f0fdf4", text: "#16a34a" },
-    Auditor: { bg: "#fefce8", text: "#ca8a04" },
-  };
-
   const tableStyles = singleTheme.tableStyles.primary;
 
   return (
@@ -204,7 +191,7 @@ const Users = () => {
             </TableHead>
             <TableBody>
               {filteredUsers.map((user) => {
-                const colors = roleColors[user.role_name] || {
+                const colors = ROLE_COLORS[user.role_name] || {
                   bg: "#f3f4f6",
                   text: "#6b7280",
                 };
@@ -235,10 +222,7 @@ const Users = () => {
                       </Stack>
                     </TableCell>
                     <TableCell sx={tableStyles.body.cell}>
-                      <Stack direction="row" alignItems="center" gap={0.5}>
-                        <Mail size={13} color="#6b7280" />
-                        <Typography sx={{ fontSize: 13 }}>{user.email}</Typography>
-                      </Stack>
+                      <Typography sx={{ fontSize: 13 }}>{user.email}</Typography>
                     </TableCell>
                     <TableCell sx={tableStyles.body.cell}>
                       <Box
@@ -277,7 +261,6 @@ const Users = () => {
                       <Button
                         size="small"
                         variant="outlined"
-                        startIcon={<Trash2 size={13} />}
                         onClick={() => {
                           setDeleteTarget(user);
                           setDeleteOpen(true);
@@ -355,7 +338,7 @@ const Users = () => {
                 fontSize: 13,
               }}
             >
-              {roleOptions.map((opt) => (
+              {ROLE_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
                   {opt.label}
                 </option>

--- a/Servers/controllers/superAdmin.ctrl.ts
+++ b/Servers/controllers/superAdmin.ctrl.ts
@@ -124,6 +124,21 @@ export async function updateOrg(req: Request, res: Response) {
 }
 
 /**
+ * Get total user count (excludes super-admins)
+ */
+export async function getUserCount(_req: Request, res: Response) {
+  try {
+    const [result]: any[] = await sequelize.query(
+      `SELECT COUNT(*) AS count FROM users WHERE role_id != 5`,
+      { type: 'SELECT' as any }
+    );
+    return res.status(200).json(STATUS_CODE[200]({ count: parseInt(result.count, 10) }));
+  } catch (error) {
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+}
+
+/**
  * List all users across all organizations
  */
 export async function listAllUsers(_req: Request, res: Response) {
@@ -200,6 +215,76 @@ export async function inviteUserToOrg(req: Request, res: Response) {
     roleId,
     organizationId: orgId,
   });
+}
+
+/**
+ * Update a user's details (name, surname, email, role)
+ */
+export async function updateUser(req: Request, res: Response) {
+  try {
+    const userId = parseInt(Array.isArray(req.params.id) ? req.params.id[0] : req.params.id, 10);
+    const { name, surname, email, roleId } = req.body;
+
+    // Prevent updating to super-admin role
+    if (roleId === 5) {
+      return res.status(403).json(STATUS_CODE[403]("Cannot assign SuperAdmin role"));
+    }
+
+    const rows: any[] = await sequelize.query(
+      `SELECT id, role_id FROM users WHERE id = :userId`,
+      { replacements: { userId }, type: 'SELECT' as any }
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json(STATUS_CODE[404]("User not found"));
+    }
+
+    if (rows[0].role_id === 5) {
+      return res.status(403).json(STATUS_CODE[403]("Super-admin user cannot be modified"));
+    }
+
+    const updates: string[] = [];
+    const replacements: any = { userId };
+
+    if (name !== undefined) {
+      updates.push('name = :name');
+      replacements.name = name;
+    }
+    if (surname !== undefined) {
+      updates.push('surname = :surname');
+      replacements.surname = surname;
+    }
+    if (email !== undefined) {
+      updates.push('email = :email');
+      replacements.email = email;
+    }
+    if (roleId !== undefined) {
+      updates.push('role_id = :roleId');
+      replacements.roleId = roleId;
+    }
+
+    if (updates.length === 0) {
+      return res.status(400).json(STATUS_CODE[400]({ message: "No fields to update" }));
+    }
+
+    const [updated] = await sequelize.query(
+      `WITH updated AS (
+        UPDATE users SET ${updates.join(', ')}, updated_at = NOW() WHERE id = :userId
+        RETURNING *
+      )
+      SELECT u.id, u.name, u.surname, u.email, u.role_id, r.name as role_name,
+             u.organization_id, o.name as organization_name,
+             u.created_at, u.last_login
+      FROM updated u
+      LEFT JOIN roles r ON u.role_id = r.id
+      LEFT JOIN organizations o ON u.organization_id = o.id`,
+      { replacements, type: 'SELECT' as any }
+    );
+
+    return res.status(200).json(STATUS_CODE[200](updated));
+  } catch (error) {
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
 }
 
 /**

--- a/Servers/routes/superAdmin.route.ts
+++ b/Servers/routes/superAdmin.route.ts
@@ -6,9 +6,11 @@ import {
   createOrg,
   deleteOrg,
   updateOrg,
+  getUserCount,
   listAllUsers,
   listOrgUsers,
   inviteUserToOrg,
+  updateUser,
   removeUser,
 } from "../controllers/superAdmin.ctrl";
 
@@ -21,9 +23,11 @@ router.get("/organizations", listOrganizations);
 router.post("/organizations", createOrg);
 router.delete("/organizations/:id", deleteOrg);
 router.patch("/organizations/:id", updateOrg);
+router.get("/users/count", getUserCount);
 router.get("/users", listAllUsers);
 router.get("/organizations/:id/users", listOrgUsers);
 router.post("/organizations/:id/invite", inviteUserToOrg);
+router.patch("/users/:id", updateUser);
 router.delete("/users/:id", removeUser);
 
 export default router;


### PR DESCRIPTION
## Summary

- **Login redirect**: Super admin now always lands on `/super-admin` after login instead of the regular dashboard.
- **User management**: Added invite user modal (with org picker) and edit user modal (click any row) on the all users page. New backend endpoints: `PATCH /super-admin/users/:id` and `GET /super-admin/users/count`.
- **UI cleanup**: Removed decorative icons from all table cells and action buttons across organizations, all users, and org users pages. Renamed "Users" button to "View users". Set consistent 8px spacing between filter controls and action buttons.
- **Sidebar badge**: User count pill on the "Users" menu item, powered by a lightweight count endpoint.
- **Settings breadcrumbs**: Title simplified to "Settings" with icon. Password tab shows "Password" in breadcrumb trail.
- **Code quality**: Extracted `ROLE_OPTIONS` and `ROLE_COLORS` as shared constants. Extracted `EditUserModal` and `InviteUserModal` as isolated components. Replaced native `<select>` with project `Select` component. Backend update query uses `RETURNING` CTE to eliminate redundant SELECT.