### PR TITLE
docs(fria): add user guide and technical documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ Read the relevant file BEFORE implementing changes in that area:
 | Share links | `docs/technical/domains/share-links.md` |
 | Dashboard | `docs/technical/domains/dashboard.md` |
 | Post-market monitoring | `docs/technical/domains/post-market-monitoring.md` |
+| FRIA (Fundamental Rights Impact Assessment) | `docs/technical/domains/fria.md` |
 | Compliance frameworks | `docs/technical/domains/compliance-frameworks.md` |
 | Docker & deployment | `docs/deployment/PRODUCTION_DEPLOYMENT_GUIDE.md` |
 | Database schema | `docs/technical/architecture/database-schema.md` |

--- a/Clients/src/presentation/pages/ProjectView/Fria/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/Fria/index.tsx
@@ -351,6 +351,7 @@ const FriaAssessment = ({ projectId }: FriaProps) => {
           setSubmitReason("");
         }}
         title="Save snapshot"
+        description=""
         onSubmit={handleSubmitConfirm}
         submitButtonText="Save snapshot"
       >

--- a/docs/technical/domains/fria.md
+++ b/docs/technical/domains/fria.md
@@ -1,0 +1,389 @@
+# Fundamental Rights Impact Assessment (FRIA)
+
+## Overview
+
+The FRIA module implements EU AI Act Article 27 compliance, which requires deployers of high-risk AI systems to perform a fundamental rights impact assessment before putting a system into use. The module provides an 8-section structured assessment with auto-save, snapshot versioning, risk scoring, evidence attachments, and a field-by-field diff viewer for version history.
+
+## EU AI Act Reference
+
+- **Article 27(1)**: Deployers of high-risk AI systems must perform a FRIA before deployment
+- **Article 6 / Annex III**: High-risk classification criteria
+- **Article 9**: Risk management integration
+- **Article 13-14**: Transparency and human oversight requirements
+- **Article 49**: Record-keeping and documentation
+
+## Assessment Sections
+
+| # | Section | ID | Description |
+|---|---------|-----|-------------|
+| 1 | Organisation & system profile | `org-profile` | Deployer org, system name, assessment owner, context |
+| 2 | Applicability & scope | `applicability` | High-risk classification, Annex III category, review cycle |
+| 3 | Affected persons & groups | `affected-persons` | Impacted groups, vulnerability context, group flags |
+| 4 | Fundamental rights matrix | `rights-matrix` | 10 EU Charter rights with flagging, severity, mitigation |
+| 5 | Specific risks of harm | `specific-risks` | Risk register with likelihood/severity, import from project risks |
+| 6 | Human oversight & transparency | `oversight` | Oversight measures, transparency, redress, data governance |
+| 7 | Stakeholder consultation | `consultation` | Legal/DPO/owner review status, stakeholder notes |
+| 8 | Summary & recommendation | `summary` | Deployment decision and conditions |
+
+## Default Rights (Section 4)
+
+The 10 fundamental rights assessed, from the EU Charter of Fundamental Rights:
+
+| Key | Title | Charter Reference |
+|-----|-------|------------------|
+| `human_dignity` | Human dignity | Art. 1 |
+| `privacy` | Right to privacy | Art. 7 |
+| `data_protection` | Protection of personal data | Art. 8 |
+| `non_discrimination` | Non-discrimination | Art. 21 |
+| `gender_equality` | Equality between women and men | Art. 23 |
+| `fair_working` | Fair and just working conditions | Art. 31 |
+| `consumer_protection` | Consumer protection | Art. 38 |
+| `freedom_expression` | Freedom of expression | Art. 11 |
+| `effective_remedy` | Right to an effective remedy | Art. 47 |
+| `child_rights` | Rights of the child | Art. 24 |
+
+## API Endpoints
+
+Base path: `/api/fria`
+
+All endpoints require `authenticateJWT` middleware.
+
+### Assessment CRUD
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/:projectId` | JWT | Get or auto-create FRIA for project |
+| `PUT` | `/:projectId` | JWT + Admin/Editor | Update assessment fields |
+
+### Rights
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `PUT` | `/:friaId/rights` | JWT + Admin/Editor | Bulk upsert rights (flagged, severity, etc.) |
+
+### Risk Items
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/:friaId/risk-items` | JWT | List risk items for assessment |
+| `POST` | `/:friaId/risk-items` | JWT + Admin/Editor | Add risk item |
+| `PUT` | `/:friaId/risk-items/:itemId` | JWT + Admin/Editor | Update risk item |
+| `DELETE` | `/:friaId/risk-items/:itemId` | JWT + Admin/Editor | Delete risk item |
+
+### Model Links
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/:friaId/models` | JWT | List linked models |
+| `POST` | `/:friaId/models/:modelId` | JWT + Admin/Editor | Link model to FRIA |
+| `DELETE` | `/:friaId/models/:modelId` | JWT + Admin/Editor | Unlink model from FRIA |
+
+### Evidence
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/:friaId/evidence/:section` | JWT | Get evidence files for section |
+| `POST` | `/:friaId/evidence` | JWT + Admin/Editor | Link evidence file to section |
+| `DELETE` | `/:friaId/evidence/:linkId` | JWT + Admin/Editor | Remove evidence link |
+
+### Versioning
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/:friaId/submit` | JWT + Admin/Editor | Save snapshot with optional note |
+| `GET` | `/:friaId/versions` | JWT | List all snapshots |
+| `GET` | `/:friaId/versions/:version` | JWT | Get specific snapshot |
+
+## Database Schema
+
+### fria_assessments
+
+Core assessment table, one per project (versioned).
+
+```
+fria_assessments
+├── id (PK, SERIAL)
+├── organization_id (FK → organizations, NOT NULL)
+├── project_id (FK → projects, NOT NULL)
+├── version (INTEGER, DEFAULT 1)
+├── status (VARCHAR(30), DEFAULT 'draft')
+│
+├── Section 1: Organisation & system profile
+│   ├── assessment_owner (VARCHAR(255))
+│   ├── assessment_date (DATE)
+│   └── operational_context (TEXT)
+│
+├── Section 2: Applicability & scope
+│   ├── is_high_risk (VARCHAR(30))
+│   ├── high_risk_basis (VARCHAR(100))
+│   ├── deployer_type (VARCHAR(100))
+│   ├── annex_iii_category (VARCHAR(100))
+│   ├── first_use_date (DATE)
+│   ├── review_cycle (VARCHAR(50))
+│   ├── period_frequency (TEXT)
+│   └── fria_rationale (TEXT)
+│
+├── Section 3: Affected persons
+│   ├── affected_groups (TEXT)
+│   ├── vulnerability_context (TEXT)
+│   └── group_flags (JSONB, DEFAULT '[]')
+│
+├── Section 5: Specific risks context
+│   ├── risk_scenarios (TEXT)
+│   └── provider_info_used (TEXT)
+│
+├── Section 6: Oversight
+│   ├── human_oversight (TEXT)
+│   ├── transparency_measures (TEXT)
+│   ├── redress_process (TEXT)
+│   └── data_governance (TEXT)
+│
+├── Section 7: Consultation
+│   ├── legal_review (VARCHAR(20))
+│   ├── dpo_review (VARCHAR(20))
+│   ├── owner_approval (VARCHAR(20))
+│   ├── stakeholders_consulted (TEXT)
+│   └── consultation_notes (TEXT)
+│
+├── Section 8: Summary
+│   ├── deployment_decision (VARCHAR(50))
+│   └── decision_conditions (TEXT)
+│
+├── Computed (cached on save)
+│   ├── completion_pct (INTEGER, DEFAULT 0)
+│   ├── risk_score (INTEGER, DEFAULT 0)
+│   ├── risk_level (VARCHAR(10), DEFAULT 'Low')
+│   └── rights_flagged (INTEGER, DEFAULT 0)
+│
+├── Metadata
+│   ├── created_by (FK → users, NOT NULL)
+│   ├── updated_by (FK → users)
+│   ├── created_at (TIMESTAMPTZ)
+│   ├── updated_at (TIMESTAMPTZ)
+│   ├── is_deleted (BOOLEAN, DEFAULT FALSE)
+│   └── deleted_at (TIMESTAMPTZ)
+│
+└── UNIQUE(project_id, version)
+```
+
+### fria_rights
+
+10 rows per assessment, one per EU Charter right.
+
+```
+fria_rights
+├── id (PK, SERIAL)
+├── organization_id (FK → organizations)
+├── fria_id (FK → fria_assessments)
+├── right_key (VARCHAR(50))
+├── right_title (VARCHAR(255))
+├── charter_ref (VARCHAR(100))
+├── flagged (BOOLEAN, DEFAULT FALSE)
+├── severity (INTEGER, DEFAULT 0)
+├── confidence (INTEGER, DEFAULT 0)
+├── impact_pathway (TEXT)
+├── mitigation (TEXT)
+├── created_at, updated_at (TIMESTAMPTZ)
+├── is_deleted, deleted_at
+└── UNIQUE(fria_id, right_key)
+```
+
+### fria_risk_items
+
+FRIA-specific risk register.
+
+```
+fria_risk_items
+├── id (PK, SERIAL)
+├── organization_id (FK → organizations)
+├── fria_id (FK → fria_assessments)
+├── risk_description (TEXT, NOT NULL)
+├── likelihood (VARCHAR(10))
+├── severity (VARCHAR(10))
+├── existing_controls (TEXT)
+├── further_action (TEXT)
+├── linked_project_risk_id (INTEGER)
+├── sort_order (INTEGER, DEFAULT 0)
+├── created_at, updated_at (TIMESTAMPTZ)
+└── is_deleted, deleted_at
+```
+
+### fria_model_links
+
+Links FRIA assessments to model inventory entries.
+
+```
+fria_model_links
+├── id (PK, SERIAL)
+├── organization_id (FK → organizations)
+├── fria_id (FK → fria_assessments)
+├── model_id (INTEGER, NOT NULL)
+├── created_at, updated_at (TIMESTAMPTZ)
+├── is_deleted, deleted_at
+└── UNIQUE(fria_id, model_id)
+```
+
+### fria_snapshots
+
+Version snapshots for audit trail.
+
+```
+fria_snapshots
+├── id (PK, SERIAL)
+├── organization_id (FK → organizations)
+├── fria_id (FK → fria_assessments)
+├── version (INTEGER, NOT NULL)
+├── snapshot_data (JSONB, NOT NULL)
+├── snapshot_reason (VARCHAR(255))
+├── created_by (FK → users)
+├── created_at, updated_at (TIMESTAMPTZ)
+└── is_deleted, deleted_at
+```
+
+### fria_change_history
+
+Change tracking for audit.
+
+```
+fria_change_history
+├── id (PK, SERIAL)
+├── organization_id (FK → organizations)
+├── fria_id (FK → fria_assessments)
+├── action (VARCHAR(20))
+├── field_name (VARCHAR(255))
+├── old_value (TEXT)
+├── new_value (TEXT)
+├── changed_by_user_id (INTEGER)
+├── changed_at (TIMESTAMPTZ)
+└── is_deleted, deleted_at
+```
+
+## Score Computation
+
+Scores are recomputed on every field save, rights update, and risk item mutation via `computeFriaScore()`.
+
+### Risk Score (0-100)
+
+```
+score = 0
+
+For each flagged right:
+  score += (severity × 15) + (confidence × 5)
+
+For each risk item:
+  L = likelihood_map[likelihood]   // Low=1, Medium=2, High=3
+  S = severity_map[severity]       // Low=1, Medium=2, High=3
+  score += L × S × 3
+
+score = min(score, 100)
+```
+
+### Risk Level
+
+| Score | Level |
+|-------|-------|
+| 0-29 | Low |
+| 30-59 | Medium |
+| 60-100 | High |
+
+### Completion Percentage
+
+Counts non-empty fields across all sections:
+
+- 17 assessment text/select fields
+- +1 if any right has been assessed (flagged, severity, confidence, impact, or mitigation set)
+- +1 if any risk items exist
+
+```
+completion_pct = round((filled_fields + rights_complete + risks_complete) / 19 × 100)
+```
+
+### Rights Flagged
+
+Count of rights where `flagged = true`.
+
+## Enums
+
+```typescript
+enum FriaStatus {
+  DRAFT = "draft",
+  SUBMITTED = "submitted",
+  APPROVED = "approved",
+  REJECTED = "rejected",
+}
+
+enum FriaRiskLevel { LOW = "Low", MEDIUM = "Medium", HIGH = "High" }
+enum FriaLikelihood { LOW = "Low", MEDIUM = "Medium", HIGH = "High" }
+enum FriaSeverity { LOW = "Low", MEDIUM = "Medium", HIGH = "High" }
+```
+
+## Frontend Architecture
+
+### Component Tree
+
+```
+FriaAssessment (index.tsx)
+├── StatCard × 4 (completion, risk score, rights flagged, status)
+├── Action buttons (Version history, Save snapshot)
+├── SectionSidebar (shared component, sticky, 300px)
+└── Section stack
+    ├── OrgProfileSection
+    ├── ApplicabilityScopeSection
+    ├── AffectedPersonsSection
+    ├── RightsMatrixSection
+    ├── SpecificRisksSection
+    │   └── FriaRiskImportModal (import from project risks)
+    ├── OversightSection
+    ├── ConsultationSection
+    └── SummarySection
+
+Each section wraps in:
+  FriaSectionCard (title, subtitle, EU Act reference, collapsible)
+  └── FriaEvidenceButton (attach/view evidence per section)
+
+Modals:
+  StandardModal (Save snapshot) → note field
+  StandardModal (Version history) → FriaVersionHistory (inline)
+```
+
+### Data Flow
+
+```
+User types in field
+  → Local state updates (useState)
+  → onBlur fires dirty check
+  → useFria.updateAssessment({ field: value })
+  → Debounced (500ms) accumulator batches fields
+  → PUT /api/fria/:projectId
+  → Backend recomputes scores + persists
+  → Frontend updates assessment state
+  → "Saved" indicator appears
+```
+
+### Auto-Save (Debounce Pattern)
+
+The `useFria` hook accumulates field updates in a `pendingUpdate` ref. Each `updateAssessment()` call merges into the ref and resets a 500ms timer. When the timer fires, all accumulated fields are flushed in a single `PUT` request. On unmount, any pending updates are flushed synchronously.
+
+### Section Sidebar (IntersectionObserver)
+
+The `SectionSidebar` component highlights the active section. An `IntersectionObserver` (threshold 0.3, rootMargin "-100px 0px -60% 0px") monitors all section `<div>` elements and updates `activeSection` state when a section enters the viewport. Clicking a sidebar item smooth-scrolls to the section.
+
+### Version History Diff Viewer
+
+The `FriaVersionHistory` component shows snapshots in a table. Expanding a row computes a field-by-field diff between that snapshot and the previous one:
+
+- **v1 (first)**: Shows all non-empty fields as baseline values
+- **v2+**: Shows only changed fields with old (strikethrough) and new (green) values
+- Tracks assessment field changes, rights flagging/severity changes, and risk item count changes
+- Shows a "3 changes" chip for quick overview
+
+## Evidence Attachments
+
+Each of the 8 sections can have evidence files attached via `FriaEvidenceButton`. Evidence uses the shared `evidenceFiles.utils.ts` system with entity types `section_1` through `section_8`. Files are linked (not copied) via the `file_entity_links` junction table.
+
+## Snapshot System
+
+- **Save snapshot**: Creates a JSONB snapshot of the full assessment (assessment + rights + riskItems + modelLinks), increments version
+- **Status**: Changes to `submitted` on snapshot save
+- **Unique versions**: Each snapshot gets a unique version number via post-save version bump
+- **Audit**: Snapshots are logged to the audit ledger

--- a/shared/user-guide-content/content/compliance/fria.ts
+++ b/shared/user-guide-content/content/compliance/fria.ts
@@ -1,0 +1,342 @@
+import type { ArticleContent } from '../../contentTypes';
+
+export const friaContent: ArticleContent = {
+  blocks: [
+    {
+      type: 'heading',
+      id: 'overview',
+      level: 2,
+      text: 'Overview',
+    },
+    {
+      type: 'paragraph',
+      text: 'The Fundamental Rights Impact Assessment (FRIA) helps you comply with EU AI Act Article 27, which requires deployers of high-risk AI systems to assess the impact on fundamental rights before putting a system into use.',
+    },
+    {
+      type: 'paragraph',
+      text: 'The FRIA in VerifyWise is an 8-section assessment. Fields auto-save as you work, risk scores update after each change, and you can save snapshots to keep a versioned audit trail.',
+    },
+    {
+      type: 'heading',
+      id: 'accessing-fria',
+      level: 2,
+      text: 'Accessing the FRIA',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Open any project from your dashboard.' },
+        { text: 'Click the **FRIA** tab in the project view.' },
+        { text: 'The assessment is created automatically the first time you open it.' },
+      ],
+    },
+    {
+      type: 'callout',
+      variant: 'info',
+      title: 'Auto-creation',
+      text: 'You don\'t need to manually create a FRIA. One is generated per project when you first visit the tab, pre-filled with the project name, organization, and assessment owner.',
+    },
+    {
+      type: 'heading',
+      id: 'assessment-sections',
+      level: 2,
+      text: 'Assessment sections',
+    },
+    {
+      type: 'paragraph',
+      text: 'The FRIA is divided into 8 sections. Use the sidebar on the left to jump between them, or scroll through the page. The sidebar highlights the section you\'re currently viewing.',
+    },
+    {
+      type: 'icon-cards',
+      items: [
+        {
+          icon: 'Building2',
+          title: '1. Organisation & system profile',
+          description: 'Identify the deployer, system name, assessment owner, date, and operational context.',
+        },
+        {
+          icon: 'Scale',
+          title: '2. Applicability & scope',
+          description: 'Classify whether the system is high-risk, select the Annex III category, set the review cycle.',
+        },
+        {
+          icon: 'Users',
+          title: '3. Affected persons & groups',
+          description: 'Describe who is affected by the AI system and their vulnerability context.',
+        },
+        {
+          icon: 'Shield',
+          title: '4. Fundamental rights matrix',
+          description: 'Assess 10 rights from the EU Charter. Flag affected rights, rate severity and confidence, document mitigation.',
+        },
+        {
+          icon: 'AlertTriangle',
+          title: '5. Specific risks of harm',
+          description: 'Build a risk register with likelihood and severity ratings. Import risks from your project risk register.',
+        },
+        {
+          icon: 'Eye',
+          title: '6. Human oversight & transparency',
+          description: 'Document oversight measures, transparency practices, redress processes, and data governance.',
+        },
+        {
+          icon: 'MessageSquare',
+          title: '7. Stakeholder consultation',
+          description: 'Record legal review, DPO review, and owner approval status. Add stakeholder consultation notes.',
+        },
+        {
+          icon: 'FileCheck',
+          title: '8. Summary & recommendation',
+          description: 'Make a deployment decision and document any conditions.',
+        },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'auto-save',
+      level: 2,
+      text: 'How auto-save works',
+    },
+    {
+      type: 'paragraph',
+      text: 'Every field auto-saves as you type. When you leave a field or stop typing for half a second, your changes are sent to the server. You\'ll see a brief "Saving..." indicator next to the action buttons, followed by "Saved" when complete.',
+    },
+    {
+      type: 'callout',
+      variant: 'tip',
+      title: 'No save button needed',
+      text: 'You never need to manually save. Just fill in the fields and move on. If you close the browser and come back, your work is there.',
+    },
+    {
+      type: 'heading',
+      id: 'stat-cards',
+      level: 2,
+      text: 'Understanding the stat cards',
+    },
+    {
+      type: 'paragraph',
+      text: 'Four cards at the top summarize the current state of your assessment:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Completion', text: 'Percentage of assessment fields filled in, including whether rights have been reviewed and risk items added.' },
+        { bold: 'Risk score', text: 'A score from 0 to 100 based on flagged rights (weighted by severity and confidence) and risk items (weighted by likelihood and severity).' },
+        { bold: 'Rights flagged', text: 'How many of the 10 fundamental rights you\'ve marked as affected.' },
+        { bold: 'Status', text: 'Current assessment status (draft or submitted) and how many snapshots have been saved.' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'rights-matrix',
+      level: 2,
+      text: 'Fundamental rights matrix',
+    },
+    {
+      type: 'paragraph',
+      text: 'Section 4 contains 10 rights from the EU Charter of Fundamental Rights. For each right:',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Check the **Flagged** box if the AI system could affect this right.' },
+        { text: 'Set the **Severity** (how serious the impact could be) and **Confidence** (how certain you are).' },
+        { text: 'Describe the **Impact pathway** explaining how the system could affect this right.' },
+        { text: 'Document the **Mitigation** measures you\'ve put in place.' },
+      ],
+    },
+    {
+      type: 'table',
+      columns: [
+        { key: 'right', label: 'Right', width: '35%' },
+        { key: 'charter', label: 'Charter article', width: '20%' },
+        { key: 'example', label: 'Example impact', width: '45%' },
+      ],
+      rows: [
+        { right: 'Human dignity', charter: 'Art. 1', example: 'System makes decisions that undermine autonomy' },
+        { right: 'Right to privacy', charter: 'Art. 7', example: 'Processing personal data beyond stated purpose' },
+        { right: 'Data protection', charter: 'Art. 8', example: 'Insufficient data minimization or retention' },
+        { right: 'Non-discrimination', charter: 'Art. 21', example: 'Biased outputs across protected groups' },
+        { right: 'Gender equality', charter: 'Art. 23', example: 'Gender-based scoring differences' },
+        { right: 'Fair working conditions', charter: 'Art. 31', example: 'Worker surveillance or automated management' },
+        { right: 'Consumer protection', charter: 'Art. 38', example: 'Misleading AI-generated recommendations' },
+        { right: 'Freedom of expression', charter: 'Art. 11', example: 'Content filtering that restricts lawful speech' },
+        { right: 'Effective remedy', charter: 'Art. 47', example: 'No way to challenge automated decisions' },
+        { right: 'Rights of the child', charter: 'Art. 24', example: 'System processes children\'s data without safeguards' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'risk-items',
+      level: 2,
+      text: 'Managing risk items',
+    },
+    {
+      type: 'paragraph',
+      text: 'Section 5 lets you build a FRIA-specific risk register. You can add risks manually or import them from your project\'s existing risk register.',
+    },
+    {
+      type: 'heading',
+      id: 'adding-risks',
+      level: 3,
+      text: 'Adding risks manually',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Click **Add risk item** in Section 5.' },
+        { text: 'Describe the risk.' },
+        { text: 'Set the likelihood (Low/Medium/High) and severity (Low/Medium/High).' },
+        { text: 'Document existing controls and any further action needed.' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'importing-risks',
+      level: 3,
+      text: 'Importing from project risks',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Click **Import from project risks** in Section 5.' },
+        { text: 'Select one or more risks from the list.' },
+        { text: 'Click **Import selected**. The risk description, likelihood, and severity are copied over.' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'evidence',
+      level: 2,
+      text: 'Attaching evidence',
+    },
+    {
+      type: 'paragraph',
+      text: 'Each section has an **Attach evidence** button at the bottom. You can link existing files from the evidence hub or upload new ones. Evidence is stored per section, so auditors can see exactly which documents support each part of the assessment.',
+    },
+    {
+      type: 'heading',
+      id: 'snapshots',
+      level: 2,
+      text: 'Saving snapshots',
+    },
+    {
+      type: 'paragraph',
+      text: 'Snapshots are point-in-time copies of your entire assessment. Save one before a review meeting, after completing a major section, or whenever you want a record you can compare against later.',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Click **Save snapshot** above the assessment sections.' },
+        { text: 'Optionally add a note (e.g., "Completed sections 1-4" or "Pre-review baseline").' },
+        { text: 'Click **Save snapshot** to confirm.' },
+      ],
+    },
+    {
+      type: 'callout',
+      variant: 'info',
+      title: 'Snapshots vs auto-save',
+      text: 'Auto-save continuously saves your latest changes. Snapshots are manual checkpoints you create when you want a permanent record of the assessment at a specific point in time.',
+    },
+    {
+      type: 'heading',
+      id: 'version-history',
+      level: 2,
+      text: 'Viewing version history',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Click **Version history** above the assessment sections.' },
+        { text: 'A modal shows all saved snapshots with their note, author, and date.' },
+        { text: 'Click any row to expand it and see what changed from the previous version.' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'The diff view shows changed fields side by side: the old value (with strikethrough) and the new value (in green). It also tracks rights flagging changes and risk item count changes between versions.',
+    },
+    {
+      type: 'heading',
+      id: 'risk-score',
+      level: 2,
+      text: 'How the risk score is calculated',
+    },
+    {
+      type: 'paragraph',
+      text: 'The risk score (0-100) combines two factors:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Flagged rights', text: 'Each flagged right contributes (severity x 15) + (confidence x 5) points.' },
+        { bold: 'Risk items', text: 'Each risk item contributes likelihood x severity x 3 points, where Low=1, Medium=2, High=3.' },
+      ],
+    },
+    {
+      type: 'table',
+      columns: [
+        { key: 'score', label: 'Score range', width: '30%' },
+        { key: 'level', label: 'Risk level', width: '30%' },
+        { key: 'meaning', label: 'What it means', width: '40%' },
+      ],
+      rows: [
+        { score: '0-29', level: 'Low', meaning: 'Minimal rights impact identified' },
+        { score: '30-59', level: 'Medium', meaning: 'Some rights concerns that need attention' },
+        { score: '60-100', level: 'High', meaning: 'Significant rights impact requiring review' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'roles',
+      level: 2,
+      text: 'Who can do what',
+    },
+    {
+      type: 'table',
+      columns: [
+        { key: 'action', label: 'Action', width: '50%' },
+        { key: 'roles', label: 'Required role', width: '50%' },
+      ],
+      rows: [
+        { action: 'View the FRIA', roles: 'Any authenticated user' },
+        { action: 'Edit assessment fields', roles: 'Admin or Editor' },
+        { action: 'Add/edit/delete risk items', roles: 'Admin or Editor' },
+        { action: 'Update rights matrix', roles: 'Admin or Editor' },
+        { action: 'Save snapshots', roles: 'Admin or Editor' },
+        { action: 'Attach evidence', roles: 'Admin or Editor' },
+        { action: 'View version history', roles: 'Any authenticated user' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'next-steps',
+      level: 2,
+      text: 'Next steps',
+    },
+    {
+      type: 'article-links',
+      title: 'Related articles',
+      items: [
+        {
+          collectionId: 'compliance',
+          articleId: 'eu-ai-act',
+          title: 'EU AI Act compliance',
+          description: 'Understand the broader EU AI Act requirements beyond FRIA.',
+        },
+        {
+          collectionId: 'risk-management',
+          articleId: 'risk-assessment',
+          title: 'Conducting risk assessments',
+          description: 'Learn about project-level risk assessments that feed into the FRIA.',
+        },
+        {
+          collectionId: 'ai-governance',
+          articleId: 'evidence-collection',
+          title: 'Evidence collection',
+          description: 'Manage the evidence files you attach to FRIA sections.',
+        },
+      ],
+    },
+  ],
+};

--- a/shared/user-guide-content/content/index.ts
+++ b/shared/user-guide-content/content/index.ts
@@ -22,6 +22,7 @@ import { iso42001Content } from './compliance/iso-42001';
 import { iso27001Content } from './compliance/iso-27001';
 import { nistAiRmfContent } from './compliance/nist-ai-rmf';
 import { assessmentsContent } from './compliance/assessments';
+import { friaContent } from './compliance/fria';
 import { policyManagementContent } from './policies/policy-management';
 import { policyVersioningContent } from './policies/policy-versioning';
 import { policyApprovalContent } from './policies/policy-approval';
@@ -93,6 +94,7 @@ export const articleContentMap: Record<string, ArticleContent> = {
   'compliance/iso-27001': iso27001Content,
   'compliance/nist-ai-rmf': nistAiRmfContent,
   'compliance/assessments': assessmentsContent,
+  'compliance/fria': friaContent,
   // Policies
   'policies/policy-management': policyManagementContent,
   'policies/policy-versioning': policyVersioningContent,

--- a/shared/user-guide-content/userGuideConfig.ts
+++ b/shared/user-guide-content/userGuideConfig.ts
@@ -275,7 +275,7 @@ export const collections: Collection[] = [
     title: 'Compliance frameworks',
     description: 'Stay compliant with AI regulations including EU AI Act, ISO 42001, and more.',
     icon: 'Shield',
-    articleCount: 5,
+    articleCount: 6,
     articles: [
       {
         id: 'assessments',
@@ -306,6 +306,12 @@ export const collections: Collection[] = [
         title: 'NIST AI RMF',
         description: 'Implement the NIST AI Risk Management Framework.',
         keywords: ['nist', 'rmf', 'framework', 'risk', 'management'],
+      },
+      {
+        id: 'fria',
+        title: 'Fundamental Rights Impact Assessment',
+        description: 'Assess the impact of high-risk AI systems on fundamental rights as required by EU AI Act Article 27.',
+        keywords: ['fria', 'fundamental rights', 'impact assessment', 'article 27', 'eu ai act', 'charter', 'rights matrix', 'deployer'],
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Add in-app user guide article for FRIA under Compliance frameworks collection
- Add technical domain documentation at docs/technical/domains/fria.md
- Register in user guide config and content index

## User guide covers
- Accessing the FRIA (auto-creation on first visit)
- 8 assessment sections with descriptions
- Auto-save behavior
- Stat cards (completion, risk score, rights flagged, status)
- Fundamental rights matrix (10 EU Charter rights with examples)
- Risk item management (manual add and import from project risks)
- Evidence attachments per section
- Snapshot system and version history with diff viewer
- Risk score calculation formula
- Role permissions table

## Technical doc covers
- 16 API endpoints across 6 groups
- 6 database tables with full column listings
- Score computation algorithm
- Frontend component tree and data flow
- Debounce/auto-save pattern
- Snapshot/versioning system