### PR TITLE
Dev-Mode Auto-Bootstrap First Organization & Admin

### DIFF
--- a/Servers/.env.example
+++ b/Servers/.env.example
@@ -1,0 +1,53 @@
+# VerifyWise Backend — Example Environment File
+# Copy to `.env` and fill in real values for local development.
+
+# Common
+BACKEND_PORT=3000
+BACKEND_URL=http://localhost:3000
+FRONTEND_PORT=5173
+FRONTEND_URL=http://localhost:5173
+HOST=localhost
+NODE_ENV=development
+
+MULTI_TENANCY_ENABLED=false
+
+# Database
+DB_PORT=5432
+DB_HOST=localhost
+DB_NAME=verifywise
+DB_USER=postgres
+DB_PASSWORD=postgres
+
+# Redis
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# Backend Settings
+JWT_SECRET=replace-me
+REFRESH_TOKEN_SECRET=replace-me
+
+# Email
+EMAIL_PROVIDER=resend
+EMAIL_ID=your-email@company.com
+RESEND_API_KEY=your-resend-api-key
+
+# Super-admin (seeded by migration on fresh installs)
+SUPERADMIN_EMAIL=super@local.dev
+SUPERADMIN_PASSWORD=Super123!
+
+# ---------------------------------------------------------------------------
+# Dev-only auto-bootstrap (DEV ONLY — hard-disabled when NODE_ENV=production)
+# ---------------------------------------------------------------------------
+# When DEV_AUTO_BOOTSTRAP=true and no organizations exist yet, the server will
+# automatically create the first organization and an active Admin user on
+# startup, so you can log in immediately on a fresh database without going
+# through the super-admin onboarding flow.
+#
+# DEV_ADMIN_PASSWORD must satisfy backend strength rules: at least 8 chars
+# and contain uppercase, lowercase, and a digit.
+# DEV_AUTO_BOOTSTRAP=true
+# DEV_ORG_NAME=Acme Dev
+# DEV_ADMIN_EMAIL=admin@local.dev
+# DEV_ADMIN_PASSWORD=Admin123!
+# DEV_ADMIN_NAME=Dev
+# DEV_ADMIN_SURNAME=Admin

--- a/Servers/CLAUDE.md
+++ b/Servers/CLAUDE.md
@@ -94,6 +94,34 @@ npx sequelize db:migrate:undo    # Rollback last
 
 ---
 
+## Dev-Only Auto-Bootstrap
+
+On a fresh database, the standard onboarding flow requires logging in as super-admin (seeded by migration from `SUPERADMIN_EMAIL` / `SUPERADMIN_PASSWORD`), creating an organization, and inviting an admin. To skip this for local development, set the following in `Servers/.env`:
+
+```env
+NODE_ENV=development
+DEV_AUTO_BOOTSTRAP=true
+DEV_ORG_NAME=Acme Dev
+DEV_ADMIN_EMAIL=admin@local.dev
+DEV_ADMIN_PASSWORD=Admin123!   # ≥8 chars, upper, lower, digit
+DEV_ADMIN_NAME=Dev
+DEV_ADMIN_SURNAME=Admin
+```
+
+On startup (after migrations, before `app.listen`), `Servers/utils/devAutoBootstrap.ts` will:
+
+1. **Hard-bail in production** — `NODE_ENV === "production"` is an unconditional return, regardless of the flag. The feature is dev-only by construction.
+2. Skip if `DEV_AUTO_BOOTSTRAP !== "true"`.
+3. Skip if any `organizations` row already exists (idempotent — safe to leave on across restarts).
+4. Validate required env vars and password strength; **fail fast** on startup with a clear error if anything is missing or invalid.
+5. In a single transaction, call `createOrganizationQuery` (`utils/organization.utils.ts`) and `createNewUserWrapper` (`controllers/user.ctrl.ts`) with `roleId: 1` (Admin). The user is created active — no email invitation flow.
+
+Log on success: `[dev-bootstrap] created org "<name>" (id=<id>) and admin <email>`.
+
+This is for local developer convenience only — never enable on shared environments.
+
+---
+
 ## Backend Development
 
 ### Layer Flow

--- a/Servers/CLAUDE.md
+++ b/Servers/CLAUDE.md
@@ -110,11 +110,12 @@ DEV_ADMIN_SURNAME=Admin
 
 On startup (after migrations, before `app.listen`), `Servers/utils/devAutoBootstrap.ts` will:
 
-1. **Hard-bail in production** — `NODE_ENV === "production"` is an unconditional return, regardless of the flag. The feature is dev-only by construction.
+1. **Hard-bail in production** — `NODE_ENV === "production"` is an unconditional return, regardless of the flag. The feature is dev-only by construction. `NODE_ENV` and the flag are trimmed + lowercased, so `" True "` and `"Production"` are handled.
 2. Skip if `DEV_AUTO_BOOTSTRAP !== "true"`.
-3. Skip if any `organizations` row already exists (idempotent — safe to leave on across restarts).
-4. Validate required env vars and password strength; **fail fast** on startup with a clear error if anything is missing or invalid.
-5. In a single transaction, call `createOrganizationQuery` (`utils/organization.utils.ts`) and `createNewUserWrapper` (`controllers/user.ctrl.ts`) with `roleId: 1` (Admin). The user is created active — no email invitation flow.
+3. **Pre-flight the `DEV_*` vars before touching the DB.** If any of `DEV_ORG_NAME`, `DEV_ADMIN_EMAIL`, `DEV_ADMIN_PASSWORD`, `DEV_ADMIN_NAME`, or `DEV_ADMIN_SURNAME` is missing, commented out, or empty, log a skip message and return — the server then falls back to the default super-admin-only flow. No throw, no `process.exit(1)`.
+4. Skip if any `organizations` row already exists (idempotent — safe to leave on across restarts). If the `organizations` table doesn't exist (`42P01`), surface a friendly "run `npx sequelize db:migrate` first" error instead of a raw SQL error.
+5. Validate email format, reject collisions with `SUPERADMIN_EMAIL`, and check password strength. These fail fast on startup with a clear error since the vars were explicitly set.
+6. In a single transaction, call `createOrganizationQuery` (`utils/organization.utils.ts`) and `createNewUserWrapper` (`controllers/user.ctrl.ts`) with `roleId: 1` (Admin). The user is created active — no email invitation flow.
 
 Log on success: `[dev-bootstrap] created org "<name>" (id=<id>) and admin <email>`.
 

--- a/Servers/domain.layer/tests/devAutoBootstrap.spec.ts
+++ b/Servers/domain.layer/tests/devAutoBootstrap.spec.ts
@@ -109,15 +109,17 @@ describe("devAutoBootstrap", () => {
     );
   });
 
-  it("throws fast when a required env var is missing", async () => {
+  it("skips silently when a required env var is missing", async () => {
     setDevEnv({ DEV_ADMIN_PASSWORD: undefined });
-    mockedSequelize.query.mockResolvedValueOnce([[{ count: 0 }], 1]);
 
-    await expect(devAutoBootstrap()).rejects.toThrow(
-      /DEV_ADMIN_PASSWORD/
-    );
+    await devAutoBootstrap();
+
+    expect(mockedSequelize.query).not.toHaveBeenCalled();
     expect(mockedCreateOrg).not.toHaveBeenCalled();
     expect(mockedCreateUser).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("DEV_ADMIN_PASSWORD")
+    );
   });
 
   it("throws fast when DEV_ADMIN_PASSWORD is too weak", async () => {

--- a/Servers/domain.layer/tests/devAutoBootstrap.spec.ts
+++ b/Servers/domain.layer/tests/devAutoBootstrap.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview devAutoBootstrap unit tests
+ *
+ * Verifies the dev-only auto-bootstrap helper:
+ *   - Hard production guard (never runs in production)
+ *   - Flag-off guard (no-op when DEV_AUTO_BOOTSTRAP !== "true")
+ *   - Idempotency (skips when organizations already exist)
+ *   - Env var validation (fails fast on missing values)
+ *   - Happy path (calls org + user creators with correct args, commits txn)
+ */
+
+jest.mock("../../database/db", () => ({
+  sequelize: {
+    query: jest.fn(),
+    transaction: jest.fn(),
+  },
+}));
+
+jest.mock("../../utils/organization.utils", () => ({
+  createOrganizationQuery: jest.fn(),
+}));
+
+jest.mock("../../controllers/user.ctrl", () => ({
+  createNewUserWrapper: jest.fn(),
+}));
+
+import { sequelize } from "../../database/db";
+import { createOrganizationQuery } from "../../utils/organization.utils";
+import { createNewUserWrapper } from "../../controllers/user.ctrl";
+import { devAutoBootstrap } from "../../utils/devAutoBootstrap";
+
+const mockedSequelize = sequelize as unknown as {
+  query: jest.Mock;
+  transaction: jest.Mock;
+};
+const mockedCreateOrg = createOrganizationQuery as jest.Mock;
+const mockedCreateUser = createNewUserWrapper as jest.Mock;
+
+const ORIGINAL_ENV = { ...process.env };
+
+const setDevEnv = (overrides: Record<string, string | undefined> = {}) => {
+  process.env.NODE_ENV = "development";
+  process.env.DEV_AUTO_BOOTSTRAP = "true";
+  process.env.DEV_ORG_NAME = "Acme Dev";
+  process.env.DEV_ADMIN_EMAIL = "admin@local.dev";
+  process.env.DEV_ADMIN_PASSWORD = "Admin123!";
+  process.env.DEV_ADMIN_NAME = "Dev";
+  process.env.DEV_ADMIN_SURNAME = "Admin";
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+};
+
+const buildTxn = () => ({
+  commit: jest.fn().mockResolvedValue(undefined),
+  rollback: jest.fn().mockResolvedValue(undefined),
+});
+
+describe("devAutoBootstrap", () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.clearAllMocks();
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("is a no-op in production even when flag is on", async () => {
+    setDevEnv();
+    process.env.NODE_ENV = "production";
+
+    await devAutoBootstrap();
+
+    expect(mockedSequelize.query).not.toHaveBeenCalled();
+    expect(mockedSequelize.transaction).not.toHaveBeenCalled();
+    expect(mockedCreateOrg).not.toHaveBeenCalled();
+    expect(mockedCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when DEV_AUTO_BOOTSTRAP is not 'true'", async () => {
+    setDevEnv({ DEV_AUTO_BOOTSTRAP: "false" });
+
+    await devAutoBootstrap();
+
+    expect(mockedSequelize.query).not.toHaveBeenCalled();
+    expect(mockedCreateOrg).not.toHaveBeenCalled();
+  });
+
+  it("skips when at least one organization already exists", async () => {
+    setDevEnv();
+    mockedSequelize.query.mockResolvedValueOnce([[{ count: 3 }], 1]);
+
+    await devAutoBootstrap();
+
+    expect(mockedSequelize.query).toHaveBeenCalledTimes(1);
+    expect(mockedSequelize.transaction).not.toHaveBeenCalled();
+    expect(mockedCreateOrg).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      "[dev-bootstrap] organizations already exist, skipping"
+    );
+  });
+
+  it("throws fast when a required env var is missing", async () => {
+    setDevEnv({ DEV_ADMIN_PASSWORD: undefined });
+    mockedSequelize.query.mockResolvedValueOnce([[{ count: 0 }], 1]);
+
+    await expect(devAutoBootstrap()).rejects.toThrow(
+      /DEV_ADMIN_PASSWORD/
+    );
+    expect(mockedCreateOrg).not.toHaveBeenCalled();
+    expect(mockedCreateUser).not.toHaveBeenCalled();
+  });
+
+  it("throws fast when DEV_ADMIN_PASSWORD is too weak", async () => {
+    setDevEnv({ DEV_ADMIN_PASSWORD: "weakpass" });
+    mockedSequelize.query.mockResolvedValueOnce([[{ count: 0 }], 1]);
+
+    await expect(devAutoBootstrap()).rejects.toThrow(/upper, lower, and digit/);
+    expect(mockedCreateOrg).not.toHaveBeenCalled();
+  });
+
+  it("creates org + admin in a single transaction on the happy path", async () => {
+    setDevEnv();
+    mockedSequelize.query.mockResolvedValueOnce([[{ count: 0 }], 1]);
+    const txn = buildTxn();
+    mockedSequelize.transaction.mockResolvedValueOnce(txn);
+    mockedCreateOrg.mockResolvedValueOnce({ id: 42, name: "Acme Dev" });
+    mockedCreateUser.mockResolvedValueOnce({ id: 7 });
+
+    await devAutoBootstrap();
+
+    expect(mockedCreateOrg).toHaveBeenCalledTimes(1);
+    expect(mockedCreateOrg).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Acme Dev" }),
+      txn
+    );
+    expect(mockedCreateUser).toHaveBeenCalledTimes(1);
+    expect(mockedCreateUser).toHaveBeenCalledWith(
+      {
+        name: "Dev",
+        surname: "Admin",
+        email: "admin@local.dev",
+        password: "Admin123!",
+        roleId: 1,
+        organizationId: 42,
+      },
+      txn
+    );
+    expect(txn.commit).toHaveBeenCalledTimes(1);
+    expect(txn.rollback).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      '[dev-bootstrap] created org "Acme Dev" (id=42) and admin admin@local.dev'
+    );
+  });
+
+  it("rolls back the transaction when org creation fails", async () => {
+    setDevEnv();
+    mockedSequelize.query.mockResolvedValueOnce([[{ count: 0 }], 1]);
+    const txn = buildTxn();
+    mockedSequelize.transaction.mockResolvedValueOnce(txn);
+    mockedCreateOrg.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(devAutoBootstrap()).rejects.toThrow("db down");
+    expect(txn.rollback).toHaveBeenCalledTimes(1);
+    expect(txn.commit).not.toHaveBeenCalled();
+    expect(mockedCreateUser).not.toHaveBeenCalled();
+  });
+});

--- a/Servers/index.ts
+++ b/Servers/index.ts
@@ -352,9 +352,8 @@ try {
       console.error("Data migration check failed:", error);
       // Server continues to start even if migration check fails
     }
-  })();
 
-  (async () => {
+    // Dev-only auto-bootstrap — runs AFTER migration check completes
     try {
       const { devAutoBootstrap } = require("./utils/devAutoBootstrap");
       await devAutoBootstrap();

--- a/Servers/index.ts
+++ b/Servers/index.ts
@@ -354,6 +354,22 @@ try {
     }
   })();
 
+  (async () => {
+    try {
+      const { devAutoBootstrap } = require("./utils/devAutoBootstrap");
+      await devAutoBootstrap();
+    } catch (error) {
+      console.error("❌ Dev auto-bootstrap failed:", error);
+      // When DEV_AUTO_BOOTSTRAP is explicitly on, fail fast so devs notice
+      if (
+        process.env.NODE_ENV !== "production" &&
+        process.env.DEV_AUTO_BOOTSTRAP === "true"
+      ) {
+        process.exit(1);
+      }
+    }
+  })();
+
   const server = app.listen(port, () => {
     console.log(`Server running on port http://${host}:${port}/`);
   });

--- a/Servers/utils/devAutoBootstrap.ts
+++ b/Servers/utils/devAutoBootstrap.ts
@@ -72,6 +72,18 @@ export async function devAutoBootstrap(): Promise<void> {
     );
   }
 
+  if (
+    process.env.SUPERADMIN_EMAIL &&
+    email.toLowerCase() ===
+      process.env.SUPERADMIN_EMAIL.trim()
+        .replace(/^['"]|['"]$/g, "")
+        .toLowerCase()
+  ) {
+    throw new Error(
+      "[dev-bootstrap] DEV_ADMIN_EMAIL must differ from SUPERADMIN_EMAIL"
+    );
+  }
+
   // Password strength is enforced by UserModel.createNewUser; we duplicate a
   // lightweight pre-check here for a friendlier startup error message.
   const strong =

--- a/Servers/utils/devAutoBootstrap.ts
+++ b/Servers/utils/devAutoBootstrap.ts
@@ -30,6 +30,19 @@ export async function devAutoBootstrap(): Promise<void> {
     return;
   }
 
+  // Pre-flight: if any required env var is missing/empty, skip silently and
+  // fall back to the default super-admin-only flow. We do this BEFORE touching
+  // the DB so a partially-configured .env never fails startup.
+  const missing = REQUIRED_VARS.filter(
+    (k) => !(process.env[k] ?? "").trim()
+  );
+  if (missing.length > 0) {
+    console.log(
+      `[dev-bootstrap] skipping — missing env vars: ${missing.join(", ")}`
+    );
+    return;
+  }
+
   // Idempotency — skip if any organization already exists
   let count = 0;
   try {
@@ -50,14 +63,6 @@ export async function devAutoBootstrap(): Promise<void> {
       "[dev-bootstrap] organizations already exist, skipping"
     );
     return;
-  }
-
-  // Validate required env vars — fail fast with clear error
-  const missing = REQUIRED_VARS.filter((k) => !process.env[k]);
-  if (missing.length > 0) {
-    throw new Error(
-      `[dev-bootstrap] missing required env vars: ${missing.join(", ")}`
-    );
   }
 
   const orgName = process.env.DEV_ORG_NAME!;

--- a/Servers/utils/devAutoBootstrap.ts
+++ b/Servers/utils/devAutoBootstrap.ts
@@ -1,0 +1,58 @@
+const REQUIRED_VARS = [
+  "DEV_ORG_NAME",
+  "DEV_ADMIN_EMAIL",
+  "DEV_ADMIN_PASSWORD",
+  "DEV_ADMIN_NAME",
+  "DEV_ADMIN_SURNAME",
+] as const;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Dev-only bootstrap: on first startup, create initial organization and admin user
+ * from environment variables so developers don't need to manually onboard every fresh DB.
+ *
+ * Hard-gated — completely inert outside development and when flag is off.
+ */
+export async function devAutoBootstrap(): Promise<void> {
+  // Hard prod guard — never run in production, regardless of flag
+  if (process.env.NODE_ENV === "production") {
+    return;
+  }
+
+  if (process.env.DEV_AUTO_BOOTSTRAP !== "true") {
+    return;
+  }
+
+  // Validate required env vars — fail fast with clear error
+  const missing = REQUIRED_VARS.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    throw new Error(
+      `[dev-bootstrap] missing required env vars: ${missing.join(", ")}`
+    );
+  }
+
+  const email = process.env.DEV_ADMIN_EMAIL!;
+  const password = process.env.DEV_ADMIN_PASSWORD!;
+
+  if (!EMAIL_RE.test(email)) {
+    throw new Error(
+      `[dev-bootstrap] DEV_ADMIN_EMAIL is not a valid email: ${email}`
+    );
+  }
+
+  // Password strength is enforced by UserModel.createNewUser; we duplicate a
+  // lightweight pre-check here for a friendlier startup error message.
+  const strong =
+    password.length >= 8 &&
+    /[A-Z]/.test(password) &&
+    /[a-z]/.test(password) &&
+    /\d/.test(password);
+  if (!strong) {
+    throw new Error(
+      "[dev-bootstrap] DEV_ADMIN_PASSWORD must be ≥8 chars and contain upper, lower, and digit"
+    );
+  }
+
+  // Idempotency check + organization/admin creation added in a follow-up commit.
+}

--- a/Servers/utils/devAutoBootstrap.ts
+++ b/Servers/utils/devAutoBootstrap.ts
@@ -31,10 +31,20 @@ export async function devAutoBootstrap(): Promise<void> {
   }
 
   // Idempotency — skip if any organization already exists
-  const [rows] = await sequelize.query(
-    "SELECT COUNT(*)::int AS count FROM organizations"
-  );
-  const count = (rows as Array<{ count: number }>)[0]?.count ?? 0;
+  let count = 0;
+  try {
+    const [rows] = await sequelize.query(
+      "SELECT COUNT(*)::int AS count FROM organizations"
+    );
+    count = (rows as Array<{ count: number }>)[0]?.count ?? 0;
+  } catch (err: any) {
+    if (err?.parent?.code === "42P01" || err?.original?.code === "42P01") {
+      throw new Error(
+        "[dev-bootstrap] organizations table not found — run `npx sequelize db:migrate` first"
+      );
+    }
+    throw err;
+  }
   if (count > 0) {
     console.log(
       "[dev-bootstrap] organizations already exist, skipping"

--- a/Servers/utils/devAutoBootstrap.ts
+++ b/Servers/utils/devAutoBootstrap.ts
@@ -20,11 +20,13 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
  */
 export async function devAutoBootstrap(): Promise<void> {
   // Hard prod guard — never run in production, regardless of flag
-  if (process.env.NODE_ENV === "production") {
+  const nodeEnv = (process.env.NODE_ENV ?? "").trim().toLowerCase();
+  const flag = (process.env.DEV_AUTO_BOOTSTRAP ?? "").trim().toLowerCase();
+  if (nodeEnv === "production") {
     return;
   }
 
-  if (process.env.DEV_AUTO_BOOTSTRAP !== "true") {
+  if (flag !== "true") {
     return;
   }
 

--- a/Servers/utils/devAutoBootstrap.ts
+++ b/Servers/utils/devAutoBootstrap.ts
@@ -1,3 +1,7 @@
+import { sequelize } from "../database/db";
+import { createOrganizationQuery } from "./organization.utils";
+import { createNewUserWrapper } from "../controllers/user.ctrl";
+
 const REQUIRED_VARS = [
   "DEV_ORG_NAME",
   "DEV_ADMIN_EMAIL",
@@ -24,6 +28,18 @@ export async function devAutoBootstrap(): Promise<void> {
     return;
   }
 
+  // Idempotency — skip if any organization already exists
+  const [rows] = await sequelize.query(
+    "SELECT COUNT(*)::int AS count FROM organizations"
+  );
+  const count = (rows as Array<{ count: number }>)[0]?.count ?? 0;
+  if (count > 0) {
+    console.log(
+      "[dev-bootstrap] organizations already exist, skipping"
+    );
+    return;
+  }
+
   // Validate required env vars — fail fast with clear error
   const missing = REQUIRED_VARS.filter((k) => !process.env[k]);
   if (missing.length > 0) {
@@ -32,8 +48,11 @@ export async function devAutoBootstrap(): Promise<void> {
     );
   }
 
+  const orgName = process.env.DEV_ORG_NAME!;
   const email = process.env.DEV_ADMIN_EMAIL!;
   const password = process.env.DEV_ADMIN_PASSWORD!;
+  const name = process.env.DEV_ADMIN_NAME!;
+  const surname = process.env.DEV_ADMIN_SURNAME!;
 
   if (!EMAIL_RE.test(email)) {
     throw new Error(
@@ -54,5 +73,31 @@ export async function devAutoBootstrap(): Promise<void> {
     );
   }
 
-  // Idempotency check + organization/admin creation added in a follow-up commit.
+  const transaction = await sequelize.transaction();
+  try {
+    const org = await createOrganizationQuery(
+      { name: orgName, logo: undefined as any },
+      transaction
+    );
+
+    await createNewUserWrapper(
+      {
+        name,
+        surname,
+        email,
+        password,
+        roleId: 1, // Admin
+        organizationId: org.id!,
+      },
+      transaction
+    );
+
+    await transaction.commit();
+    console.log(
+      `[dev-bootstrap] created org "${orgName}" (id=${org.id}) and admin ${email}`
+    );
+  } catch (err) {
+    await transaction.rollback();
+    throw err;
+  }
 }


### PR DESCRIPTION
## Dev-Mode Auto-Bootstrap First Organization & Admin

## Please ensure all items are checked off before requesting a review:

Addressing to close #3689 

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.

------------------

# Dev-Mode Auto-Bootstrap First Organization & Admin

**Branch:** `mo-331-apr-8-auto-create-user`
**Date:** 2026-04-08

---

## What we had before

A fresh VerifyWise install required a multi-step manual onboarding ritual on **every** new database, just to get to a usable dashboard:

1. The Sequelize migration `Servers/database/migrations/20260326142051-add-superadmin-role.js` would seed a super-admin from `SUPERADMIN_EMAIL` / `SUPERADMIN_PASSWORD`.
2. The developer had to log in as that super-admin in the frontend.
3. Manually create an Organization through the UI.
4. Manually invite an Admin user through the UI — which goes through the email-invite flow, so the developer also had to wire up email or click through the activation link.
5. Only **then** could they actually log in as the Admin and see the real dashboard.

This was repeated friction every time anyone wiped a dev DB, switched branches with incompatible migrations, or onboarded a new contributor. It also discouraged tearing down DBs even when that would have been the cleanest debugging move.

---

## What's new

A **strictly dev-only**, env-flag-gated startup hook that auto-creates the first Organization and an active Admin user on a fresh database — no UI clicks, no email invitation, no super-admin detour.

### How it works

A new helper, `Servers/utils/devAutoBootstrap.ts`, runs from an async IIFE in `Servers/index.ts`, placed after the existing `migrateToSharedSchema` block and before `app.listen`. The helper applies a layered set of guards before doing anything:

1. **Hard production guard.** `process.env.NODE_ENV === "production"` → unconditional return. The feature is dev-only by construction; even if someone fat-fingers `DEV_AUTO_BOOTSTRAP=true` into a prod env file, nothing happens and nothing is logged. `NODE_ENV` and the flag are trimmed + lowercased so `" True "` and `"Production"` are handled correctly.
2. **Flag guard.** `DEV_AUTO_BOOTSTRAP` must be `"true"` (case/whitespace-insensitive) or the function returns silently.
3. **Pre-flight env-var check — skip silently if incomplete.** Before touching the DB or reading any value, the helper verifies that every required `DEV_*` var (`DEV_ORG_NAME`, `DEV_ADMIN_EMAIL`, `DEV_ADMIN_PASSWORD`, `DEV_ADMIN_NAME`, `DEV_ADMIN_SURNAME`) is set and non-empty. If any is missing, commented out, or blank, it logs `[dev-bootstrap] skipping — missing env vars: ...` and returns. The server then falls back cleanly to the default super-admin-only flow — **no throw, no `process.exit(1)`.** This keeps a partially-configured `.env` from ever breaking startup.
4. **Idempotency.** `SELECT COUNT(*) FROM organizations` — if any organization already exists, log `[dev-bootstrap] organizations already exist, skipping` and return. This means the flag is safe to leave on across restarts; it only fires on a truly fresh DB. If the `organizations` table doesn't exist (Postgres error `42P01`), the helper re-throws a friendly "run `npx sequelize db:migrate` first" message instead of a cryptic SQL error.
5. **Validation, fail-fast.** Once the vars are known to be present, invalid email format, collision with `SUPERADMIN_EMAIL`, or a weak password (must be ≥8 chars with upper, lower, digit) all throw a clear error on startup. The wire-up in `index.ts` `process.exit(1)`s on this so misconfiguration that was explicit-but-wrong is impossible to miss.
6. **Atomic creation.** Inside a single `sequelize.transaction()`, the helper calls existing helpers — `createOrganizationQuery` from `Servers/utils/organization.utils.ts` and `createNewUserWrapper` from `Servers/controllers/user.ctrl.ts` (already exported via the named export block) — passing `roleId: 1` (Admin). The user is created **active**, completely bypassing the email-invite flow. On any error the transaction is rolled back.
7. **Success log.** `[dev-bootstrap] created org "<name>" (id=<id>) and admin <email>`.

### Startup sequencing

`devAutoBootstrap()` runs at the **tail** of the same async IIFE as `migrateToSharedSchema` in `Servers/index.ts`, not as a separate IIFE, so it's guaranteed to run after the migration check resolves (no race).

### Files added or modified

| File | Status | Purpose |
|------|--------|---------|
| `Servers/utils/devAutoBootstrap.ts` | **new** | The bootstrap helper itself: guards, validation, idempotency, transactional org+admin creation. |
| `Servers/index.ts` | modified | Async IIFE invoking `devAutoBootstrap()` after migration check, before `app.listen`. Exits 1 on failure when the flag is on in non-prod. |
| `Servers/.env.example` | **new** | First example env file in `Servers/`, including the new `DEV_*` placeholders so contributors can copy a working template. |
| `Servers/.env` | modified locally | Real values added by the developer (gitignored, not committed). |
| `Servers/CLAUDE.md` | modified | New "Dev-Only Auto-Bootstrap" section documenting the env vars, the production guard, idempotency behavior, and success log. |
| `Servers/domain.layer/tests/devAutoBootstrap.spec.ts` | **new** | 7 unit tests covering all guards and the happy/failure paths. |

### Reused existing code (no duplication)

- `createOrganizationQuery` — `Servers/utils/organization.utils.ts:120`
- `createNewUserWrapper` — `Servers/controllers/user.ctrl.ts:239` (already exported in the named export block at line 1876, no refactor needed)
- `UserModel.createNewUser` — provides bcrypt hashing and password strength validation transitively, via `createNewUserWrapper`
- `sequelize.transaction()` — same pattern as the `createOrganization` controller
- Admin role id `1` — already established convention across the codebase

### Tests

`Servers/domain.layer/tests/devAutoBootstrap.spec.ts` mocks `sequelize`, `createOrganizationQuery`, and `createNewUserWrapper`, then verifies:

1. Production guard — `NODE_ENV=production` short-circuits even with the flag on; no DB calls made.
2. Flag-off guard — `DEV_AUTO_BOOTSTRAP="false"` is a no-op.
3. Idempotency — when org count > 0, the helper logs the skip message and returns without opening a transaction.
4. Missing env var — omitting `DEV_ADMIN_PASSWORD` now **skips silently**, logs a skip message naming the missing var, and never touches the DB (updated from the original throw-behavior).
5. Weak password — `"weakpass"` throws the strength-rule error (only reachable when vars are explicitly set).
6. Happy path — `createOrganizationQuery` and `createNewUserWrapper` are called with the right args (including `roleId: 1` and the new org id), the transaction is committed, and the success line is logged.
7. Failure path — when org creation rejects, the transaction is rolled back and `createNewUserWrapper` is never called.

### Verification performed

- `cd Servers && npx tsc --noEmit` — clean.
- All commits land on `mo-331-apr-8-auto-create-user` and the working tree only retains an unrelated `.claude/settings.local.json` change.

---

## Commit history

The plan called for 7 atomic commits. In practice we landed **6**, because the planned `refactor(user.ctrl): export createNewUserWrapper` commit turned out to be a no-op — `createNewUserWrapper` was already in the named export block at the bottom of `Servers/controllers/user.ctrl.ts`, so no source change was needed at all. The other 6 commits map 1:1 to the plan:

| # | Commit | Hash |
|---|--------|------|
| 1 | `chore(env): add .env.example with DEV_AUTO_BOOTSTRAP placeholders` | `0d3610f99` |
| 2 | `feat(bootstrap): add devAutoBootstrap util with prod guard, flag check, env validation` | `6060c27a4` |
| 3 | `feat(bootstrap): idempotency check + transactional org+admin creation in devAutoBootstrap` | `c96a451b3` |
| 4 | `feat(bootstrap): wire devAutoBootstrap into server startup in index.ts` | `1ec8e28da` |
| 5 | `test(bootstrap): unit tests for devAutoBootstrap` | `dee257463` |
| 6 | `docs(bootstrap): document DEV_AUTO_BOOTSTRAP usage in Servers/CLAUDE.md` | `8820bd800` |

### Follow-up robustness fixes

After an in-repo review flagged several edge cases, a second pass landed six small, atomic fixes on the same branch:

| # | Commit | Hash |
|---|--------|------|
| 7 | `fix(bootstrap): sequence devAutoBootstrap after migration check to avoid race` | `d3a9fef97` |
| 8 | `fix(bootstrap): trim+lowercase NODE_ENV and DEV_AUTO_BOOTSTRAP checks` | `4b99157cf` |
| 9 | `fix(bootstrap): friendly error when organizations table is missing` | `ab9b651a6` |
| 10 | `fix(bootstrap): reject DEV_ADMIN_EMAIL collision with SUPERADMIN_EMAIL` | `cbba885dd` |
| 11 | `fix(bootstrap): pre-flight DEV_* env vars and skip silently if any missing` | `f90183787` |
| 12 | `test(bootstrap): update missing-env test to assert silent skip` | `6d1eae5a7` |

Highlights:
- **Sequencing (7).** The original wire-up used two parallel IIFEs for migration and bootstrap; these could race. The bootstrap call was merged into the tail of the migration IIFE so it always runs after the migration check completes.
- **Whitespace/casing guards (8).** `NODE_ENV` and `DEV_AUTO_BOOTSTRAP` are now trimmed + lowercased before comparison, closing the `" True "` / `"Production"` footguns.
- **Friendlier 42P01 (9).** Missing `organizations` table now surfaces as "run `npx sequelize db:migrate` first" instead of a raw SQL error.
- **Super-admin collision (10).** `DEV_ADMIN_EMAIL === SUPERADMIN_EMAIL` throws an explicit, actionable error up-front instead of the downstream `ConflictException`.
- **Silent-skip fallback (11, 12).** This is the biggest behavior change: partially-configured `DEV_*` vars no longer throw or exit — they log and return, letting the standard super-admin-only onboarding flow proceed. The corresponding unit test was updated to assert the new behavior.

Each commit is independently buildable, scoped to a single concern, and tells a clean story when read in order: env template → util skeleton → util body → server wire-up → tests → docs.

---

## How to use it

In `Servers/.env`:

```env
NODE_ENV=development
DEV_AUTO_BOOTSTRAP=true
DEV_ORG_NAME=Acme Dev
DEV_ADMIN_EMAIL=admin@local.dev
DEV_ADMIN_PASSWORD=Admin123!     # ≥8 chars, upper, lower, digit
DEV_ADMIN_NAME=Dev
DEV_ADMIN_SURNAME=Admin
```

Then on a fresh DB:

```bash
cd Servers && npm run build && npx sequelize db:migrate && npm run watch
```

Watch for the line `[dev-bootstrap] created org "Acme Dev" (id=1) and admin admin@local.dev` and log straight in. Restarting the server is a no-op (`organizations already exist, skipping`). Setting `NODE_ENV=production` makes the entire feature inert.

---

## Production safety summary

- **Hard guard, not soft check.** `NODE_ENV === "production"` returns *before* reading any other env var, so a misconfigured prod box leaks nothing and does nothing.
- **Idempotent by design.** The first thing the active path does is check whether organizations exist. Even if a prod-like environment somehow ran with the flag on, an existing fleet would never be touched.
- **No new attack surface.** All actual writes go through the same helpers (`createOrganizationQuery`, `createNewUserWrapper`) used by the regular onboarding APIs, including their existing validation, password hashing, and transaction guarantees.
- **Fails loud on explicit misconfiguration, graceful on incomplete.** When every `DEV_*` var is set but one is malformed (bad email, weak password, super-admin collision), the server exits 1 instead of starting in a confusing half-state. When `DEV_*` vars are simply missing or commented, the helper skips silently and the default super-admin-only flow still works — so a partially-configured `.env` never blocks startup.
