### PR TITLE
fix: update nginx config to use docker service name for upstream

### DIFF
--- a/Clients/nginx.conf
+++ b/Clients/nginx.conf
@@ -17,7 +17,7 @@ server {
 
     # Proxy API requests to backend
     location /api {
-        proxy_pass http://localhost:3000; # no trailing slash - keeps /api prefix
+        proxy_pass http://verifywise_backend_1:3000; # no trailing slash - keeps /api prefix
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Problem
The frontend container was failing to connect to the backend (502 Bad Gateway) because `127.0.0.1` inside a container refers to the container itself, not the backend service.

## Solution
Updated the Nginx `proxy_pass` to use the Docker Compose service name `verifywise_backend_1` instead of `localhost` or `127.0.0.1`. This allows Docker's internal DNS to correctly route the traffic.

## Testing
Verified locally that the login request at `http://localhost:8080/login` no longer returns a 502 error and correctly communicates with the backend API.