### PR TITLE
Feature/ add resource modal replace inline validation with generic hook

### DIFF
--- a/Clients/src/domain/interfaces/i.aiTrustCenter.ts
+++ b/Clients/src/domain/interfaces/i.aiTrustCenter.ts
@@ -14,3 +14,24 @@ export interface Subprocessor {
     location: string;
     url: string;
 }
+
+export interface FormData {
+  intro?: Record<string, unknown>;
+  compliance_badges?: Record<string, unknown>;
+  company_description?: Record<string, unknown>;
+  terms_and_contact?: Record<string, unknown>;
+  info?: {
+    resources_visible?: boolean;
+  };
+}
+
+export interface NewResourceFormValues {
+  name: string;
+  description: string;
+  file: File | null;
+}
+
+export interface EditResourceFormValues {
+  name: string;
+  description: string;
+}

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -722,7 +722,7 @@ const TrustCenterResources: React.FC = () => {
                 <Typography
                   component="span"
                   color="error"
-                  sx={{ opacity: 0.8, fontSize: 11, mt: 1, display: "block" }}
+                  sx={styles.fileErrorText}
                 >
                   {addErrors.file}
                 </Typography>

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useState, Suspense, useCallback, useEffect, useRef } from "react";
+import React, { useState, Suspense, useCallback, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   Box,
@@ -41,6 +41,8 @@ import { useTableGrouping, useGroupByState } from "../../../../application/hooks
 import { GroupedTableView } from "../../../components/Table/GroupedTableView";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { text, background, border as borderPalette } from "../../../themes/palette";
+import { useFormValidation } from "../../../../application/hooks/useFormValidation";
+import { checkStringValidation } from "../../../../application/validations/stringValidation";
 
 // Helper component for Resource Table Row
 const ResourceTableRow: React.FC<{
@@ -149,6 +151,17 @@ interface FormData {
   };
 }
 
+interface NewResourceFormValues {
+  name: string;
+  description: string;
+  file: File | null;
+}
+
+interface EditResourceFormValues {
+  name: string;
+  description: string;
+}
+
 const TrustCenterResources: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const hasProcessedUrlParam = useRef(false);
@@ -168,6 +181,45 @@ const TrustCenterResources: React.FC = () => {
   const deleteResourceMutation = useDeleteAITrustCentreResourceMutation();
   const theme = useTheme();
   const styles = useStyles(theme);
+
+  // Add resource form validation
+  const addResourceValidators = useMemo(() => ({
+    name: (v: unknown) => {
+      const r = checkStringValidation("Resource name", v as string, 1, 256);
+      return r.accepted ? "" : r.message;
+    },
+    description: (v: unknown) => {
+      const r = checkStringValidation("Type or purpose of resource", v as string, 10, 512);
+      return r.accepted ? "" : r.message;
+    },
+    file: (v: unknown) => (!v ? "A file is required." : ""),
+  }), []);
+
+  const {
+    errors: addErrors,
+    validateAll: validateAdd,
+    clearFieldError: clearAddFieldError,
+    resetErrors: resetAddErrors,
+  } = useFormValidation<NewResourceFormValues>(addResourceValidators);
+
+  // Edit resource form validation
+  const editResourceValidators = useMemo(() => ({
+    name: (v: unknown) => {
+      const r = checkStringValidation("Resource name", v as string, 1, 256);
+      return r.accepted ? "" : r.message;
+    },
+    description: (v: unknown) => {
+      const r = checkStringValidation("Type or purpose of resource", v as string, 10, 512);
+      return r.accepted ? "" : r.message;
+    },
+  }), []);
+
+  const {
+    errors: editErrors,
+    validateAll: validateEdit,
+    clearFieldError: clearEditFieldError,
+    resetErrors: resetEditErrors,
+  } = useFormValidation<EditResourceFormValues>(editResourceValidators);
 
   // GroupBy state
   const { groupBy, groupSortOrder, handleGroupChange } = useGroupByState();
@@ -286,12 +338,14 @@ const TrustCenterResources: React.FC = () => {
     setAddModalOpen(true);
     setNewResource({ name: "", description: "", file: null });
     setAddResourceError(null);
+    resetAddErrors();
   };
 
   const handleCloseAddModal = () => {
     setAddModalOpen(false);
     setNewResource({ name: "", description: "", file: null });
     setAddResourceError(null);
+    resetAddErrors();
   };
 
   const handleOpenEditModal = (resource: any) => {
@@ -307,6 +361,7 @@ const TrustCenterResources: React.FC = () => {
     });
     setEditModalOpen(true);
     setEditResourceError(null);
+    resetEditErrors();
   };
 
   const handleCloseEditModal = () => {
@@ -321,31 +376,18 @@ const TrustCenterResources: React.FC = () => {
       file_id: undefined,
     });
     setEditResourceError(null);
+    resetEditErrors();
   };
 
   // Resource operations
   const handleAddResource = async () => {
-    if (
-      !formData?.info?.resources_visible ||
-      !newResource.name ||
-      !newResource.description ||
-      !newResource.file
-    ) {
-      setAddResourceError("Please fill in all fields and upload a file");
-      return;
-    }
-  
-    // Check if description is at least 10 characters
-    if (newResource.description.length < 10) {
-      setAddResourceError("Description must be at least 10 characters long");
-      return;
-    }
-    // Proceed with adding the resource
-    setAddResourceError(""); 
+    if (!formData?.info?.resources_visible) return;
+
+    if (!validateAdd(newResource)) return;
 
     try {
       await createResourceMutation.mutateAsync({
-        file: newResource.file,
+        file: newResource.file!,
         name: newResource.name,
         description: newResource.description,
         visible: true,
@@ -364,23 +406,9 @@ const TrustCenterResources: React.FC = () => {
   };
 
   const handleSaveEditResource = async () => {
-    if (
-      !formData?.info?.resources_visible ||
-      !editResource.name ||
-      !editResource.description 
-    ) {
-      setEditResourceError("Please fill in all fields and upload a file");
-      return;
-    }
-  
-    // Check if description is at least 10 characters
-    if (editResource.description.length < 10) {
-      setEditResourceError("Description must be at least 10 characters long");
-      return;
-    }
-  
-    // Proceed with adding the resource
-    setEditResourceError(""); 
+    if (!formData?.info?.resources_visible) return;
+
+    if (!validateEdit(editResource)) return;
 
     try {
       // Pass the old file ID only when a new file is being uploaded
@@ -667,9 +695,11 @@ const TrustCenterResources: React.FC = () => {
               id="resource-name"
               label="Resource name"
               value={newResource.name}
-              onChange={(e) =>
-                setNewResource((r) => ({ ...r, name: e.target.value }))
-              }
+              onChange={(e) => {
+                setNewResource((r) => ({ ...r, name: e.target.value }));
+                clearAddFieldError("name");
+              }}
+              error={addErrors.name}
               disabled={!formData?.info?.resources_visible}
               isRequired
               sx={styles.fieldStyle}
@@ -679,9 +709,11 @@ const TrustCenterResources: React.FC = () => {
               id="resource-description"
               label="Type or purpose of resource"
               value={newResource.description}
-              onChange={(e) =>
-                setNewResource((r) => ({ ...r, description: e.target.value }))
-              }
+              onChange={(e) => {
+                setNewResource((r) => ({ ...r, description: e.target.value }));
+                clearAddFieldError("description");
+              }}
+              error={addErrors.description}
               disabled={!formData?.info?.resources_visible}
               isRequired
               sx={styles.fieldStyle}
@@ -707,6 +739,15 @@ const TrustCenterResources: React.FC = () => {
                   {newResource.file.name}
                 </Typography>
               )}
+              {addErrors.file && (
+                <Typography
+                  component="span"
+                  color="error"
+                  sx={{ opacity: 0.8, fontSize: 11, mt: 1, display: "block" }}
+                >
+                  {addErrors.file}
+                </Typography>
+              )}
             </Box>
           </Stack>
         </StandardModal>
@@ -723,6 +764,7 @@ const TrustCenterResources: React.FC = () => {
             if (files[0]) {
               setNewResource((r) => ({ ...r, file: files[0] }));
               setAddResourceError(null);
+              clearAddFieldError("file");
             }
             setAddFileModalOpen(false);
           }}
@@ -747,9 +789,11 @@ const TrustCenterResources: React.FC = () => {
               id="edit-resource-name"
               label="Resource name"
               value={editResource.name}
-              onChange={(e) =>
-                setEditResource((r) => ({ ...r, name: e.target.value }))
-              }
+              onChange={(e) => {
+                setEditResource((r) => ({ ...r, name: e.target.value }));
+                clearEditFieldError("name");
+              }}
+              error={editErrors.name}
               disabled={!formData?.info?.resources_visible}
               isRequired
               sx={styles.fieldStyle}
@@ -759,12 +803,14 @@ const TrustCenterResources: React.FC = () => {
               id="edit-resource-description"
               label="Type or purpose of resource"
               value={editResource.description}
-              onChange={(e) =>
+              onChange={(e) => {
                 setEditResource((r) => ({
                   ...r,
                   description: e.target.value,
-                }))
-              }
+                }));
+                clearEditFieldError("description");
+              }}
+              error={editErrors.description}
               disabled={!formData?.info?.resources_visible}
               isRequired
               sx={styles.fieldStyle}

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -660,12 +660,7 @@ const TrustCenterResources: React.FC = () => {
           description="Upload a resource document for your AI Trust Center"
           onSubmit={handleAddResource}
           submitButtonText="Add resource"
-          isSubmitting={
-            !formData?.info?.resources_visible ||
-            !newResource.name ||
-            !newResource.description ||
-            !newResource.file
-          }
+          isSubmitting={!formData?.info?.resources_visible}
         >
           <Stack spacing={6}>
             <Field

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -35,7 +35,7 @@ import { TABLE_COLUMNS, WARNING_MESSAGES } from "./constants";
 import { AITrustCentreOverviewData } from "../../../../application/hooks/useAITrustCentreOverview";
 import { useTheme } from "@mui/material/styles";
 import AITrustCenterTable from "../../../components/Table/AITrustCenterTable";
-import { Resource } from "../../../../domain/interfaces/i.aiTrustCenter";
+import { EditResourceFormValues, NewResourceFormValues, Resource, FormData } from "../../../../domain/interfaces/i.aiTrustCenter";
 import { GroupBy } from "../../../components/Table/GroupBy";
 import { useTableGrouping, useGroupByState } from "../../../../application/hooks/useTableGrouping";
 import { GroupedTableView } from "../../../components/Table/GroupedTableView";
@@ -140,27 +140,6 @@ const ResourceTableRow: React.FC<{
     </>
   );
 };
-
-interface FormData {
-  intro?: Record<string, unknown>;
-  compliance_badges?: Record<string, unknown>;
-  company_description?: Record<string, unknown>;
-  terms_and_contact?: Record<string, unknown>;
-  info?: {
-    resources_visible?: boolean;
-  };
-}
-
-interface NewResourceFormValues {
-  name: string;
-  description: string;
-  file: File | null;
-}
-
-interface EditResourceFormValues {
-  name: string;
-  description: string;
-}
 
 const TrustCenterResources: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -757,11 +757,7 @@ const TrustCenterResources: React.FC = () => {
           description="Update resource details and manage visibility"
           onSubmit={handleSaveEditResource}
           submitButtonText="Save"
-          isSubmitting={
-            !formData?.info?.resources_visible ||
-            !editResource.name ||
-            !editResource.description
-          }
+          isSubmitting={!formData?.info?.resources_visible}
         >
           <Stack spacing={6}>
             <Field

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/styles.ts
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/styles.ts
@@ -42,6 +42,7 @@ type StylesType = {
   fileUploadButton: SxProps<Theme>;
   fileName: SxProps<Theme>;
   existingFileName: SxProps<Theme>;
+  fileErrorText: SxProps<Theme>;
   modalActionButton: SxProps<Theme>;
   modalCancelButton: SxProps<Theme>;
   successAlert: SxProps<Theme>;
@@ -234,6 +235,14 @@ export const useStyles = (theme: Theme): StylesType => ({
     mt: 1,
     ml: 1,
     fontStyle: 'italic',
+  },
+
+  fileErrorText: {
+    opacity: 0.8,
+    fontSize: theme.typography.caption.fontSize,
+    color: theme.palette.error.main,
+    mt: 1,
+    display: 'block',
   },
 
   modalActionButton: {


### PR DESCRIPTION
## Describe your changes

A reusable generic useFormValidation hook has been integrated into the "Add recourse" modal.

## Write your issue number after "Fixes "

Fixes #3659 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="1184" height="709" alt="Screenshot 2026-04-08 at 5 54 12 PM" src="https://github.com/user-attachments/assets/48b4a805-7624-4948-a688-2f7d4f674787" />
