### PR TITLE
Feat/risk modal replace inline validation with generic hook

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
@@ -1,8 +1,9 @@
-import {
+import React, {
   FC,
   useState,
   useCallback,
   useMemo,
+  useEffect,
   lazy,
   Suspense,
   Dispatch,
@@ -16,7 +17,10 @@ import {
   useTheme,
 } from "@mui/material";
 import dayjs, { Dayjs } from "dayjs";
-import { MitigationFormValues, MitigationFormErrors } from "../interface";
+import { MitigationFormValues } from "../interface";
+import { useFormValidation } from "../../../../application/hooks/useFormValidation";
+import { checkStringValidation } from "../../../../application/validations/stringValidation";
+import selectValidation from "../../../../application/validations/selectValidation";
 import styles from "../styles.module.css";
 import useUsers from "../../../../application/hooks/useUsers";
 import {
@@ -60,7 +64,7 @@ const Alert = lazy(() => import("../../Alert"));
 interface MitigationSectionProps {
   mitigationValues: MitigationFormValues;
   setMitigationValues: Dispatch<SetStateAction<MitigationFormValues>>;
-  mitigationErrors?: MitigationFormErrors;
+  validateRef?: React.MutableRefObject<((values: MitigationFormValues) => boolean) | null>;
   userRoleName: string;
   disableInternalScroll?: boolean;
   compactMode?: boolean;
@@ -82,7 +86,7 @@ interface MitigationSectionProps {
 const MitigationSection: FC<MitigationSectionProps> = ({
   mitigationValues,
   setMitigationValues,
-  mitigationErrors = {},
+  validateRef,
   userRoleName,
   disableInternalScroll = false,
   compactMode = false,
@@ -109,6 +113,61 @@ const MitigationSection: FC<MitigationSectionProps> = ({
     width: contentWidth,
   };
 
+  const validators = useMemo(
+    () => ({
+      mitigationStatus: (v: unknown) => {
+        const r = selectValidation("Mitigation status", v as number);
+        return r.accepted ? "" : r.message;
+      },
+      currentRiskLevel: (v: unknown) => {
+        const r = selectValidation("Current risk level", v as number);
+        return r.accepted ? "" : r.message;
+      },
+      deadline: (v: unknown) => {
+        const r = checkStringValidation("Deadline", v as string, 1);
+        return r.accepted ? "" : r.message;
+      },
+      mitigationPlan: (v: unknown) => {
+        const r = checkStringValidation("Mitigation plan", v as string, 1, 1024);
+        return r.accepted ? "" : r.message;
+      },
+      implementationStrategy: (v: unknown) => {
+        const r = checkStringValidation("Implementation strategy", v as string, 1, 1024);
+        return r.accepted ? "" : r.message;
+      },
+      approver: (v: unknown) => {
+        const r = selectValidation("Approver", v as number);
+        return r.accepted ? "" : r.message;
+      },
+      approvalStatus: (v: unknown) => {
+        const r = selectValidation("Approval status", v as number);
+        return r.accepted ? "" : r.message;
+      },
+      dateOfAssessment: (v: unknown) => {
+        const r = checkStringValidation("Date of assessment", v as string, 1);
+        return r.accepted ? "" : r.message;
+      },
+      recommendations: (v: unknown) => {
+        const s = v as string;
+        if (!s || s.length === 0) return "";
+        const r = checkStringValidation("Recommendation", s, 1, 1024);
+        return r.accepted ? "" : r.message;
+      },
+    }),
+    []
+  );
+
+  const { errors, validateAll, clearFieldError } =
+    useFormValidation<MitigationFormValues>(validators);
+
+  useEffect(() => {
+    if (validateRef) {
+      validateRef.current = validateAll;
+    }
+    // No cleanup: TabPanel unmounts inactive tabs, so clearing the ref here
+    // would break parent validation when the user is on a different tab.
+  }, [validateRef, validateAll]);
+
   // Memoized values
   const userOptions = useMemo(
     () =>
@@ -134,8 +193,9 @@ const MitigationSection: FC<MitigationSectionProps> = ({
           ...prevValues,
           [prop]: event.target.value,
         }));
+        clearFieldError(prop);
       },
-    [setMitigationValues]
+    [setMitigationValues, clearFieldError]
   );
 
   const handleDateChange = useCallback(
@@ -148,11 +208,12 @@ const MitigationSection: FC<MitigationSectionProps> = ({
           ...prevValues,
           [field]: newDate.toISOString(),
         }));
+        clearFieldError(field);
       } else {
         console.warn(`Invalid date provided for field: ${field}`);
       }
     },
-    [setMitigationValues]
+    [setMitigationValues, clearFieldError]
   );
 
   const handleOnTextFieldChange = useCallback(
@@ -162,8 +223,9 @@ const MitigationSection: FC<MitigationSectionProps> = ({
           ...prevValues,
           [prop]: event.target.value,
         }));
+        clearFieldError(prop);
       },
-    [setMitigationValues]
+    [setMitigationValues, clearFieldError]
   );
 
   return (
@@ -211,7 +273,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                   items={mitigationStatusItems}
                   sx={formFieldStyles}
                   isRequired
-                  error={mitigationErrors?.mitigationStatus}
+                  error={errors.mitigationStatus}
                   disabled={isEditingDisabled}
                 />
                 {/* Current Risk Level */}
@@ -228,7 +290,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                   items={riskLevelItems}
                   sx={formFieldStyles}
                   isRequired
-                  error={mitigationErrors?.currentRiskLevel}
+                  error={errors.currentRiskLevel}
                   disabled={isEditingDisabled}
                 />
                 {/* Deadline */}
@@ -242,7 +304,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                   handleDateChange={(e) => handleDateChange("deadline", e)}
                   sx={{ width: fieldWidth }}
                   isRequired
-                  error={mitigationErrors?.deadline}
+                  error={errors.deadline}
                   disabled={isEditingDisabled}
                 />
               </Stack>
@@ -258,7 +320,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                   onChange={handleOnTextFieldChange("mitigationPlan")}
                   sx={{ width: fieldWidth }}
                   isRequired
-                  error={mitigationErrors?.mitigationPlan}
+                  error={errors.mitigationPlan}
                   disabled={isEditingDisabled}
                   placeholder="Write mitigation plan"
                 />
@@ -272,7 +334,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                   onChange={handleOnTextFieldChange("implementationStrategy")}
                   sx={{ width: twoColumnWidth }}
                   isRequired
-                  error={mitigationErrors?.implementationStrategy}
+                  error={errors.implementationStrategy}
                   disabled={isEditingDisabled}
                   placeholder="Write implementation strategy"
                 />
@@ -318,7 +380,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
               items={userOptions}
               sx={formFieldStyles}
               isRequired
-              error={mitigationErrors?.approver}
+              error={errors.approver}
               disabled={isEditingDisabled || usersLoading}
             />
             <Select
@@ -334,7 +396,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
               items={approvalStatusItems}
               sx={formFieldStyles}
               isRequired
-              error={mitigationErrors?.approvalStatus}
+              error={errors.approvalStatus}
               disabled={isEditingDisabled}
             />
             <DatePicker
@@ -347,7 +409,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
               handleDateChange={(e) => handleDateChange("dateOfAssessment", e)}
               sx={{ width: fieldWidth }}
               isRequired
-              error={mitigationErrors?.dateOfAssessment}
+              error={errors.dateOfAssessment}
               disabled={isEditingDisabled}
             />
           </Stack>

--- a/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
@@ -163,11 +163,6 @@ const RiskSection: FC<RiskSectionProps> = ({
     if (validateRef) {
       validateRef.current = validateAll;
     }
-    return () => {
-      if (validateRef) {
-        validateRef.current = null;
-      }
-    };
   }, [validateRef, validateAll]);
 
   const handleOnSelectChange = useCallback(

--- a/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/RisksSection/index.tsx
@@ -2,6 +2,8 @@ import React, {
   FC,
   useState,
   useCallback,
+  useMemo,
+  useEffect,
   Suspense,
   Dispatch,
   SetStateAction,
@@ -19,7 +21,7 @@ import { ChevronDown as GreyDownArrowIcon } from "lucide-react";
 import Field from "../../Inputs/Field";
 import Select from "../../Inputs/Select";
 import Alert from "../../Alert";
-import { RiskFormValues, RiskFormErrors } from "../interface";
+import { RiskFormValues } from "../interface";
 import { aiLifecyclePhase, riskCategoryItems } from "../projectRiskValue";
 import { alertState } from "../../../../domain/interfaces/i.alert";
 import useUsers from "../../../../application/hooks/useUsers";
@@ -28,6 +30,9 @@ import useFrameworks from "../../../../application/hooks/useFrameworks";
 import allowedRoles from "../../../../application/constants/permissions";
 import styles from "../styles.module.css";
 import { getAutocompleteStyles as getCentralizedAutocompleteStyles } from "../../../utils/inputStyles";
+import { useFormValidation } from "../../../../application/hooks/useFormValidation";
+import { checkStringValidation } from "../../../../application/validations/stringValidation";
+import selectValidation from "../../../../application/validations/selectValidation";
 
 const RiskLevel = React.lazy(() => import("../../RiskLevel"));
 
@@ -63,7 +68,7 @@ const FORM_STYLES = {
 interface RiskSectionProps {
   riskValues: RiskFormValues;
   setRiskValues: Dispatch<SetStateAction<RiskFormValues>>;
-  riskErrors: RiskFormErrors;
+  validateRef?: React.MutableRefObject<((values: RiskFormValues) => boolean) | null>;
   userRoleName: string;
   disableInternalScroll?: boolean;
   compactMode?: boolean;
@@ -79,14 +84,13 @@ interface RiskSectionProps {
  * @param {RiskSectionProps} props - The props for the RiskSection component
  * @param {RiskFormValues} props.riskValues - Current form values
  * @param {Dispatch<SetStateAction<RiskFormValues>>} props.setRiskValues - Function to update form values
- * @param {RiskFormErrors} props.riskErrors - Current form validation errors
  * @param {string} props.userRoleName - Current user's role name for permissions
  * @returns {JSX.Element} The rendered RiskSection component
  */
 const RiskSection: FC<RiskSectionProps> = ({
   riskValues,
   setRiskValues,
-  riskErrors,
+  validateRef,
   userRoleName,
   disableInternalScroll = false,
   compactMode = false,
@@ -115,6 +119,57 @@ const RiskSection: FC<RiskSectionProps> = ({
   const { approvedProjects, isLoading: projectsLoading } = useProjects();
   const { allFrameworks: frameworks, loading: frameworksLoading } = useFrameworks({ listOfFrameworks: [] });
 
+  const validators = useMemo(
+    () => ({
+      riskName: (v: unknown) => {
+        const r = checkStringValidation("Risk name", v as string, 3, 255);
+        return r.accepted ? "" : r.message;
+      },
+      riskDescription: (v: unknown) => {
+        const r = checkStringValidation("Risk description", v as string, 1, 256);
+        return r.accepted ? "" : r.message;
+      },
+      potentialImpact: (v: unknown) => {
+        const r = checkStringValidation("Potential impact", v as string, 1, 256);
+        return r.accepted ? "" : r.message;
+      },
+      reviewNotes: (v: unknown) => {
+        const s = v as string;
+        if (!s || s.length === 0) return "";
+        const r = checkStringValidation("Review notes", s, 0, 1024);
+        return r.accepted ? "" : r.message;
+      },
+      aiLifecyclePhase: (v: unknown) => {
+        const r = selectValidation("AI lifecycle phase", v as number);
+        return r.accepted ? "" : r.message;
+      },
+      riskCategory: (v: unknown) => {
+        const categories = v as number[];
+        if (!categories || categories.length === 0) return "Risk category is required.";
+        for (const category of categories) {
+          const r = selectValidation("Risk category", category);
+          if (!r.accepted) return r.message;
+        }
+        return "";
+      },
+    }),
+    []
+  );
+
+  const { errors, validateAll, clearFieldError } =
+    useFormValidation<RiskFormValues>(validators);
+
+  useEffect(() => {
+    if (validateRef) {
+      validateRef.current = validateAll;
+    }
+    return () => {
+      if (validateRef) {
+        validateRef.current = null;
+      }
+    };
+  }, [validateRef, validateAll]);
+
   const handleOnSelectChange = useCallback(
     (prop: keyof RiskFormValues) =>
       (event: SelectChangeEvent<string | number>) => {
@@ -122,8 +177,9 @@ const RiskSection: FC<RiskSectionProps> = ({
           ...prevValues,
           [prop]: event.target.value,
         }));
+        clearFieldError(prop);
       },
-    [setRiskValues]
+    [setRiskValues, clearFieldError]
   );
 
   const handleOnMultiselectChange = useCallback(
@@ -137,8 +193,9 @@ const RiskSection: FC<RiskSectionProps> = ({
           ...prevValues,
           [prop]: newValue.map((item) => Number(item._id || item.id)),
         }));
+        clearFieldError(prop);
       },
-    [setRiskValues]
+    [setRiskValues, clearFieldError]
   );
 
   const handleOnTextFieldChange = useCallback(
@@ -148,8 +205,9 @@ const RiskSection: FC<RiskSectionProps> = ({
           ...prevValues,
           [prop]: event.target.value,
         }));
+        clearFieldError(prop);
       },
-    [setRiskValues]
+    [setRiskValues, clearFieldError]
   );
 
   return (
@@ -264,7 +322,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 )}
                 onChange={handleOnMultiselectChange("applicableProjects")}
                 sx={{
-                  ...getCentralizedAutocompleteStyles(theme, { hasError: !!riskErrors.applicableProjects }),
+                  ...getCentralizedAutocompleteStyles(theme, { hasError: !!errors.applicableProjects }),
                   width: "100%",
                   backgroundColor: theme.palette.background.main,
                   "& .MuiChip-root": {
@@ -297,7 +355,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 }}
                 disabled={projectsLoading}
               />
-              {riskErrors.applicableProjects && (
+              {errors.applicableProjects && (
                 <Typography
                   sx={{
                     color: theme.palette.error.main,
@@ -306,7 +364,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                     ml: 1.75,
                   }}
                 >
-                  {riskErrors.applicableProjects}
+                  {errors.applicableProjects}
                 </Typography>
               )}
             </Stack>
@@ -371,7 +429,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 )}
                 onChange={handleOnMultiselectChange("applicableFrameworks")}
                 sx={{
-                  ...getCentralizedAutocompleteStyles(theme, { hasError: !!riskErrors.applicableFrameworks }),
+                  ...getCentralizedAutocompleteStyles(theme, { hasError: !!errors.applicableFrameworks }),
                   width: "100%",
                   backgroundColor: theme.palette.background.main,
                   "& .MuiChip-root": {
@@ -404,7 +462,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 }}
                 disabled={frameworksLoading}
               />
-              {riskErrors.applicableFrameworks && (
+              {errors.applicableFrameworks && (
                 <Typography
                   sx={{
                     color: theme.palette.error.main,
@@ -413,7 +471,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                     ml: 1.75,
                   }}
                 >
-                  {riskErrors.applicableFrameworks}
+                  {errors.applicableFrameworks}
                 </Typography>
               )}
             </Stack>
@@ -431,7 +489,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 value={riskValues.riskName}
                 onChange={handleOnTextFieldChange("riskName")}
                 isRequired
-                error={riskErrors.riskName}
+                error={errors.riskName}
                 sx={{
                   width: fieldWidth,
                 }}
@@ -456,7 +514,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                   })) || []
                 }
                 // isRequired
-                // error={riskErrors.actionOwner}
+                // error={errors.actionOwner}
                 sx={{
                   width: fieldWidth,
                 }}
@@ -474,7 +532,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 onChange={handleOnSelectChange("aiLifecyclePhase")}
                 items={aiLifecyclePhase}
                 isRequired
-                error={riskErrors.aiLifecyclePhase}
+                error={errors.aiLifecyclePhase}
                 sx={{
                   width: fieldWidth,
                 }}
@@ -482,7 +540,7 @@ const RiskSection: FC<RiskSectionProps> = ({
               />
             </Stack>
 
-            {/* Row 2 */}
+            {/* Row 2 */ }
             <Stack sx={formRowStyles}>
               <Field
                 id="risk-description-input"
@@ -491,7 +549,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 value={riskValues.riskDescription}
                 onChange={handleOnTextFieldChange("riskDescription")}
                 isRequired
-                error={riskErrors.riskDescription}
+                error={errors.riskDescription}
                 sx={{
                   width: fieldWidth,
                 }}
@@ -547,7 +605,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                   )}
                   onChange={handleOnMultiselectChange("riskCategory")}
                   sx={{
-                    ...getCentralizedAutocompleteStyles(theme, { hasError: !!riskErrors.riskCategory }),
+                    ...getCentralizedAutocompleteStyles(theme, { hasError: !!errors.riskCategory }),
                     width: "100%",
                     backgroundColor: theme.palette.background.main,
                     "& .MuiChip-root": {
@@ -588,7 +646,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                     },
                   }}
                 />
-                {riskErrors.riskCategory && (
+                {errors.riskCategory && (
                   <Typography
                     sx={{
                       color: theme.palette.error.main,
@@ -597,7 +655,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                       ml: 1.75,
                     }}
                   >
-                    {riskErrors.riskCategory}
+                    {errors.riskCategory}
                   </Typography>
                 )}
               </Stack>
@@ -608,7 +666,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 value={riskValues.potentialImpact}
                 onChange={handleOnTextFieldChange("potentialImpact")}
                 isRequired
-                error={riskErrors.potentialImpact}
+                error={errors.potentialImpact}
                 sx={{
                   width: fieldWidth,
                 }}
@@ -652,7 +710,7 @@ const RiskSection: FC<RiskSectionProps> = ({
                 maxHeight: FORM_CONSTANTS.TEXT_AREA_MAX_HEIGHT,
               },
             }}
-            error={riskErrors.reviewNotes}
+            error={errors.reviewNotes}
             disabled={isEditingDisabled}
           />
         </Stack>

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -19,7 +19,6 @@ import { RiskLikelihood, RiskSeverity } from "../RiskLevel/riskValues";
 import {
   RiskFormValues,
   MitigationFormValues,
-  MitigationFormErrors,
 } from "./interface";
 import {
   aiLifecyclePhase,
@@ -32,8 +31,6 @@ import {
 } from "./projectRiskValue";
 import { AddNewRiskFormProps } from "../../types/riskForm.types";
 import { ApiResponse } from "../../../domain/interfaces/i.response";
-import { checkStringValidation } from "../../../application/validations/stringValidation";
-import selectValidation from "../../../application/validations/selectValidation";
 import { createProjectRisk, updateProjectRisk } from "../../../application/repository/projectRisk.repository";
 import useUsers from "../../../application/hooks/useUsers";
 import { useAuth } from "../../../application/hooks/useAuth";
@@ -159,8 +156,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
     theme.components?.MuiButton?.defaultProps?.disableRipple ?? false;
 
   const riskValidateRef = useRef<((values: RiskFormValues) => boolean) | null>(null);
-  const [mitigationErrors, setMitigationErrors] =
-    useState<MitigationFormErrors>({});
+  const mitigateValidateRef = useRef<((values: MitigationFormValues) => boolean) | null>(null);
   const [riskValues, setRiskValues] =
     useState<RiskFormValues>(initialRiskValues); // Use initialValues
   const [mitigationValues, setMitigationValues] =
@@ -311,107 +307,16 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
     }
   }, [popupStatus, inputValues, users, usersLoading]);
 
-  // Helper functions for validation
-  const validateMitigationFields = useCallback(
-    (values: MitigationFormValues): MitigationFormErrors => {
-      const errors: MitigationFormErrors = {};
-
-      const mitigationPlan = checkStringValidation(
-        "Mitigation plan",
-        values.mitigationPlan,
-        VALIDATION_LIMITS.MITIGATION_PLAN.MIN,
-        VALIDATION_LIMITS.MITIGATION_PLAN.MAX
-      );
-      if (!mitigationPlan.accepted) {
-        errors.mitigationPlan = mitigationPlan.message;
-      }
-
-      const implementationStrategy = checkStringValidation(
-        "Implementation strategy",
-        values.implementationStrategy,
-        VALIDATION_LIMITS.IMPLEMENTATION_STRATEGY.MIN,
-        VALIDATION_LIMITS.IMPLEMENTATION_STRATEGY.MAX
-      );
-      if (!implementationStrategy.accepted) {
-        errors.implementationStrategy = implementationStrategy.message;
-      }
-
-      const deadline = checkStringValidation(
-        "Deadline",
-        values.deadline,
-        VALIDATION_LIMITS.REQUIRED_FIELD.MIN
-      );
-      if (!deadline.accepted) {
-        errors.deadline = deadline.message;
-      }
-
-      const dateOfAssessment = checkStringValidation(
-        "Date Of Assessment",
-        values.dateOfAssessment,
-        VALIDATION_LIMITS.REQUIRED_FIELD.MIN
-      );
-      if (!dateOfAssessment.accepted) {
-        errors.dateOfAssessment = dateOfAssessment.message;
-      }
-
-      const mitigationStatus = selectValidation(
-        "Mitigation status",
-        values.mitigationStatus
-      );
-      if (!mitigationStatus.accepted) {
-        errors.mitigationStatus = mitigationStatus.message;
-      }
-
-      const currentRiskLevel = selectValidation(
-        "Current risk level",
-        values.currentRiskLevel
-      );
-      if (!currentRiskLevel.accepted) {
-        errors.currentRiskLevel = currentRiskLevel.message;
-      }
-
-      const approver = selectValidation("Approver", values.approver);
-      if (!approver.accepted) {
-        errors.approver = approver.message;
-      }
-
-      const approvalStatus = selectValidation(
-        "Approval status",
-        values.approvalStatus
-      );
-      if (!approvalStatus.accepted) {
-        errors.approvalStatus = approvalStatus.message;
-      }
-
-      if (values.recommendations.length > 0) {
-        const recommendations = checkStringValidation(
-          "Recommendation",
-          values.recommendations,
-          VALIDATION_LIMITS.RECOMMENDATIONS.MIN,
-          VALIDATION_LIMITS.RECOMMENDATIONS.MAX
-        );
-        if (!recommendations.accepted) {
-          errors.recommendations = recommendations.message;
-        }
-      }
-
-      return errors;
-    },
-    []
-  );
-
   const validateForm = useCallback((): { isValid: boolean; riskValid: boolean } => {
     const riskValid = riskValidateRef.current ? riskValidateRef.current(riskValues) : false;
-    const newMitigationErrors = validateMitigationFields(mitigationValues);
-    setMitigationErrors(newMitigationErrors);
+    const mitigationValid = mitigateValidateRef.current ? mitigateValidateRef.current(mitigationValues) : false;
     return {
-      isValid: riskValid && Object.keys(newMitigationErrors).length === 0,
+      isValid: riskValid && mitigationValid,
       riskValid,
     };
   }, [
     riskValues,
     mitigationValues,
-    validateMitigationFields,
   ]);
 
   // Helper function to get only changed fields for UPDATE requests
@@ -833,6 +738,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
         <Suspense fallback={<div>Loading...</div>}>
           <TabPanel
             value="risks"
+            keepMounted
             sx={{
               p: COMPONENT_CONSTANTS.TAB_PADDING,
               // Only set maxHeight when not in StandardModal (no onSubmitRef)
@@ -850,6 +756,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
           </TabPanel>
           <TabPanel
             value="mitigation"
+            keepMounted
             sx={{
               p: COMPONENT_CONSTANTS.TAB_PADDING,
               // Only set maxHeight when not in StandardModal (no onSubmitRef)
@@ -859,7 +766,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
             <MitigationSection
               mitigationValues={mitigationValues}
               setMitigationValues={setMitigationValues}
-              mitigationErrors={mitigationErrors}
+              validateRef={mitigateValidateRef}
               userRoleName={userRoleName}
               disableInternalScroll={!!onSubmitRef}
               compactMode={compactMode}

--- a/Clients/src/presentation/components/AddNewRiskForm/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/index.tsx
@@ -2,6 +2,7 @@ import React, {
   FC,
   useState,
   useCallback,
+  useRef,
   lazy,
   Suspense,
   useContext,
@@ -17,7 +18,6 @@ import { Likelihood, Severity } from "../RiskLevel/constants";
 import { RiskLikelihood, RiskSeverity } from "../RiskLevel/riskValues";
 import {
   RiskFormValues,
-  RiskFormErrors,
   MitigationFormValues,
   MitigationFormErrors,
 } from "./interface";
@@ -158,7 +158,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
   const disableRipple =
     theme.components?.MuiButton?.defaultProps?.disableRipple ?? false;
 
-  const [riskErrors, setRiskErrors] = useState<RiskFormErrors>({});
+  const riskValidateRef = useRef<((values: RiskFormValues) => boolean) | null>(null);
   const [mitigationErrors, setMitigationErrors] =
     useState<MitigationFormErrors>({});
   const [riskValues, setRiskValues] =
@@ -312,72 +312,6 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
   }, [popupStatus, inputValues, users, usersLoading]);
 
   // Helper functions for validation
-  const validateRiskFields = useCallback(
-    (values: RiskFormValues): RiskFormErrors => {
-      const errors: RiskFormErrors = {};
-
-      const riskName = checkStringValidation(
-        "Risk name",
-        values.riskName,
-        VALIDATION_LIMITS.RISK_NAME.MIN,
-        VALIDATION_LIMITS.RISK_NAME.MAX
-      );
-      if (!riskName.accepted) {
-        errors.riskName = riskName.message;
-      }
-
-      const riskDescription = checkStringValidation(
-        "Risk description",
-        values.riskDescription,
-        VALIDATION_LIMITS.RISK_DESCRIPTION.MIN,
-        VALIDATION_LIMITS.RISK_DESCRIPTION.MAX
-      );
-      if (!riskDescription.accepted) {
-        errors.riskDescription = riskDescription.message;
-      }
-
-      const potentialImpact = checkStringValidation(
-        "Potential impact",
-        values.potentialImpact,
-        VALIDATION_LIMITS.POTENTIAL_IMPACT.MIN,
-        VALIDATION_LIMITS.POTENTIAL_IMPACT.MAX
-      );
-      if (!potentialImpact.accepted) {
-        errors.potentialImpact = potentialImpact.message;
-      }
-
-      if (values.reviewNotes.length > 0) {
-        const reviewNotes = checkStringValidation(
-          "Review notes",
-          values.reviewNotes,
-          VALIDATION_LIMITS.REVIEW_NOTES.MIN,
-          VALIDATION_LIMITS.REVIEW_NOTES.MAX
-        );
-        if (!reviewNotes.accepted) {
-          errors.reviewNotes = reviewNotes.message;
-        }
-      }
-
-      const aiLifecyclePhase = selectValidation(
-        "AI lifecycle phase",
-        values.aiLifecyclePhase
-      );
-      if (!aiLifecyclePhase.accepted) {
-        errors.aiLifecyclePhase = aiLifecyclePhase.message;
-      }
-
-      values.riskCategory.forEach((category) => {
-        const riskCategory = selectValidation("Risk category", category);
-        if (!riskCategory.accepted) {
-          errors.riskCategory = [riskCategory.message];
-        }
-      });
-
-      return errors;
-    },
-    []
-  );
-
   const validateMitigationFields = useCallback(
     (values: MitigationFormValues): MitigationFormErrors => {
       const errors: MitigationFormErrors = {};
@@ -466,28 +400,17 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
     []
   );
 
-  const validateForm = useCallback((): {
-    isValid: boolean;
-    errors: RiskFormErrors;
-    mitigationErrors: MitigationFormErrors;
-  } => {
-    const newErrors = validateRiskFields(riskValues);
+  const validateForm = useCallback((): { isValid: boolean; riskValid: boolean } => {
+    const riskValid = riskValidateRef.current ? riskValidateRef.current(riskValues) : false;
     const newMitigationErrors = validateMitigationFields(mitigationValues);
-
     setMitigationErrors(newMitigationErrors);
-    setRiskErrors(newErrors);
-
     return {
-      isValid:
-        Object.keys(newErrors).length === 0 &&
-        Object.keys(newMitigationErrors).length === 0,
-      errors: newErrors,
-      mitigationErrors: newMitigationErrors,
+      isValid: riskValid && Object.keys(newMitigationErrors).length === 0,
+      riskValid,
     };
   }, [
     riskValues,
     mitigationValues,
-    validateRiskFields,
     validateMitigationFields,
   ]);
 
@@ -672,7 +595,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
   );
 
   const riskFormSubmitHandler = async () => {
-    const { isValid, errors } = validateForm();
+    const { isValid, riskValid } = validateForm();
     const selectedRiskLikelihood = likelihoodItems.find(
       (r) => r._id === riskValues.likelihood
     );
@@ -829,7 +752,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
         }
       }
     } else {
-      if (Object.keys(errors).length) {
+      if (!riskValid) {
         setValue("risks");
       } else {
         setValue("mitigation");
@@ -919,7 +842,7 @@ const AddNewRiskForm: FC<AddNewRiskFormProps> = ({
             <RiskSection
               riskValues={riskValues}
               setRiskValues={setRiskValues}
-              riskErrors={riskErrors}
+              validateRef={riskValidateRef}
               userRoleName={userRoleName}
               disableInternalScroll={!!onSubmitRef}
               compactMode={compactMode}


### PR DESCRIPTION
## Describe your changes

A reusable generic useFormValidation hook has been integrated into the "Add risk" modal.

## Write your issue number after "Fixes "

Fixes #3626 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="800" height="600" alt="Screenshot 2026-04-10 at 8 00 17 PM" src="https://github.com/user-attachments/assets/769c0558-aece-4c54-a845-04bbe561e31e" />

<img width="800" height="600" alt="Screenshot 2026-04-10 at 8 00 27 PM" src="https://github.com/user-attachments/assets/f0c847b1-4a34-43d4-bb06-ebe0f9c8ab44" />
