### PR TITLE
fix(risks): unify add-new-risk menu as a single list

### DIFF
--- a/Clients/src/presentation/pages/RiskManagement/index.tsx
+++ b/Clients/src/presentation/pages/RiskManagement/index.tsx
@@ -37,7 +37,6 @@ import { useColumnVisibility, ColumnConfig } from "../../../application/hooks/us
 import { useEntityChangeHistory } from "../../../application/hooks/useEntityChangeHistory";
 import { PluginSlot } from "../../components/PluginSlot";
 import { PLUGIN_SLOTS } from "../../../domain/constants/pluginSlots";
-import { usePluginRegistry } from "../../../application/contexts/PluginRegistry.context";
 import { apiServices } from "../../../infrastructure/api/networkServices";
 import {
   riskMainStackStyle,
@@ -47,18 +46,12 @@ import {
   riskPopoverStyle,
   riskPopoverContentStyle,
   riskMenuItemStyle,
+  riskMenuItemTextWrapStyle,
+  riskMenuItemTitleRowStyle,
   riskMenuItemTitleStyle,
   riskMenuItemSubtitleStyle,
-  riskDividerContainerStyle,
-  riskDividerLineStyle,
-  riskDividerTextStyle,
-  riskCardsGridStyle,
-  aiRiskCardBaseStyle,
-  aiRiskCardIbmStyle,
-  aiRiskCardRecommendedBadgeStyle,
-  aiRiskCardLogoStyle,
-  aiRiskCardTitleStyle,
-  aiRiskCardCaptionStyle,
+  riskMenuItemLogoStyle,
+  riskMenuItemRecommendedBadgeStyle,
 } from "./style";
 import { text } from "../../themes/palette";
 
@@ -131,10 +124,6 @@ const RiskManagement = () => {
   // Refs for form submission
   const onSubmitRef = useRef<(() => void) | null>(null);
   const onAiRiskSubmitRef = useRef<(() => void) | null>(null);
-
-  // Check if risk-import plugin is installed via plugin registry
-  const { getComponentsForSlot } = usePluginRegistry();
-  const hasRiskImportPlugin = getComponentsForSlot(PLUGIN_SLOTS.RISKS_ACTIONS).length > 0;
 
   // GroupBy state
   const { groupBy, groupSortOrder, handleGroupChange } = useGroupByState();
@@ -836,7 +825,7 @@ const RiskManagement = () => {
                   aria-label="Add new risk menu"
                   sx={riskPopoverContentStyle}
                 >
-                  {/* Add new risk option */}
+                  {/* Manual entry */}
                   <Box
                     role="menuitem"
                     tabIndex={0}
@@ -854,35 +843,19 @@ const RiskManagement = () => {
                     }}
                     sx={riskMenuItemStyle}
                   >
-                    <Box>
-                      <Typography
-                        sx={riskMenuItemTitleStyle}
-                      >
-                        Add new risk
-                      </Typography>
-                      <Typography
-                        sx={riskMenuItemSubtitleStyle}
-                      >
+                    <Box sx={riskMenuItemTextWrapStyle}>
+                      <Box sx={riskMenuItemTitleRowStyle}>
+                        <Typography sx={riskMenuItemTitleStyle}>
+                          Add new risk
+                        </Typography>
+                      </Box>
+                      <Typography sx={riskMenuItemSubtitleStyle}>
                         Create a custom risk manually
                       </Typography>
                     </Box>
                   </Box>
 
-                  {/* Divider with text */}
-                  <Box
-                    sx={riskDividerContainerStyle}
-                  >
-                    <Box sx={riskDividerLineStyle} />
-                    <Typography sx={riskDividerTextStyle}>
-                      Or import from
-                    </Typography>
-                    <Box sx={riskDividerLineStyle} />
-                  </Box>
-
-                  {/* AI Risk databases grid */}
-                  <Box
-                    sx={riskCardsGridStyle(hasRiskImportPlugin)}
-                  >
+                  {/* IBM AI Risk database */}
                   <Box
                     role="menuitem"
                     tabIndex={0}
@@ -894,27 +867,25 @@ const RiskManagement = () => {
                         handleIBMModalOpen();
                       }
                     }}
-                    sx={aiRiskCardIbmStyle}
+                    sx={riskMenuItemStyle}
                   >
-                    <Box
-                      sx={aiRiskCardRecommendedBadgeStyle}
-                    >
-                      Recommended
+                    <Box sx={riskMenuItemTextWrapStyle}>
+                      <Box sx={riskMenuItemTitleRowStyle}>
+                        <Typography sx={riskMenuItemTitleStyle}>
+                          Import from IBM AI Risk database
+                        </Typography>
+                        <Box sx={riskMenuItemRecommendedBadgeStyle}>
+                          Recommended
+                        </Box>
+                      </Box>
+                      <Typography sx={riskMenuItemSubtitleStyle}>
+                        113 risks covering agentic AI, data privacy, inference attacks, and operational failures
+                      </Typography>
                     </Box>
-                    <img src={ibmLogo} alt="IBM Logo" style={aiRiskCardLogoStyle} />
-                    <Typography
-                      variant="body2"
-                      sx={aiRiskCardTitleStyle}
-                    >
-                      IBM AI Risk database
-                    </Typography>
-                    <Typography
-                      variant="caption"
-                      sx={aiRiskCardCaptionStyle}
-                    >
-                      113 risks covering agentic AI, data privacy, inference attacks, and operational failures
-                    </Typography>
+                    <img src={ibmLogo} alt="" style={riskMenuItemLogoStyle} />
                   </Box>
+
+                  {/* MIT AI Risk database */}
                   <Box
                     role="menuitem"
                     tabIndex={0}
@@ -926,21 +897,19 @@ const RiskManagement = () => {
                         handleMITModalOpen();
                       }
                     }}
-                    sx={aiRiskCardBaseStyle}
+                    sx={riskMenuItemStyle}
                   >
-                    <img src={mitLogo} alt="MIT Logo" style={aiRiskCardLogoStyle} />
-                    <Typography
-                      variant="body2"
-                      sx={aiRiskCardTitleStyle}
-                    >
-                      MIT AI Risk database
-                    </Typography>
-                    <Typography
-                      variant="caption"
-                      sx={aiRiskCardCaptionStyle}
-                    >
-                      Academic research-based risks covering AI safety, fairness, and societal impact
-                    </Typography>
+                    <Box sx={riskMenuItemTextWrapStyle}>
+                      <Box sx={riskMenuItemTitleRowStyle}>
+                        <Typography sx={riskMenuItemTitleStyle}>
+                          Import from MIT AI Risk Repository
+                        </Typography>
+                      </Box>
+                      <Typography sx={riskMenuItemSubtitleStyle}>
+                        Academic research-based risks covering AI safety, fairness, and societal impact
+                      </Typography>
+                    </Box>
+                    <img src={mitLogo} alt="" style={riskMenuItemLogoStyle} />
                   </Box>
 
                   {/* Plugin Slot for Risk Import menu items */}
@@ -957,7 +926,6 @@ const RiskManagement = () => {
                       },
                     }}
                   />
-                  </Box>
                 </Box>
               </Popover>
 

--- a/Clients/src/presentation/pages/RiskManagement/style.ts
+++ b/Clients/src/presentation/pages/RiskManagement/style.ts
@@ -39,25 +39,48 @@ export const riskPopoverStyle = {
 };
 
 export const riskPopoverContentStyle = {
-  p: 2,
-  width: "420px",
+  p: 1,
+  width: "440px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
 };
 
-// D. Menu Item (Add New Risk Manually)
+// D. Uniform list row (used by Manual, IBM, MIT, and plugin items)
 export const riskMenuItemStyle = {
   display: "flex",
   alignItems: "center",
-  padding: "12px 16px",
+  gap: "12px",
+  padding: "12px 14px",
   borderRadius: singleTheme.borderRadius,
   cursor: "pointer",
-  border: "1px solid rgba(0, 0, 0, 0.08)",
-  backgroundColor: "background.main",
-  transition: "all 0.2s ease",
-  mb: 2,
+  border: "1px solid transparent",
+  backgroundColor: "transparent",
+  transition: "background-color 0.15s ease, border-color 0.15s ease",
+  position: "relative" as const,
   "&:hover": {
-    backgroundColor: "background.accent",
-    border: "1px solid rgba(0, 0, 0, 0.12)",
+    backgroundColor: "rgba(19, 113, 91, 0.04)",
+    border: "1px solid rgba(19, 113, 91, 0.12)",
   },
+  "&:focus-visible": {
+    outline: "none",
+    backgroundColor: "rgba(19, 113, 91, 0.04)",
+    border: "1px solid rgba(19, 113, 91, 0.24)",
+  },
+};
+
+export const riskMenuItemTextWrapStyle = {
+  flex: 1,
+  minWidth: 0,
+  display: "flex",
+  flexDirection: "column",
+  gap: "2px",
+};
+
+export const riskMenuItemTitleRowStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
 };
 
 export const riskMenuItemTitleStyle = {
@@ -69,72 +92,18 @@ export const riskMenuItemTitleStyle = {
 export const riskMenuItemSubtitleStyle = {
   fontSize: singleTheme.fontSizes.small,
   color: "rgba(0, 0, 0, 0.6)",
+  lineHeight: 1.4,
 };
 
-// E. Divider ("Or Import From")
-export const riskDividerContainerStyle = {
-  display: "flex",
-  alignItems: "center",
-  gap: 1.5,
-  mb: 2,
+export const riskMenuItemLogoStyle: React.CSSProperties = {
+  height: 18,
+  width: "auto",
+  flexShrink: 0,
+  opacity: 0.75,
 };
 
-export const riskDividerLineStyle = {
-  flex: 1,
-  height: "1px",
-  backgroundColor: "rgba(0, 0, 0, 0.08)",
-};
-
-export const riskDividerTextStyle = {
-  fontSize: singleTheme.fontSizes.small,
-  color: "rgba(0, 0, 0, 0.45)",
-  textTransform: "uppercase" as const,
-  letterSpacing: "0.5px",
-};
-
-// F. AI Risk Cards Grid
-export const riskCardsGridStyle = (hasPlugin: boolean) => ({
-  display: "grid",
-  gridTemplateColumns: hasPlugin ? "repeat(3, 1fr)" : "repeat(2, 1fr)",
-  gap: 2,
-});
-
-// F. AI Risk Cards (deduplicated IBM/MIT)
-export const aiRiskCardBaseStyle = {
-  background:
-    "linear-gradient(135deg, rgba(252, 252, 252, 1) 0%, rgba(248, 248, 248, 1) 100%)",
-  borderRadius: singleTheme.borderRadius,
-  padding: "20px 16px",
-  cursor: "pointer",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  justifyContent: "flex-start",
-  gap: 1.5,
-  border: "1px solid rgba(0, 0, 0, 0.04)",
-  transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
-  minHeight: "140px",
-  "&:hover": {
-    boxShadow: "0 2px 6px rgba(0, 0, 0, 0.06)",
-    border: "1px solid rgba(0, 0, 0, 0.08)",
-    background:
-      "linear-gradient(135deg, rgba(255, 255, 255, 1) 0%, rgba(250, 250, 250, 1) 100%)",
-  },
-  "&:active": {
-    transform: "scale(0.98)",
-  },
-};
-
-export const aiRiskCardIbmStyle = {
-  ...aiRiskCardBaseStyle,
-  position: "relative" as const,
-};
-
-export const aiRiskCardRecommendedBadgeStyle = {
-  position: "absolute",
-  top: 8,
-  right: 8,
-  backgroundColor: "#10B981",
+export const riskMenuItemRecommendedBadgeStyle = {
+  backgroundColor: "#13715B",
   color: "white",
   fontSize: "9px",
   fontWeight: 600,
@@ -142,22 +111,5 @@ export const aiRiskCardRecommendedBadgeStyle = {
   borderRadius: "3px",
   textTransform: "uppercase" as const,
   letterSpacing: "0.5px",
-};
-
-export const aiRiskCardLogoStyle: React.CSSProperties = {
-  height: 24,
-};
-
-export const aiRiskCardTitleStyle = {
-  fontWeight: 600,
-  fontSize: singleTheme.fontSizes.medium,
-  color: "rgba(0, 0, 0, 0.85)",
-  textAlign: "center",
-};
-
-export const aiRiskCardCaptionStyle = {
-  fontSize: singleTheme.fontSizes.small,
-  color: "rgba(0, 0, 0, 0.6)",
-  textAlign: "center",
-  lineHeight: 1.4,
+  lineHeight: 1.2,
 };


### PR DESCRIPTION
## Summary
- The add-new-risk popover previously showed "Add new risk" as a small text row and then two large logo cards for IBM and MIT. The logos visually dominated the menu, and users clicked the logos expecting them to open external tools while overlooking the manual entry option.
- All three options are now uniform horizontal list rows with title and subtitle on the left. Logos shrink to 18px decorative accents on the right. The "Recommended" badge moves inline next to the IBM title. The "Or import from" divider and the grid layout are gone.
- Removed the now-unused `hasRiskImportPlugin` variable and its plugin registry import.

## Test plan
- [ ] Open `/risk-management` and click "Add new risk"
- [ ] Verify the three options render as uniform list rows with equal visual weight
- [ ] Verify "Recommended" badge is inline with the IBM row title
- [ ] Click "Add new risk" — opens the manual risk modal
- [ ] Click the IBM row — opens the IBM import modal
- [ ] Click the MIT row — opens the MIT import modal
- [ ] Keyboard navigation (Tab + Enter/Space) works on all three rows