### PR TITLE
fix(framework): guard against null name crash on /framework page

### DIFF
--- a/Clients/src/presentation/pages/Framework/Dashboard/NISTFunctionsOverviewCard.tsx
+++ b/Clients/src/presentation/pages/Framework/Dashboard/NISTFunctionsOverviewCard.tsx
@@ -187,7 +187,7 @@ const NISTFunctionsOverviewCard = ({ frameworksData, onNavigate }: NISTFunctions
 
     const handleCardClick = () => {
       if (onNavigate) {
-        onNavigate("NIST AI RMF", func.type.toLowerCase());
+        onNavigate("NIST AI RMF", func.type?.toLowerCase() ?? "");
       }
     };
 
@@ -313,10 +313,10 @@ const NISTFunctionsOverviewCard = ({ frameworksData, onNavigate }: NISTFunctions
   };
 
   // Get functions by type for 2x2 grid layout
-  const governFunc = functionsData.find(f => f.type.toLowerCase() === "govern");
-  const mapFunc = functionsData.find(f => f.type.toLowerCase() === "map");
-  const measureFunc = functionsData.find(f => f.type.toLowerCase() === "measure");
-  const manageFunc = functionsData.find(f => f.type.toLowerCase() === "manage");
+  const governFunc = functionsData.find(f => f.type?.toLowerCase() === "govern");
+  const mapFunc = functionsData.find(f => f.type?.toLowerCase() === "map");
+  const measureFunc = functionsData.find(f => f.type?.toLowerCase() === "measure");
+  const manageFunc = functionsData.find(f => f.type?.toLowerCase() === "manage");
 
   return (
     <Stack spacing={0}>

--- a/Clients/src/presentation/pages/Framework/Settings/index.tsx
+++ b/Clients/src/presentation/pages/Framework/Settings/index.tsx
@@ -81,6 +81,7 @@ const FrameworkSettings: React.FC<FrameworkSettingsProps> = ({
 
   // Get available frameworks for organizational projects (ISO 27001, ISO 42001, and NIST AI RMF)
   const availableFrameworks = allFrameworks.filter((framework) => {
+    if (!framework.name) return false;
     const isNotEuAiAct = !framework.name.toLowerCase().includes("eu ai act");
     const isComplianceFramework =
       framework.name.toLowerCase().includes("iso 27001") ||

--- a/Clients/src/presentation/pages/Framework/index.tsx
+++ b/Clients/src/presentation/pages/Framework/index.tsx
@@ -227,6 +227,7 @@ const Framework = () => {
 
     // Filter frameworks to only include those assigned to the project and exclude EU AI Act
     const filtered = allFrameworks.filter((framework) => {
+      if (!framework.name) return false;
       const frameworkId = Number(framework.id);
       const isAssignedToProject = projectFrameworkIds.includes(frameworkId);
       const isNotEuAiAct = !framework.name.toLowerCase().includes("eu ai act");
@@ -586,7 +587,7 @@ const Framework = () => {
     }
 
     const framework = filteredFrameworks[selectedFramework];
-    if (!framework) return null;
+    if (!framework || !framework.name) return null;
 
     // Check if the selected framework is ISO 27001, ISO 42001, or NIST AI RMF
     const isISO27001 = framework.name.toLowerCase().includes("iso 27001");
@@ -1202,6 +1203,7 @@ const Framework = () => {
           onClose={() => setIsFrameworkModalOpen(false)}
           frameworks={allFrameworks
             .filter((framework) => {
+              if (!framework.name) return false;
               // Only show organizational frameworks (ISO 27001, ISO 42001, and NIST AI RMF) for organizational projects
               const isNotEuAiAct = !framework.name
                 .toLowerCase()

--- a/Clients/src/presentation/utils/cardEnhancements.ts
+++ b/Clients/src/presentation/utils/cardEnhancements.ts
@@ -35,14 +35,14 @@ export const getQuickStats = (
   switch (entityType) {
     case "models": {
       const productionModels =
-        statusData?.find((s) => s.label.toLowerCase().includes("production"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("production"))
           ?.value || Math.floor(total * 0.4);
       return `${productionModels} in production`;
     }
 
     case "trainings": {
       const completedTrainings =
-        statusData?.find((s) => s.label.toLowerCase().includes("completed"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("completed"))
           ?.value || Math.floor(total * 0.6);
       const completionRate = Math.round((completedTrainings / total) * 100);
       return `${completionRate}% completion rate`;
@@ -50,14 +50,14 @@ export const getQuickStats = (
 
     case "policies": {
       const publishedPolicies =
-        statusData?.find((s) => s.label.toLowerCase().includes("published"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("published"))
           ?.value || Math.floor(total * 0.5);
       return `${publishedPolicies} published`;
     }
 
     case "vendors": {
       const activeVendors =
-        statusData?.find((s) => s.label.toLowerCase().includes("active"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("active"))
           ?.value || Math.floor(total * 0.7);
       return `${activeVendors} active`;
     }
@@ -67,13 +67,13 @@ export const getQuickStats = (
         statusData
           ?.filter(
             (s) =>
-              s.label.toLowerCase().includes("high") &&
-              !s.label.toLowerCase().includes("very")
+              s.label?.toLowerCase().includes("high") &&
+              !s.label?.toLowerCase().includes("very")
           )
           ?.reduce((sum, item) => sum + item.value, 0) ||
         Math.floor(total * 0.2);
       const veryHighRisks =
-        statusData?.find((s) => s.label.toLowerCase().includes("very high"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("very high"))
           ?.value || Math.floor(total * 0.05);
       const criticalCount = highRisks + veryHighRisks;
       return criticalCount > 0
@@ -83,7 +83,7 @@ export const getQuickStats = (
 
     case "incidents": {
       const openIncidents =
-        statusData?.find((s) => s.label.toLowerCase().includes("open"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("open"))
           ?.value || Math.floor(total * 0.3);
       return openIncidents > 0 ? `${openIncidents} open` : "All resolved";
     }
@@ -112,10 +112,10 @@ export const hasCriticalItems = (
   switch (entityType) {
     case "vendorRisks": {
       const highRisk =
-        statusData.find((s) => s.label.toLowerCase().includes("high"))?.value ||
+        statusData.find((s) => s.label?.toLowerCase().includes("high"))?.value ||
         0;
       const veryHighRisk =
-        statusData.find((s) => s.label.toLowerCase().includes("very high"))
+        statusData.find((s) => s.label?.toLowerCase().includes("very high"))
           ?.value || 0;
       const criticalRisks = highRisk + veryHighRisk;
 
@@ -128,10 +128,10 @@ export const hasCriticalItems = (
 
     case "policies": {
       const inReview =
-        statusData.find((s) => s.label.toLowerCase().includes("in review"))
+        statusData.find((s) => s.label?.toLowerCase().includes("in review"))
           ?.value || 0;
       const draft =
-        statusData.find((s) => s.label.toLowerCase().includes("draft"))
+        statusData.find((s) => s.label?.toLowerCase().includes("draft"))
           ?.value || 0;
       const needsAttention = inReview + draft;
 
@@ -144,7 +144,7 @@ export const hasCriticalItems = (
 
     case "trainings": {
       const inProgress =
-        statusData.find((s) => s.label.toLowerCase().includes("in progress"))
+        statusData.find((s) => s.label?.toLowerCase().includes("in progress"))
           ?.value || 0;
 
       return {
@@ -156,7 +156,7 @@ export const hasCriticalItems = (
 
     case "vendors": {
       const requiresFollowUp =
-        statusData.find((s) => s.label.toLowerCase().includes("follow up"))
+        statusData.find((s) => s.label?.toLowerCase().includes("follow up"))
           ?.value || 0;
 
       return {
@@ -168,7 +168,7 @@ export const hasCriticalItems = (
 
     case "incidents": {
       const openIncidents =
-        statusData.find((s) => s.label.toLowerCase().includes("open"))
+        statusData.find((s) => s.label?.toLowerCase().includes("open"))
           ?.value || 0;
 
       return {
@@ -201,13 +201,13 @@ export const getPriorityLevel = (
   switch (entityType) {
     case "vendorRisks": {
       const veryHighRisk =
-        statusData?.find((s) => s.label.toLowerCase().includes("very high"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("very high"))
           ?.value || 0;
       const highRisk =
         statusData?.find(
           (s) =>
-            s.label.toLowerCase().includes("high") &&
-            !s.label.toLowerCase().includes("very")
+            s.label?.toLowerCase().includes("high") &&
+            !s.label?.toLowerCase().includes("very")
         )?.value || 0;
 
       if (veryHighRisk > 0) return "high";
@@ -217,7 +217,7 @@ export const getPriorityLevel = (
 
     case "policies": {
       const overdue =
-        statusData?.find((s) => s.label.toLowerCase().includes("draft"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("draft"))
           ?.value || 0;
       const draftPercentage = (overdue / total) * 100;
 
@@ -228,7 +228,7 @@ export const getPriorityLevel = (
 
     case "trainings": {
       const completed =
-        statusData?.find((s) => s.label.toLowerCase().includes("completed"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("completed"))
           ?.value || 0;
       const completionRate = (completed / total) * 100;
 
@@ -239,7 +239,7 @@ export const getPriorityLevel = (
 
     case "incidents": {
       const openIncidents =
-        statusData?.find((s) => s.label.toLowerCase().includes("open"))
+        statusData?.find((s) => s.label?.toLowerCase().includes("open"))
           ?.value || 0;
       const openPercentage = (openIncidents / total) * 100;
 


### PR DESCRIPTION
## Summary
- Adds null guards before `.toLowerCase()` calls on framework `name`, `type`, and `label` properties across the Framework pages and utilities
- Prevents `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` crash on production when framework data is incomplete or missing names

## Root cause
On `cyberpros.verifywise.ai`, some framework objects returned from the API have `null`/`undefined` `name` fields (likely due to partial database state or auth issues), causing the `/framework` page to crash. Works locally because local DB has complete data.

## Files changed
- `Framework/index.tsx` — 3 null guards in filters and render
- `Framework/Settings/index.tsx` — 1 null guard in filter
- `Framework/Dashboard/NISTFunctionsOverviewCard.tsx` — optional chaining on `.type`
- `presentation/utils/cardEnhancements.ts` — optional chaining on `.label`

## Test plan
- [ ] Navigate to /framework with NIST AI RMF enabled — no crash
- [ ] Navigate to /framework with ISO 27001, ISO 42001 enabled — no crash
- [ ] Verify framework settings page loads correctly
- [ ] Verify dashboard cards render without errors