### PR TITLE
Feat(policy): Add PDF upload capability to Policy Manager

### DIFF
--- a/Clients/src/presentation/components/Policies/PolicyAttachments.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyAttachments.tsx
@@ -1,0 +1,201 @@
+import { useState, useEffect, useCallback } from "react";
+import { Box, Typography, Stack } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import { Paperclip, X, Upload } from "lucide-react";
+import { CustomizableButton } from "../button/customizable-button";
+import { FilePickerModal } from "../FilePickerModal";
+import FileUploadModal from "../Modals/FileUpload";
+import {
+  attachFileToEntity,
+  detachFileFromEntity,
+  getEntityFiles,
+  FileMetadata,
+} from "../../../application/repository/file.repository";
+import { FileData } from "../../../domain/types/File";
+
+interface PolicyAttachmentsProps {
+  policyId: number;
+}
+
+const FRAMEWORK_TYPE = "policy_manager";
+const ENTITY_TYPE = "policy";
+const LINK_TYPE = "attachment";
+
+const PolicyAttachments = ({ policyId }: PolicyAttachmentsProps) => {
+  const theme = useTheme();
+  const [files, setFiles] = useState<FileMetadata[]>([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchAttachments = useCallback(async () => {
+    if (!policyId) return;
+    try {
+      const data = await getEntityFiles(FRAMEWORK_TYPE, ENTITY_TYPE, policyId);
+      setFiles(Array.isArray(data) ? data : []);
+    } catch {
+      setFiles([]);
+    }
+  }, [policyId]);
+
+  useEffect(() => {
+    fetchAttachments();
+  }, [fetchAttachments]);
+
+  const handleSelect = async (
+    selectedFiles: FileData[]
+  ) => {
+    setIsLoading(true);
+    try {
+      for (const file of selectedFiles) {
+        await attachFileToEntity({
+          file_id: parseInt(file.id),
+          framework_type: FRAMEWORK_TYPE,
+          entity_type: ENTITY_TYPE,
+          entity_id: policyId,
+          link_type: LINK_TYPE,
+        });
+      }
+      await fetchAttachments();
+    } finally {
+      setIsLoading(false);
+      setPickerOpen(false);
+    }
+  };
+
+  const handleUploadSuccess = async (fileResponse: {
+    data?: { id?: number };
+    id?: number;
+  }) => {
+    setUploadOpen(false);
+    const fileId = fileResponse?.data?.id ?? fileResponse?.id;
+    if (!fileId) return;
+    setIsLoading(true);
+    try {
+      await attachFileToEntity({
+        file_id: fileId,
+        framework_type: FRAMEWORK_TYPE,
+        entity_type: ENTITY_TYPE,
+        entity_id: policyId,
+        link_type: LINK_TYPE,
+      });
+      await fetchAttachments();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleRemove = async (file: FileMetadata) => {
+    try {
+      await detachFileFromEntity({
+        file_id: parseInt(file.id),
+        framework_type: FRAMEWORK_TYPE,
+        entity_type: ENTITY_TYPE,
+        entity_id: policyId,
+      });
+      setFiles((prev) => prev.filter((f) => f.id !== file.id));
+    } catch {
+      // UI state remains consistent on next fetch
+    }
+  };
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          flexWrap: "wrap",
+        }}
+      >
+        <CustomizableButton
+          text="Attach PDF"
+          variant="text"
+          onClick={() => setPickerOpen(true)}
+          disabled={isLoading}
+          startIcon={<Paperclip size={13} />}
+          sx={{
+            height: 28,
+            fontSize: 12,
+            color: theme.palette.text.secondary,
+            textTransform: "none",
+            padding: "4px 8px",
+          }}
+        />
+        <CustomizableButton
+          text="Upload new"
+          variant="text"
+          onClick={() => setUploadOpen(true)}
+          disabled={isLoading}
+          startIcon={<Upload size={13} />}
+          sx={{
+            height: 28,
+            fontSize: 12,
+            color: theme.palette.text.secondary,
+            textTransform: "none",
+            padding: "4px 8px",
+          }}
+        />
+        {files.length > 0 && (
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+            {files.map((file) => (
+              <Box
+                key={file.id}
+                sx={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "4px",
+                  padding: "2px 8px",
+                  borderRadius: "4px",
+                  border: `1px solid ${theme.palette.divider}`,
+                  backgroundColor: theme.palette.background.default,
+                }}
+              >
+                <Paperclip size={11} color={theme.palette.text.secondary} />
+                <Typography
+                  sx={{ fontSize: 11, color: theme.palette.text.primary }}
+                >
+                  {file.filename}
+                </Typography>
+                <Box
+                  component="span"
+                  onClick={() => handleRemove(file)}
+                  sx={{
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    "&:hover": { opacity: 0.7 },
+                  }}
+                >
+                  <X size={11} color={theme.palette.text.secondary} />
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </Box>
+
+      <FilePickerModal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={handleSelect}
+        excludeFileIds={files.map((f) => f.id)}
+        multiSelect
+        title="Attach PDF to policy"
+      />
+
+      <FileUploadModal
+        uploadProps={{
+          open: uploadOpen,
+          onClose: () => setUploadOpen(false),
+          onSuccess: handleUploadSuccess,
+          uploadEndpoint: "/file-manager",
+          allowedFileTypes: ["application/pdf"],
+        }}
+      />
+    </Box>
+  );
+};
+
+export default PolicyAttachments;

--- a/Clients/src/presentation/components/Policies/PolicyAttachments.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyAttachments.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "@mui/material/styles";
 import { Paperclip, X, Upload } from "lucide-react";
 import { CustomizableButton } from "../button/customizable-button";
 import { FilePickerModal } from "../FilePickerModal";
-import FileUploadModal from "../Modals/FileUpload";
+import FileManagerUploadModal from "../Modals/FileManagerUpload";
 import {
   attachFileToEntity,
   detachFileFromEntity,
@@ -63,22 +63,20 @@ const PolicyAttachments = ({ policyId }: PolicyAttachmentsProps) => {
     }
   };
 
-  const handleUploadSuccess = async (fileResponse: {
-    data?: { id?: number };
-    id?: number;
-  }) => {
+  const handleUploadSuccess = async (uploadedFiles: Array<{ id?: number }>) => {
     setUploadOpen(false);
-    const fileId = fileResponse?.data?.id ?? fileResponse?.id;
-    if (!fileId) return;
     setIsLoading(true);
     try {
-      await attachFileToEntity({
-        file_id: fileId,
-        framework_type: FRAMEWORK_TYPE,
-        entity_type: ENTITY_TYPE,
-        entity_id: policyId,
-        link_type: LINK_TYPE,
-      });
+      for (const file of uploadedFiles) {
+        if (!file?.id) continue;
+        await attachFileToEntity({
+          file_id: file.id,
+          framework_type: FRAMEWORK_TYPE,
+          entity_type: ENTITY_TYPE,
+          entity_id: policyId,
+          link_type: LINK_TYPE,
+        });
+      }
       await fetchAttachments();
     } finally {
       setIsLoading(false);
@@ -185,14 +183,13 @@ const PolicyAttachments = ({ policyId }: PolicyAttachmentsProps) => {
         title="Attach PDF to policy"
       />
 
-      <FileUploadModal
-        uploadProps={{
-          open: uploadOpen,
-          onClose: () => setUploadOpen(false),
-          onSuccess: handleUploadSuccess,
-          uploadEndpoint: "/file-manager",
-          allowedFileTypes: ["application/pdf"],
-        }}
+      <FileManagerUploadModal
+        open={uploadOpen}
+        onClose={() => setUploadOpen(false)}
+        onSuccess={handleUploadSuccess}
+        acceptedMimeTypes={["application/pdf"]}
+        title="Upload PDF"
+        multiple
       />
     </Box>
   );

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -97,6 +97,7 @@ import { CustomizableButton } from "../../components/button/customizable-button"
 import { HistorySidebar } from "../../components/Common/HistorySidebar";
 import { usePolicyChangeHistory } from "../../../application/hooks/usePolicyChangeHistory";
 import PolicyForm from "../../components/Policies/PolicyForm";
+import PolicyAttachments from "../../components/Policies/PolicyAttachments";
 import InsertLinkModal from "../../components/Modals/InsertLinkModal/InsertLinkModal";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
 import { uploadFileToManager } from "../../../application/repository/file.repository";
@@ -1743,6 +1744,13 @@ export default function PolicyEditorPage() {
             clearFieldError={clearFieldError}
           />
         </Box>
+
+        {/* ── PDF Attachments ──────────────────────────────────────── */}
+        {!isNew && policy?.id && (
+          <Box sx={{ mb: "8px", flexShrink: 0 }}>
+            <PolicyAttachments policyId={policy.id} />
+          </Box>
+        )}
 
         {/* ── Toolbar ──────────────────────────────────────────────── */}
         <Box

--- a/Servers/database/migrations/20260408185230-fix-file-entity-links-unique-constraint.js
+++ b/Servers/database/migrations/20260408185230-fix-file-entity-links-unique-constraint.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * Fix file_entity_links unique constraint to include organization_id.
+ *
+ * The ON CONFLICT clause in file.repository.ts references
+ * (organization_id, file_id, framework_type, entity_type, entity_id)
+ * but the existing constraint only covers
+ * (file_id, framework_type, entity_type, entity_id).
+ */
+module.exports = {
+  async up(queryInterface) {
+    // Drop the old constraint (without organization_id)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE verifywise.file_entity_links
+        DROP CONSTRAINT IF EXISTS file_entity_links_file_id_framework_type_entity_type_entity_id_key;
+    `);
+
+    // Create the new constraint that matches the ON CONFLICT specification
+    await queryInterface.sequelize.query(`
+      ALTER TABLE verifywise.file_entity_links
+        ADD CONSTRAINT file_entity_links_org_file_framework_entity_uq
+        UNIQUE (organization_id, file_id, framework_type, entity_type, entity_id);
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE verifywise.file_entity_links
+        DROP CONSTRAINT IF EXISTS file_entity_links_org_file_framework_entity_uq;
+    `);
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE verifywise.file_entity_links
+        ADD CONSTRAINT file_entity_links_file_id_framework_type_entity_type_entity_id_key
+        UNIQUE (file_id, framework_type, entity_type, entity_id);
+    `);
+  }
+};


### PR DESCRIPTION
## Describe your changes

- Add `PolicyAttachments` component for attaching PDF files to policies using existing `FileManagerUploadModal` and `FilePickerModal`
- Integrate PDF attachments into `PolicyEditorPage` (visible for existing policies, below metadata form)
- Fix `file_entity_links` unique constraint to include `organization_id`, aligning with the `ON CONFLICT` clause in `file.repository.ts`

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="642" height="42" alt="Screenshot 2026-04-09 at 00 24 27" src="https://github.com/user-attachments/assets/498fdf7d-546a-4798-8b2e-53d9032a0506" />
