### PR TITLE
feat(bias-audit): enterprise-grade metrics and formal PDF report

### DIFF
--- a/Clients/src/application/repository/deepEval.repository.ts
+++ b/Clients/src/application/repository/deepEval.repository.ts
@@ -67,7 +67,13 @@ import {
   type GroupResultRow,
   type CategoryTableResult,
   type BiasAuditResultFull,
+  type BiasAuditMetric,
   type CreateBiasAuditConfig,
+  type FairnessMetricsTable,
+  type ConfusionMatrixGroupResult,
+  type ScoreDistributionTable,
+  type ScoreDistributionGroup,
+  type ScoreDistributionBin,
 } from "../../infrastructure/api/biasAuditService";
 
 // Re-export types for presentation layer
@@ -109,7 +115,13 @@ export type {
   GroupResultRow,
   CategoryTableResult,
   BiasAuditResultFull,
+  BiasAuditMetric,
   CreateBiasAuditConfig,
+  FairnessMetricsTable,
+  ConfusionMatrixGroupResult,
+  ScoreDistributionTable,
+  ScoreDistributionGroup,
+  ScoreDistributionBin,
 };
 
 // Re-export utility functions for presentation layer

--- a/Clients/src/application/repository/deepEval.repository.ts
+++ b/Clients/src/application/repository/deepEval.repository.ts
@@ -346,6 +346,9 @@ export const listBiasAudits = (params?: { org_id?: string; project_id?: string }
 export const deleteBiasAudit = (auditId: string) =>
   biasAuditService.deleteAudit(auditId);
 
+export const updateBiasAuditName = (auditId: string, systemName: string) =>
+  biasAuditService.updateAuditName(auditId, systemName);
+
 export const downloadBiasAuditReport = (auditId: string) =>
   biasAuditService.downloadReport(auditId);
 

--- a/Clients/src/application/repository/deepEval.repository.ts
+++ b/Clients/src/application/repository/deepEval.repository.ts
@@ -346,5 +346,8 @@ export const listBiasAudits = (params?: { org_id?: string; project_id?: string }
 export const deleteBiasAudit = (auditId: string) =>
   biasAuditService.deleteAudit(auditId);
 
+export const downloadBiasAuditReport = (auditId: string) =>
+  biasAuditService.downloadReport(auditId);
+
 export const parseBiasAuditCsvHeaders = (dataset: File) =>
   biasAuditService.parseHeaders(dataset);

--- a/Clients/src/infrastructure/api/biasAuditService.ts
+++ b/Clients/src/infrastructure/api/biasAuditService.ts
@@ -283,6 +283,14 @@ class BiasAuditService {
     return res.data as { message: string; auditId: string };
   }
 
+  async downloadReport(auditId: string): Promise<Blob> {
+    const res = await CustomAxios.get(
+      `/deepeval/bias-audits/${auditId}/report.pdf`,
+      { responseType: "blob" }
+    );
+    return res.data as Blob;
+  }
+
   async parseHeaders(dataset: File): Promise<string[]> {
     const formData = new FormData();
     formData.append("dataset", dataset);

--- a/Clients/src/infrastructure/api/biasAuditService.ts
+++ b/Clients/src/infrastructure/api/biasAuditService.ts
@@ -283,6 +283,17 @@ class BiasAuditService {
     return res.data as { message: string; auditId: string };
   }
 
+  async updateAuditName(
+    auditId: string,
+    systemName: string
+  ): Promise<{ auditId: string; systemName: string }> {
+    const res = await CustomAxios.patch(
+      `/deepeval/bias-audits/${auditId}`,
+      { systemName }
+    );
+    return res.data as { auditId: string; systemName: string };
+  }
+
   async downloadReport(auditId: string): Promise<Blob> {
     const res = await CustomAxios.get(
       `/deepeval/bias-audits/${auditId}/report.pdf`,

--- a/Clients/src/infrastructure/api/biasAuditService.ts
+++ b/Clients/src/infrastructure/api/biasAuditService.ts
@@ -96,8 +96,72 @@ export interface CategoryTableResult {
   highest_rate: number | null;
 }
 
+export type BiasAuditMetric =
+  | "selection_rate"
+  | "scoring_rate"
+  | "fairness_metrics";
+
+export interface ScoreDistributionBin {
+  lower: number;
+  upper: number;
+  count: number;
+}
+
+export interface ScoreDistributionGroup {
+  category_type: string;
+  category_name: string;
+  count: number;
+  mean: number;
+  median: number;
+  std: number;
+  bins: ScoreDistributionBin[];
+  ks_statistic: number | null;
+  ks_pvalue: number | null;
+}
+
+export interface ScoreDistributionTable {
+  title: string;
+  category_key: string;
+  groups: ScoreDistributionGroup[];
+  overall_mean: number;
+  overall_median: number;
+}
+
+export interface ConfusionMatrixGroupResult {
+  category_type: string;
+  category_name: string;
+  count: number;
+  true_positive: number;
+  false_positive: number;
+  true_negative: number;
+  false_negative: number;
+  true_positive_rate: number;
+  false_positive_rate: number;
+  false_negative_rate: number;
+  true_negative_rate: number;
+  precision: number;
+  accuracy: number;
+  excluded: boolean;
+}
+
+export interface FairnessMetricsTable {
+  title: string;
+  category_key: string;
+  groups: ConfusionMatrixGroupResult[];
+  equal_opportunity_difference: number | null;
+  equalized_odds_difference: number | null;
+  predictive_parity_difference: number | null;
+  tpr_max_group: string | null;
+  tpr_min_group: string | null;
+  fpr_max_group: string | null;
+  fpr_min_group: string | null;
+}
+
 export interface BiasAuditResultFull {
+  metric?: BiasAuditMetric;
   tables: CategoryTableResult[];
+  score_distribution_tables?: ScoreDistributionTable[];
+  fairness_metrics_tables?: FairnessMetricsTable[];
   overall_selection_rate: number;
   total_applicants: number;
   total_selected: number;
@@ -125,6 +189,7 @@ export interface CreateBiasAuditConfig {
   presetId: string;
   presetName?: string;
   mode?: string;
+  metric?: BiasAuditMetric;
   orgId: string;
   projectId?: string;
   categories?: Record<string, CategoryConfig>;
@@ -133,8 +198,22 @@ export interface CreateBiasAuditConfig {
   threshold?: number | null;
   smallSampleExclusion?: number | null;
   outcomeColumn: string;
+  scoreColumn?: string;
+  predictionColumn?: string;
+  groundTruthColumn?: string;
   columnMapping: Record<string, string>;
   metadata?: Record<string, string>;
+  // Audit metadata for the formal PDF report
+  systemName?: string;
+  systemVersion?: string;
+  systemDescription?: string;
+  auditorName?: string;
+  auditorRole?: string;
+  auditorIndependence?: "self" | "internal" | "third_party";
+  deploymentContext?: string;
+  dataSource?: string;
+  dataDateRangeStart?: string;
+  dataDateRangeEnd?: string;
 }
 
 // ==================== SERVICE ====================

--- a/Clients/src/presentation/components/EditableText/index.tsx
+++ b/Clients/src/presentation/components/EditableText/index.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from "react";
+import { Box, IconButton, TextField, Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material";
+import { Check, Pencil, X } from "lucide-react";
+import { palette } from "../../themes/palette";
+
+interface EditableTextProps {
+  /** Current value to display */
+  value: string;
+  /** Called with the trimmed new value when the user confirms the edit. May be async. */
+  onSave: (next: string) => Promise<void> | void;
+  /** Optional fallback when `value` is empty. */
+  placeholder?: string;
+  /** Max length enforced client-side. */
+  maxLength?: number;
+  /** Whether the user is allowed to edit. When false, the pencil never appears. */
+  disabled?: boolean;
+  /** Style overrides for the displayed text / input (font size, weight, color). */
+  textSx?: SxProps<Theme>;
+  /** Accessible label for the edit button. */
+  editAriaLabel?: string;
+  /** Min width of the input while editing. Defaults to 320px. */
+  inputMinWidth?: number | string;
+}
+
+/**
+ * Hover-to-reveal inline text editor. Pattern: show text with an edit icon that
+ * fades in on hover; clicking the icon swaps the text for a TextField with
+ * save/cancel controls. Enter saves, Escape cancels.
+ *
+ * onSave is awaited — while in flight the controls are disabled.
+ */
+export default function EditableText({
+  value,
+  onSave,
+  placeholder = "(not set)",
+  maxLength = 255,
+  disabled = false,
+  textSx,
+  editAriaLabel = "Edit",
+  inputMinWidth = 320,
+}: EditableTextProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      setDraft(value);
+    }
+  }, [isEditing, value]);
+
+  const handleStart = () => {
+    if (disabled) return;
+    setDraft(value);
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
+
+  const handleSave = async () => {
+    const next = draft.trim();
+    if (!next || next === value || saving) {
+      setIsEditing(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(next);
+      setIsEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <Box sx={{ display: "inline-flex", alignItems: "center", gap: "4px" }}>
+        <TextField
+          inputRef={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value.slice(0, maxLength))}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleSave();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              handleCancel();
+            }
+          }}
+          variant="outlined"
+          size="small"
+          autoFocus
+          disabled={saving}
+          sx={{
+            minWidth: inputMinWidth,
+            "& .MuiOutlinedInput-root": textSx as object,
+          }}
+        />
+        <IconButton
+          size="small"
+          onClick={handleSave}
+          disabled={saving || !draft.trim()}
+          aria-label="Save"
+          sx={{ color: palette.brand.primary }}
+        >
+          <Check size={16} strokeWidth={1.75} />
+        </IconButton>
+        <IconButton
+          size="small"
+          onClick={handleCancel}
+          disabled={saving}
+          aria-label="Cancel"
+          sx={{ color: palette.text.disabled }}
+        >
+          <X size={16} strokeWidth={1.75} />
+        </IconButton>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "4px",
+        "&:hover .editable-text-icon": { opacity: disabled ? 0 : 1 },
+      }}
+    >
+      <Typography sx={textSx}>{value || placeholder}</Typography>
+      {!disabled && (
+        <IconButton
+          size="small"
+          onClick={handleStart}
+          className="editable-text-icon"
+          aria-label={editAriaLabel}
+          sx={{
+            opacity: 0,
+            transition: "opacity 0.15s",
+            color: palette.text.disabled,
+            "&:hover": {
+              color: palette.brand.primary,
+              backgroundColor: "rgba(19, 113, 91, 0.1)",
+            },
+          }}
+        >
+          <Pencil size={14} strokeWidth={1.75} />
+        </IconButton>
+      )}
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
@@ -11,6 +11,7 @@ import {
   getBiasAuditResults,
   getBiasAuditStatus,
   deleteBiasAudit,
+  downloadBiasAuditReport,
   type BiasAuditDetailResponse,
   type CategoryTableResult,
   type FairnessMetricsTable,
@@ -303,6 +304,8 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
     }
   }, [status, error, fetchResults]);
 
+  const [isDownloadingPdf, setIsDownloadingPdf] = useState(false);
+
   const handleDownload = () => {
     if (!audit?.results) return;
     try {
@@ -318,6 +321,26 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
       URL.revokeObjectURL(url);
     } catch (err) {
       console.error("Failed to download results:", err);
+    }
+  };
+
+  const handleDownloadPdf = async () => {
+    if (isDownloadingPdf) return;
+    setIsDownloadingPdf(true);
+    try {
+      const blob = await downloadBiasAuditReport(auditId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `bias-audit-${auditId}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("Failed to download PDF report:", err);
+    } finally {
+      setIsDownloadingPdf(false);
     }
   };
 
@@ -359,6 +382,15 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
           )}
         </Stack>
         <Stack direction="row" spacing={1}>
+          {audit?.results && status === "completed" && (
+            <CustomizableButton
+              variant="contained"
+              text={isDownloadingPdf ? "Generating..." : "Download PDF report"}
+              onClick={handleDownloadPdf}
+              isDisabled={isDownloadingPdf}
+              sx={{ height: 34, fontSize: 13 }}
+            />
+          )}
           {audit?.results && (
             <CustomizableButton
               variant="outlined"

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
@@ -6,6 +6,7 @@ import { StatCard } from "../../components/Cards/StatCard";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { getStatusChip, getModeChip } from "./biasAuditHelpers";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
+import { triggerBrowserDownload } from "../../utils/browserDownload.utils";
 import { palette } from "../../themes/palette";
 import {
   getBiasAuditResults,
@@ -311,14 +312,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
     try {
       const json = JSON.stringify(audit.results, null, 2);
       const blob = new Blob([json], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `bias-audit-${auditId}.json`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      triggerBrowserDownload(blob, `bias-audit-${auditId}.json`);
     } catch (err) {
       console.error("Failed to download results:", err);
     }
@@ -329,14 +323,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
     setIsDownloadingPdf(true);
     try {
       const blob = await downloadBiasAuditReport(auditId);
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `bias-audit-${auditId}.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      triggerBrowserDownload(blob, `bias-audit-${auditId}.pdf`);
     } catch (err) {
       console.error("Failed to download PDF report:", err);
     } finally {
@@ -368,7 +355,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
           <ArrowLeft size={18} color={theme.palette.text.secondary} strokeWidth={1.5} />
         </Box>
         <Stack spacing={0.5} flex={1}>
-          <Stack direction="row" alignItems="center" spacing={1.5}>
+          <Stack direction="row" alignItems="center" sx={{ gap: "8px" }}>
             <Typography sx={{ fontSize: 15, fontWeight: 600, color: theme.palette.text.primary }}>
               {audit?.presetName || "Bias audit"}
             </Typography>
@@ -381,7 +368,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
             </Typography>
           )}
         </Stack>
-        <Stack direction="row" spacing={1}>
+        <Stack direction="row" sx={{ gap: "8px" }}>
           {audit?.results && status === "completed" && (
             <CustomizableButton
               variant="contained"

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
@@ -13,11 +13,13 @@ import {
   getBiasAuditStatus,
   deleteBiasAudit,
   downloadBiasAuditReport,
+  updateBiasAuditName,
   type BiasAuditDetailResponse,
   type CategoryTableResult,
   type FairnessMetricsTable,
   type ScoreDistributionTable,
 } from "../../../application/repository/deepEval.repository";
+import EditableText from "../../components/EditableText";
 
 interface BiasAuditDetailProps {
   auditId: string;
@@ -318,6 +320,17 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
     }
   };
 
+  const handleSaveName = async (next: string) => {
+    try {
+      await updateBiasAuditName(auditId, next);
+      setAudit((prev) =>
+        prev ? { ...prev, config: { ...(prev.config || {}), systemName: next } } : prev
+      );
+    } catch (err) {
+      console.error("Failed to update audit name:", err);
+    }
+  };
+
   const handleDownloadPdf = async () => {
     if (isDownloadingPdf) return;
     setIsDownloadingPdf(true);
@@ -356,15 +369,20 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
         </Box>
         <Stack spacing={0.5} flex={1}>
           <Stack direction="row" alignItems="center" sx={{ gap: "8px" }}>
-            <Typography sx={{ fontSize: 15, fontWeight: 600, color: theme.palette.text.primary }}>
-              {audit?.presetName || "Bias audit"}
-            </Typography>
+            <EditableText
+              value={(audit?.config?.systemName as string | undefined) || audit?.presetName || "Bias audit"}
+              onSave={handleSaveName}
+              placeholder="Untitled audit"
+              editAriaLabel="Edit audit name"
+              textSx={{ fontSize: 15, fontWeight: 600, color: theme.palette.text.primary }}
+              inputMinWidth={360}
+            />
             {audit?.mode && getModeChip(audit.mode)}
             {getStatusChip(status)}
           </Stack>
           {audit?.createdAt && (
             <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
-              Created {new Date(audit.createdAt).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
+              {audit.presetName} · Created {new Date(audit.createdAt).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
             </Typography>
           )}
         </Stack>

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
@@ -13,6 +13,8 @@ import {
   deleteBiasAudit,
   type BiasAuditDetailResponse,
   type CategoryTableResult,
+  type FairnessMetricsTable,
+  type ScoreDistributionTable,
 } from "../../../application/repository/deepEval.repository";
 
 interface BiasAuditDetailProps {
@@ -91,6 +93,140 @@ function ResultsTable({ table, threshold: _threshold }: { table: CategoryTableRe
             </Box>
           ))}
         </Box>
+      </Box>
+    </Box>
+  );
+}
+
+function FairnessMetricsTableView({ table }: { table: FairnessMetricsTable }) {
+  const theme = useTheme();
+  const headerCellSx = {
+    fontSize: 12,
+    fontWeight: 600,
+    color: theme.palette.text.secondary,
+    textAlign: "right" as const,
+    padding: "8px",
+  };
+
+  return (
+    <Box sx={{ border: `1px solid ${theme.palette.border.dark}`, borderRadius: "4px", mb: "16px", overflow: "hidden" }}>
+      <Box sx={{ padding: "8px", backgroundColor: palette.background.accent, borderBottom: `1px solid ${theme.palette.border.dark}` }}>
+        <Typography sx={{ fontSize: 13, fontWeight: 600, color: theme.palette.text.primary }}>{table.title}</Typography>
+        {(table.equal_opportunity_difference != null ||
+          table.equalized_odds_difference != null ||
+          table.predictive_parity_difference != null) && (
+          <Typography sx={{ fontSize: 11, color: theme.palette.text.secondary, mt: "2px" }}>
+            {table.equal_opportunity_difference != null && (
+              <>Equal opportunity diff: <strong>{table.equal_opportunity_difference.toFixed(3)}</strong>{table.tpr_max_group && table.tpr_min_group ? ` (${table.tpr_max_group} vs ${table.tpr_min_group})` : ""}{" · "}</>
+            )}
+            {table.equalized_odds_difference != null && (
+              <>Equalized odds diff: <strong>{table.equalized_odds_difference.toFixed(3)}</strong>{" · "}</>
+            )}
+            {table.predictive_parity_difference != null && (
+              <>Predictive parity diff: <strong>{table.predictive_parity_difference.toFixed(3)}</strong></>
+            )}
+          </Typography>
+        )}
+      </Box>
+
+      <Box component="table" sx={{ width: "100%", borderCollapse: "collapse" }}>
+        <Box component="thead">
+          <Box component="tr" sx={{ borderBottom: `1px solid ${theme.palette.border.light}` }}>
+            <Box component="th" sx={{ ...headerCellSx, textAlign: "left", width: "18%" }}>Group</Box>
+            <Box component="th" sx={{ ...headerCellSx, width: "10%" }}>Count</Box>
+            <Box component="th" sx={{ ...headerCellSx, width: "12%" }}>TPR</Box>
+            <Box component="th" sx={{ ...headerCellSx, width: "12%" }}>FPR</Box>
+            <Box component="th" sx={{ ...headerCellSx, width: "12%" }}>FNR</Box>
+            <Box component="th" sx={{ ...headerCellSx, width: "12%" }}>Precision</Box>
+            <Box component="th" sx={{ ...headerCellSx, width: "12%" }}>Accuracy</Box>
+            <Box component="th" sx={{ ...headerCellSx, width: "12%" }}>Confusion (TP/FP/TN/FN)</Box>
+          </Box>
+        </Box>
+        <Box component="tbody">
+          {table.groups.map((g, idx) => (
+            <Box component="tr" key={idx} sx={{ borderBottom: idx < table.groups.length - 1 ? `1px solid ${theme.palette.border.light}` : "none", opacity: g.excluded ? 0.5 : 1 }}>
+              <Box component="td" sx={{ padding: "8px" }}>
+                <Typography sx={{ fontSize: 13, color: theme.palette.text.primary }}>{g.category_name}</Typography>
+              </Box>
+              <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
+                <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>{g.count.toLocaleString()}</Typography>
+              </Box>
+              <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
+                <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>{(g.true_positive_rate * 100).toFixed(1)}%</Typography>
+              </Box>
+              <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
+                <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>{(g.false_positive_rate * 100).toFixed(1)}%</Typography>
+              </Box>
+              <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
+                <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>{(g.false_negative_rate * 100).toFixed(1)}%</Typography>
+              </Box>
+              <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
+                <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>{(g.precision * 100).toFixed(1)}%</Typography>
+              </Box>
+              <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
+                <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>{(g.accuracy * 100).toFixed(1)}%</Typography>
+              </Box>
+              <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
+                <Typography sx={{ fontSize: 12, color: theme.palette.text.tertiary, fontFamily: "monospace" }}>
+                  {g.true_positive}/{g.false_positive}/{g.true_negative}/{g.false_negative}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+function ScoreDistributionView({ table }: { table: ScoreDistributionTable }) {
+  const theme = useTheme();
+  const maxCount = Math.max(
+    1,
+    ...table.groups.flatMap((g) => g.bins.map((b) => b.count))
+  );
+
+  return (
+    <Box sx={{ border: `1px solid ${theme.palette.border.dark}`, borderRadius: "4px", mb: "16px", overflow: "hidden" }}>
+      <Box sx={{ padding: "8px", backgroundColor: palette.background.accent, borderBottom: `1px solid ${theme.palette.border.dark}` }}>
+        <Typography sx={{ fontSize: 13, fontWeight: 600, color: theme.palette.text.primary }}>{table.title}</Typography>
+        <Typography sx={{ fontSize: 11, color: theme.palette.text.secondary }}>
+          Overall mean: {table.overall_mean.toFixed(3)} · Overall median: {table.overall_median.toFixed(3)}
+        </Typography>
+      </Box>
+      <Box sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          {table.groups.map((g, idx) => (
+            <Box key={idx}>
+              <Stack direction="row" justifyContent="space-between" alignItems="baseline" mb={0.5}>
+                <Typography sx={{ fontSize: 13, fontWeight: 500, color: theme.palette.text.primary }}>{g.category_name}</Typography>
+                <Typography sx={{ fontSize: 11, color: theme.palette.text.secondary }}>
+                  n={g.count} · mean={g.mean.toFixed(3)} · median={g.median.toFixed(3)} · std={g.std.toFixed(3)}
+                  {g.ks_statistic != null && (
+                    <> · K-S={g.ks_statistic.toFixed(3)}{g.ks_pvalue != null ? ` (p=${g.ks_pvalue.toFixed(3)})` : ""}</>
+                  )}
+                </Typography>
+              </Stack>
+              <Box sx={{ display: "flex", alignItems: "flex-end", gap: "1px", height: 60, background: palette.background.accent, p: "4px", borderRadius: "2px" }}>
+                {g.bins.map((bin, bidx) => {
+                  const h = (bin.count / maxCount) * 100;
+                  return (
+                    <Box
+                      key={bidx}
+                      title={`[${bin.lower.toFixed(2)}, ${bin.upper.toFixed(2)}): ${bin.count}`}
+                      sx={{
+                        flex: 1,
+                        height: `${h}%`,
+                        backgroundColor: palette.brand.primary,
+                        minHeight: bin.count > 0 ? "2px" : 0,
+                      }}
+                    />
+                  );
+                })}
+              </Box>
+            </Box>
+          ))}
+        </Stack>
       </Box>
     </Box>
   );
@@ -270,8 +406,16 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
           {/* Summary cards */}
           <Box sx={{ display: "grid", gridTemplateColumns: `repeat(${audit.results.unknown_count > 0 ? 5 : 4}, 1fr)`, gap: "16px", mb: "16px" }}>
             <StatCard title="Total applicants" value={audit.results.total_applicants.toLocaleString()} Icon={Users} />
-            <StatCard title="Total selected" value={audit.results.total_selected.toLocaleString()} Icon={UserCheck} />
-            <StatCard title="Selection rate" value={`${(audit.results.overall_selection_rate * 100).toFixed(1)}%`} Icon={Percent} />
+            <StatCard
+              title={audit.results.metric === "scoring_rate" ? "Above median" : audit.results.metric === "fairness_metrics" ? "Predicted positive" : "Total selected"}
+              value={audit.results.total_selected.toLocaleString()}
+              Icon={UserCheck}
+            />
+            <StatCard
+              title={audit.results.metric === "scoring_rate" ? "Scoring rate" : audit.results.metric === "fairness_metrics" ? "Positive rate" : "Selection rate"}
+              value={`${(audit.results.overall_selection_rate * 100).toFixed(1)}%`}
+              Icon={Percent}
+            />
             <StatCard title="Flags" value={audit.results.flags_count.toString()} Icon={AlertTriangle} highlight={audit.results.flags_count > 0} />
             {audit.results.unknown_count > 0 && (
               <StatCard title="Unknown" value={audit.results.unknown_count.toLocaleString()} Icon={HelpCircle} />
@@ -283,9 +427,19 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
             <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary, lineHeight: 1.6 }}>{audit.results.summary}</Typography>
           </Box>
 
-          {/* Results tables */}
+          {/* Results tables (selection rate / scoring rate) */}
           {audit.results.tables.map((table, index) => (
             <ResultsTable key={index} table={table} threshold={audit.config?.threshold ?? 0.80} />
+          ))}
+
+          {/* Fairness metrics tables (confusion-matrix mode) */}
+          {audit.results.fairness_metrics_tables?.map((table, index) => (
+            <FairnessMetricsTableView key={`fm-${index}`} table={table} />
+          ))}
+
+          {/* Score distributions */}
+          {audit.results.score_distribution_tables?.map((table, index) => (
+            <ScoreDistributionView key={`sd-${index}`} table={table} />
           ))}
         </>
       )}

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -64,8 +64,10 @@ function getResultSummary(audit: BiasAuditSummary) {
 
 function getSortValue(audit: BiasAuditSummary, key: string): string | number {
   switch (key) {
-    case "framework":
-      return audit.presetName.toLowerCase();
+    case "framework": {
+      const systemName = (audit.config?.systemName as string | undefined) || "";
+      return (systemName || audit.presetName).toLowerCase();
+    }
     case "mode":
       return audit.mode.toLowerCase();
     case "status":
@@ -168,9 +170,13 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
   };
 
   const sortedAudits = useMemo(() => {
-    const filtered = audits.filter((a) =>
-      a.presetName.toLowerCase().includes(searchQuery.toLowerCase())
-    );
+    const q = searchQuery.toLowerCase();
+    const filtered = audits.filter((a) => {
+      const systemName = ((a.config?.systemName as string | undefined) || "").toLowerCase();
+      return (
+        a.presetName.toLowerCase().includes(q) || systemName.includes(q)
+      );
+    });
     if (!sortConfig.key || !sortConfig.direction) return filtered;
 
     return [...filtered].sort((a, b) => {
@@ -305,9 +311,16 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
                   }}
                 >
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    <Typography sx={{ fontSize: 13, color: theme.palette.text.primary }}>
-                      {audit.presetName}
-                    </Typography>
+                    <Stack spacing={0.25}>
+                      <Typography sx={{ fontSize: 13, fontWeight: 500, color: theme.palette.text.primary }}>
+                        {(audit.config?.systemName as string | undefined) || audit.presetName}
+                      </Typography>
+                      {(audit.config?.systemName as string | undefined) && (
+                        <Typography sx={{ fontSize: 11, color: theme.palette.text.secondary }}>
+                          {audit.presetName}
+                        </Typography>
+                      )}
+                    </Stack>
                   </TableCell>
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>{getModeChip(audit.mode)}</TableCell>
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>{getStatusChip(audit.status)}</TableCell>

--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
@@ -112,6 +112,13 @@ export default function EvalsSidebar({
       disabled: false, // Always enabled - org-scoped
     },
     {
+      id: "bias-audits",
+      label: "Bias audits",
+      value: "bias-audits",
+      icon: <Scale size={16} strokeWidth={1.5} />,
+      disabled: false,
+    },
+    {
       id: "playground",
       label: "Playground",
       value: "playground",
@@ -131,13 +138,6 @@ export default function EvalsSidebar({
       label: "Leaderboard",
       value: "leaderboard",
       icon: <Trophy size={16} strokeWidth={1.5} />,
-      disabled: false,
-    },
-    {
-      id: "bias-audits",
-      label: "Bias audits",
-      value: "bias-audits",
-      icon: <Scale size={16} strokeWidth={1.5} />,
       disabled: false,
     },
     {

--- a/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
@@ -28,6 +28,7 @@ import {
   runBiasAudit,
   type BiasAuditPresetSummary,
   type BiasAuditPreset,
+  type BiasAuditMetric,
   type CreateBiasAuditConfig,
 } from "../../../application/repository/deepEval.repository";
 import { palette } from "../../themes/palette";
@@ -196,7 +197,11 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
   const [csvHeaders, setCsvHeaders] = useState<string[]>([]);
   const [csvPreview, setCsvPreview] = useState<string[][]>([]);
   const [columnMapping, setColumnMapping] = useState<Record<string, string>>({});
+  const [metric, setMetric] = useState<BiasAuditMetric>("selection_rate");
   const [outcomeColumn, setOutcomeColumn] = useState("");
+  const [scoreColumn, setScoreColumn] = useState("");
+  const [predictionColumn, setPredictionColumn] = useState("");
+  const [groundTruthColumn, setGroundTruthColumn] = useState("");
 
   // Step 4: Review & run
   const [threshold, setThreshold] = useState<number | null>(0.8);
@@ -315,6 +320,7 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
         presetId: fullPreset.id,
         presetName: fullPreset.name,
         mode: fullPreset.mode,
+        metric,
         orgId,
         categories: fullPreset.categories,
         intersectional: {
@@ -324,10 +330,18 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
         metrics: fullPreset.metrics,
         threshold,
         smallSampleExclusion: smallSampleExclusion,
-        outcomeColumn,
+        outcomeColumn: metric === "selection_rate" ? outcomeColumn : "",
+        scoreColumn: metric === "scoring_rate" ? scoreColumn : undefined,
+        predictionColumn:
+          metric === "fairness_metrics" ? predictionColumn : undefined,
+        groundTruthColumn:
+          metric === "fairness_metrics" ? groundTruthColumn : undefined,
         columnMapping: Object.fromEntries(
           Object.entries(columnMapping).filter(([, v]) => v)
         ),
+        systemName: aedtName,
+        systemDescription: aedtDescription,
+        dataSource: dataSourceDescription,
         metadata: {
           aedt_name: aedtName,
           description: aedtDescription,
@@ -367,7 +381,11 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
     setCsvHeaders([]);
     setCsvPreview([]);
     setColumnMapping({});
+    setMetric("selection_rate");
     setOutcomeColumn("");
+    setScoreColumn("");
+    setPredictionColumn("");
+    setGroundTruthColumn("");
     setThreshold(0.8);
     setSmallSampleExclusion(null);
     setIntersectionalEnabled(false);
@@ -384,7 +402,20 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
       case 1:
         return aedtName.trim().length > 0;
       case 2: {
-        if (!csvFile || !outcomeColumn) return false;
+        if (!csvFile) return false;
+        // Metric-specific column requirements
+        const metricColumns: string[] = [];
+        if (metric === "selection_rate") {
+          if (!outcomeColumn) return false;
+          metricColumns.push(outcomeColumn);
+        } else if (metric === "scoring_rate") {
+          if (!scoreColumn) return false;
+          metricColumns.push(scoreColumn);
+        } else if (metric === "fairness_metrics") {
+          if (!predictionColumn || !groundTruthColumn) return false;
+          if (predictionColumn === groundTruthColumn) return false;
+          metricColumns.push(predictionColumn, groundTruthColumn);
+        }
         // Only require mapping for categories with defined groups (non-empty)
         const requiredKeys = Object.entries(fullPreset?.categories || {})
           .filter(([, cat]) => cat.groups && cat.groups.length > 0)
@@ -393,8 +424,8 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
         const mappedValues = Object.values(columnMapping).filter(Boolean);
         // Prevent duplicate column mappings (same CSV column mapped to multiple categories)
         if (new Set(mappedValues).size !== mappedValues.length) return false;
-        // Outcome column must not be used as a category column
-        if (mappedValues.includes(outcomeColumn)) return false;
+        // Metric columns must not overlap with category columns
+        if (metricColumns.some((col) => mappedValues.includes(col))) return false;
         return true;
       }
       case 3:
@@ -536,6 +567,34 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
         </Typography>
       </Box>
 
+      {/* Metric mode selector */}
+      <Box>
+        <Stack direction="row" alignItems="center" spacing={0.5} mb={1}>
+          <Typography sx={{ fontSize: 13, fontWeight: 600, color: palette.text.secondary }}>
+            Audit metric
+          </Typography>
+          <VWTooltip
+            content="The metric determines what your CSV needs to contain. Selection rate works for binary hire/reject decisions. Scoring rate is for tools that output a continuous score — it compares how often each group scores above the overall median. Fairness metrics compute TPR, FPR, and equalized odds from model predictions vs. ground truth."
+            placement="top"
+            maxWidth={320}
+          >
+            <Box sx={{ display: "flex", cursor: "help" }}>
+              <Info size={14} strokeWidth={1.5} color={palette.text.accent} />
+            </Box>
+          </VWTooltip>
+        </Stack>
+        <Select
+          id="metric-mode"
+          value={metric}
+          onChange={(e) => setMetric(e.target.value as BiasAuditMetric)}
+          items={[
+            { _id: "selection_rate", name: "Selection rate (binary outcome)" },
+            { _id: "scoring_rate", name: "Scoring rate (continuous score, LL144 compliant)" },
+            { _id: "fairness_metrics", name: "Fairness metrics (prediction + ground truth)" },
+          ]}
+        />
+      </Box>
+
       {/* Data requirements */}
       <Box sx={{ border: `1px solid ${palette.border.dark}`, borderRadius: "4px", p: "12px", backgroundColor: palette.background.accent }}>
         <Typography sx={{ fontSize: 13, fontWeight: 600, color: palette.text.secondary, mb: 1 }}>
@@ -550,12 +609,38 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
               </Typography>
             </Stack>
           ))}
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Box sx={{ width: 4, height: 4, borderRadius: "50%", backgroundColor: palette.brand.primary, flexShrink: 0 }} />
-            <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
-              <strong>Outcome</strong> — binary result column (1/yes/selected = selected, 0/no = not selected)
-            </Typography>
-          </Stack>
+          {metric === "selection_rate" && (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Box sx={{ width: 4, height: 4, borderRadius: "50%", backgroundColor: palette.brand.primary, flexShrink: 0 }} />
+              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                <strong>Outcome</strong> — binary result column (1/yes/selected = selected, 0/no = not selected)
+              </Typography>
+            </Stack>
+          )}
+          {metric === "scoring_rate" && (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Box sx={{ width: 4, height: 4, borderRadius: "50%", backgroundColor: palette.brand.primary, flexShrink: 0 }} />
+              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                <strong>Score</strong> — numeric column. Impact ratio is computed from the rate at which each group scores above the overall median.
+              </Typography>
+            </Stack>
+          )}
+          {metric === "fairness_metrics" && (
+            <>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Box sx={{ width: 4, height: 4, borderRadius: "50%", backgroundColor: palette.brand.primary, flexShrink: 0 }} />
+                <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                  <strong>Prediction</strong> — binary column with what the model predicted
+                </Typography>
+              </Stack>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Box sx={{ width: 4, height: 4, borderRadius: "50%", backgroundColor: palette.brand.primary, flexShrink: 0 }} />
+                <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                  <strong>Ground truth</strong> — binary column with the actual correct answer
+                </Typography>
+              </Stack>
+            </>
+          )}
         </Stack>
         <Typography sx={{ fontSize: 11, color: palette.text.accent, mt: 1.5 }}>
           Column names don't need to match exactly — you'll map them in the next section after uploading.
@@ -642,19 +727,68 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
               );
             })}
 
-          <Stack direction="row" alignItems="center" spacing={2}>
-            <Typography sx={{ fontSize: 13, color: palette.text.tertiary, minWidth: 140 }}>
-              Outcome column
-            </Typography>
-            <Select
-              id="outcome-column"
-              value={outcomeColumn}
-              onChange={(e) => setOutcomeColumn(String(e.target.value))}
-              items={csvHeaders.map((h) => ({ _id: h, name: h }))}
-              placeholder="Select outcome column"
-              sx={{ flex: 1 }}
-            />
-          </Stack>
+          {metric === "selection_rate" && (
+            <Stack direction="row" alignItems="center" spacing={2}>
+              <Typography sx={{ fontSize: 13, color: palette.text.tertiary, minWidth: 140 }}>
+                Outcome column
+              </Typography>
+              <Select
+                id="outcome-column"
+                value={outcomeColumn}
+                onChange={(e) => setOutcomeColumn(String(e.target.value))}
+                items={csvHeaders.map((h) => ({ _id: h, name: h }))}
+                placeholder="Select outcome column"
+                sx={{ flex: 1 }}
+              />
+            </Stack>
+          )}
+
+          {metric === "scoring_rate" && (
+            <Stack direction="row" alignItems="center" spacing={2}>
+              <Typography sx={{ fontSize: 13, color: palette.text.tertiary, minWidth: 140 }}>
+                Score column
+              </Typography>
+              <Select
+                id="score-column"
+                value={scoreColumn}
+                onChange={(e) => setScoreColumn(String(e.target.value))}
+                items={csvHeaders.map((h) => ({ _id: h, name: h }))}
+                placeholder="Select numeric score column"
+                sx={{ flex: 1 }}
+              />
+            </Stack>
+          )}
+
+          {metric === "fairness_metrics" && (
+            <>
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <Typography sx={{ fontSize: 13, color: palette.text.tertiary, minWidth: 140 }}>
+                  Prediction column
+                </Typography>
+                <Select
+                  id="prediction-column"
+                  value={predictionColumn}
+                  onChange={(e) => setPredictionColumn(String(e.target.value))}
+                  items={csvHeaders.map((h) => ({ _id: h, name: h }))}
+                  placeholder="Select prediction column"
+                  sx={{ flex: 1 }}
+                />
+              </Stack>
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <Typography sx={{ fontSize: 13, color: palette.text.tertiary, minWidth: 140 }}>
+                  Ground truth column
+                </Typography>
+                <Select
+                  id="ground-truth-column"
+                  value={groundTruthColumn}
+                  onChange={(e) => setGroundTruthColumn(String(e.target.value))}
+                  items={csvHeaders.map((h) => ({ _id: h, name: h }))}
+                  placeholder="Select ground truth column"
+                  sx={{ flex: 1 }}
+                />
+              </Stack>
+            </>
+          )}
         </Stack>
       )}
 

--- a/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
@@ -343,10 +343,7 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
         systemDescription: aedtDescription,
         dataSource: dataSourceDescription,
         metadata: {
-          aedt_name: aedtName,
-          description: aedtDescription,
           distribution_date: distributionDate,
-          data_source_description: dataSourceDescription,
         },
       };
       const result = await runBiasAudit(csvFile, config);

--- a/EvalServer/src/controllers/bias_audits.py
+++ b/EvalServer/src/controllers/bias_audits.py
@@ -202,26 +202,42 @@ async def run_bias_audit_task(
             preset_id=config_data.get("presetId", "custom"),
             preset_name=preset["name"] if preset else "Custom",
             mode=preset["mode"] if preset else config_data.get("mode", "quantitative_audit"),
+            metric=config_data.get("metric", "selection_rate"),
             categories=categories,
             intersectional=intersectional,
             metrics=config_data.get("metrics") or (preset.get("metrics") if preset else ["selection_rate", "impact_ratio"]),
             threshold=config_data.get("threshold") if "threshold" in config_data else (preset.get("threshold") if preset else 0.80),
             small_sample_exclusion=config_data.get("smallSampleExclusion") if "smallSampleExclusion" in config_data else (preset.get("small_sample_exclusion") if preset else None),
             outcome_column=config_data.get("outcomeColumn", "selected"),
+            score_column=config_data.get("scoreColumn"),
+            prediction_column=config_data.get("predictionColumn"),
+            ground_truth_column=config_data.get("groundTruthColumn"),
             column_mapping=filtered_column_mapping,
             metadata=config_data.get("metadata", {}),
+            system_name=config_data.get("systemName"),
+            system_version=config_data.get("systemVersion"),
+            system_description=config_data.get("systemDescription"),
+            auditor_name=config_data.get("auditorName"),
+            auditor_role=config_data.get("auditorRole"),
+            auditor_independence=config_data.get("auditorIndependence"),
+            deployment_context=config_data.get("deploymentContext"),
+            data_source=config_data.get("dataSource"),
+            data_date_range_start=config_data.get("dataDateRangeStart"),
+            data_date_range_end=config_data.get("dataDateRangeEnd"),
         )
 
         # Parse CSV
+        logger.info(f"[BiasAudit] metric={audit_config.metric}")
         logger.info(f"[BiasAudit] column_mapping={audit_config.column_mapping}")
         logger.info(f"[BiasAudit] outcome_column={audit_config.outcome_column}")
-        logger.info(f"[BiasAudit] CSV bytes length={len(csv_bytes)}")
-        logger.info(f"[BiasAudit] CSV first 200 bytes: {csv_bytes[:200]}")
 
         records, unknown_count = parse_csv_dataset(
             csv_bytes=csv_bytes,
             column_mapping=audit_config.column_mapping,
             outcome_column=audit_config.outcome_column,
+            score_column=audit_config.score_column,
+            prediction_column=audit_config.prediction_column,
+            ground_truth_column=audit_config.ground_truth_column,
         )
 
         logger.info(f"[BiasAudit] parse_csv_dataset returned {len(records)} records, {unknown_count} unknown")

--- a/EvalServer/src/controllers/bias_audits.py
+++ b/EvalServer/src/controllers/bias_audits.py
@@ -24,6 +24,7 @@ from crud.bias_audits import (
     create_bias_audit,
     get_bias_audit,
     update_bias_audit_status,
+    update_bias_audit_system_name,
     list_bias_audits,
     delete_bias_audit,
     create_bias_audit_result_rows,
@@ -400,6 +401,40 @@ async def delete_bias_audit_controller(
     except Exception as e:
         logger.error(f"[BiasAudit] Failed to delete audit {audit_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to delete audit. Please try again.")
+
+
+async def update_bias_audit_name_controller(
+    audit_id: str,
+    organization_id: int,
+    system_name: str,
+) -> JSONResponse:
+    """Update the user-editable system name for an audit."""
+    name = (system_name or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="System name cannot be empty")
+    if len(name) > 255:
+        raise HTTPException(status_code=400, detail="System name must be 255 characters or fewer")
+
+    try:
+        async with get_db() as db:
+            updated = await update_bias_audit_system_name(
+                organization_id=organization_id,
+                db=db,
+                audit_id=audit_id,
+                system_name=name,
+            )
+            await db.commit()
+    except Exception as e:
+        logger.error(f"[BiasAudit] Failed to update system name for {audit_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to update audit name.")
+
+    if not updated:
+        raise HTTPException(status_code=404, detail=f"Audit {audit_id} not found")
+
+    return JSONResponse(
+        status_code=200,
+        content={"auditId": audit_id, "systemName": name},
+    )
 
 
 async def get_bias_audit_report_controller(

--- a/EvalServer/src/controllers/bias_audits.py
+++ b/EvalServer/src/controllers/bias_audits.py
@@ -12,7 +12,7 @@ import uuid
 from datetime import datetime
 from typing import Dict, Any, Optional
 from fastapi import HTTPException, BackgroundTasks, UploadFile
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
 logger = logging.getLogger(__name__)
 
@@ -400,6 +400,38 @@ async def delete_bias_audit_controller(
     except Exception as e:
         logger.error(f"[BiasAudit] Failed to delete audit {audit_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to delete audit. Please try again.")
+
+
+async def get_bias_audit_report_controller(
+    audit_id: str,
+    organization_id: int,
+) -> Response:
+    """Generate and stream a PDF report for a completed bias audit."""
+    async with get_db() as db:
+        audit = await get_bias_audit(organization_id, db, audit_id)
+
+    if not audit:
+        raise HTTPException(status_code=404, detail=f"Audit {audit_id} not found")
+    if audit["status"] != "completed":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Audit is not completed (status: {audit['status']}). Reports are only available for completed audits.",
+        )
+
+    from engines.bias_audit.report_generator import generate_pdf_report
+    try:
+        pdf_bytes = generate_pdf_report(audit)
+    except Exception as e:
+        logger.error(f"[BiasAudit] Failed to generate report for {audit_id}: {e}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(status_code=500, detail="Failed to generate PDF report.")
+
+    filename = f"bias_audit_{audit_id}.pdf"
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 async def get_csv_headers_controller(

--- a/EvalServer/src/controllers/bias_audits.py
+++ b/EvalServer/src/controllers/bias_audits.py
@@ -115,7 +115,6 @@ async def create_bias_audit_controller(
                 organization_id=organization_id,
                 db=db,
                 audit_id=audit_id,
-                org_id=effective_org_id,
                 project_id=config_data.get("projectId"),
                 preset_id=preset_id,
                 preset_name=preset_name,

--- a/EvalServer/src/controllers/bias_audits.py
+++ b/EvalServer/src/controllers/bias_audits.py
@@ -5,6 +5,7 @@ Handles bias audit creation, background task execution,
 status polling, and result retrieval.
 """
 
+import asyncio
 import json
 import logging
 import traceback
@@ -419,7 +420,8 @@ async def get_bias_audit_report_controller(
 
     from engines.bias_audit.report_generator import generate_pdf_report
     try:
-        pdf_bytes = generate_pdf_report(audit)
+        # PDF rendering is CPU-bound and holds the GIL; run off the event loop
+        pdf_bytes = await asyncio.to_thread(generate_pdf_report, audit)
     except Exception as e:
         logger.error(f"[BiasAudit] Failed to generate report for {audit_id}: {e}")
         logger.error(traceback.format_exc())

--- a/EvalServer/src/crud/bias_audits.py
+++ b/EvalServer/src/crud/bias_audits.py
@@ -124,6 +124,41 @@ async def update_bias_audit_status(
     return _row_to_dict(row)
 
 
+async def update_bias_audit_system_name(
+    organization_id: int,
+    db: AsyncSession,
+    audit_id: str,
+    system_name: str,
+) -> Optional[Dict[str, Any]]:
+    """Update the user-editable system name stored in config.systemName."""
+    result = await db.execute(
+        text(
+            '''
+            UPDATE llm_evals_bias_audits
+            SET config = jsonb_set(
+                COALESCE(config, '{}'::jsonb),
+                '{systemName}',
+                to_jsonb(:system_name::text),
+                true
+            ),
+            updated_at = CURRENT_TIMESTAMP
+            WHERE organization_id = :organization_id AND id = :id
+            RETURNING id, organization_id, project_id, preset_id, preset_name, mode, status,
+                      config, results, error, created_at, updated_at, completed_at, created_by
+            '''
+        ),
+        {
+            "id": audit_id,
+            "organization_id": organization_id,
+            "system_name": system_name,
+        },
+    )
+    row = result.mappings().first()
+    if not row:
+        return None
+    return _row_to_dict(row)
+
+
 async def list_bias_audits(
     organization_id: int,
     db: AsyncSession,

--- a/EvalServer/src/engines/bias_audit/dataset_parser.py
+++ b/EvalServer/src/engines/bias_audit/dataset_parser.py
@@ -1,14 +1,15 @@
 """
 Parse CSV demographic data for bias audits.
 
-Reads a CSV file with demographic columns and a binary outcome column,
-then produces structured records for the computation engine.
+Reads a CSV file with demographic columns and either a binary outcome column,
+a numeric score column, or prediction + ground-truth columns, then produces
+structured records for the computation engine.
 """
 
 import csv
 import io
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -26,35 +27,58 @@ def _decode_csv(csv_bytes: bytes) -> str:
     raise ValueError("Unable to decode CSV file. Please ensure it is UTF-8 encoded.")
 
 
+def _parse_bool(value: str) -> Optional[bool]:
+    """Parse a cell value into True/False, or None if unrecognized."""
+    v = value.strip().lower()
+    if v in VALID_TRUE:
+        return True
+    if v in VALID_FALSE:
+        return False
+    return None
+
+
+def _parse_float(value: str) -> Optional[float]:
+    """Parse a cell value into a float, or None if not numeric."""
+    v = value.strip()
+    if not v:
+        return None
+    try:
+        return float(v)
+    except (ValueError, TypeError):
+        return None
+
+
 def parse_csv_dataset(
     csv_bytes: bytes,
     column_mapping: Dict[str, str],
     outcome_column: str,
-) -> Tuple[List[Dict[str, str]], int]:
+    score_column: Optional[str] = None,
+    prediction_column: Optional[str] = None,
+    ground_truth_column: Optional[str] = None,
+) -> Tuple[List[Dict], int]:
     """
     Parse CSV bytes into a list of record dicts.
 
     Args:
         csv_bytes: Raw CSV file content.
         column_mapping: Maps preset category keys to CSV column names.
-            e.g. {"sex": "Gender", "race_ethnicity": "Race"}
-        outcome_column: Name of the CSV column containing the binary outcome
-            (1/true/yes/selected = selected, 0/false/no = not selected).
+        outcome_column: Column containing the binary outcome (selection rate mode).
+        score_column: Optional column containing a numeric score (scoring rate mode).
+        prediction_column: Optional column containing the model prediction (binary).
+        ground_truth_column: Optional column containing the ground truth label (binary).
 
     Returns:
-        Tuple of (records, unknown_count):
-        - records: List of dicts with keys for each category + "selected" (bool).
-        - unknown_count: Number of rows with missing demographic data in any
-          mapped category.
+        (records, unknown_count) where each record has keys for each category,
+        plus any of "selected" / "score" / "prediction" / "ground_truth" that were
+        resolved from the CSV.
     """
     text = _decode_csv(csv_bytes)
     reader = csv.DictReader(io.StringIO(text))
 
-    records: List[Dict[str, str]] = []
+    records: List[Dict] = []
     unknown_count = 0
     unknown_outcome_count = 0
 
-    # Normalize header names for case-insensitive matching
     if reader.fieldnames is None:
         return [], 0
 
@@ -71,11 +95,18 @@ def parse_csv_dataset(
         else:
             resolved_mapping[category_key] = csv_col.strip()
 
-    outcome_col_lower = outcome_column.strip().lower()
-    resolved_outcome = header_map.get(outcome_col_lower, outcome_column.strip())
+    def _resolve(col: Optional[str]) -> Optional[str]:
+        if not col:
+            return None
+        return header_map.get(col.strip().lower(), col.strip())
+
+    resolved_outcome = _resolve(outcome_column)
+    resolved_score = _resolve(score_column)
+    resolved_prediction = _resolve(prediction_column)
+    resolved_ground_truth = _resolve(ground_truth_column)
 
     for row in reader:
-        record: Dict[str, str] = {}
+        record: Dict = {}
         has_missing = False
 
         for category_key, csv_col in resolved_mapping.items():
@@ -84,15 +115,33 @@ def parse_csv_dataset(
                 has_missing = True
             record[category_key] = value
 
-        # Parse outcome — log unrecognized values to help users debug data issues
-        outcome_raw = (row.get(resolved_outcome) or "").strip().lower()
-        if outcome_raw in VALID_TRUE:
-            record["selected"] = True
-        elif outcome_raw in VALID_FALSE or outcome_raw == "":
-            record["selected"] = False
-        else:
-            record["selected"] = False
-            unknown_outcome_count += 1
+        if resolved_outcome:
+            outcome_raw = (row.get(resolved_outcome) or "").strip()
+            parsed = _parse_bool(outcome_raw)
+            if parsed is None:
+                record["selected"] = False
+                if outcome_raw:
+                    unknown_outcome_count += 1
+            else:
+                record["selected"] = parsed
+
+        if resolved_score:
+            score_val = _parse_float(row.get(resolved_score) or "")
+            if score_val is None:
+                has_missing = True
+            record["score"] = score_val
+
+        if resolved_prediction:
+            pred = _parse_bool(row.get(resolved_prediction) or "")
+            if pred is None:
+                has_missing = True
+            record["prediction"] = pred
+
+        if resolved_ground_truth:
+            truth = _parse_bool(row.get(resolved_ground_truth) or "")
+            if truth is None:
+                has_missing = True
+            record["ground_truth"] = truth
 
         if has_missing:
             unknown_count += 1
@@ -109,16 +158,7 @@ def parse_csv_dataset(
 
 
 def parse_csv_headers(csv_bytes: bytes) -> List[str]:
-    """
-    Parse just the headers from a CSV file.
-    Used client-side (or server-side) for column mapping UI.
-
-    Args:
-        csv_bytes: Raw CSV file content.
-
-    Returns:
-        List of column header names.
-    """
+    """Parse just the headers from a CSV file."""
     text = _decode_csv(csv_bytes)
     reader = csv.DictReader(io.StringIO(text))
     if reader.fieldnames is None:

--- a/EvalServer/src/engines/bias_audit/engine.py
+++ b/EvalServer/src/engines/bias_audit/engine.py
@@ -1,11 +1,18 @@
 """
 Bias audit computation engine.
 
-Computes selection rates, impact ratios, and intersectional analyses
-for demographic bias audits. Operates on structured record data
-(not ML tensors or fairlearn MetricFrames).
+Supports three metric modes:
+- selection_rate: binary outcome, impact ratios via 4/5ths rule
+- scoring_rate: continuous score, impact ratio based on rate above overall median
+- fairness_metrics: confusion-matrix metrics (TPR/FPR/equalized odds) when
+  predictions and ground truth are both supplied
+
+All modes also compute intersectional analysis when the preset requires it.
+Score distribution analysis runs whenever a score column is present.
 """
 
+import math
+import statistics
 from typing import Dict, List, Optional
 from collections import defaultdict
 
@@ -13,7 +20,12 @@ from .models import (
     BiasAuditConfig,
     BiasAuditResult,
     CategoryTable,
+    ConfusionMatrixGroupResult,
+    FairnessMetricsTable,
     GroupResult,
+    ScoreDistributionBin,
+    ScoreDistributionGroup,
+    ScoreDistributionTable,
 )
 
 
@@ -25,72 +37,152 @@ def compute_bias_audit(
     """
     Run the full bias audit computation.
 
-    Args:
-        records: List of record dicts. Each has category keys + "selected" (bool).
-        config: Audit configuration with categories, thresholds, etc.
-        unknown_count: Count of rows excluded due to missing demographic data.
-
-    Returns:
-        BiasAuditResult with per-category tables and aggregate statistics.
+    Dispatches on config.metric:
+    - "selection_rate" (default): requires "selected" bool on each record
+    - "scoring_rate": requires "score" float on each record
+    - "fairness_metrics": requires "prediction" bool and "ground_truth" bool
     """
     total_applicants = len(records)
-    total_selected = sum(1 for r in records if r.get("selected"))
-    overall_rate = total_selected / total_applicants if total_applicants > 0 else 0.0
+    metric = config.metric or "selection_rate"
 
     tables: List[CategoryTable] = []
+    score_distribution_tables: List[ScoreDistributionTable] = []
+    fairness_metrics_tables: List[FairnessMetricsTable] = []
     total_flags = 0
     total_excluded = 0
+    total_selected = 0
+    overall_rate = 0.0
 
-    # Compute per-category tables
-    for category_key, category_config in config.categories.items():
-        table = _compute_category_table(
-            records=records,
-            category_key=category_key,
-            category_label=category_config.label,
-            total_applicants=total_applicants,
-            threshold=config.threshold,
-            small_sample_exclusion=config.small_sample_exclusion,
-        )
-        tables.append(table)
-        total_flags += sum(1 for r in table.rows if r.flagged)
-        total_excluded += sum(1 for r in table.rows if r.excluded)
+    if metric == "selection_rate":
+        total_selected = sum(1 for r in records if r.get("selected"))
+        overall_rate = total_selected / total_applicants if total_applicants > 0 else 0.0
 
-    # Compute intersectional table if required
-    if config.intersectional.required and len(config.intersectional.cross) >= 2:
-        intersectional_table = _compute_intersectional_table(
-            records=records,
-            cross_keys=config.intersectional.cross,
-            categories=config.categories,
-            total_applicants=total_applicants,
-            threshold=config.threshold,
-            small_sample_exclusion=config.small_sample_exclusion,
-        )
-        tables.append(intersectional_table)
-        total_flags += sum(1 for r in intersectional_table.rows if r.flagged)
-        total_excluded += sum(1 for r in intersectional_table.rows if r.excluded)
+        for category_key, category_config in config.categories.items():
+            table = _compute_category_table(
+                records=records,
+                category_key=category_key,
+                category_label=category_config.label,
+                total_applicants=total_applicants,
+                threshold=config.threshold,
+                small_sample_exclusion=config.small_sample_exclusion,
+                rate_of=lambda r: bool(r.get("selected")),
+            )
+            tables.append(table)
+            total_flags += sum(1 for r in table.rows if r.flagged)
+            total_excluded += sum(1 for r in table.rows if r.excluded)
 
-    # Build summary
+        if config.intersectional.required and len(config.intersectional.cross) >= 2:
+            intersectional_table = _compute_intersectional_table(
+                records=records,
+                cross_keys=config.intersectional.cross,
+                total_applicants=total_applicants,
+                threshold=config.threshold,
+                small_sample_exclusion=config.small_sample_exclusion,
+                rate_of=lambda r: bool(r.get("selected")),
+            )
+            tables.append(intersectional_table)
+            total_flags += sum(1 for r in intersectional_table.rows if r.flagged)
+            total_excluded += sum(1 for r in intersectional_table.rows if r.excluded)
+
+    elif metric == "scoring_rate":
+        scores = [r.get("score") for r in records if r.get("score") is not None]
+        if not scores:
+            raise ValueError("Scoring rate mode requires a score column with numeric values.")
+        overall_median = statistics.median(scores)
+        total_selected = sum(1 for s in scores if s > overall_median)
+        overall_rate = total_selected / len(scores) if scores else 0.0
+
+        def _above_median(r: Dict) -> bool:
+            score = r.get("score")
+            return score is not None and score > overall_median
+
+        for category_key, category_config in config.categories.items():
+            table = _compute_category_table(
+                records=records,
+                category_key=category_key,
+                category_label=category_config.label,
+                total_applicants=total_applicants,
+                threshold=config.threshold,
+                small_sample_exclusion=config.small_sample_exclusion,
+                rate_of=_above_median,
+                title_prefix="Scoring rate impact ratios",
+            )
+            tables.append(table)
+            total_flags += sum(1 for r in table.rows if r.flagged)
+            total_excluded += sum(1 for r in table.rows if r.excluded)
+
+        if config.intersectional.required and len(config.intersectional.cross) >= 2:
+            intersectional_table = _compute_intersectional_table(
+                records=records,
+                cross_keys=config.intersectional.cross,
+                total_applicants=total_applicants,
+                threshold=config.threshold,
+                small_sample_exclusion=config.small_sample_exclusion,
+                rate_of=_above_median,
+                title="Scoring rate impact ratios by intersectional category",
+            )
+            tables.append(intersectional_table)
+            total_flags += sum(1 for r in intersectional_table.rows if r.flagged)
+            total_excluded += sum(1 for r in intersectional_table.rows if r.excluded)
+
+    elif metric == "fairness_metrics":
+        if not any("prediction" in r and "ground_truth" in r for r in records):
+            raise ValueError(
+                "Fairness metrics mode requires both prediction and ground_truth columns."
+            )
+        total_selected = sum(1 for r in records if r.get("prediction"))
+        overall_rate = total_selected / total_applicants if total_applicants > 0 else 0.0
+
+        for category_key, category_config in config.categories.items():
+            table = _compute_fairness_metrics_table(
+                records=records,
+                category_key=category_key,
+                category_label=category_config.label,
+                total_applicants=total_applicants,
+                small_sample_exclusion=config.small_sample_exclusion,
+            )
+            fairness_metrics_tables.append(table)
+            total_excluded += sum(1 for g in table.groups if g.excluded)
+
+    else:
+        raise ValueError(f"Unknown metric mode: {metric}")
+
+    # Score distributions run whenever score data is present, regardless of metric
+    if any(r.get("score") is not None for r in records):
+        for category_key, category_config in config.categories.items():
+            dist_table = _compute_score_distribution_table(
+                records=records,
+                category_key=category_key,
+                category_label=category_config.label,
+            )
+            if dist_table.groups:
+                score_distribution_tables.append(dist_table)
+
     summary_parts = [
-        f"Audit analyzed {total_applicants:,} applicants with {total_selected:,} selections "
+        f"Audit analyzed {total_applicants:,} applicants "
         f"(overall rate: {overall_rate:.1%}).",
     ]
     if unknown_count > 0:
-        summary_parts.append(f"{unknown_count:,} rows excluded due to missing demographic data.")
-    if total_flags > 0:
-        summary_parts.append(
-            f"{total_flags} group(s) flagged with impact ratio below "
-            f"{config.threshold or 0.80:.2f} threshold."
-        )
-    else:
-        summary_parts.append("No adverse impact flags detected.")
+        summary_parts.append(f"{unknown_count:,} rows excluded due to missing data.")
+    if metric in ("selection_rate", "scoring_rate"):
+        if total_flags > 0:
+            summary_parts.append(
+                f"{total_flags} group(s) flagged with impact ratio below "
+                f"{config.threshold or 0.80:.2f} threshold."
+            )
+        else:
+            summary_parts.append("No adverse impact flags detected.")
     if total_excluded > 0:
         summary_parts.append(
-            f"{total_excluded} group(s) excluded from impact ratio calculations "
+            f"{total_excluded} group(s) excluded from calculations "
             f"due to small sample size."
         )
 
     return BiasAuditResult(
+        metric=metric,
         tables=tables,
+        score_distribution_tables=score_distribution_tables,
+        fairness_metrics_tables=fairness_metrics_tables,
         overall_selection_rate=round(overall_rate, 6),
         total_applicants=total_applicants,
         total_selected=total_selected,
@@ -108,24 +200,24 @@ def _compute_category_table(
     total_applicants: int,
     threshold: Optional[float],
     small_sample_exclusion: Optional[float],
+    rate_of,
+    title_prefix: str = "Impact ratios",
 ) -> CategoryTable:
-    """
-    Compute selection rates and impact ratios for a single category.
+    """Compute rates and impact ratios for a single category.
 
-    Groups records by category value, calculates per-group stats,
-    then computes impact ratios relative to the highest selection rate.
+    The ``rate_of`` callable determines whether a record counts toward the
+    numerator. For selection rate, that's the ``selected`` bool; for scoring
+    rate, it's whether score > overall median.
     """
-    # Group records
     groups: Dict[str, Dict] = defaultdict(lambda: {"applicants": 0, "selected": 0})
     for record in records:
         group_name = record.get(category_key, "")
         if not group_name:
             continue
         groups[group_name]["applicants"] += 1
-        if record.get("selected"):
+        if rate_of(record):
             groups[group_name]["selected"] += 1
 
-    # Compute selection rates
     group_results: List[GroupResult] = []
     highest_rate = 0.0
     highest_group = ""
@@ -147,9 +239,7 @@ def _compute_category_table(
             selection_rate=round(rate, 6),
         ))
 
-    # Compute impact ratios
     for result in group_results:
-        # Check small sample exclusion
         if small_sample_exclusion and total_applicants > 0:
             proportion = result.applicant_count / total_applicants
             if proportion < small_sample_exclusion:
@@ -160,15 +250,13 @@ def _compute_category_table(
         if highest_rate > 0:
             ratio = result.selection_rate / highest_rate
             result.impact_ratio = round(ratio, 6)
-
-            # Flag if below threshold
             if threshold is not None and ratio < threshold:
                 result.flagged = True
         else:
             result.impact_ratio = None
 
     return CategoryTable(
-        title=f"Impact ratios by {category_label.lower()}",
+        title=f"{title_prefix} by {category_label.lower()}",
         category_key=category_key,
         rows=group_results,
         highest_group=highest_group,
@@ -179,18 +267,13 @@ def _compute_category_table(
 def _compute_intersectional_table(
     records: List[Dict],
     cross_keys: List[str],
-    categories: Dict,
     total_applicants: int,
     threshold: Optional[float],
     small_sample_exclusion: Optional[float],
+    rate_of,
+    title: str = "Impact ratios by intersectional category",
 ) -> CategoryTable:
-    """
-    Compute intersectional cross-tabulation.
-
-    Creates compound group names (e.g. "Male - Hispanic or Latino")
-    and computes selection rates and impact ratios across all combinations.
-    """
-    # Group records by compound key
+    """Compute intersectional cross-tabulation."""
     groups: Dict[str, Dict] = defaultdict(lambda: {"applicants": 0, "selected": 0})
 
     for record in records:
@@ -207,10 +290,9 @@ def _compute_intersectional_table(
 
         compound_name = " - ".join(parts)
         groups[compound_name]["applicants"] += 1
-        if record.get("selected"):
+        if rate_of(record):
             groups[compound_name]["selected"] += 1
 
-    # Compute selection rates
     group_results: List[GroupResult] = []
     highest_rate = 0.0
     highest_group = ""
@@ -232,7 +314,6 @@ def _compute_intersectional_table(
             selection_rate=round(rate, 6),
         ))
 
-    # Compute impact ratios
     for result in group_results:
         if small_sample_exclusion and total_applicants > 0:
             proportion = result.applicant_count / total_applicants
@@ -250,9 +331,234 @@ def _compute_intersectional_table(
             result.impact_ratio = None
 
     return CategoryTable(
-        title="Impact ratios by intersectional category",
+        title=title,
         category_key="intersectional",
         rows=group_results,
         highest_group=highest_group,
         highest_rate=round(highest_rate, 6) if highest_rate > 0 else None,
+    )
+
+
+def _compute_score_distribution_table(
+    records: List[Dict],
+    category_key: str,
+    category_label: str,
+    bins: int = 20,
+) -> ScoreDistributionTable:
+    """Compute per-group histograms and a K-S test against the overall distribution.
+
+    The K-S statistic is computed from empirical CDFs without SciPy. For
+    p-values we use the standard Kolmogorov two-sample asymptotic formula,
+    which is accurate for moderate sample sizes.
+    """
+    overall_scores = [r["score"] for r in records if r.get("score") is not None]
+    if not overall_scores:
+        return ScoreDistributionTable(
+            title=f"Score distributions by {category_label.lower()}",
+            category_key=category_key,
+            groups=[],
+        )
+
+    overall_mean = statistics.mean(overall_scores)
+    overall_median = statistics.median(overall_scores)
+    lo, hi = min(overall_scores), max(overall_scores)
+    if hi == lo:
+        hi = lo + 1.0  # avoid zero-width bins
+    bin_width = (hi - lo) / bins
+
+    grouped: Dict[str, List[float]] = defaultdict(list)
+    for record in records:
+        score = record.get("score")
+        if score is None:
+            continue
+        group_name = record.get(category_key, "")
+        if not group_name:
+            continue
+        grouped[group_name].append(score)
+
+    group_results: List[ScoreDistributionGroup] = []
+    sorted_overall = sorted(overall_scores)
+
+    for group_name, scores in sorted(grouped.items()):
+        if not scores:
+            continue
+        counts = [0] * bins
+        for s in scores:
+            idx = int((s - lo) / bin_width)
+            if idx >= bins:
+                idx = bins - 1
+            if idx < 0:
+                idx = 0
+            counts[idx] += 1
+
+        bin_models = [
+            ScoreDistributionBin(
+                lower=round(lo + i * bin_width, 6),
+                upper=round(lo + (i + 1) * bin_width, 6),
+                count=counts[i],
+            )
+            for i in range(bins)
+        ]
+
+        ks_stat, ks_p = _ks_two_sample(sorted(scores), sorted_overall)
+
+        group_results.append(ScoreDistributionGroup(
+            category_type=category_key,
+            category_name=group_name,
+            count=len(scores),
+            mean=round(statistics.mean(scores), 6),
+            median=round(statistics.median(scores), 6),
+            std=round(statistics.pstdev(scores) if len(scores) > 1 else 0.0, 6),
+            bins=bin_models,
+            ks_statistic=round(ks_stat, 6) if ks_stat is not None else None,
+            ks_pvalue=round(ks_p, 6) if ks_p is not None else None,
+        ))
+
+    return ScoreDistributionTable(
+        title=f"Score distributions by {category_label.lower()}",
+        category_key=category_key,
+        groups=group_results,
+        overall_mean=round(overall_mean, 6),
+        overall_median=round(overall_median, 6),
+    )
+
+
+def _ks_two_sample(a_sorted: List[float], b_sorted: List[float]):
+    """Two-sample Kolmogorov-Smirnov statistic and asymptotic p-value.
+
+    Uses an O(n + m) merge-style traversal. Returns (D, p) or (None, None)
+    if either sample is empty.
+    """
+    n, m = len(a_sorted), len(b_sorted)
+    if n == 0 or m == 0:
+        return None, None
+
+    i = j = 0
+    d = 0.0
+    while i < n and j < m:
+        if a_sorted[i] <= b_sorted[j]:
+            i += 1
+        else:
+            j += 1
+        cdf_a = i / n
+        cdf_b = j / m
+        diff = abs(cdf_a - cdf_b)
+        if diff > d:
+            d = diff
+
+    # Asymptotic p-value via the Kolmogorov distribution.
+    en = math.sqrt(n * m / (n + m))
+    lam = (en + 0.12 + 0.11 / en) * d
+    p = _ks_p(lam)
+    return d, p
+
+
+def _ks_p(lam: float) -> float:
+    """Kolmogorov distribution survival function (Numerical Recipes form)."""
+    if lam < 0.001:
+        return 1.0
+    eps1 = 0.001
+    eps2 = 1.0e-8
+    a2 = -2.0 * lam * lam
+    total = 0.0
+    term_prev = 0.0
+    for j in range(1, 101):
+        term = 2.0 * ((-1) ** (j - 1)) * math.exp(a2 * j * j)
+        total += term
+        if abs(term) <= eps1 * term_prev or abs(term) <= eps2 * total:
+            return max(0.0, min(1.0, total))
+        term_prev = abs(term)
+    return 1.0
+
+
+def _compute_fairness_metrics_table(
+    records: List[Dict],
+    category_key: str,
+    category_label: str,
+    total_applicants: int,
+    small_sample_exclusion: Optional[float],
+) -> FairnessMetricsTable:
+    """Compute per-group confusion matrices and cross-group fairness gaps."""
+    groups: Dict[str, List[Dict]] = defaultdict(list)
+    for record in records:
+        group_name = record.get(category_key, "")
+        if not group_name:
+            continue
+        if "prediction" not in record or "ground_truth" not in record:
+            continue
+        groups[group_name].append(record)
+
+    group_results: List[ConfusionMatrixGroupResult] = []
+    for group_name, group_records in sorted(groups.items()):
+        count = len(group_records)
+        tp = sum(1 for r in group_records if r["prediction"] and r["ground_truth"])
+        fp = sum(1 for r in group_records if r["prediction"] and not r["ground_truth"])
+        tn = sum(1 for r in group_records if not r["prediction"] and not r["ground_truth"])
+        fn = sum(1 for r in group_records if not r["prediction"] and r["ground_truth"])
+
+        positives = tp + fn
+        negatives = fp + tn
+        predicted_positives = tp + fp
+
+        tpr = tp / positives if positives > 0 else 0.0
+        fpr = fp / negatives if negatives > 0 else 0.0
+        fnr = fn / positives if positives > 0 else 0.0
+        tnr = tn / negatives if negatives > 0 else 0.0
+        precision = tp / predicted_positives if predicted_positives > 0 else 0.0
+        accuracy = (tp + tn) / count if count > 0 else 0.0
+
+        excluded = False
+        if small_sample_exclusion and total_applicants > 0:
+            if count / total_applicants < small_sample_exclusion:
+                excluded = True
+
+        group_results.append(ConfusionMatrixGroupResult(
+            category_type=category_key,
+            category_name=group_name,
+            count=count,
+            true_positive=tp,
+            false_positive=fp,
+            true_negative=tn,
+            false_negative=fn,
+            true_positive_rate=round(tpr, 6),
+            false_positive_rate=round(fpr, 6),
+            false_negative_rate=round(fnr, 6),
+            true_negative_rate=round(tnr, 6),
+            precision=round(precision, 6),
+            accuracy=round(accuracy, 6),
+            excluded=excluded,
+        ))
+
+    # Cross-group differences (only across included groups)
+    included = [g for g in group_results if not g.excluded]
+    eq_opp = eq_odds = pred_parity = None
+    tpr_max = tpr_min = fpr_max = fpr_min = None
+    if len(included) >= 2:
+        tpr_sorted = sorted(included, key=lambda g: g.true_positive_rate)
+        fpr_sorted = sorted(included, key=lambda g: g.false_positive_rate)
+        prec_sorted = sorted(included, key=lambda g: g.precision)
+
+        tpr_gap = tpr_sorted[-1].true_positive_rate - tpr_sorted[0].true_positive_rate
+        fpr_gap = fpr_sorted[-1].false_positive_rate - fpr_sorted[0].false_positive_rate
+        prec_gap = prec_sorted[-1].precision - prec_sorted[0].precision
+
+        eq_opp = round(tpr_gap, 6)
+        eq_odds = round(max(tpr_gap, fpr_gap), 6)
+        pred_parity = round(prec_gap, 6)
+        tpr_max = tpr_sorted[-1].category_name
+        tpr_min = tpr_sorted[0].category_name
+        fpr_max = fpr_sorted[-1].category_name
+        fpr_min = fpr_sorted[0].category_name
+
+    return FairnessMetricsTable(
+        title=f"Fairness metrics by {category_label.lower()}",
+        category_key=category_key,
+        groups=group_results,
+        equal_opportunity_difference=eq_opp,
+        equalized_odds_difference=eq_odds,
+        predictive_parity_difference=pred_parity,
+        tpr_max_group=tpr_max,
+        tpr_min_group=tpr_min,
+        fpr_max_group=fpr_max,
+        fpr_min_group=fpr_min,
     )

--- a/EvalServer/src/engines/bias_audit/models.py
+++ b/EvalServer/src/engines/bias_audit/models.py
@@ -2,8 +2,11 @@
 Pydantic models for bias audit configuration and results.
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
+
+
+MetricMode = Literal["selection_rate", "scoring_rate", "fairness_metrics"]
 
 
 class CategoryConfig(BaseModel):
@@ -35,6 +38,7 @@ class BiasAuditConfig(BaseModel):
     preset_id: str
     preset_name: str = ""
     mode: str = "quantitative_audit"
+    metric: MetricMode = "selection_rate"
     categories: Dict[str, CategoryConfig] = Field(default_factory=dict)
     intersectional: IntersectionalConfig = Field(default_factory=IntersectionalConfig)
     metrics: List[str] = Field(default_factory=lambda: ["selection_rate", "impact_ratio"])
@@ -44,7 +48,22 @@ class BiasAuditConfig(BaseModel):
     metadata: Dict[str, str] = Field(default_factory=dict)
     results_format: ResultsFormatConfig = Field(default_factory=ResultsFormatConfig)
     outcome_column: str = "selected"
+    score_column: Optional[str] = None
+    prediction_column: Optional[str] = None
+    ground_truth_column: Optional[str] = None
     column_mapping: Dict[str, str] = Field(default_factory=dict)
+
+    # Optional audit metadata for the formal PDF report (workstream 2.2)
+    system_name: Optional[str] = None
+    system_version: Optional[str] = None
+    system_description: Optional[str] = None
+    auditor_name: Optional[str] = None
+    auditor_role: Optional[str] = None
+    auditor_independence: Optional[Literal["self", "internal", "third_party"]] = None
+    deployment_context: Optional[str] = None
+    data_source: Optional[str] = None
+    data_date_range_start: Optional[str] = None
+    data_date_range_end: Optional[str] = None
 
 
 class GroupResult(BaseModel):
@@ -68,9 +87,74 @@ class CategoryTable(BaseModel):
     highest_rate: Optional[float] = None
 
 
+class ScoreDistributionBin(BaseModel):
+    """A single histogram bin."""
+    lower: float
+    upper: float
+    count: int
+
+
+class ScoreDistributionGroup(BaseModel):
+    """Score distribution for one demographic group."""
+    category_type: str
+    category_name: str
+    count: int
+    mean: float
+    median: float
+    std: float
+    bins: List[ScoreDistributionBin] = Field(default_factory=list)
+    ks_statistic: Optional[float] = None
+    ks_pvalue: Optional[float] = None
+
+
+class ScoreDistributionTable(BaseModel):
+    """Score distribution analysis for one category."""
+    title: str
+    category_key: str
+    groups: List[ScoreDistributionGroup] = Field(default_factory=list)
+    overall_mean: float = 0.0
+    overall_median: float = 0.0
+
+
+class ConfusionMatrixGroupResult(BaseModel):
+    """Confusion-matrix based fairness metrics for one group."""
+    category_type: str
+    category_name: str
+    count: int
+    true_positive: int
+    false_positive: int
+    true_negative: int
+    false_negative: int
+    true_positive_rate: float  # TPR / recall / sensitivity
+    false_positive_rate: float
+    false_negative_rate: float
+    true_negative_rate: float
+    precision: float
+    accuracy: float
+    excluded: bool = False
+
+
+class FairnessMetricsTable(BaseModel):
+    """Confusion-matrix fairness metrics for one category."""
+    title: str
+    category_key: str
+    groups: List[ConfusionMatrixGroupResult] = Field(default_factory=list)
+    # Cross-group differences
+    equal_opportunity_difference: Optional[float] = None  # max TPR - min TPR
+    equalized_odds_difference: Optional[float] = None  # max of TPR-gap or FPR-gap
+    predictive_parity_difference: Optional[float] = None  # max precision gap
+    tpr_max_group: Optional[str] = None
+    tpr_min_group: Optional[str] = None
+    fpr_max_group: Optional[str] = None
+    fpr_min_group: Optional[str] = None
+
+
 class BiasAuditResult(BaseModel):
     """Complete results from a bias audit computation."""
+    metric: MetricMode = "selection_rate"
     tables: List[CategoryTable] = Field(default_factory=list)
+    score_distribution_tables: List[ScoreDistributionTable] = Field(default_factory=list)
+    fairness_metrics_tables: List[FairnessMetricsTable] = Field(default_factory=list)
     overall_selection_rate: float = 0.0
     total_applicants: int = 0
     total_selected: int = 0

--- a/EvalServer/src/engines/bias_audit/report_generator.py
+++ b/EvalServer/src/engines/bias_audit/report_generator.py
@@ -159,7 +159,7 @@ def _cover_page(
     config = audit.get("config", {}) or {}
     results = audit.get("results", {}) or {}
 
-    system_name = config.get("systemName") or config.get("metadata", {}).get("aedt_name") or "AI system"
+    system_name = config.get("systemName") or "AI system"
     system_version = config.get("systemVersion") or ""
     preset_name = audit.get("presetName", "Custom")
 
@@ -234,13 +234,12 @@ def _system_description(
     story: list, styles: Dict[str, ParagraphStyle], audit: Dict[str, Any]
 ) -> None:
     config = audit.get("config", {}) or {}
-    meta = config.get("metadata", {}) or {}
 
     story.append(Paragraph("System description", styles["h1"]))
     story.append(_key_value_table([
-        ("Name", config.get("systemName") or meta.get("aedt_name", "")),
+        ("Name", config.get("systemName", "")),
         ("Version", config.get("systemVersion", "")),
-        ("Description", config.get("systemDescription") or meta.get("description", "")),
+        ("Description", config.get("systemDescription", "")),
         ("Deployment context", config.get("deploymentContext", "")),
     ]))
 
@@ -249,7 +248,6 @@ def _data_description(
     story: list, styles: Dict[str, ParagraphStyle], audit: Dict[str, Any]
 ) -> None:
     config = audit.get("config", {}) or {}
-    meta = config.get("metadata", {}) or {}
     results = audit.get("results", {}) or {}
 
     story.append(Paragraph("Data description", styles["h1"]))
@@ -265,7 +263,7 @@ def _data_description(
         date_range = f"up to {end}"
 
     story.append(_key_value_table([
-        ("Source", config.get("dataSource") or meta.get("data_source_description", "")),
+        ("Source", config.get("dataSource", "")),
         ("Date range", date_range),
         ("Total records", _count(results.get("total_applicants"))),
         ("Records with missing data", _count(results.get("unknown_count"))),

--- a/EvalServer/src/engines/bias_audit/report_generator.py
+++ b/EvalServer/src/engines/bias_audit/report_generator.py
@@ -1,0 +1,561 @@
+"""Bias audit PDF report generator.
+
+Produces a self-contained PDF that can be read without access to the app.
+Uses ReportLab's Platypus flowable API so page breaks, table splits and
+long-content wrapping are handled automatically.
+
+The report is intentionally structured around what an enterprise procurement
+team actually needs to assess the audit: system definition, data description,
+methodology, results, and a limitations section. It is NOT formatted as an
+ISAE 3000 assurance report — it is a technical compliance artifact.
+"""
+
+from datetime import datetime
+from io import BytesIO
+from typing import Any, Dict, List, Optional
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import LETTER
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+# ------------------------------------------------------------------ colors
+BRAND = colors.HexColor("#13715B")
+BORDER = colors.HexColor("#d0d5dd")
+BG_ACCENT = colors.HexColor("#f8fafc")
+TEXT = colors.HexColor("#1f2937")
+TEXT_MUTED = colors.HexColor("#6b7280")
+FLAG_BG = colors.HexColor("#fee2e2")
+FLAG_TEXT = colors.HexColor("#b91c1c")
+
+
+# ------------------------------------------------------------------ styles
+def _styles() -> Dict[str, ParagraphStyle]:
+    base = getSampleStyleSheet()
+    return {
+        "cover_title": ParagraphStyle(
+            "cover_title",
+            parent=base["Title"],
+            fontSize=28,
+            leading=34,
+            textColor=BRAND,
+            spaceAfter=20,
+        ),
+        "cover_subtitle": ParagraphStyle(
+            "cover_subtitle",
+            parent=base["Normal"],
+            fontSize=14,
+            leading=20,
+            textColor=TEXT_MUTED,
+            spaceAfter=8,
+        ),
+        "h1": ParagraphStyle(
+            "h1",
+            parent=base["Heading1"],
+            fontSize=16,
+            leading=22,
+            textColor=BRAND,
+            spaceBefore=20,
+            spaceAfter=10,
+        ),
+        "h2": ParagraphStyle(
+            "h2",
+            parent=base["Heading2"],
+            fontSize=13,
+            leading=18,
+            textColor=TEXT,
+            spaceBefore=14,
+            spaceAfter=6,
+        ),
+        "body": ParagraphStyle(
+            "body",
+            parent=base["Normal"],
+            fontSize=10,
+            leading=15,
+            textColor=TEXT,
+            spaceAfter=8,
+        ),
+        "muted": ParagraphStyle(
+            "muted",
+            parent=base["Normal"],
+            fontSize=9,
+            leading=13,
+            textColor=TEXT_MUTED,
+            spaceAfter=4,
+        ),
+        "label": ParagraphStyle(
+            "label",
+            parent=base["Normal"],
+            fontSize=9,
+            leading=13,
+            textColor=TEXT_MUTED,
+            fontName="Helvetica-Bold",
+        ),
+    }
+
+
+# ------------------------------------------------------------------ helpers
+def _pct(v: Optional[float]) -> str:
+    if v is None:
+        return "—"
+    return f"{v * 100:.1f}%"
+
+
+def _num(v: Optional[float], places: int = 3) -> str:
+    if v is None:
+        return "—"
+    return f"{v:.{places}f}"
+
+
+def _count(v: Optional[int]) -> str:
+    if v is None:
+        return "—"
+    return f"{v:,}"
+
+
+def _independence_label(code: Optional[str]) -> str:
+    if not code:
+        return "Not declared"
+    return {
+        "self": "Self-declared (no independence)",
+        "internal": "Internal (company employee, not the tool vendor)",
+        "third_party": "Third-party (independent of tool vendor and deployer)",
+    }.get(code, code)
+
+
+def _key_value_table(rows: List[tuple], col_widths=(1.8 * inch, 4.7 * inch)) -> Table:
+    """Two-column label/value table used for metadata blocks."""
+    styles = _styles()
+    data = []
+    for label, value in rows:
+        data.append([
+            Paragraph(label, styles["label"]),
+            Paragraph(value or "<i>not provided</i>", styles["body"]),
+        ])
+    t = Table(data, colWidths=list(col_widths))
+    t.setStyle(TableStyle([
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("LINEBELOW", (0, 0), (-1, -2), 0.25, BORDER),
+    ]))
+    return t
+
+
+# ------------------------------------------------------------------ sections
+def _cover_page(
+    story: list, styles: Dict[str, ParagraphStyle], audit: Dict[str, Any]
+) -> None:
+    config = audit.get("config", {}) or {}
+    results = audit.get("results", {}) or {}
+
+    system_name = config.get("systemName") or config.get("metadata", {}).get("aedt_name") or "AI system"
+    system_version = config.get("systemVersion") or ""
+    preset_name = audit.get("presetName", "Custom")
+
+    # Compute plain-English metric label
+    metric = results.get("metric") or config.get("metric") or "selection_rate"
+    metric_label = {
+        "selection_rate": "Selection rate (4/5ths rule)",
+        "scoring_rate": "Scoring rate (LL144 alternative)",
+        "fairness_metrics": "Fairness metrics (TPR / FPR / equalized odds)",
+    }.get(metric, metric)
+
+    story.append(Spacer(1, 1.2 * inch))
+    story.append(Paragraph("Bias audit report", styles["cover_title"]))
+    story.append(Paragraph(
+        f"for <b>{system_name}</b>" + (f" (version {system_version})" if system_version else ""),
+        styles["cover_subtitle"],
+    ))
+    story.append(Spacer(1, 0.4 * inch))
+    story.append(_key_value_table([
+        ("Compliance framework", preset_name),
+        ("Metric", metric_label),
+        ("Audit date", datetime.now().strftime("%B %d, %Y")),
+        ("Auditor", config.get("auditorName") or "Not declared"),
+        ("Auditor role", config.get("auditorRole") or "Not declared"),
+        ("Independence", _independence_label(config.get("auditorIndependence"))),
+    ]))
+    story.append(Spacer(1, 0.3 * inch))
+
+    # Prominent warning when the audit is self-declared
+    if config.get("auditorIndependence") == "self":
+        warning = Table([[Paragraph(
+            "<b>Self-declared audit.</b> This report was produced by the tool "
+            "vendor or system owner with no third-party independence. Receiving "
+            "parties should weight the results accordingly.",
+            ParagraphStyle("warn", parent=styles["body"], textColor=FLAG_TEXT),
+        )]], colWidths=[6.5 * inch])
+        warning.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, -1), FLAG_BG),
+            ("BOX", (0, 0), (-1, -1), 0.5, FLAG_TEXT),
+            ("LEFTPADDING", (0, 0), (-1, -1), 10),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 10),
+            ("TOPPADDING", (0, 0), (-1, -1), 8),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+        ]))
+        story.append(warning)
+
+    story.append(PageBreak())
+
+
+def _executive_summary(
+    story: list, styles: Dict[str, ParagraphStyle], audit: Dict[str, Any]
+) -> None:
+    results = audit.get("results", {}) or {}
+
+    story.append(Paragraph("Executive summary", styles["h1"]))
+
+    story.append(_key_value_table([
+        ("Total records", _count(results.get("total_applicants"))),
+        ("Total selected", _count(results.get("total_selected"))),
+        ("Overall rate", _pct(results.get("overall_selection_rate"))),
+        ("Flagged groups", str(results.get("flags_count", 0))),
+        ("Excluded groups", str(results.get("excluded_count", 0))),
+        ("Records with missing data", _count(results.get("unknown_count"))),
+    ]))
+    story.append(Spacer(1, 0.15 * inch))
+
+    summary_text = results.get("summary") or "No summary available."
+    story.append(Paragraph(summary_text, styles["body"]))
+
+
+def _system_description(
+    story: list, styles: Dict[str, ParagraphStyle], audit: Dict[str, Any]
+) -> None:
+    config = audit.get("config", {}) or {}
+    meta = config.get("metadata", {}) or {}
+
+    story.append(Paragraph("System description", styles["h1"]))
+    story.append(_key_value_table([
+        ("Name", config.get("systemName") or meta.get("aedt_name", "")),
+        ("Version", config.get("systemVersion", "")),
+        ("Description", config.get("systemDescription") or meta.get("description", "")),
+        ("Deployment context", config.get("deploymentContext", "")),
+    ]))
+
+
+def _data_description(
+    story: list, styles: Dict[str, ParagraphStyle], audit: Dict[str, Any]
+) -> None:
+    config = audit.get("config", {}) or {}
+    meta = config.get("metadata", {}) or {}
+    results = audit.get("results", {}) or {}
+
+    story.append(Paragraph("Data description", styles["h1"]))
+
+    date_range = ""
+    start = config.get("dataDateRangeStart")
+    end = config.get("dataDateRangeEnd")
+    if start and end:
+        date_range = f"{start} to {end}"
+    elif start:
+        date_range = f"from {start}"
+    elif end:
+        date_range = f"up to {end}"
+
+    story.append(_key_value_table([
+        ("Source", config.get("dataSource") or meta.get("data_source_description", "")),
+        ("Date range", date_range),
+        ("Total records", _count(results.get("total_applicants"))),
+        ("Records with missing data", _count(results.get("unknown_count"))),
+    ]))
+
+    # Category breakdowns
+    tables = results.get("tables", [])
+    if tables:
+        story.append(Spacer(1, 0.1 * inch))
+        story.append(Paragraph("Records per demographic category", styles["h2"]))
+        for tbl in tables:
+            if tbl.get("category_key") == "intersectional":
+                continue
+            rows = [["Group", "Records", "Share"]]
+            total = sum(r.get("applicant_count", 0) for r in tbl.get("rows", []))
+            for row in tbl.get("rows", []):
+                count = row.get("applicant_count", 0)
+                share = (count / total * 100) if total else 0
+                rows.append([
+                    row.get("category_name", ""),
+                    f"{count:,}",
+                    f"{share:.1f}%",
+                ])
+            t = Table(rows, colWidths=[3.5 * inch, 1.5 * inch, 1.5 * inch])
+            t.setStyle(_data_table_style())
+            story.append(Paragraph(tbl.get("title", ""), styles["muted"]))
+            story.append(t)
+            story.append(Spacer(1, 0.1 * inch))
+
+
+def _methodology(
+    story: list, styles: Dict[str, ParagraphStyle], audit: Dict[str, Any]
+) -> None:
+    config = audit.get("config", {}) or {}
+    results = audit.get("results", {}) or {}
+    metric = results.get("metric") or config.get("metric") or "selection_rate"
+    threshold = config.get("threshold", 0.80) or 0.80
+    small_sample = config.get("smallSampleExclusion") or config.get("small_sample_exclusion")
+
+    story.append(Paragraph("Methodology", styles["h1"]))
+
+    method_text = {
+        "selection_rate": (
+            f"The audit uses the <b>selection rate</b> metric. For each demographic "
+            f"group, the selection rate is computed as the number of selected "
+            f"records divided by the total number of records in that group. "
+            f"Each group's rate is then compared to the group with the highest "
+            f"selection rate to produce an <b>impact ratio</b>."
+        ),
+        "scoring_rate": (
+            f"The audit uses the <b>scoring rate</b> metric, the LL144-compliant "
+            f"alternative for tools that output a continuous score. The rate for "
+            f"each group is the proportion of records whose score is above the "
+            f"overall median. Impact ratios are then computed relative to the "
+            f"highest-rate group."
+        ),
+        "fairness_metrics": (
+            f"The audit uses <b>confusion-matrix fairness metrics</b>. For each "
+            f"group, the report computes true positive rate (TPR), false positive "
+            f"rate (FPR), precision, and accuracy from the model's predictions "
+            f"compared against ground truth. Cross-group differences are "
+            f"summarized as equal opportunity difference (TPR gap), equalized "
+            f"odds difference (max of TPR and FPR gaps), and predictive parity "
+            f"difference (precision gap)."
+        ),
+    }.get(metric, "")
+
+    story.append(Paragraph(method_text, styles["body"]))
+
+    if metric in ("selection_rate", "scoring_rate"):
+        story.append(Paragraph(
+            f"The <b>4/5ths rule</b> (EEOC adverse impact standard) is applied: "
+            f"a group with an impact ratio below <b>{threshold:.2f}</b> is "
+            f"flagged for potential adverse impact. A flag does not automatically "
+            f"indicate a violation — it indicates the disparity is large enough "
+            f"to warrant closer examination.",
+            styles["body"],
+        ))
+
+    if small_sample:
+        story.append(Paragraph(
+            f"<b>Small-sample exclusion.</b> Groups representing fewer than "
+            f"{small_sample * 100:.1f}% of the total records are excluded from "
+            f"impact ratio calculations to avoid statistically unreliable results.",
+            styles["body"],
+        ))
+
+    intersectional = config.get("intersectional") or {}
+    if intersectional.get("required") and len(intersectional.get("cross", [])) >= 2:
+        cross = " × ".join(intersectional.get("cross", []))
+        story.append(Paragraph(
+            f"<b>Intersectional analysis</b> is included: compound groups formed "
+            f"by combining {cross} are also evaluated against the same threshold.",
+            styles["body"],
+        ))
+
+
+def _results(
+    story: list, styles: Dict[str, ParagraphStyle], audit: Dict[str, Any]
+) -> None:
+    results = audit.get("results", {}) or {}
+    tables = results.get("tables") or []
+    fairness = results.get("fairness_metrics_tables") or []
+    distributions = results.get("score_distribution_tables") or []
+
+    if not (tables or fairness or distributions):
+        return
+
+    story.append(Paragraph("Results", styles["h1"]))
+
+    for tbl in tables:
+        story.append(Paragraph(tbl.get("title", ""), styles["h2"]))
+        if tbl.get("highest_group") and tbl.get("highest_rate") is not None:
+            story.append(Paragraph(
+                f"Highest-rate group: <b>{tbl['highest_group']}</b> ({tbl['highest_rate'] * 100:.1f}%)",
+                styles["muted"],
+            ))
+
+        header = ["Group", "Records", "Selected", "Rate", "Impact ratio", "Status"]
+        body_rows: List[List[Any]] = [header]
+        flagged_rows: List[int] = []
+        for idx, row in enumerate(tbl.get("rows", []), start=1):
+            excluded = row.get("excluded")
+            flagged = row.get("flagged")
+            if flagged:
+                flagged_rows.append(idx)
+            status = "Excluded (<threshold)" if excluded else ("Flagged" if flagged else "Pass")
+            body_rows.append([
+                row.get("category_name", ""),
+                f"{row.get('applicant_count', 0):,}",
+                f"{row.get('selected_count', 0):,}",
+                _pct(row.get("selection_rate")),
+                "—" if excluded else _num(row.get("impact_ratio")),
+                status,
+            ])
+        t = Table(body_rows, colWidths=[2.0 * inch, 0.85 * inch, 0.85 * inch, 0.75 * inch, 1.0 * inch, 1.05 * inch])
+        style = _data_table_style()
+        for fr in flagged_rows:
+            style.add("BACKGROUND", (0, fr), (-1, fr), FLAG_BG)
+            style.add("TEXTCOLOR", (0, fr), (-1, fr), FLAG_TEXT)
+        t.setStyle(style)
+        story.append(t)
+        story.append(Spacer(1, 0.15 * inch))
+
+    for tbl in fairness:
+        story.append(Paragraph(tbl.get("title", ""), styles["h2"]))
+        diffs = []
+        if tbl.get("equal_opportunity_difference") is not None:
+            diffs.append(
+                f"Equal opportunity difference: <b>{tbl['equal_opportunity_difference']:.3f}</b>"
+            )
+        if tbl.get("equalized_odds_difference") is not None:
+            diffs.append(
+                f"Equalized odds difference: <b>{tbl['equalized_odds_difference']:.3f}</b>"
+            )
+        if tbl.get("predictive_parity_difference") is not None:
+            diffs.append(
+                f"Predictive parity difference: <b>{tbl['predictive_parity_difference']:.3f}</b>"
+            )
+        if diffs:
+            story.append(Paragraph(" &nbsp;·&nbsp; ".join(diffs), styles["muted"]))
+
+        header = ["Group", "Count", "TPR", "FPR", "Precision", "Accuracy", "TP/FP/TN/FN"]
+        body_rows = [header]
+        for g in tbl.get("groups", []):
+            body_rows.append([
+                g.get("category_name", ""),
+                f"{g.get('count', 0):,}",
+                _pct(g.get("true_positive_rate")),
+                _pct(g.get("false_positive_rate")),
+                _pct(g.get("precision")),
+                _pct(g.get("accuracy")),
+                f"{g.get('true_positive', 0)}/{g.get('false_positive', 0)}/{g.get('true_negative', 0)}/{g.get('false_negative', 0)}",
+            ])
+        t = Table(body_rows, colWidths=[1.5 * inch, 0.7 * inch, 0.7 * inch, 0.7 * inch, 0.9 * inch, 0.9 * inch, 1.1 * inch])
+        t.setStyle(_data_table_style())
+        story.append(t)
+        story.append(Spacer(1, 0.15 * inch))
+
+    for tbl in distributions:
+        story.append(Paragraph(tbl.get("title", ""), styles["h2"]))
+        story.append(Paragraph(
+            f"Overall mean: {tbl.get('overall_mean', 0):.3f} &nbsp;·&nbsp; "
+            f"Overall median: {tbl.get('overall_median', 0):.3f}",
+            styles["muted"],
+        ))
+        header = ["Group", "n", "Mean", "Median", "Std", "K-S stat", "K-S p-value"]
+        body_rows = [header]
+        for g in tbl.get("groups", []):
+            body_rows.append([
+                g.get("category_name", ""),
+                f"{g.get('count', 0):,}",
+                _num(g.get("mean")),
+                _num(g.get("median")),
+                _num(g.get("std")),
+                _num(g.get("ks_statistic")),
+                _num(g.get("ks_pvalue")),
+            ])
+        t = Table(body_rows, colWidths=[1.8 * inch, 0.6 * inch, 0.85 * inch, 0.85 * inch, 0.85 * inch, 0.85 * inch, 0.95 * inch])
+        t.setStyle(_data_table_style())
+        story.append(t)
+        story.append(Spacer(1, 0.15 * inch))
+
+
+def _limitations(story: list, styles: Dict[str, ParagraphStyle]) -> None:
+    story.append(PageBreak())
+    story.append(Paragraph("Conclusion and limitations", styles["h1"]))
+    story.append(Paragraph(
+        "This report documents the results of a bias audit performed against "
+        "the configured compliance framework. The following limitations apply:",
+        styles["body"],
+    ))
+
+    items = [
+        "The audit measures statistical disparity, not causation. A flagged "
+        "group does not imply the tool is the cause of that disparity.",
+        "Results are specific to the dataset provided. They do not automatically "
+        "generalize to different deployment contexts, time periods, or populations.",
+        "Compliance obligations vary by jurisdiction. A passing audit under one "
+        "framework does not imply compliance with all applicable laws.",
+        "The audit does not evaluate the quality, relevance, or job-relatedness "
+        "of the underlying features used by the tool.",
+        "Readers should consult qualified legal counsel for interpretation of "
+        "these results in their specific regulatory context.",
+    ]
+    for item in items:
+        story.append(Paragraph(f"• {item}", styles["body"]))
+
+
+def _data_table_style() -> TableStyle:
+    return TableStyle([
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, -1), 9),
+        ("TEXTCOLOR", (0, 0), (-1, 0), TEXT),
+        ("BACKGROUND", (0, 0), (-1, 0), BG_ACCENT),
+        ("LINEBELOW", (0, 0), (-1, 0), 0.5, BORDER),
+        ("LINEBELOW", (0, 1), (-1, -2), 0.25, BORDER),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+        ("TOPPADDING", (0, 0), (-1, -1), 5),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+        ("ALIGN", (1, 1), (-1, -1), "RIGHT"),
+        ("ALIGN", (0, 0), (0, -1), "LEFT"),
+    ])
+
+
+def _footer(canvas, doc):
+    """Page footer with page number and report identifier."""
+    canvas.saveState()
+    canvas.setFont("Helvetica", 8)
+    canvas.setFillColor(TEXT_MUTED)
+    canvas.drawString(0.75 * inch, 0.5 * inch, "VerifyWise bias audit report")
+    canvas.drawRightString(7.75 * inch, 0.5 * inch, f"Page {doc.page}")
+    canvas.restoreState()
+
+
+# ------------------------------------------------------------------ entry point
+def generate_pdf_report(audit: Dict[str, Any]) -> bytes:
+    """Generate a PDF report for a completed bias audit.
+
+    Args:
+        audit: The full audit record as returned by get_bias_audit_results
+            (must include status="completed", results, config).
+
+    Returns:
+        PDF bytes ready to serve as application/pdf.
+    """
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=LETTER,
+        leftMargin=0.75 * inch,
+        rightMargin=0.75 * inch,
+        topMargin=0.75 * inch,
+        bottomMargin=0.75 * inch,
+        title="Bias audit report",
+        author="VerifyWise",
+    )
+
+    styles = _styles()
+    story: list = []
+
+    _cover_page(story, styles, audit)
+    _executive_summary(story, styles, audit)
+    _system_description(story, styles, audit)
+    _data_description(story, styles, audit)
+    _methodology(story, styles, audit)
+    _results(story, styles, audit)
+    _limitations(story, styles)
+
+    doc.build(story, onFirstPage=_footer, onLaterPages=_footer)
+    return buffer.getvalue()

--- a/EvalServer/src/routers/bias_audits.py
+++ b/EvalServer/src/routers/bias_audits.py
@@ -12,6 +12,7 @@ from controllers.bias_audits import (
     create_bias_audit_controller,
     get_bias_audit_status_controller,
     get_bias_audit_results_controller,
+    get_bias_audit_report_controller,
     list_bias_audits_controller,
     delete_bias_audit_controller,
     get_csv_headers_controller,
@@ -85,6 +86,16 @@ async def get_audit_results(audit_id: str, request: Request):
     """Get full results of a completed bias audit."""
     organization_id = _get_organization_id(request)
     return await get_bias_audit_results_controller(
+        audit_id,
+        organization_id=organization_id,
+    )
+
+
+@router.get("/bias-audits/{audit_id}/report.pdf")
+async def get_audit_report(audit_id: str, request: Request):
+    """Download a formal PDF report for a completed bias audit."""
+    organization_id = _get_organization_id(request)
+    return await get_bias_audit_report_controller(
         audit_id,
         organization_id=organization_id,
     )

--- a/EvalServer/src/routers/bias_audits.py
+++ b/EvalServer/src/routers/bias_audits.py
@@ -6,6 +6,7 @@ Shared-schema multi-tenancy: Uses organization_id from request.state.
 """
 
 from fastapi import APIRouter, BackgroundTasks, Request, UploadFile, File, Form, HTTPException
+from pydantic import BaseModel
 from controllers.bias_audits import (
     list_presets_controller,
     get_preset_controller,
@@ -13,10 +14,15 @@ from controllers.bias_audits import (
     get_bias_audit_status_controller,
     get_bias_audit_results_controller,
     get_bias_audit_report_controller,
+    update_bias_audit_name_controller,
     list_bias_audits_controller,
     delete_bias_audit_controller,
     get_csv_headers_controller,
 )
+
+
+class UpdateAuditNameRequest(BaseModel):
+    systemName: str
 
 router = APIRouter()
 
@@ -88,6 +94,21 @@ async def get_audit_results(audit_id: str, request: Request):
     return await get_bias_audit_results_controller(
         audit_id,
         organization_id=organization_id,
+    )
+
+
+@router.patch("/bias-audits/{audit_id}")
+async def update_audit(
+    audit_id: str,
+    request: Request,
+    payload: UpdateAuditNameRequest,
+):
+    """Update the user-editable system name for an audit."""
+    organization_id = _get_organization_id(request)
+    return await update_bias_audit_name_controller(
+        audit_id,
+        organization_id=organization_id,
+        system_name=payload.systemName,
     )
 
 

--- a/docs/plans/bias-audit-enterprise-credibility.md
+++ b/docs/plans/bias-audit-enterprise-credibility.md
@@ -1,0 +1,321 @@
+# Bias Audit — Enterprise Credibility Upgrade Plan
+
+**Date:** 2026-04-10
+**Owner:** Backend (EvalServer) + Frontend (Clients)
+**Estimated effort:** ~3 weeks of focused work
+**Status:** Approved approach, implementation pending
+
+---
+
+## Goal
+
+Move the bias audit feature from "a 4/5ths rule calculator" to "a tool an enterprise procurement team will accept as their NYC Local Law 144 compliance evidence and a credible bias audit for scoring models."
+
+This plan is **not** about matching BABL AI's professional-services engagement model. It's about giving the tool enough mathematical breadth, output quality, and LL144 workflow coverage that the output is defensible on its own.
+
+---
+
+## Scope
+
+### In scope
+1. **Math breadth** — scoring rate, confusion-matrix fairness metrics, score distributions
+2. **Formal PDF report** — self-contained audit artifact a reader can understand without the app
+3. **LL144 workflow layer** — audit package with public summary snippet, candidate notice template, annual renewal reminder, independence declaration
+
+### Out of scope (explicitly)
+- ❌ ISAE 3000 framing / formal assurance language
+- ❌ Attestation vs direct engagement distinction
+- ❌ Governance pillar tracking (lives in ISO 42001 module)
+- ❌ Bias mitigation recommendation engine (high legal liability)
+- ❌ Third-party auditor workflow (they can use the tool, we don't market to them specifically)
+
+---
+
+## Workstream 1 — Math breadth
+
+### 1.1 Scoring rate metric
+
+**Why:** LL144 explicitly permits impact ratio derived from "scoring rate" (rate at which a group scores above the overall median) as an alternative to selection rate. Tools that output continuous scores rather than binary hire/reject can't use the current audit.
+
+**Changes:**
+
+- `EvalServer/src/engines/bias_audit/dataset_parser.py`
+  - Add a new optional column: `score` (numeric, continuous)
+  - Accept either `outcome` column (binary) OR `score` column (numeric) OR both
+  - New function: `parse_csv_dataset_with_score()` or refactor existing one to return both `selected: bool` and `score: Optional[float]`
+
+- `EvalServer/src/engines/bias_audit/engine.py`
+  - New function `_compute_scoring_rate_table(records, category_key, median_score, threshold, small_sample_exclusion)` modeled on `_compute_category_table()`
+  - `compute_bias_audit()` dispatches based on `config.metric` field: `selection_rate` (default) or `scoring_rate`
+  - Compute the overall median once, then per-group rate is `count(score > median) / count(group)`
+
+- `EvalServer/src/engines/bias_audit/models.py`
+  - Add `metric: Literal["selection_rate", "scoring_rate"] = "selection_rate"` to `BiasAuditConfig`
+  - Add `score: Optional[float]` to parsed record type
+
+- Presets: add `"metric": "selection_rate"` explicitly to all 10 preset JSON files in `EvalServer/src/presets/bias_audits/`. No behavioral change; makes the field explicit.
+
+- Frontend (`Clients/src/infrastructure/api/biasAuditService.ts` + the config UI): add a metric toggle (Selection rate / Scoring rate). When scoring rate is picked, the column mapping step asks for a "score column" instead of an "outcome column."
+
+**Effort:** 1–2 days
+
+---
+
+### 1.2 Confusion-matrix fairness metrics
+
+**Why:** For any model that outputs predictions, buyers increasingly want TPR/FPR/equalized odds/equal opportunity — these are what actually indicate harm for a classifier, not selection rate alone.
+
+**Changes:**
+
+- `EvalServer/src/engines/bias_audit/dataset_parser.py`
+  - New parsing mode that accepts **both** a `prediction` column and a `ground_truth` column (separate from `outcome` which is the "what the tool did")
+  - Support binary predictions and ground truth with the same VALID_TRUE/VALID_FALSE recognition
+
+- `EvalServer/src/engines/bias_audit/engine.py`
+  - New functions:
+    - `_compute_confusion_matrix(records, group)` → returns (tp, fp, tn, fn)
+    - `_compute_fairness_metrics(records, category_key, threshold)` → per group: TPR, FPR, FNR, TNR, precision, accuracy
+    - Cross-group metrics: **equal opportunity difference** (max TPR - min TPR), **equalized odds difference** (max across TPR and FPR gaps), **predictive parity difference** (max precision gap)
+  - Add new result models:
+    - `ConfusionMatrixGroupResult` — per-group TPR/FPR/FNR/precision/accuracy
+    - `FairnessMetricsSummary` — cross-group differences + which groups set the min/max
+  - `compute_bias_audit()` dispatches a third mode: `metric="fairness_metrics"` when predictions + ground_truth are supplied
+
+- `EvalServer/src/engines/bias_audit/models.py`
+  - Extend `BiasAuditConfig`:
+    - `metric: Literal["selection_rate", "scoring_rate", "fairness_metrics"] = "selection_rate"`
+    - `prediction_column: Optional[str]`
+    - `ground_truth_column: Optional[str]`
+
+- Database: the existing `llm_evals_bias_audit_results` flat table is built for `GroupResult` (applicant_count, selected_count, etc.). Add nullable columns for the new metrics, or (cleaner) rely on the `results` JSONB in `llm_evals_bias_audits` for confusion-matrix output and only populate the flat table for the selection/scoring rate case. **Recommendation:** keep the flat table as-is, put new metrics in JSONB only. New migration not needed.
+
+- Frontend: metric toggle adds a third option "Fairness metrics (predictions + ground truth)". Column mapping UI asks for prediction column + ground truth column in that mode. New result view renders the confusion-matrix-per-group table and the cross-group difference summary.
+
+**Effort:** ~1 week
+
+---
+
+### 1.3 Score distribution view
+
+**Why:** BABL lists score distributions across demographic groups as a valid bias signal. Even without computing a metric, showing the histograms is diagnostic.
+
+**Changes:**
+
+- `EvalServer/src/engines/bias_audit/engine.py`
+  - New function `_compute_score_distribution(records, category_key, bins=20)` → per-group histogram bins + count
+  - Also compute **Kolmogorov-Smirnov test** between each group and the overall distribution (SciPy is likely already a dep in EvalServer; verify). Report the D statistic and p-value per group.
+  - Only runs when `score` column is present
+
+- Result model: `ScoreDistributionTable` with per-group `bins[]`, `counts[]`, `ks_statistic`, `ks_pvalue`
+
+- Frontend: new result tab "Score distributions" that renders histograms per group (Recharts, already in use) with the K-S p-value annotated
+
+**Effort:** 1–2 days
+
+---
+
+## Workstream 2 — Formal PDF report
+
+### 2.1 Report generator
+
+**Why:** The single biggest credibility move. A buyer who receives a self-contained PDF doesn't need to log into the app to verify the numbers. It's also what LL144 "summary of results" posting can link to.
+
+**Decision: server-side generation.** `jsPDF` is already in Clients' `package.json` but client-side PDF generation has poor typography, struggles with charts, and means the report can only be produced when a user is viewing the page. The audit is already async server-side; the report should be too.
+
+**Python options:**
+- **WeasyPrint** — HTML+CSS to PDF, best typography. Adds a system dependency (cairo, pango). Medium weight.
+- **ReportLab** — pure Python, lower-level API. Verbose but no system deps.
+- **Recommendation:** WeasyPrint. The report is a formal document; typography matters. Use a Jinja2 HTML template + CSS.
+
+**Changes:**
+
+- Add `weasyprint` and `jinja2` to `EvalServer/requirements.txt`
+- New module: `EvalServer/src/engines/bias_audit/report_generator.py`
+  - Function `generate_pdf_report(audit_id: str, result: BiasAuditResult, metadata: AuditMetadata) -> bytes`
+  - Loads HTML template, renders with Jinja2, pipes through WeasyPrint
+- New Jinja2 template: `EvalServer/src/templates/bias_audit_report.html`
+- New CSS: `EvalServer/src/templates/bias_audit_report.css`
+
+**Report sections (fixed structure):**
+
+1. **Cover page**
+   - Tool name (captured from new field — see 2.2), version, audit date
+   - Auditor name + role + independence declaration
+   - Scope: "Audit performed for compliance with [preset name]"
+   - VerifyWise logo (optional — treat as internal compliance evidence, not a marketing piece)
+
+2. **Executive summary**
+   - Total applicants, total selected (or scored), overall rate
+   - Number of categories audited, number of flags raised
+   - One-paragraph plain-English summary
+
+3. **System description** (captured from new fields — see 2.2)
+   - What does the tool do
+   - What decision does it inform
+   - Deployment context
+
+4. **Data description**
+   - Source, size, date range
+   - Demographic category breakdown with counts
+   - Missing data handling (unknown_count, excluded groups and why)
+
+5. **Methodology**
+   - Metric chosen (selection rate / scoring rate / fairness metrics) and one-sentence rationale
+   - 4/5ths rule explained in plain English with EEOC citation
+   - Small-sample exclusion rule and threshold
+   - Intersectional analysis explanation if applicable
+
+6. **Results**
+   - All category tables (sex, race/ethnicity, intersectional)
+   - Each row: group, count, rate, impact ratio, flag status
+   - Flags explained individually: "Group X has impact ratio 0.72 (below 0.80 threshold). This indicates selection rate is 72% of the highest-selected group." — plain English, not jargon
+
+7. **Conclusion & limitations**
+   - What the audit does NOT show (causation, compliance with other jurisdictions, etc.)
+   - Recommendations: **none** — just "consult qualified counsel for interpretation"
+
+8. **Appendix**
+   - Raw per-group numbers
+   - Preset config JSON
+   - CSV column mapping used
+
+- New API endpoint: `GET /bias-audits/{id}/report.pdf` — streams the generated PDF. Generation is synchronous (the audit compute is already done; PDF generation is ~2s). Caches on disk by audit_id.
+
+- Frontend: "Download PDF report" button on the audit results view.
+
+**Effort:** 3–5 days
+
+---
+
+### 2.2 Audit metadata capture
+
+**Why:** The PDF needs fields that don't exist in the current schema: system description, auditor identity, independence declaration, version.
+
+**Changes:**
+
+- New Alembic migration: add columns to `llm_evals_bias_audits`:
+  - `system_name` TEXT
+  - `system_version` TEXT
+  - `system_description` TEXT
+  - `auditor_name` TEXT
+  - `auditor_role` TEXT
+  - `auditor_independence` TEXT — enum: `self`, `internal`, `third_party`
+  - `deployment_context` TEXT
+  - `data_source` TEXT
+  - `data_date_range_start` DATE
+  - `data_date_range_end` DATE
+
+- `EvalServer/src/engines/bias_audit/models.py` — extend `BiasAuditConfig` with these fields (all optional, captured in the run request)
+
+- Frontend: new step in the audit creation flow BEFORE column mapping — "About this audit." Form fields for all of the above. Can be skipped; fields render as "(not provided)" in the PDF.
+
+**Effort:** 1 day
+
+---
+
+## Workstream 3 — LL144 workflow layer
+
+### 3.1 LL144 audit package mode
+
+**Why:** LL144 requires deployers to post a public summary of results in a specific format. Today a user running the audit gets the numbers but then has to manually assemble what to paste on their careers page. We should generate the HTML snippet.
+
+**Changes:**
+
+- `EvalServer/src/engines/bias_audit/report_generator.py`
+  - New function `generate_ll144_summary_html(audit_id, result, metadata) -> str`
+  - Returns a standalone HTML snippet meeting LL144 posting requirements:
+    - Date of most recent bias audit
+    - Date of distribution of AEDT (captured as new optional field)
+    - Selection/scoring rate per EEO category
+    - Impact ratio per category
+    - Notice that candidates can request alternative process
+  - Template: `EvalServer/src/templates/ll144_summary.html`
+
+- New endpoint: `GET /bias-audits/{id}/ll144-summary.html`
+
+- Frontend: when preset is `nyc_ll144`, show a "Download LL144 public summary" button on the results view alongside the PDF download. Also generate the candidate notice template text (static template, just renders the tool name and the 10-business-day notice language).
+
+**Effort:** 1–2 days
+
+---
+
+### 3.2 Annual renewal tracking
+
+**Why:** LL144 requires the audit to be within one year of use. A deployer running the tool annually needs a reminder.
+
+**Changes:**
+
+- Extend the existing bias audit list view to show "Last audit: X days ago" per preset. When > 335 days (30-day warning window), highlight in amber. When > 365, highlight in red.
+- Use existing notification system (backend already has scheduled notifications via BullMQ per project memory) to send an in-app notification at 30 days before expiry and on the expiry date. Check `Servers/services/automations/` for where to wire this in.
+- No new database columns needed — compute from existing `created_at`.
+
+**Effort:** 2–3 days (most of it is wiring into the existing notification system)
+
+---
+
+### 3.3 Independence declaration capture
+
+Already covered in 2.2 (`auditor_independence` field). No additional work here beyond making sure the PDF renders it prominently on the cover page.
+
+---
+
+## Workstream 4 — Tests & documentation
+
+### 4.1 Unit tests
+
+- `EvalServer/tests/test_bias_audit_engine.py` (or wherever existing tests live; verify):
+  - Test scoring rate with fixture CSVs
+  - Test fairness metrics with known confusion matrices
+  - Test score distribution with a synthetic distribution and a known K-S result
+  - Regression tests for existing selection rate to make sure the dispatch logic doesn't break it
+
+### 4.2 Integration test
+
+- One end-to-end test: upload a known CSV, run the audit, fetch the PDF, assert the PDF is a valid PDF with expected text content (use `pypdf` for text extraction).
+
+### 4.3 Documentation
+
+- Update `docs/technical/domains/` with a new `bias-audit.md` documenting the three metric modes and the LL144 flow.
+- Update user guide content under `shared/user-guide-content/` per the documentation workflow in project memory.
+
+**Effort:** 2 days
+
+---
+
+## Timeline
+
+| Week | Workstream | Items |
+|---|---|---|
+| Week 1 | Math breadth | 1.1 (scoring rate), 1.2 (fairness metrics), 1.3 (score distributions) |
+| Week 2 | Report + metadata | 2.1 (PDF generator), 2.2 (metadata capture) |
+| Week 3 | LL144 workflow + tests | 3.1, 3.2, 4.1, 4.2, 4.3 |
+
+---
+
+## Success criteria
+
+- [ ] A user can upload a CSV with a `score` column and get a scoring rate audit
+- [ ] A user can upload a CSV with `prediction` + `ground_truth` columns and get fairness metrics with equalized odds and equal opportunity differences
+- [ ] A user can download a PDF report that is self-contained and readable without access to the app
+- [ ] The PDF includes system description, auditor identity, methodology rationale, and all result tables
+- [ ] For NYC LL144 preset, the user can also download a public summary HTML snippet that matches LL144 posting requirements
+- [ ] Audits older than 335 days surface a renewal warning in the list view
+- [ ] All new code has unit tests; integration test covers CSV-to-PDF end-to-end
+
+---
+
+## Non-goals for this plan
+
+- Marketing positioning (how we talk about credibility publicly — separate discussion)
+- Expanding preset coverage to new jurisdictions (separate effort)
+- Integrating with a professional auditor network (out of scope)
+- Mitigation recommendations (out of scope, legal liability)
+
+---
+
+## Open questions
+
+1. **Score distribution K-S test vs Mann-Whitney U** — K-S is distribution-shape-sensitive; MWU is rank-based. For the initial ship, K-S is fine; flag as future work if reviewers disagree.
+2. **PDF generation: WeasyPrint or ReportLab?** — Plan defaults to WeasyPrint for typography. If the cairo/pango system dependency is a problem in the EvalServer Docker image, fall back to ReportLab.
+3. **Who captures the "data date range"?** — Proposed as optional metadata. If users consistently skip it, the PDF will say "not provided." Acceptable for v1.
+4. **Independence declaration enforcement** — Should we block audits marked `self` from being exported as a "formal" PDF? Proposed: no, but the PDF cover page says "Self-declared audit; no third-party independence" prominently when that's the mode. Buyer can decide how to weight it.

--- a/shared/user-guide-content/content/llm-evals/bias-audits.ts
+++ b/shared/user-guide-content/content/llm-evals/bias-audits.ts
@@ -10,11 +10,15 @@ export const biasAuditsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'A bias audit analyzes whether an AI system treats demographic groups fairly. You upload applicant data with demographic categories and outcomes (selected or not), and the system calculates selection rates and impact ratios for each group. If any group\'s selection rate falls below the threshold compared to the most-selected group, it gets flagged.',
+      text: 'A bias audit checks whether an automated decision tool treats demographic groups consistently. You upload records with demographic columns and one of three kinds of outcome data, and VerifyWise calculates per-group rates, cross-group disparities and flags groups that fall below the configured threshold. The tool is not LLM-specific; it works for any system that produces a decision, a score or a classification.',
     },
     {
       type: 'paragraph',
-      text: 'This matters for regulatory compliance. NYC Local Law 144, for example, requires annual independent bias audits for any automated employment decision tool. The EU AI Act and EEOC guidelines have similar expectations. VerifyWise supports 15 compliance frameworks out of the box, each with pre-configured categories, thresholds, and reporting requirements.',
+      text: 'NYC Local Law 144 requires annual independent bias audits for any automated employment decision tool. EU AI Act Article 9 and the EEOC guidelines set comparable expectations. VerifyWise ships with 15 compliance frameworks out of the box, each pre-configured with the right categories, thresholds and reporting requirements.',
+    },
+    {
+      type: 'paragraph',
+      text: 'Every run gives you an interactive results dashboard, a raw JSON export and a formal PDF report you can hand to a reviewer or procurement team without any additional explanation.',
     },
     {
       type: 'heading',
@@ -25,6 +29,29 @@ export const biasAuditsContent: ArticleContent = {
     {
       type: 'paragraph',
       text: 'Open the LLM Evals module from the sidebar and click **Bias audits**. You\'ll see a list of all audits for your organization, sortable by date, status, framework, or mode. Running audits update automatically every few seconds.',
+    },
+    {
+      type: 'heading',
+      id: 'choosing-metric',
+      level: 2,
+      text: 'Choosing a metric',
+    },
+    {
+      type: 'paragraph',
+      text: 'Before uploading your data, you pick an audit metric. The metric determines what your CSV needs to contain and what the results mean. VerifyWise supports three modes:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Selection rate', text: 'The default, and the right choice for any tool that produces a binary decision (hire or reject, approve or deny, flag or pass). Your CSV needs one outcome column. The audit computes each group\'s selection rate and an impact ratio against the highest-rate group. NYC Local Law 144 mandates this metric for binary employment decisions.' },
+        { bold: 'Scoring rate', text: 'Use this when your tool outputs a continuous score rather than a yes/no: a ranker, a risk score, a suitability score. Your CSV needs one numeric score column. VerifyWise computes each group\'s "above-median rate" (the share of records whose score beats the overall median) and then applies the same impact ratio logic. Local Law 144 explicitly allows this as an alternative to selection rate for scoring tools.' },
+        { bold: 'Fairness metrics', text: 'Pick this when you have both the model\'s prediction and the real answer. Your CSV needs a prediction column and a ground-truth column. You get a confusion matrix per group (true positive rate, false positive rate, precision, accuracy) plus the three standard cross-group differences: equal opportunity (TPR gap), equalized odds, predictive parity. This is the most informative mode but it also requires the most data.' },
+      ],
+    },
+    {
+      type: 'callout',
+      variant: 'tip',
+      text: 'Not sure which metric fits? Let your data pick for you. If the outcome is a yes/no flag, go with selection rate. If it\'s a numeric score, go with scoring rate. Fairness metrics is the right choice only when you also have ground-truth labels sitting next to the predictions.',
     },
     {
       type: 'heading',
@@ -90,28 +117,33 @@ export const biasAuditsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'Upload a CSV file where each row represents one applicant. The file needs demographic columns and a binary outcome column.',
+      text: 'Upload a CSV file where each row represents one record. The file needs demographic columns plus the metric-specific column(s) described in the "Choosing a metric" section above.',
     },
     {
       type: 'callout',
       variant: 'info',
-      text: 'The wizard shows required columns based on your selected framework. For NYC LL144, you need sex and race/ethnicity columns plus an outcome column. Categories with empty group definitions are marked as optional.',
+      text: 'The wizard shows required columns based on your selected framework and your chosen metric. For NYC LL144 with selection rate, you need sex and race/ethnicity columns plus an outcome column. Categories with empty group definitions are marked as optional.',
     },
     {
       type: 'paragraph',
-      text: 'After uploading, you\'ll see:',
+      text: 'Step 3 starts with a metric dropdown. Pick selection rate, scoring rate or fairness metrics, and the rest of the step adapts to your choice. After uploading the CSV you\'ll see:',
     },
     {
       type: 'bullet-list',
       items: [
+        { bold: 'Metric selector', text: 'Dropdown at the top of the step. Changing the metric swaps the column selectors below it.' },
         { bold: 'Column mapping', text: 'Dropdowns that map each required demographic category to a column in your CSV. For example, map "Sex" to your CSV\'s "Gender" column.' },
-        { bold: 'Outcome column', text: 'Select the column that indicates selection outcomes. Accepted values: 1, true, yes, selected, hired, promoted (and their inverses for non-selection).' },
+        { bold: 'Metric column(s)', text: 'For selection rate, an outcome column. For scoring rate, a numeric score column. For fairness metrics, a prediction column plus a ground-truth column.' },
         { bold: 'Data preview', text: 'A preview of the first five rows so you can confirm the data looks correct before proceeding.' },
       ],
     },
     {
       type: 'paragraph',
-      text: 'The wizard validates that required categories are mapped, no duplicate mappings exist, and the outcome column isn\'t reused as a demographic column.',
+      text: 'Accepted outcome values for selection-rate and fairness-metrics modes are 1/true/yes/selected/hired/promoted as positive, and 0/false/no/rejected/declined as negative. Scoring-rate columns need to parse as numbers; missing or non-numeric values are counted as unknown.',
+    },
+    {
+      type: 'paragraph',
+      text: 'The wizard validates that required categories are mapped, no duplicate mappings exist, and your metric columns aren\'t reused as demographic columns.',
     },
     {
       type: 'heading',
@@ -143,7 +175,17 @@ export const biasAuditsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'Click into a completed audit to see the results. The detail page has three sections: summary cards, a text summary, and the impact ratio tables.',
+      text: 'Click into a completed audit to see the results. The detail page shows the audit title, the compliance framework, headline summary cards, a plain-English summary, and the metric-specific results tables underneath.',
+    },
+    {
+      type: 'heading',
+      id: 'editable-name',
+      level: 3,
+      text: 'Naming your audit',
+    },
+    {
+      type: 'paragraph',
+      text: 'Hover over the audit title at the top of the detail page and click the pencil icon to rename it. New audits inherit the compliance framework as their default title ("NYC Local Law 144"), but a descriptive name like "Acme Resume Screener Q1 2026" makes the list view easier to scan. The compliance framework continues to appear as a subtitle.',
     },
     {
       type: 'heading',
@@ -153,7 +195,7 @@ export const biasAuditsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'At the top you\'ll see cards for total applicants, total selected, overall selection rate, and number of flags. If rows were excluded due to missing demographic data, an "Unknown" card also appears.',
+      text: 'At the top you\'ll see cards for total records, the count and rate of positive outcomes, and the number of flagged groups. The positive-outcome label depends on the metric: "Total selected" for selection rate, "Above median" for scoring rate, "Predicted positive" for fairness metrics. If rows were excluded due to missing demographic data, an "Unknown" card also appears.',
     },
     {
       type: 'heading',
@@ -197,6 +239,47 @@ export const biasAuditsContent: ArticleContent = {
     },
     {
       type: 'heading',
+      id: 'fairness-metrics-results',
+      level: 3,
+      text: 'Fairness metrics tables',
+    },
+    {
+      type: 'paragraph',
+      text: 'When you run the audit with the fairness-metrics mode, the results page renders a confusion-matrix table for each demographic category. Each row shows one group with its true positive rate, false positive rate, false negative rate, precision, accuracy, and the raw TP/FP/TN/FN counts.',
+    },
+    {
+      type: 'paragraph',
+      text: 'Above the per-group table you\'ll find three cross-group differences that summarize the disparity in a single number each:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Equal opportunity difference', text: 'The gap between the highest and lowest true positive rate across groups. A value near zero means every group\'s qualified members get correctly identified at the same rate. Big values mean some groups are systematically missed.' },
+        { bold: 'Equalized odds difference', text: 'The larger of the TPR gap and the FPR gap. A stricter version of equal opportunity that penalizes both missed positives and false alarms.' },
+        { bold: 'Predictive parity difference', text: 'The gap in precision across groups. A positive prediction should mean roughly the same thing regardless of which group it applies to.' },
+      ],
+    },
+    {
+      type: 'callout',
+      variant: 'info',
+      text: 'No single fairness metric is "correct." They can conflict with each other: optimizing for equal opportunity can worsen predictive parity and vice versa. Which one matters most depends on the downstream consequences of a wrong decision in your specific context.',
+    },
+    {
+      type: 'heading',
+      id: 'score-distributions',
+      level: 3,
+      text: 'Score distributions',
+    },
+    {
+      type: 'paragraph',
+      text: 'If your CSV includes a score column, the results page shows a score-distribution section alongside the impact-ratio tables. Each group gets a histogram of its scores plus descriptive statistics (mean, median, standard deviation) and a Kolmogorov-Smirnov statistic comparing the group\'s distribution to the overall one. Small K-S values mean the group looks like the overall distribution; large values mean it\'s shifted in some way.',
+    },
+    {
+      type: 'paragraph',
+      text: 'Score distributions are diagnostic. Two groups can have identical impact ratios but very different score distributions, and the distribution view surfaces that difference.',
+    },
+    {
+      type: 'heading',
       id: 'actions',
       level: 2,
       text: 'Audit actions',
@@ -208,9 +291,29 @@ export const biasAuditsContent: ArticleContent = {
     {
       type: 'bullet-list',
       items: [
-        { bold: 'Download JSON', text: 'Export the full results as a JSON file for external reporting or record-keeping.' },
+        { bold: 'Download PDF report', text: 'Generate a formal PDF audit report. This is the artifact to hand to a reviewer, auditor, or procurement team. Described in detail below.' },
+        { bold: 'Download JSON', text: 'Export the full raw results as a JSON file for external reporting, record-keeping, or downstream tooling.' },
         { bold: 'Delete', text: 'Permanently remove the audit and all its results. This requires confirmation.' },
       ],
+    },
+    {
+      type: 'heading',
+      id: 'pdf-report',
+      level: 2,
+      text: 'The PDF report',
+    },
+    {
+      type: 'paragraph',
+      text: 'The PDF is built so a reader who has never opened VerifyWise can still understand what was audited and what the numbers mean. It starts with a cover page, moves through an executive summary, describes the system and the data, walks through the methodology, then presents the results tables with any fairness metrics or score distributions your audit produced. It closes with a limitations section. Nowhere does the PDF offer mitigation advice: that\'s a conversation for qualified counsel, not a tool output.',
+    },
+    {
+      type: 'paragraph',
+      text: 'The cover page also shows the auditor\'s declared independence level. Self-declared audits carry a warning box so readers know the tool vendor or system owner produced the report without third-party oversight. Plenty of legitimate audits are self-declared, but it\'s the first thing a reviewer should see.',
+    },
+    {
+      type: 'callout',
+      variant: 'warning',
+      text: 'The PDF report does not constitute legal advice. It documents statistical results against a chosen framework. Interpretation in your specific regulatory context is a conversation to have with qualified counsel.',
     },
     {
       type: 'heading',
@@ -281,23 +384,100 @@ export const biasAuditsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'The core calculation is straightforward. For each demographic group:',
+      text: 'Each metric mode uses a slightly different formula, but the shape of the output is the same: a per-group rate, a ratio against the highest-rate group, and a flag when the ratio falls below the threshold.',
+    },
+    {
+      type: 'heading',
+      id: 'math-selection-rate',
+      level: 3,
+      text: 'Selection rate',
     },
     {
       type: 'ordered-list',
       items: [
-        { text: '**Selection rate** = number selected / total applicants in that group' },
+        { text: '**Selection rate** = number selected / total records in that group' },
         { text: '**Impact ratio** = this group\'s selection rate / highest group\'s selection rate' },
         { text: 'If the impact ratio falls below the threshold (typically 0.80), the group is **flagged**' },
       ],
     },
     {
       type: 'paragraph',
-      text: 'The 0.80 threshold is the "four-fifths rule" from the EEOC Uniform Guidelines on Employee Selection Procedures. It means a group\'s selection rate should be at least 80% of the most-selected group\'s rate. A ratio of 0.75 means that group is selected at 75% the rate of the top group, which falls below the threshold.',
+      text: 'The 0.80 threshold is the "four-fifths rule" from the EEOC Uniform Guidelines on Employee Selection Procedures. A group\'s selection rate should be at least 80% of the most-selected group\'s rate. A ratio of 0.75 means that group is selected at 75% the rate of the top group, which falls below the threshold.',
+    },
+    {
+      type: 'heading',
+      id: 'math-scoring-rate',
+      level: 3,
+      text: 'Scoring rate',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Compute the **overall median** of every record\'s score (one number across all groups)' },
+        { text: '**Scoring rate** for a group = share of that group\'s records whose score is above the overall median' },
+        { text: '**Impact ratio** = this group\'s scoring rate / highest group\'s scoring rate' },
+        { text: 'The same threshold and flagging rules apply as for selection rate' },
+      ],
     },
     {
       type: 'paragraph',
-      text: 'Groups that make up less than the small sample exclusion percentage (default 2%) are excluded from the calculation entirely, since small samples produce unreliable ratios.',
+      text: 'Scoring rate is the right metric for ranking tools and continuous-score tools because it asks "does this tool place group X above its overall median as often as it places group Y?" rather than collapsing the score into a yes/no first.',
+    },
+    {
+      type: 'heading',
+      id: 'math-fairness-metrics',
+      level: 3,
+      text: 'Fairness metrics',
+    },
+    {
+      type: 'paragraph',
+      text: 'Fairness metrics are computed from a confusion matrix per group. Each record has both a model prediction and a ground-truth label, so every record falls into exactly one of four cells:',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'TP (true positive)', text: 'Predicted positive, actually positive.' },
+        { bold: 'FP (false positive)', text: 'Predicted positive, actually negative.' },
+        { bold: 'TN (true negative)', text: 'Predicted negative, actually negative.' },
+        { bold: 'FN (false negative)', text: 'Predicted negative, actually positive.' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'From these counts VerifyWise derives the standard per-group rates:',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: '**True positive rate (TPR)** = TP / (TP + FN), also called recall or sensitivity' },
+        { text: '**False positive rate (FPR)** = FP / (FP + TN)' },
+        { text: '**Precision** = TP / (TP + FP)' },
+        { text: '**Accuracy** = (TP + TN) / total' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      text: 'Cross-group differences are then reported as the max-minus-min gap across groups: equal opportunity difference is the TPR gap, equalized odds difference takes the larger of the TPR and FPR gaps, and predictive parity difference is the precision gap.',
+    },
+    {
+      type: 'heading',
+      id: 'math-ks',
+      level: 3,
+      text: 'Kolmogorov-Smirnov for score distributions',
+    },
+    {
+      type: 'paragraph',
+      text: 'The score distribution view uses a two-sample Kolmogorov-Smirnov test to compare each group\'s scores against the overall distribution. The K-S statistic is the largest gap between the two empirical cumulative distribution functions. A statistic of 0.0 means the distributions are identical; 1.0 means they are completely disjoint. The reported p-value uses the standard Kolmogorov asymptotic formula and tells you how surprising that gap would be under the null hypothesis that both samples come from the same distribution.',
+    },
+    {
+      type: 'heading',
+      id: 'math-exclusion',
+      level: 3,
+      text: 'Small sample exclusion',
+    },
+    {
+      type: 'paragraph',
+      text: 'Groups that make up less than the small sample exclusion percentage (default 2%) are excluded from the calculation entirely. Small samples produce unreliable ratios, and including them can mask real patterns with noise. Excluded groups appear in the results with a grey "N/A" status so it\'s obvious they were present in the data but set aside.',
     },
     {
       type: 'article-links',


### PR DESCRIPTION
## Summary

Extends the bias audit feature from a single-metric calculator into a tool that's defensible as enterprise compliance evidence. Four big changes, plus a reusable UI primitive, plus updated user-guide docs.

**1. Three metric modes instead of one.** The engine now dispatches on `config.metric`:
- `selection_rate` (unchanged default) — binary outcome, 4/5ths rule
- `scoring_rate` — continuous score column, impact ratio based on rate above the overall median. LL144 explicitly allows this as an alternative to selection rate and it's the right metric for tools that output a score rather than a binary decision.
- `fairness_metrics` — confusion-matrix metrics computed from separate prediction and ground-truth columns. Per-group TPR, FPR, FNR, precision, accuracy. Cross-group equal opportunity difference, equalized odds difference, predictive parity difference.

Score distribution analysis runs whenever a score column is present, producing per-group histograms, mean/median/std, and a Kolmogorov-Smirnov test against the overall distribution (implemented without scipy via the standard asymptotic Kolmogorov formula).

**2. Formal PDF report.** A new `GET /bias-audits/{id}/report.pdf` endpoint generates a self-contained report a reader can evaluate without access to the app. Built with ReportLab Platypus (pure Python, no system dependencies). PDF generation runs on a threadpool via `asyncio.to_thread()` so it doesn't block the event loop on concurrent downloads.

The report includes: cover page with system name, framework, auditor identity, and independence declaration (self-declared audits get a prominent warning); executive summary; system description; data description with category-level record breakdowns; methodology (dispatches text based on metric mode, explains the 4/5ths rule, small-sample exclusion, intersectional analysis); results tables with flagged groups highlighted; fairness metrics tables with cross-group differences; score distribution tables with K-S statistics; and a limitations section. No mitigation recommendations — that's left to qualified counsel.

**3. Editable audit name.** Audits now have a user-editable title (`config.systemName`) shown at the top of the detail page. Hover the title, click the pencil, edit inline, Enter to save or Escape to cancel. The compliance framework (previously the primary title) becomes a subtitle. The list view and search both prefer the system name when present and fall back to the framework name. New `PATCH /bias-audits/{id}` endpoint uses PostgreSQL `jsonb_set` to update just the one key in the config JSONB.

**4. Reusable `EditableText` component.** The hover-to-edit pattern is extracted into `Clients/src/presentation/components/EditableText/`. Takes `value` + `onSave` + styling overrides; no domain-specific assumptions. Handles Enter/Escape, save-in-flight state, max length, and accessible labels. The existing inline edit pattern in `ExperimentDetailContent.tsx` can adopt it in a follow-up without refactoring its controller.

**5. Frontend for all of the above.** New metric-mode selector on the CSV upload step with conditional column mapping. New result views for fairness metrics tables and score distributions with CSS bar-chart histograms. New "Download PDF report" button (in primary/contained style) on the audit detail view. Bias audits sidebar item moved above Playground in the LLM Evals sidebar so it sits with the evaluation flow rather than the exploration tools.

## Documentation

The in-app user guide at `shared/user-guide-content/content/llm-evals/bias-audits.ts` has been extended from 311 to 491 lines to cover the new capabilities: a "Choosing a metric" section, extended step-3 walkthrough, fairness metrics and score distribution sections in the results walkthrough, the PDF report artifact, the editable audit name, and per-metric math explanations (TPR/FPR/equalized odds, K-S test, small-sample exclusion). New content was also run through a humanizer pass to strip em dashes, rule-of-three patterns, and AI cliches. The file has also been copied to the website monorepo per the docs workflow; the website repo commit is separate and handled by the maintainer.

## Other changes

- Fixes a pre-existing bug where `create_bias_audit()` was called with an `org_id` kwarg it doesn't accept, causing every POST `/bias-audits/run` to 500. Present since the initial bias audit commit.
- Adds audit metadata to the config schema (systemName, systemVersion, systemDescription, auditorName, auditorRole, auditorIndependence, deploymentContext, dataSource, dataDateRangeStart, dataDateRangeEnd). No Alembic migration — these round-trip through the existing `config` JSONB column.
- Reuses the existing `triggerBrowserDownload` helper for blob downloads in the audit detail view instead of rolling inline blob-download code.
- Drops duplicated `metadata.aedt_name` / `metadata.description` / `metadata.data_source_description` fields that shadowed the top-level `systemName` / `systemDescription` / `dataSource`. Only `distribution_date` remains in the metadata dict.
- Runs PDF generation off the event loop via `asyncio.to_thread()`.

## Files

- `EvalServer/src/engines/bias_audit/engine.py` — three-mode dispatch, score distributions with K-S test, fairness metrics
- `EvalServer/src/engines/bias_audit/models.py` — new result types, extended config
- `EvalServer/src/engines/bias_audit/dataset_parser.py` — optional score/prediction/ground-truth columns
- `EvalServer/src/engines/bias_audit/report_generator.py` — new, PDF generation
- `EvalServer/src/crud/bias_audits.py` — new `update_bias_audit_system_name` using `jsonb_set`
- `EvalServer/src/controllers/bias_audits.py` — report endpoint, threadpool, name update, org_id kwarg fix
- `EvalServer/src/routers/bias_audits.py` — new report + PATCH routes
- `Clients/src/infrastructure/api/biasAuditService.ts` — new types, download method, update method
- `Clients/src/application/repository/deepEval.repository.ts` — re-exports
- `Clients/src/presentation/components/EditableText/index.tsx` — new, reusable hover-to-edit primitive
- `Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx` — metric selector, conditional columns
- `Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx` — fairness + distribution result views, PDF download, editable title
- `Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx` — prefers systemName in list + search + sort
- `Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx` — bias audits above Playground
- `shared/user-guide-content/content/llm-evals/bias-audits.ts` — extended user guide
- `docs/plans/bias-audit-enterprise-credibility.md` — the plan this PR executes

## Not in this PR

- Workstream 3 (LL144 public summary HTML snippet, annual renewal tracking) — follow-up
- Workstream 4 (unit + integration tests, integration test CSV-to-PDF end-to-end) — follow-up
- Dedicated "About this audit" step with auditor identity + independence declaration capture — the existing step 2 repurposes system-name/description fields; a dedicated auditor-metadata step is a small follow-up
- Adopting `EditableText` in `ExperimentDetailContent.tsx` — follow-up, the component is ready for it
