### PR TITLE
Link LLM evals to model inventory

### DIFF
--- a/Clients/src/application/repository/modelEvaluations.repository.ts
+++ b/Clients/src/application/repository/modelEvaluations.repository.ts
@@ -1,0 +1,29 @@
+import apiServices from "../../infrastructure/api/customAxios";
+
+export interface ModelEvaluation {
+  id: string;
+  name: string;
+  status: string;
+  config: Record<string, any>;
+  results?: Record<string, any>;
+  error_message?: string;
+  error?: string;
+  completed_at?: string;
+  created_at: string;
+  created_by?: string;
+  eval_type: "experiment" | "bias_audit";
+  model_inventory_id?: number;
+  model_provider?: string;
+  model_name?: string;
+  model_version?: string;
+}
+
+export interface ModelEvaluationsResponse {
+  experiments: ModelEvaluation[];
+  biasAudits: ModelEvaluation[];
+}
+
+export async function getAllModelEvaluations(): Promise<ModelEvaluationsResponse> {
+  const response = await apiServices.get("/modelInventory/evaluations");
+  return response.data;
+}

--- a/Clients/src/application/repository/modelEvaluations.repository.ts
+++ b/Clients/src/application/repository/modelEvaluations.repository.ts
@@ -1,4 +1,4 @@
-import apiServices from "../../infrastructure/api/customAxios";
+import { apiServices } from "../../infrastructure/api/networkServices";
 
 export interface ModelEvaluation {
   id: string;
@@ -25,5 +25,5 @@ export interface ModelEvaluationsResponse {
 
 export async function getAllModelEvaluations(): Promise<ModelEvaluationsResponse> {
   const response = await apiServices.get("/modelInventory/evaluations");
-  return response.data;
+  return response.data as ModelEvaluationsResponse;
 }

--- a/Clients/src/infrastructure/api/biasAuditService.ts
+++ b/Clients/src/infrastructure/api/biasAuditService.ts
@@ -63,6 +63,7 @@ export interface BiasAuditSummary {
   updatedAt: string;
   completedAt: string | null;
   createdBy: string | null;
+  modelInventoryId?: number | null;
 }
 
 export interface GroupResultRow {

--- a/Clients/src/infrastructure/api/biasAuditService.ts
+++ b/Clients/src/infrastructure/api/biasAuditService.ts
@@ -214,6 +214,7 @@ export interface CreateBiasAuditConfig {
   dataSource?: string;
   dataDateRangeStart?: string;
   dataDateRangeEnd?: string;
+  modelInventoryId?: number;
 }
 
 // ==================== SERVICE ====================

--- a/Clients/src/infrastructure/api/evaluationLogsService.ts
+++ b/Clients/src/infrastructure/api/evaluationLogsService.ts
@@ -53,6 +53,7 @@ export interface Experiment {
   updated_at: string;
   tenant: string;
   created_by?: number;
+  model_inventory_id?: number;
 }
 
 export interface MetricAggregates {
@@ -194,6 +195,7 @@ export const experimentsService = {
     description?: string;
     config: Record<string, any>;
     baseline_experiment_id?: string;
+    model_inventory_id?: number;
   }) {
     const response = await CustomAxios.post("/deepeval/experiments", data);
     return response.data;

--- a/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
@@ -199,6 +199,40 @@ const EvaluationTableBody: React.FC<IEvaluationTableBodyProps> = ({
               {row.dataset}
             </TableCell>
 
+            {/* LINKED MODEL - center aligned */}
+            {row.linkedModel !== undefined && (
+              <TableCell
+                sx={{
+                  ...singleTheme.tableStyles.primary.body.cell,
+                  paddingLeft: "12px",
+                  paddingRight: "12px",
+                  textTransform: "none",
+                  textAlign: "center",
+                  width: "10%",
+                }}
+              >
+                {row.linkedModel ? (
+                  <Box
+                    sx={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      px: "8px",
+                      py: "2px",
+                      borderRadius: "4px",
+                      backgroundColor: "#e8f5e9",
+                      color: "#2e7d32",
+                      fontSize: "11px",
+                      fontWeight: 500,
+                    }}
+                  >
+                    Linked
+                  </Box>
+                ) : (
+                  <Typography sx={{ fontSize: "11px", color: "#98a2b3" }}>Unlinked</Typography>
+                )}
+              </TableCell>
+            )}
+
             {/* DATE - center aligned */}
             {row.date !== undefined && (
               <TableCell

--- a/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/TableBody/index.tsx
@@ -219,8 +219,8 @@ const EvaluationTableBody: React.FC<IEvaluationTableBodyProps> = ({
                       px: "8px",
                       py: "2px",
                       borderRadius: "4px",
-                      backgroundColor: "#e8f5e9",
-                      color: "#2e7d32",
+                      backgroundColor: palette.status.success.bg,
+                      color: palette.status.success.text,
                       fontSize: "11px",
                       fontWeight: 500,
                     }}
@@ -228,7 +228,7 @@ const EvaluationTableBody: React.FC<IEvaluationTableBodyProps> = ({
                     Linked
                   </Box>
                 ) : (
-                  <Typography sx={{ fontSize: "11px", color: "#98a2b3" }}>Unlinked</Typography>
+                  <Typography sx={{ fontSize: "11px", color: palette.text.secondary }}>Unlinked</Typography>
                 )}
               </TableCell>
             )}

--- a/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
@@ -52,8 +52,9 @@ const columnWidths: Record<string, string> = {
   "MODEL": "12%",
   "JUDGE/SCORER": "16%",
   "# PROMPTS": "8%",
-  "DATASET": "14%",
-  "DATE": "16%",
+  "DATASET": "12%",
+  "LINKED MODEL": "10%",
+  "DATE": "14%",
   "ACTION": "60px",
 };
 

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -335,8 +335,8 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
                           px: "8px",
                           py: "2px",
                           borderRadius: "4px",
-                          backgroundColor: "#e8f5e9",
-                          color: "#2e7d32",
+                          backgroundColor: palette.status.success.bg,
+                          color: palette.status.success.text,
                           fontSize: "11px",
                           fontWeight: 500,
                         }}
@@ -344,7 +344,7 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
                         Linked
                       </Box>
                     ) : (
-                      <Typography sx={{ fontSize: "11px", color: "#98a2b3" }}>Unlinked</Typography>
+                      <Typography sx={{ fontSize: "11px", color: palette.text.secondary }}>Unlinked</Typography>
                     )}
                   </TableCell>
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
@@ -43,10 +43,11 @@ type SortConfig = { key: string; direction: SortDirection };
 const SORTING_KEY = "verifywise_bias_audits_sorting";
 
 const columns = [
-  { id: "framework", label: "FRAMEWORK", sortable: true, width: "25%" },
-  { id: "mode", label: "MODE", sortable: true, width: "15%" },
-  { id: "status", label: "STATUS", sortable: true, width: "15%" },
-  { id: "result", label: "RESULT", sortable: true, width: "15%" },
+  { id: "framework", label: "FRAMEWORK", sortable: true, width: "22%" },
+  { id: "mode", label: "MODE", sortable: true, width: "12%" },
+  { id: "status", label: "STATUS", sortable: true, width: "12%" },
+  { id: "result", label: "RESULT", sortable: true, width: "12%" },
+  { id: "linkedModel", label: "LINKED MODEL", sortable: false, width: "12%" },
   { id: "date", label: "DATE", sortable: true, width: "20%" },
   { id: "action", label: "ACTION", sortable: false, width: "60px" },
 ];
@@ -325,6 +326,27 @@ export default function BiasAuditsList({ orgId, onViewAudit }: BiasAuditsListPro
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>{getModeChip(audit.mode)}</TableCell>
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>{getStatusChip(audit.status)}</TableCell>
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>{getResultSummary(audit)}</TableCell>
+                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                    {audit.modelInventoryId ? (
+                      <Box
+                        sx={{
+                          display: "inline-flex",
+                          alignItems: "center",
+                          px: "8px",
+                          py: "2px",
+                          borderRadius: "4px",
+                          backgroundColor: "#e8f5e9",
+                          color: "#2e7d32",
+                          fontSize: "11px",
+                          fontWeight: 500,
+                        }}
+                      >
+                        Linked
+                      </Box>
+                    ) : (
+                      <Typography sx={{ fontSize: "11px", color: "#98a2b3" }}>Unlinked</Typography>
+                    )}
+                  </TableCell>
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
                     <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
                       {formatDate(audit.createdAt)}

--- a/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
@@ -567,7 +567,7 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
           label="Link to model inventory (optional)"
           placeholder="None — don't link to inventory"
           value={selectedModelInventoryId !== null ? String(selectedModelInventoryId) : ""}
-          onChange={(e: { target: { value: string } }) =>
+          onChange={(e) =>
             setSelectedModelInventoryId(e.target.value === "" ? null : Number(e.target.value))
           }
           items={[

--- a/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
@@ -31,6 +31,7 @@ import {
   type BiasAuditMetric,
   type CreateBiasAuditConfig,
 } from "../../../application/repository/deepEval.repository";
+import { getAllEntities } from "../../../application/repository/entity.repository";
 import { palette } from "../../themes/palette";
 
 /** Parse a single CSV row handling quoted fields (RFC 4180). */
@@ -215,6 +216,10 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
   const [alert, setAlert] = useState<{ show: boolean; variant: "success" | "error" | "info"; title: string; body: string } | null>(null);
   const presetRequestIdRef = useRef(0);
 
+  // Model inventory link
+  const [modelInventories, setModelInventories] = useState<Array<{ id: number; provider: string; model: string; version: string; status: string }>>([]);
+  const [selectedModelInventoryId, setSelectedModelInventoryId] = useState<number | null>(null);
+
   // Load presets on modal open
   useEffect(() => {
     if (!isOpen) return;
@@ -231,6 +236,18 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
         setPresetsError("Failed to load compliance frameworks. Please try again.");
       })
       .finally(() => setLoadingPresets(false));
+  }, [isOpen]);
+
+  // Load model inventories on modal open
+  useEffect(() => {
+    if (!isOpen) return;
+    getAllEntities({ routeUrl: "/modelInventory" })
+      .then((response) => {
+        if (response?.data) {
+          setModelInventories(response.data);
+        }
+      })
+      .catch(() => {});
   }, [isOpen]);
 
   // Handle preset selection (request ID prevents race conditions on rapid clicks)
@@ -345,6 +362,7 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
         metadata: {
           distribution_date: distributionDate,
         },
+        modelInventoryId: selectedModelInventoryId || undefined,
       };
       const result = await runBiasAudit(csvFile, config);
       const rowCount = csvPreview.length > 0 ? `${csvHeaders.length} columns` : "";
@@ -388,6 +406,7 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
     setIntersectionalEnabled(false);
     setSubmitError(null);
     setPresetsError(null);
+    setSelectedModelInventoryId(null);
     onClose();
   };
 
@@ -541,6 +560,26 @@ const NewBiasAuditModal: React.FC<NewBiasAuditModalProps> = ({
         rows={3}
         isOptional
       />
+
+      <Box mt="16px">
+        <Select
+          id="model-inventory-link"
+          label="Link to model inventory (optional)"
+          placeholder="None — don't link to inventory"
+          value={selectedModelInventoryId !== null ? String(selectedModelInventoryId) : ""}
+          onChange={(e: { target: { value: string } }) =>
+            setSelectedModelInventoryId(e.target.value === "" ? null : Number(e.target.value))
+          }
+          items={[
+            { _id: "", name: "None — don't link to inventory" },
+            ...modelInventories.map((m) => ({
+              _id: String(m.id),
+              name: `${m.provider} — ${m.model} (v${m.version})`,
+            })),
+          ]}
+          sx={{ width: "100%" }}
+        />
+      </Box>
     </Stack>
   );
 

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -58,6 +58,7 @@ import {
   type LLMApiKey,
   type LLMProvider,
 } from "../../../application/repository/deepEval.repository";
+import { getAllEntities } from "../../../application/repository/entity.repository";
 import { PROVIDERS, type ModelInfo } from "../../utils/providers";
 import { evalModelsService, type SavedModel } from "../../../infrastructure/api/evalModelsService";
 import { useModelPreferences } from "../../../application/hooks/useModelPreferences";
@@ -138,6 +139,10 @@ export default function NewExperimentModal({
   // Model preferences hook for auto-loading saved settings
   const { preferences: savedPreferences, loading: preferencesLoading, savePreferences } = useModelPreferences(projectId, orgId);
   const [preferencesApplied, setPreferencesApplied] = useState(false);
+
+  // Model inventory link (optional)
+  const [modelInventories, setModelInventories] = useState<Array<{ id: number; provider: string; model: string; version: string; status: string }>>([]);
+  const [selectedModelInventoryId, setSelectedModelInventoryId] = useState<number | null>(null);
 
   // Configuration state - taskType initialized from project's useCase prop
   const [config, setConfig] = useState({
@@ -240,6 +245,21 @@ export default function NewExperimentModal({
   useEffect(() => {
     setApiKeyWarningAcknowledged(false);
   }, [config.model.name, config.model.accessMethod]);
+
+  // Fetch model inventories when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      getAllEntities({ routeUrl: "/modelInventory" })
+        .then((response) => {
+          if (response?.data) {
+            setModelInventories(response.data);
+          }
+        })
+        .catch(() => {
+          // Non-critical — dropdown just stays empty
+        });
+    }
+  }, [isOpen]);
 
   // Track if selected dataset is multi-turn
   const isMultiTurnDataset = selectedUserDataset?.turnType === "multi-turn" ||
@@ -598,6 +618,7 @@ export default function NewExperimentModal({
         project_id: projectId,
         name: `${experimentModelName} - ${dateTimeStr}`,
         description: `Evaluating ${experimentModelName} with ${datasetPrompts.length} prompts`,
+        model_inventory_id: selectedModelInventoryId || undefined,
         config: {
           project_id: projectId,  // Include in config for runner
           model: {
@@ -767,6 +788,7 @@ export default function NewExperimentModal({
     // Reset custom model name toggles
     setUseCustomModelName(false);
     setUseCustomJudgeModelName(false);
+    setSelectedModelInventoryId(null);
     setConfig({
       taskType: useCase,
       model: {
@@ -1346,6 +1368,33 @@ export default function NewExperimentModal({
                 </Stack>
               </Box>
             )}
+
+            {/* Link to model inventory (optional) */}
+            <Box sx={{ mt: "16px" }}>
+              <Typography variant="body2" sx={{ mb: "4px", fontWeight: 500, fontSize: "13px", color: palette.text.secondary }}>
+                Link to model inventory (optional)
+              </Typography>
+              <FormControl fullWidth size="small">
+                <Select
+                  value={selectedModelInventoryId ?? ""}
+                  onChange={(e) => setSelectedModelInventoryId(e.target.value === "" ? null : Number(e.target.value))}
+                  displayEmpty
+                  sx={{ height: "34px", fontSize: "13px", borderRadius: "4px" }}
+                >
+                  <MenuItem value="">
+                    <Typography sx={{ fontSize: "13px", color: palette.text.secondary }}>None — don't link to inventory</Typography>
+                  </MenuItem>
+                  {modelInventories.map((m) => (
+                    <MenuItem key={m.id} value={m.id}>
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Typography sx={{ fontSize: "13px" }}>{m.provider} — {m.model}</Typography>
+                        <Typography sx={{ fontSize: "11px", color: palette.text.secondary }}>v{m.version}</Typography>
+                      </Stack>
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
           </Stack>
         );
 

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -1376,8 +1376,11 @@ export default function NewExperimentModal({
               </Typography>
               <FormControl fullWidth size="small">
                 <Select
-                  value={selectedModelInventoryId ?? ""}
-                  onChange={(e) => setSelectedModelInventoryId(e.target.value === "" ? null : Number(e.target.value))}
+                  value={selectedModelInventoryId !== null ? selectedModelInventoryId : ""}
+                  onChange={(e) => {
+                    const val = String(e.target.value);
+                    setSelectedModelInventoryId(val === "" ? null : Number(val));
+                  }}
                   displayEmpty
                   sx={{ height: "34px", fontSize: "13px", borderRadius: "4px" }}
                 >

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx
@@ -481,7 +481,7 @@ export default function ProjectExperiments({ projectId, orgId, onViewExperiment,
   }, [experiments, filterData, searchTerm]);
 
   // Transform to table format
-  const tableColumns = ["EXPERIMENT NAME", "MODEL", "JUDGE/SCORER", "# PROMPTS", "DATASET", "DATE", "ACTION"];
+  const tableColumns = ["EXPERIMENT NAME", "MODEL", "JUDGE/SCORER", "# PROMPTS", "DATASET", "LINKED MODEL", "DATE", "ACTION"];
 
   const tableRows: IEvaluationRow[] = filteredExperiments.map((exp) => {
     // Get dataset name from config - try multiple sources
@@ -545,6 +545,7 @@ export default function ProjectExperiments({ projectId, orgId, onViewExperiment,
       judge: judgeDisplay,
       dataset: datasetName,
       prompts: exp.sampleCount || 0,
+      linkedModel: exp.model_inventory_id ?? null,
       date: createdDate,
       status:
         exp.status === "completed" ? "Completed" :

--- a/Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx
@@ -1,0 +1,231 @@
+import { useState, useEffect, useMemo } from "react";
+import { Box, Stack, Typography, Alert as MuiAlert } from "@mui/material";
+import { FlaskConical, AlertTriangle } from "lucide-react";
+import Chip from "../../components/Chip";
+import { palette } from "../../themes/palette";
+import {
+  getAllModelEvaluations,
+  type ModelEvaluation,
+  type ModelEvaluationsResponse,
+} from "../../../application/repository/modelEvaluations.repository";
+
+const statusColorMap: Record<string, string> = {
+  completed: "#4caf50",
+  running: "#ff9800",
+  pending: "#9e9e9e",
+  failed: "#f44336",
+};
+
+function hasFailedMetrics(eval_: ModelEvaluation): boolean {
+  if (eval_.eval_type === "experiment") {
+    const results = eval_.results;
+    if (!results?.metric_results) return false;
+    const thresholds =
+      eval_.config?.thresholds || eval_.config?.metric_thresholds || {};
+    for (const [metric, data] of Object.entries(results.metric_results)) {
+      const score = (data as any)?.average ?? (data as any)?.score;
+      const threshold = thresholds[metric];
+      if (score !== undefined && threshold !== undefined && score < threshold) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (eval_.eval_type === "bias_audit") {
+    const results = eval_.results;
+    if (!results?.categories) return false;
+    for (const cat of Object.values(results.categories) as any[]) {
+      if (cat?.groups) {
+        for (const group of cat.groups) {
+          if (group.flagged) return true;
+        }
+      }
+    }
+    return false;
+  }
+  return false;
+}
+
+function getKeyResult(eval_: ModelEvaluation): string {
+  if (eval_.eval_type === "experiment") {
+    const results = eval_.results?.metric_results;
+    if (!results) return "—";
+    const entries = Object.entries(results);
+    if (entries.length === 0) return "—";
+    const [metric, data] = entries[0];
+    const score = (data as any)?.average ?? (data as any)?.score;
+    return score !== undefined
+      ? `${metric}: ${(score as number).toFixed(2)}`
+      : "—";
+  }
+  if (eval_.eval_type === "bias_audit") {
+    const results = eval_.results;
+    if (!results?.categories) return "—";
+    const cats = Object.values(results.categories) as any[];
+    const totalGroups = cats.reduce(
+      (sum, c) => sum + (c?.groups?.length || 0),
+      0
+    );
+    const flagged = cats.reduce(
+      (sum, c) =>
+        sum + (c?.groups?.filter((g: any) => g.flagged)?.length || 0),
+      0
+    );
+    return flagged > 0
+      ? `${flagged}/${totalGroups} flagged`
+      : `${totalGroups} groups passed`;
+  }
+  return "—";
+}
+
+export default function ModelEvaluationsTab() {
+  const [data, setData] = useState<ModelEvaluationsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getAllModelEvaluations()
+      .then(setData)
+      .catch(() => setData({ experiments: [], biasAudits: [] }))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const allEvals = useMemo(() => {
+    if (!data) return [];
+    return [...data.experiments, ...data.biasAudits].sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+  }, [data]);
+
+  const flaggedCount = useMemo(
+    () => allEvals.filter(hasFailedMetrics).length,
+    [allEvals]
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ p: "24px", textAlign: "center" }}>
+        <Typography sx={{ fontSize: "13px", color: palette.text.secondary }}>
+          Loading evaluations...
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: "16px" }}>
+      {flaggedCount > 0 && (
+        <MuiAlert
+          severity="warning"
+          icon={<AlertTriangle size={16} strokeWidth={1.5} />}
+          sx={{ mb: "16px", fontSize: "13px", borderRadius: "4px" }}
+        >
+          {flaggedCount} evaluation{flaggedCount !== 1 ? "s" : ""} flagged a
+          potential risk. Consider adding{" "}
+          {flaggedCount !== 1 ? "these" : "this"} to the risk register.
+        </MuiAlert>
+      )}
+
+      {allEvals.length === 0 ? (
+        <Box sx={{ textAlign: "center", py: "48px" }}>
+          <FlaskConical
+            size={32}
+            color={palette.text.secondary}
+            strokeWidth={1.5}
+          />
+          <Typography
+            sx={{ mt: "8px", fontSize: "13px", color: palette.text.secondary }}
+          >
+            No evaluations linked to any model yet
+          </Typography>
+          <Typography
+            sx={{ mt: "4px", fontSize: "12px", color: palette.text.secondary }}
+          >
+            Link evaluations to models when creating experiments or bias audits
+            in LLM Evals
+          </Typography>
+        </Box>
+      ) : (
+        <Box
+          component="table"
+          sx={{
+            width: "100%",
+            borderCollapse: "collapse",
+            "& th": {
+              textAlign: "left",
+              fontSize: "11px",
+              fontWeight: 600,
+              color: palette.text.secondary,
+              textTransform: "uppercase",
+              p: "8px 12px",
+              borderBottom: `1px solid ${palette.border.light}`,
+            },
+            "& td": {
+              fontSize: "13px",
+              p: "10px 12px",
+              borderBottom: `1px solid ${palette.border.light}`,
+            },
+          }}
+        >
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Model</th>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Key result</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {allEvals.map((e) => (
+              <tr key={e.id}>
+                <td>{e.name || e.id}</td>
+                <td>
+                  {e.model_provider && e.model_name
+                    ? `${e.model_provider} — ${e.model_name}`
+                    : "—"}
+                </td>
+                <td>
+                  {e.eval_type === "experiment" ? "Experiment" : "Bias audit"}
+                </td>
+                <td>
+                  <Chip
+                    label={e.status}
+                    backgroundColor={`${statusColorMap[e.status] || "#9e9e9e"}20`}
+                    textColor={statusColorMap[e.status] || "#9e9e9e"}
+                    size="small"
+                  />
+                </td>
+                <td>
+                  <Stack direction="row" alignItems="center" spacing={0.5}>
+                    <Typography sx={{ fontSize: "13px" }}>
+                      {getKeyResult(e)}
+                    </Typography>
+                    {hasFailedMetrics(e) && (
+                      <AlertTriangle
+                        size={14}
+                        color="#f44336"
+                        strokeWidth={1.5}
+                      />
+                    )}
+                  </Stack>
+                </td>
+                <td>
+                  {e.created_at
+                    ? new Date(e.created_at).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })
+                    : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -71,6 +71,7 @@ import { EvidenceHubModel } from "../../../domain/models/Common/evidenceHub/evid
 import NewEvidenceHub from "../../components/Modals/EvidenceHub";
 import { createEvidenceHub } from "../../../application/repository/evidenceHub.repository";
 import EvidenceHubTable from "./evidenceHubTable";
+import ModelEvaluationsTab from "./ModelEvaluationsTab";
 import ShareButton from "../../components/ShareViewDropdown/ShareButton";
 import ShareViewDropdown, {
   ShareViewSettings,
@@ -700,6 +701,7 @@ const ModelInventory: React.FC = () => {
   const getTabFromPath = useCallback((pathname: string, tabs: typeof pluginTabs) => {
     if (pathname.includes("model-risks")) return "model-risks";
     if (pathname.includes("evidence-hub")) return "evidence-hub";
+    if (pathname.includes("evaluations")) return "evaluations";
     // Check for plugin tabs dynamically
     for (const tab of tabs) {
       if (pathname.includes(tab.value)) return tab.value;
@@ -717,7 +719,7 @@ const ModelInventory: React.FC = () => {
 
     // If trying to access a plugin tab but plugin is not installed, redirect to models
     const isPluginTab = pluginTabs.some((t) => t.value === newTab);
-    const isBuiltInTab = ["models", "model-risks", "evidence-hub"].includes(newTab);
+    const isBuiltInTab = ["models", "model-risks", "evidence-hub", "evaluations"].includes(newTab);
 
     if (!isBuiltInTab && !isPluginTab) {
       setActiveTab("models");
@@ -2133,6 +2135,13 @@ const ModelInventory: React.FC = () => {
                   isLoading: isModelRisksLoading,
                   tooltip: "Risks identified for models in your inventory",
                 },
+                {
+                  label: "Evaluations",
+                  value: "evaluations",
+                  icon: "Database" as const,
+                  tooltip:
+                    "LLM evaluations and bias audits linked to models in your inventory",
+                },
                 // Dynamically add plugin tabs
                 ...pluginTabs.map((tab) => ({
                   label: tab.label,
@@ -2453,6 +2462,12 @@ const ModelInventory: React.FC = () => {
               )}
             />
           </>
+        )}
+
+        {activeTab === "evaluations" && (
+          <Box sx={{ mt: "16px" }}>
+            <ModelEvaluationsTab />
+          </Box>
         )}
 
       {/* Analytics Drawer */}

--- a/Clients/src/presentation/types/interfaces/i.table.ts
+++ b/Clients/src/presentation/types/interfaces/i.table.ts
@@ -64,6 +64,7 @@ export interface IEvaluationRow {
   judge?: string;
   dataset: string;
   prompts?: number;
+  linkedModel?: number | null;
   date?: string;
   status:
   | "In Progress"

--- a/EvalServer/src/controllers/bias_audits.py
+++ b/EvalServer/src/controllers/bias_audits.py
@@ -123,6 +123,7 @@ async def create_bias_audit_controller(
                 mode=mode,
                 config=config_data,
                 created_by=user_id,
+                model_inventory_id=config_data.get("modelInventoryId"),
             )
             await db.commit()
     except Exception as e:

--- a/EvalServer/src/controllers/evaluation_logs.py
+++ b/EvalServer/src/controllers/evaluation_logs.py
@@ -159,6 +159,7 @@ async def create_experiment_controller(
                 description=data.get("description"),
                 baseline_experiment_id=data.get("baseline_experiment_id"),
                 created_by=user_id,
+                model_inventory_id=data.get("model_inventory_id"),
             )
             print(f"✅ Controller - Experiment created successfully")
             return {"experiment": experiment}

--- a/EvalServer/src/crud/bias_audits.py
+++ b/EvalServer/src/crud/bias_audits.py
@@ -27,17 +27,18 @@ async def create_bias_audit(
     mode: str,
     config: Dict[str, Any],
     created_by: Optional[str] = None,
+    model_inventory_id: Optional[int] = None,
 ) -> Optional[Dict[str, Any]]:
     """Create a new bias audit record."""
     result = await db.execute(
         text(
             '''
             INSERT INTO llm_evals_bias_audits
-            (id, organization_id, project_id, preset_id, preset_name, mode, status, config, created_by)
+            (id, organization_id, project_id, preset_id, preset_name, mode, status, config, created_by, model_inventory_id)
             VALUES
-            (:id, :organization_id, :project_id, :preset_id, :preset_name, :mode, 'pending', :config, :created_by)
+            (:id, :organization_id, :project_id, :preset_id, :preset_name, :mode, 'pending', :config, :created_by, :model_inventory_id)
             RETURNING id, organization_id, project_id, preset_id, preset_name, mode, status,
-                      config, results, error, created_at, updated_at, completed_at, created_by
+                      config, results, error, created_at, updated_at, completed_at, created_by, model_inventory_id
             '''
         ),
         {
@@ -49,6 +50,7 @@ async def create_bias_audit(
             "mode": mode,
             "config": json.dumps(config),
             "created_by": created_by,
+            "model_inventory_id": model_inventory_id,
         },
     )
     row = result.mappings().first()
@@ -67,7 +69,7 @@ async def get_bias_audit(
         text(
             '''
             SELECT id, organization_id, project_id, preset_id, preset_name, mode, status,
-                   config, results, error, created_at, updated_at, completed_at, created_by
+                   config, results, error, created_at, updated_at, completed_at, created_by, model_inventory_id
             FROM llm_evals_bias_audits
             WHERE organization_id = :organization_id AND id = :id
             '''
@@ -113,7 +115,7 @@ async def update_bias_audit_status(
             SET {", ".join(updates)}
             WHERE organization_id = :organization_id AND id = :id
             RETURNING id, organization_id, project_id, preset_id, preset_name, mode, status,
-                      config, results, error, created_at, updated_at, completed_at, created_by
+                      config, results, error, created_at, updated_at, completed_at, created_by, model_inventory_id
             '''
         ),
         params,
@@ -144,7 +146,7 @@ async def update_bias_audit_system_name(
             updated_at = CURRENT_TIMESTAMP
             WHERE organization_id = :organization_id AND id = :id
             RETURNING id, organization_id, project_id, preset_id, preset_name, mode, status,
-                      config, results, error, created_at, updated_at, completed_at, created_by
+                      config, results, error, created_at, updated_at, completed_at, created_by, model_inventory_id
             '''
         ),
         {
@@ -178,7 +180,7 @@ async def list_bias_audits(
         text(
             f'''
             SELECT id, organization_id, project_id, preset_id, preset_name, mode, status,
-                   config, results, error, created_at, updated_at, completed_at, created_by
+                   config, results, error, created_at, updated_at, completed_at, created_by, model_inventory_id
             FROM llm_evals_bias_audits
             {where_sql}
             ORDER BY created_at DESC
@@ -314,4 +316,5 @@ def _row_to_dict(row) -> Dict[str, Any]:
         "updatedAt": row["updated_at"].isoformat() if row["updated_at"] else None,
         "completedAt": row["completed_at"].isoformat() if row["completed_at"] else None,
         "createdBy": row["created_by"],
+        "modelInventoryId": row["model_inventory_id"],
     }

--- a/EvalServer/src/crud/evaluation_logs.py
+++ b/EvalServer/src/crud/evaluation_logs.py
@@ -309,6 +309,7 @@ async def create_experiment(
     description: Optional[str] = None,
     baseline_experiment_id: Optional[str] = None,
     created_by: Optional[int] = None,
+    model_inventory_id: Optional[int] = None,
 ) -> Optional[Dict[str, Any]]:
     """Create a new experiment"""
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
@@ -325,9 +326,9 @@ async def create_experiment(
         result = await db.execute(
             text('''
                 INSERT INTO llm_evals_experiments
-                (id, organization_id, project_id, name, description, config, baseline_experiment_id, status, created_by)
-                VALUES (:id, :organization_id, :project_id, :name, :description, CAST(:config_json AS jsonb), :baseline_experiment_id, :status, :created_by)
-                RETURNING id, name, status, created_at
+                (id, organization_id, project_id, name, description, config, baseline_experiment_id, status, created_by, model_inventory_id)
+                VALUES (:id, :organization_id, :project_id, :name, :description, CAST(:config_json AS jsonb), :baseline_experiment_id, :status, :created_by, :model_inventory_id)
+                RETURNING id, name, status, created_at, model_inventory_id
             '''),
             {
                 "id": experiment_id,
@@ -339,6 +340,7 @@ async def create_experiment(
                 "baseline_experiment_id": baseline_experiment_id,
                 "status": "pending",
                 "created_by": str(created_by) if created_by is not None else None,
+                "model_inventory_id": model_inventory_id,
             }
         )
 
@@ -352,6 +354,7 @@ async def create_experiment(
                 "name": row["name"],
                 "status": row["status"],
                 "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+                "model_inventory_id": row["model_inventory_id"],
             }
         return None
     except Exception as e:
@@ -372,7 +375,7 @@ async def get_experiment_by_id(
         text('''
             SELECT id, project_id, name, description, config, baseline_experiment_id,
                    status, results, error_message, started_at, completed_at,
-                   created_at, updated_at, created_by
+                   created_at, updated_at, created_by, model_inventory_id
             FROM llm_evals_experiments
             WHERE organization_id = :organization_id AND id = :experiment_id
         '''),
@@ -397,6 +400,7 @@ async def get_experiment_by_id(
             "created_at": row["created_at"].isoformat() if row["created_at"] else None,
             "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
             "created_by": row["created_by"],
+            "model_inventory_id": row["model_inventory_id"],
         }
     return None
 
@@ -426,7 +430,7 @@ async def get_experiments(
     result = await db.execute(
         text(f'''
             SELECT id, project_id, name, description, config, status,
-                   results, created_at, updated_at, started_at, completed_at
+                   results, created_at, updated_at, started_at, completed_at, model_inventory_id
             FROM llm_evals_experiments
             {where_clause}
             ORDER BY created_at DESC
@@ -449,6 +453,7 @@ async def get_experiments(
             "updated_at": row["updated_at"].isoformat() if row["updated_at"] else None,
             "started_at": row["started_at"].isoformat() if row["started_at"] else None,
             "completed_at": row["completed_at"].isoformat() if row["completed_at"] else None,
+            "model_inventory_id": row["model_inventory_id"],
         })
 
     return experiments

--- a/EvalServer/src/database/migrations/versions/f20260412000000_add_model_inventory_id.py
+++ b/EvalServer/src/database/migrations/versions/f20260412000000_add_model_inventory_id.py
@@ -1,0 +1,58 @@
+"""add-model-inventory-id
+
+Revision ID: f20260412000000
+Revises: e20260319200000
+Create Date: 2026-04-12
+
+Adds nullable model_inventory_id column to llm_evals_experiments and
+llm_evals_bias_audits for optional linking to the model inventory.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'f20260412000000'
+down_revision: Union[str, None] = 'e20260319200000'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add model_inventory_id to experiments and bias audits."""
+    op.execute(sa.text('''
+        ALTER TABLE verifywise.llm_evals_experiments
+        ADD COLUMN IF NOT EXISTS model_inventory_id INTEGER NULL;
+    '''))
+    op.execute(sa.text('''
+        CREATE INDEX IF NOT EXISTS idx_llm_evals_experiments_model_inventory_id
+        ON verifywise.llm_evals_experiments(model_inventory_id);
+    '''))
+
+    op.execute(sa.text('''
+        ALTER TABLE verifywise.llm_evals_bias_audits
+        ADD COLUMN IF NOT EXISTS model_inventory_id INTEGER NULL;
+    '''))
+    op.execute(sa.text('''
+        CREATE INDEX IF NOT EXISTS idx_llm_evals_bias_audits_model_inventory_id
+        ON verifywise.llm_evals_bias_audits(model_inventory_id);
+    '''))
+
+
+def downgrade() -> None:
+    """Remove model_inventory_id columns."""
+    op.execute(sa.text('''
+        DROP INDEX IF EXISTS verifywise.idx_llm_evals_bias_audits_model_inventory_id;
+    '''))
+    op.execute(sa.text('''
+        ALTER TABLE verifywise.llm_evals_bias_audits
+        DROP COLUMN IF EXISTS model_inventory_id;
+    '''))
+    op.execute(sa.text('''
+        DROP INDEX IF EXISTS verifywise.idx_llm_evals_experiments_model_inventory_id;
+    '''))
+    op.execute(sa.text('''
+        ALTER TABLE verifywise.llm_evals_experiments
+        DROP COLUMN IF EXISTS model_inventory_id;
+    '''))

--- a/EvalServer/src/routers/evaluation_logs.py
+++ b/EvalServer/src/routers/evaluation_logs.py
@@ -140,6 +140,7 @@ class CreateExperimentRequest(BaseModel):
     description: Optional[str] = None
     config: Dict[str, Any]  # Contains model, dataset, metrics config
     baseline_experiment_id: Optional[str] = None
+    model_inventory_id: Optional[int] = None
 
 
 class UpdateExperimentStatusRequest(BaseModel):

--- a/Servers/controllers/modelEvaluations.ctrl.ts
+++ b/Servers/controllers/modelEvaluations.ctrl.ts
@@ -1,8 +1,51 @@
 import { Request, Response } from "express";
-import { getEvaluationsByModelInventoryId } from "../utils/modelEvaluations.utils";
+import {
+  getEvaluationsByModelInventoryId,
+  getAllLinkedEvaluations,
+} from "../utils/modelEvaluations.utils";
 import { logProcessing, logSuccess, logFailure } from "../utils/logger/logHelper";
 
 const FILE_NAME = "modelEvaluations.ctrl.ts";
+
+export async function getAllModelEvaluations(req: Request, res: Response): Promise<Response> {
+  const userId = req.userId!;
+  const organizationId = req.organizationId!;
+
+  logProcessing({
+    description: "starting getAllModelEvaluations",
+    functionName: "getAllModelEvaluations",
+    fileName: FILE_NAME,
+    userId,
+    organizationId,
+  });
+
+  try {
+    const data = await getAllLinkedEvaluations(organizationId);
+
+    await logSuccess({
+      description: "getAllModelEvaluations succeeded",
+      functionName: "getAllModelEvaluations",
+      fileName: FILE_NAME,
+      eventType: "Read",
+      userId,
+      organizationId,
+    });
+
+    return res.status(200).json(data);
+  } catch (error) {
+    await logFailure({
+      description: "getAllModelEvaluations failed",
+      functionName: "getAllModelEvaluations",
+      fileName: FILE_NAME,
+      eventType: "Error",
+      userId,
+      organizationId,
+      error: error as Error,
+    });
+
+    return res.status(500).json({ error: "Failed to fetch evaluations" });
+  }
+}
 
 export async function getModelEvaluations(req: Request, res: Response): Promise<Response> {
   const userId = req.userId!;

--- a/Servers/controllers/modelEvaluations.ctrl.ts
+++ b/Servers/controllers/modelEvaluations.ctrl.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from "express";
+import { getEvaluationsByModelInventoryId } from "../utils/modelEvaluations.utils";
+import { logProcessing, logSuccess, logFailure } from "../utils/logger/logHelper";
+
+const FILE_NAME = "modelEvaluations.ctrl.ts";
+
+export async function getModelEvaluations(req: Request, res: Response): Promise<Response> {
+  const userId = req.userId!;
+  const organizationId = req.organizationId!;
+
+  logProcessing({
+    description: "starting getModelEvaluations",
+    functionName: "getModelEvaluations",
+    fileName: FILE_NAME,
+    userId,
+    organizationId,
+  });
+
+  try {
+    const modelInventoryId = parseInt(req.params.id as string, 10);
+
+    if (isNaN(modelInventoryId)) {
+      return res.status(400).json({ error: "Invalid model inventory ID" });
+    }
+
+    const data = await getEvaluationsByModelInventoryId(modelInventoryId, organizationId);
+
+    await logSuccess({
+      description: "getModelEvaluations succeeded",
+      functionName: "getModelEvaluations",
+      fileName: FILE_NAME,
+      eventType: "Read",
+      userId,
+      organizationId,
+    });
+
+    return res.status(200).json(data);
+  } catch (error) {
+    await logFailure({
+      description: "getModelEvaluations failed",
+      functionName: "getModelEvaluations",
+      fileName: FILE_NAME,
+      eventType: "Error",
+      userId,
+      organizationId,
+      error: error as Error,
+    });
+
+    return res.status(500).json({ error: "Failed to fetch evaluations" });
+  }
+}

--- a/Servers/routes/modelInventory.route.ts
+++ b/Servers/routes/modelInventory.route.ts
@@ -10,9 +10,11 @@ import {
   getModelInventoryById,
   updateModelInventoryById,
 } from "../controllers/modelInventory.ctrl";
+import { getModelEvaluations } from "../controllers/modelEvaluations.ctrl";
 
 // GET
 router.get("/", authenticateJWT, getAllModelInventories);
+router.get("/:id/evaluations", authenticateJWT, getModelEvaluations);
 router.get("/:id", authenticateJWT, getModelInventoryById);
 router.get("/by-projectId/:projectId", authenticateJWT, getModelByProjectId);
 router.get("/by-frameworkId/:frameworkId", authenticateJWT, getModelByFrameworkId);

--- a/Servers/routes/modelInventory.route.ts
+++ b/Servers/routes/modelInventory.route.ts
@@ -10,10 +10,11 @@ import {
   getModelInventoryById,
   updateModelInventoryById,
 } from "../controllers/modelInventory.ctrl";
-import { getModelEvaluations } from "../controllers/modelEvaluations.ctrl";
+import { getModelEvaluations, getAllModelEvaluations } from "../controllers/modelEvaluations.ctrl";
 
 // GET
 router.get("/", authenticateJWT, getAllModelInventories);
+router.get("/evaluations", authenticateJWT, getAllModelEvaluations);
 router.get("/:id/evaluations", authenticateJWT, getModelEvaluations);
 router.get("/:id", authenticateJWT, getModelInventoryById);
 router.get("/by-projectId/:projectId", authenticateJWT, getModelByProjectId);

--- a/Servers/utils/modelEvaluations.utils.ts
+++ b/Servers/utils/modelEvaluations.utils.ts
@@ -2,6 +2,48 @@ import { sequelize } from "../database/db";
 import { QueryTypes } from "sequelize";
 
 /**
+ * Fetch all experiments and bias audits linked to ANY model inventory record
+ * for a given organization. Used by the Evaluations tab on the Model Inventory page.
+ */
+export async function getAllLinkedEvaluations(organizationId: number) {
+  const experiments = await sequelize.query(
+    `SELECT e.id, e.name, e.status, e.config, e.results, e.error_message,
+            e.started_at, e.completed_at, e.created_at, e.created_by,
+            e.model_inventory_id,
+            m.provider AS model_provider, m.model AS model_name, m.version AS model_version,
+            'experiment' AS eval_type
+     FROM llm_evals_experiments e
+     LEFT JOIN model_inventories m ON m.id = e.model_inventory_id
+     WHERE e.model_inventory_id IS NOT NULL
+       AND e.organization_id = :organizationId
+     ORDER BY e.created_at DESC`,
+    {
+      replacements: { organizationId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  const biasAudits = await sequelize.query(
+    `SELECT b.id, b.preset_name AS name, b.status, b.config, b.results, b.error,
+            b.completed_at, b.created_at, b.created_by,
+            b.model_inventory_id,
+            m.provider AS model_provider, m.model AS model_name, m.version AS model_version,
+            'bias_audit' AS eval_type
+     FROM llm_evals_bias_audits b
+     LEFT JOIN model_inventories m ON m.id = b.model_inventory_id
+     WHERE b.model_inventory_id IS NOT NULL
+       AND b.organization_id = :organizationId
+     ORDER BY b.created_at DESC`,
+    {
+      replacements: { organizationId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  return { experiments, biasAudits };
+}
+
+/**
  * Fetch all experiments and bias audits linked to a model inventory record.
  * Reads from llm_evals_* tables (same Postgres, verifywise schema).
  */

--- a/Servers/utils/modelEvaluations.utils.ts
+++ b/Servers/utils/modelEvaluations.utils.ts
@@ -1,0 +1,41 @@
+import { sequelize } from "../database/db";
+import { QueryTypes } from "sequelize";
+
+/**
+ * Fetch all experiments and bias audits linked to a model inventory record.
+ * Reads from llm_evals_* tables (same Postgres, verifywise schema).
+ */
+export async function getEvaluationsByModelInventoryId(
+  modelInventoryId: number,
+  organizationId: number
+) {
+  const experiments = await sequelize.query(
+    `SELECT id, name, status, config, results, error_message,
+            started_at, completed_at, created_at, created_by,
+            'experiment' AS eval_type
+     FROM llm_evals_experiments
+     WHERE model_inventory_id = :modelInventoryId
+       AND organization_id = :organizationId
+     ORDER BY created_at DESC`,
+    {
+      replacements: { modelInventoryId, organizationId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  const biasAudits = await sequelize.query(
+    `SELECT id, preset_name AS name, status, config, results, error,
+            completed_at, created_at, created_by,
+            'bias_audit' AS eval_type
+     FROM llm_evals_bias_audits
+     WHERE model_inventory_id = :modelInventoryId
+       AND organization_id = :organizationId
+     ORDER BY created_at DESC`,
+    {
+      replacements: { modelInventoryId, organizationId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  return { experiments, biasAudits };
+}

--- a/Servers/utils/modelEvaluations.utils.ts
+++ b/Servers/utils/modelEvaluations.utils.ts
@@ -1,83 +1,77 @@
 import { sequelize } from "../database/db";
 import { QueryTypes } from "sequelize";
 
-/**
- * Fetch all experiments and bias audits linked to ANY model inventory record
- * for a given organization. Used by the Evaluations tab on the Model Inventory page.
- */
 export async function getAllLinkedEvaluations(organizationId: number) {
-  const experiments = await sequelize.query(
-    `SELECT e.id, e.name, e.status, e.config, e.results, e.error_message,
-            e.started_at, e.completed_at, e.created_at, e.created_by,
-            e.model_inventory_id,
-            m.provider AS model_provider, m.model AS model_name, m.version AS model_version,
-            'experiment' AS eval_type
-     FROM llm_evals_experiments e
-     LEFT JOIN model_inventories m ON m.id = e.model_inventory_id
-     WHERE e.model_inventory_id IS NOT NULL
-       AND e.organization_id = :organizationId
-     ORDER BY e.created_at DESC`,
-    {
-      replacements: { organizationId },
-      type: QueryTypes.SELECT,
-    }
-  );
-
-  const biasAudits = await sequelize.query(
-    `SELECT b.id, b.preset_name AS name, b.status, b.config, b.results, b.error,
-            b.completed_at, b.created_at, b.created_by,
-            b.model_inventory_id,
-            m.provider AS model_provider, m.model AS model_name, m.version AS model_version,
-            'bias_audit' AS eval_type
-     FROM llm_evals_bias_audits b
-     LEFT JOIN model_inventories m ON m.id = b.model_inventory_id
-     WHERE b.model_inventory_id IS NOT NULL
-       AND b.organization_id = :organizationId
-     ORDER BY b.created_at DESC`,
-    {
-      replacements: { organizationId },
-      type: QueryTypes.SELECT,
-    }
-  );
+  const [experiments, biasAudits] = await Promise.all([
+    sequelize.query(
+      `SELECT e.id, e.name, e.status, e.config, e.results, e.error_message,
+              e.started_at, e.completed_at, e.created_at, e.created_by,
+              e.model_inventory_id,
+              m.provider AS model_provider, m.model AS model_name, m.version AS model_version,
+              'experiment' AS eval_type
+       FROM llm_evals_experiments e
+       LEFT JOIN model_inventories m ON m.id = e.model_inventory_id
+       WHERE e.model_inventory_id IS NOT NULL
+         AND e.organization_id = :organizationId
+       ORDER BY e.created_at DESC`,
+      {
+        replacements: { organizationId },
+        type: QueryTypes.SELECT,
+      }
+    ),
+    sequelize.query(
+      `SELECT b.id, b.preset_name AS name, b.status, b.config, b.results, b.error,
+              b.completed_at, b.created_at, b.created_by,
+              b.model_inventory_id,
+              m.provider AS model_provider, m.model AS model_name, m.version AS model_version,
+              'bias_audit' AS eval_type
+       FROM llm_evals_bias_audits b
+       LEFT JOIN model_inventories m ON m.id = b.model_inventory_id
+       WHERE b.model_inventory_id IS NOT NULL
+         AND b.organization_id = :organizationId
+       ORDER BY b.created_at DESC`,
+      {
+        replacements: { organizationId },
+        type: QueryTypes.SELECT,
+      }
+    ),
+  ]);
 
   return { experiments, biasAudits };
 }
 
-/**
- * Fetch all experiments and bias audits linked to a model inventory record.
- * Reads from llm_evals_* tables (same Postgres, verifywise schema).
- */
 export async function getEvaluationsByModelInventoryId(
   modelInventoryId: number,
   organizationId: number
 ) {
-  const experiments = await sequelize.query(
-    `SELECT id, name, status, config, results, error_message,
-            started_at, completed_at, created_at, created_by,
-            'experiment' AS eval_type
-     FROM llm_evals_experiments
-     WHERE model_inventory_id = :modelInventoryId
-       AND organization_id = :organizationId
-     ORDER BY created_at DESC`,
-    {
-      replacements: { modelInventoryId, organizationId },
-      type: QueryTypes.SELECT,
-    }
-  );
-
-  const biasAudits = await sequelize.query(
-    `SELECT id, preset_name AS name, status, config, results, error,
-            completed_at, created_at, created_by,
-            'bias_audit' AS eval_type
-     FROM llm_evals_bias_audits
-     WHERE model_inventory_id = :modelInventoryId
-       AND organization_id = :organizationId
-     ORDER BY created_at DESC`,
-    {
-      replacements: { modelInventoryId, organizationId },
-      type: QueryTypes.SELECT,
-    }
-  );
+  const [experiments, biasAudits] = await Promise.all([
+    sequelize.query(
+      `SELECT id, name, status, config, results, error_message,
+              started_at, completed_at, created_at, created_by,
+              'experiment' AS eval_type
+       FROM llm_evals_experiments
+       WHERE model_inventory_id = :modelInventoryId
+         AND organization_id = :organizationId
+       ORDER BY created_at DESC`,
+      {
+        replacements: { modelInventoryId, organizationId },
+        type: QueryTypes.SELECT,
+      }
+    ),
+    sequelize.query(
+      `SELECT id, preset_name AS name, status, config, results, error,
+              completed_at, created_at, created_by,
+              'bias_audit' AS eval_type
+       FROM llm_evals_bias_audits
+       WHERE model_inventory_id = :modelInventoryId
+         AND organization_id = :organizationId
+       ORDER BY created_at DESC`,
+      {
+        replacements: { modelInventoryId, organizationId },
+        type: QueryTypes.SELECT,
+      }
+    ),
+  ]);
 
   return { experiments, biasAudits };
 }

--- a/docs/superpowers/plans/2026-04-12-eval-model-inventory-link.md
+++ b/docs/superpowers/plans/2026-04-12-eval-model-inventory-link.md
@@ -1,0 +1,1080 @@
+# Eval → Model Inventory Linking — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to optionally link LLM experiments and bias audits to a model in their inventory, then view linked evaluations on the model detail page with risk nudges for flagged results.
+
+**Architecture:** Add nullable `model_inventory_id` column to `llm_evals_experiments` and `llm_evals_bias_audits` via Alembic migration. Frontend adds an optional dropdown to creation modals, populated from the existing model inventory API. The model detail page gets a new "Evaluations" tab that reads from `llm_evals_*` tables via a new Servers endpoint. A risk nudge banner surfaces when linked evals have failed metrics.
+
+**Tech Stack:** Python/FastAPI (EvalServer), Node.js/Express (Servers), React/TypeScript/MUI (Clients), PostgreSQL, Alembic migrations
+
+---
+
+### Task 1: Alembic migration — add model_inventory_id columns
+
+**Files:**
+- Create: `EvalServer/src/database/migrations/versions/f20260412000000_add_model_inventory_id.py`
+
+- [ ] **Step 1: Create the migration file**
+
+```python
+"""add-model-inventory-id
+
+Revision ID: f20260412000000
+Revises: e20260319200000
+Create Date: 2026-04-12
+
+Adds nullable model_inventory_id column to llm_evals_experiments and
+llm_evals_bias_audits for optional linking to the model inventory.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'f20260412000000'
+down_revision: Union[str, None] = 'e20260319200000'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add model_inventory_id to experiments and bias audits."""
+    op.execute(sa.text('''
+        ALTER TABLE verifywise.llm_evals_experiments
+        ADD COLUMN IF NOT EXISTS model_inventory_id INTEGER NULL;
+    '''))
+    op.execute(sa.text('''
+        CREATE INDEX IF NOT EXISTS idx_llm_evals_experiments_model_inventory_id
+        ON verifywise.llm_evals_experiments(model_inventory_id);
+    '''))
+
+    op.execute(sa.text('''
+        ALTER TABLE verifywise.llm_evals_bias_audits
+        ADD COLUMN IF NOT EXISTS model_inventory_id INTEGER NULL;
+    '''))
+    op.execute(sa.text('''
+        CREATE INDEX IF NOT EXISTS idx_llm_evals_bias_audits_model_inventory_id
+        ON verifywise.llm_evals_bias_audits(model_inventory_id);
+    '''))
+
+
+def downgrade() -> None:
+    """Remove model_inventory_id columns."""
+    op.execute(sa.text('''
+        DROP INDEX IF EXISTS verifywise.idx_llm_evals_bias_audits_model_inventory_id;
+    '''))
+    op.execute(sa.text('''
+        ALTER TABLE verifywise.llm_evals_bias_audits
+        DROP COLUMN IF EXISTS model_inventory_id;
+    '''))
+    op.execute(sa.text('''
+        DROP INDEX IF EXISTS verifywise.idx_llm_evals_experiments_model_inventory_id;
+    '''))
+    op.execute(sa.text('''
+        ALTER TABLE verifywise.llm_evals_experiments
+        DROP COLUMN IF EXISTS model_inventory_id;
+    '''))
+```
+
+- [ ] **Step 2: Run the migration**
+
+Run: `cd EvalServer/src && alembic upgrade head`
+Expected: Migration applies successfully, both columns added.
+
+- [ ] **Step 3: Verify columns exist**
+
+Run: `cd EvalServer/src && python -c "import asyncio; from database.db import get_db; asyncio.run((lambda: None)())" && psql -d verifywise_db -c "SELECT column_name FROM information_schema.columns WHERE table_schema='verifywise' AND table_name='llm_evals_experiments' AND column_name='model_inventory_id';"`
+
+Expected: One row returned showing `model_inventory_id`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add EvalServer/src/database/migrations/versions/f20260412000000_add_model_inventory_id.py
+git commit -m "feat(eval): add model_inventory_id column to experiments and bias audits
+
+Alembic migration adds nullable INTEGER column and index to both
+llm_evals_experiments and llm_evals_bias_audits tables. No FK constraint
+(cross-schema reference) — validated at application level."
+```
+
+---
+
+### Task 2: EvalServer CRUD — accept and return model_inventory_id
+
+**Files:**
+- Modify: `EvalServer/src/crud/evaluation_logs.py:303-360` (create_experiment function)
+- Modify: `EvalServer/src/crud/bias_audits.py:19-57` (create_bias_audit function)
+- Modify: `EvalServer/src/crud/bias_audits.py:300-317` (_row_to_dict function)
+
+- [ ] **Step 1: Update experiment CRUD — create_experiment**
+
+In `EvalServer/src/crud/evaluation_logs.py`, update the `create_experiment` function (line 303) to accept `model_inventory_id`:
+
+Add parameter:
+```python
+async def create_experiment(
+    db: AsyncSession,
+    project_id: str,
+    name: str,
+    config: Dict,
+    organization_id: int,
+    description: Optional[str] = None,
+    baseline_experiment_id: Optional[str] = None,
+    created_by: Optional[int] = None,
+    model_inventory_id: Optional[int] = None,  # NEW
+) -> Optional[Dict[str, Any]]:
+```
+
+Update the INSERT SQL (line 327) to include the new column:
+```sql
+INSERT INTO llm_evals_experiments
+(id, organization_id, project_id, name, description, config, baseline_experiment_id, status, created_by, model_inventory_id)
+VALUES (:id, :organization_id, :project_id, :name, :description, CAST(:config_json AS jsonb), :baseline_experiment_id, :status, :created_by, :model_inventory_id)
+RETURNING id, name, status, created_at, model_inventory_id
+```
+
+Add to params dict:
+```python
+"model_inventory_id": model_inventory_id,
+```
+
+Update the return dict to include `model_inventory_id`:
+```python
+return {
+    "id": row["id"],
+    "name": row["name"],
+    "status": row["status"],
+    "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+    "model_inventory_id": row["model_inventory_id"],
+}
+```
+
+- [ ] **Step 2: Update experiment CRUD — get/list functions**
+
+Find all SELECT queries in `EvalServer/src/crud/evaluation_logs.py` that read from `llm_evals_experiments` and add `model_inventory_id` to the SELECT column list and to the returned dict. Key functions to update:
+- `get_experiment` 
+- `get_experiments` (list function)
+
+Search for these with: `grep -n "SELECT.*FROM llm_evals_experiments" EvalServer/src/crud/evaluation_logs.py`
+
+For each SELECT, add `model_inventory_id` to the column list. For each result mapping, add `"model_inventory_id": row["model_inventory_id"]` or `"modelInventoryId": row["model_inventory_id"]` (match the existing camelCase/snake_case convention used in that function).
+
+- [ ] **Step 3: Update bias audit CRUD — create_bias_audit**
+
+In `EvalServer/src/crud/bias_audits.py:19`, add `model_inventory_id` parameter:
+
+```python
+async def create_bias_audit(
+    organization_id: int,
+    db: AsyncSession,
+    *,
+    audit_id: str,
+    project_id: Optional[str],
+    preset_id: str,
+    preset_name: str,
+    mode: str,
+    config: Dict[str, Any],
+    created_by: Optional[str] = None,
+    model_inventory_id: Optional[int] = None,  # NEW
+) -> Optional[Dict[str, Any]]:
+```
+
+Update the INSERT SQL (line 35):
+```sql
+INSERT INTO llm_evals_bias_audits
+(id, organization_id, project_id, preset_id, preset_name, mode, status, config, created_by, model_inventory_id)
+VALUES
+(:id, :organization_id, :project_id, :preset_id, :preset_name, :mode, 'pending', :config, :created_by, :model_inventory_id)
+RETURNING id, organization_id, project_id, preset_id, preset_name, mode, status,
+          config, results, error, created_at, updated_at, completed_at, created_by, model_inventory_id
+```
+
+Add to params dict:
+```python
+"model_inventory_id": model_inventory_id,
+```
+
+- [ ] **Step 4: Update bias audit CRUD — _row_to_dict**
+
+In `EvalServer/src/crud/bias_audits.py:300`, add `model_inventory_id` to the `_row_to_dict` function:
+
+```python
+def _row_to_dict(row) -> Dict[str, Any]:
+    """Convert a database row to a camelCase dict for API responses."""
+    return {
+        "id": row["id"],
+        "orgId": str(row["organization_id"]) if row["organization_id"] else None,
+        "projectId": row["project_id"],
+        "presetId": row["preset_id"],
+        "presetName": row["preset_name"],
+        "mode": row["mode"],
+        "status": row["status"],
+        "config": _safe_json_load(row["config"], {}),
+        "results": _safe_json_load(row["results"]),
+        "error": row["error"],
+        "createdAt": row["created_at"].isoformat() if row["created_at"] else None,
+        "updatedAt": row["updated_at"].isoformat() if row["updated_at"] else None,
+        "completedAt": row["completed_at"].isoformat() if row["completed_at"] else None,
+        "createdBy": row["created_by"],
+        "modelInventoryId": row["model_inventory_id"],  # NEW
+    }
+```
+
+Also update ALL SELECT queries in `get_bias_audit`, `list_bias_audits`, and `update_bias_audit_status` to include `model_inventory_id` in their column lists and RETURNING clauses.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add EvalServer/src/crud/evaluation_logs.py EvalServer/src/crud/bias_audits.py
+git commit -m "feat(eval): accept model_inventory_id in experiment and bias audit CRUD
+
+Both create functions now accept optional model_inventory_id parameter.
+All SELECT/RETURNING queries include the new column. Bias audit
+_row_to_dict returns it as camelCase modelInventoryId."
+```
+
+---
+
+### Task 3: EvalServer API — pass model_inventory_id through routers and controllers
+
+**Files:**
+- Modify: `EvalServer/src/routers/evaluation_logs.py:137-142` (CreateExperimentRequest)
+- Modify: `EvalServer/src/controllers/evaluation_logs.py` (create_experiment_controller)
+- Modify: `EvalServer/src/controllers/bias_audits.py:59-149` (create_bias_audit_controller)
+
+- [ ] **Step 1: Update CreateExperimentRequest Pydantic model**
+
+In `EvalServer/src/routers/evaluation_logs.py:137`:
+
+```python
+class CreateExperimentRequest(BaseModel):
+    project_id: str
+    name: str
+    description: Optional[str] = None
+    config: Dict[str, Any]
+    baseline_experiment_id: Optional[str] = None
+    model_inventory_id: Optional[int] = None  # NEW
+```
+
+- [ ] **Step 2: Pass model_inventory_id through experiment controller**
+
+Find `create_experiment_controller` in `EvalServer/src/controllers/evaluation_logs.py`. It receives `data` dict from `experiment_data.dict()` (called at `evaluation_logs.py:347`). Ensure it passes `model_inventory_id` to the CRUD `create_experiment` call.
+
+Search for where `create_experiment` is called from the controller:
+```bash
+grep -n "create_experiment" EvalServer/src/controllers/evaluation_logs.py
+```
+
+Add `model_inventory_id=data.get("model_inventory_id")` to the CRUD call.
+
+- [ ] **Step 3: Pass model_inventory_id through bias audit controller**
+
+In `EvalServer/src/controllers/bias_audits.py:116`, the `create_bias_audit` CRUD call:
+
+```python
+created = await create_bias_audit(
+    organization_id=organization_id,
+    db=db,
+    audit_id=audit_id,
+    project_id=config_data.get("projectId"),
+    preset_id=preset_id,
+    preset_name=preset_name,
+    mode=mode,
+    config=config_data,
+    created_by=user_id,
+    model_inventory_id=config_data.get("modelInventoryId"),  # NEW
+)
+```
+
+The frontend sends `modelInventoryId` inside `config_json` (the JSON string in the multipart form). The controller already parses `config_json` into `config_data` at line 76, so `config_data.get("modelInventoryId")` will extract it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add EvalServer/src/routers/evaluation_logs.py EvalServer/src/controllers/evaluation_logs.py EvalServer/src/controllers/bias_audits.py
+git commit -m "feat(eval): pass model_inventory_id through API layer
+
+Experiment Pydantic model accepts optional model_inventory_id.
+Bias audit controller extracts modelInventoryId from config_json.
+Both pass through to CRUD layer."
+```
+
+---
+
+### Task 4: Frontend — model inventory dropdown on NewExperimentModal
+
+**Files:**
+- Modify: `Clients/src/infrastructure/api/evaluationLogsService.ts:40-56` (Experiment interface)
+- Modify: `Clients/src/infrastructure/api/evaluationLogsService.ts:191-199` (createExperiment)
+- Modify: `Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx`
+
+- [ ] **Step 1: Update Experiment interface**
+
+In `Clients/src/infrastructure/api/evaluationLogsService.ts:40`, add:
+
+```typescript
+export interface Experiment {
+  id: string;
+  project_id: string;
+  name: string;
+  description?: string;
+  config: Record<string, any>;
+  baseline_experiment_id?: string;
+  status: string;
+  results?: Record<string, any>;
+  error_message?: string;
+  started_at?: string;
+  completed_at?: string;
+  created_at: string;
+  updated_at: string;
+  tenant: string;
+  created_by?: number;
+  model_inventory_id?: number;  // NEW
+}
+```
+
+Also update the `createExperiment` method signature (line 191) to accept `model_inventory_id`:
+
+```typescript
+async createExperiment(data: {
+  project_id: string;
+  name: string;
+  description?: string;
+  config: Record<string, any>;
+  baseline_experiment_id?: string;
+  model_inventory_id?: number;  // NEW
+}) {
+  const response = await CustomAxios.post("/deepeval/experiments", data);
+  return response.data;
+},
+```
+
+- [ ] **Step 2: Add model inventory state and fetch to NewExperimentModal**
+
+In `NewExperimentModal.tsx`, add imports and state near the top (after existing imports around line 60):
+
+```typescript
+import { getAllModelInventories } from "../../../application/repository/modelInventory.repository";
+```
+
+Find the repository file first to confirm the exact function name:
+```bash
+grep -n "export.*getAll\|export.*list.*Model" Clients/src/application/repository/modelInventory.repository.ts
+```
+
+Add state inside the component (near other useState declarations):
+
+```typescript
+const [modelInventories, setModelInventories] = useState<Array<{ id: number; provider: string; model: string; version: string; status: string }>>([]);
+const [selectedModelInventoryId, setSelectedModelInventoryId] = useState<number | null>(null);
+```
+
+Add a useEffect to fetch model inventories when the modal opens:
+
+```typescript
+useEffect(() => {
+  if (open) {
+    getAllModelInventories().then((data) => {
+      setModelInventories(data || []);
+    }).catch(() => {
+      // Non-critical — dropdown just stays empty
+    });
+  }
+}, [open]);
+```
+
+Confirm the exact function and route by checking the repository file.
+
+- [ ] **Step 3: Add dropdown UI to the experiment form**
+
+Find a good placement — ideally in the first step of the StepperModal, near the model selection area. Add after the model name/access method fields:
+
+```tsx
+{/* Link to model inventory (optional) */}
+<Box sx={{ mt: "16px" }}>
+  <Typography variant="body2" sx={{ mb: "4px", fontWeight: 500, fontSize: "13px", color: palette.text.secondary }}>
+    Link to model inventory (optional)
+  </Typography>
+  <FormControl fullWidth size="small">
+    <Select
+      value={selectedModelInventoryId ?? ""}
+      onChange={(e) => setSelectedModelInventoryId(e.target.value === "" ? null : Number(e.target.value))}
+      displayEmpty
+      sx={{ height: "34px", fontSize: "13px", borderRadius: "4px" }}
+    >
+      <MenuItem value="">
+        <Typography sx={{ fontSize: "13px", color: palette.text.secondary }}>None — don't link to inventory</Typography>
+      </MenuItem>
+      {modelInventories.map((m) => (
+        <MenuItem key={m.id} value={m.id}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography sx={{ fontSize: "13px" }}>{m.provider} — {m.model}</Typography>
+            <Typography sx={{ fontSize: "11px", color: palette.text.secondary }}>v{m.version}</Typography>
+          </Stack>
+        </MenuItem>
+      ))}
+    </Select>
+  </FormControl>
+</Box>
+```
+
+- [ ] **Step 4: Pass selectedModelInventoryId in the submit handler**
+
+In `NewExperimentModal.tsx` around line 686, where `createExperiment(experimentConfig)` is called, ensure `model_inventory_id` is included in `experimentConfig`:
+
+Find where `experimentConfig` is built (around line 620-681) and add `model_inventory_id`:
+
+```typescript
+const experimentConfig = {
+  project_id: projectId,
+  name: experimentName.trim(),
+  config: {
+    // ... existing config fields ...
+  },
+  model_inventory_id: selectedModelInventoryId || undefined,  // NEW
+};
+```
+
+- [ ] **Step 5: Reset state on close**
+
+Find the modal close/reset handler and add:
+```typescript
+setSelectedModelInventoryId(null);
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Clients/src/infrastructure/api/evaluationLogsService.ts Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+git commit -m "feat(eval): add model inventory dropdown to experiment creation modal
+
+Optional Select dropdown populated from model inventory API. Selected
+model_inventory_id is sent with the experiment creation payload.
+Default is 'None — don't link to inventory'."
+```
+
+---
+
+### Task 5: Frontend — model inventory dropdown on NewBiasAuditModal
+
+**Files:**
+- Modify: `Clients/src/infrastructure/api/biasAuditService.ts:188-217` (CreateBiasAuditConfig)
+- Modify: `Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx`
+
+- [ ] **Step 1: Update CreateBiasAuditConfig interface**
+
+In `Clients/src/infrastructure/api/biasAuditService.ts:188`, add:
+
+```typescript
+export interface CreateBiasAuditConfig {
+  // ... existing fields ...
+  dataDateRangeStart?: string;
+  dataDateRangeEnd?: string;
+  modelInventoryId?: number;  // NEW
+}
+```
+
+- [ ] **Step 2: Add model inventory state and dropdown to NewBiasAuditModal**
+
+Same pattern as Task 4. In `NewBiasAuditModal.tsx`:
+
+Add import:
+```typescript
+import { getAllModelInventories } from "../../../application/repository/modelInventory.repository";
+```
+
+Add state:
+```typescript
+const [modelInventories, setModelInventories] = useState<Array<{ id: number; provider: string; model: string; version: string; status: string }>>([]);
+const [selectedModelInventoryId, setSelectedModelInventoryId] = useState<number | null>(null);
+```
+
+Add useEffect (same as Task 4 Step 2).
+
+Place the dropdown in step 2 of the StepperModal (the AEDT information step), near the existing `systemName` and `systemVersion` fields. Use `Select` from `../../components/Inputs/Select` (already imported at line 22):
+
+```tsx
+{/* Link to model inventory (optional) */}
+<Box sx={{ mt: "16px" }}>
+  <Select
+    id="model-inventory-link"
+    label="Link to model inventory (optional)"
+    placeholder="None — don't link to inventory"
+    value={selectedModelInventoryId !== null ? String(selectedModelInventoryId) : ""}
+    onChange={(e: { target: { value: string } }) =>
+      setSelectedModelInventoryId(e.target.value === "" ? null : Number(e.target.value))
+    }
+    items={[
+      { _id: "", name: "None — don't link to inventory" },
+      ...modelInventories.map((m) => ({
+        _id: String(m.id),
+        name: `${m.provider} — ${m.model} (v${m.version})`,
+      })),
+    ]}
+    sx={{ width: "100%" }}
+  />
+</Box>
+```
+
+Note: Check the exact `Select` component API — it may use `items` with `{ _id, name }` shape (VerifyWise custom Select pattern). Verify by reading `Clients/src/presentation/components/Inputs/Select/index.tsx`.
+
+- [ ] **Step 3: Pass modelInventoryId in the submit config**
+
+In `NewBiasAuditModal.tsx:319-348`, where `config: CreateBiasAuditConfig` is built, add:
+
+```typescript
+const config: CreateBiasAuditConfig = {
+  // ... existing fields ...
+  dataSource: dataSourceDescription,
+  modelInventoryId: selectedModelInventoryId || undefined,  // NEW
+  metadata: {
+    distribution_date: distributionDate,
+  },
+};
+```
+
+- [ ] **Step 4: Reset state on close, commit**
+
+Add `setSelectedModelInventoryId(null)` to the close handler.
+
+```bash
+git add Clients/src/infrastructure/api/biasAuditService.ts Clients/src/presentation/pages/EvalsDashboard/NewBiasAuditModal.tsx
+git commit -m "feat(eval): add model inventory dropdown to bias audit creation modal
+
+Optional Select dropdown in AEDT information step. Sends
+modelInventoryId in config_json payload for bias audit creation."
+```
+
+---
+
+### Task 6: Servers endpoint — fetch evaluations by model inventory ID
+
+**Files:**
+- Create: `Servers/utils/modelEvaluations.utils.ts`
+- Create: `Servers/controllers/modelEvaluations.ctrl.ts`
+- Modify: `Servers/routes/modelInventory.route.ts`
+
+- [ ] **Step 1: Create the utils file with raw SQL query**
+
+Create `Servers/utils/modelEvaluations.utils.ts`:
+
+```typescript
+import { sequelize } from "../database/db";
+import { QueryTypes } from "sequelize";
+
+/**
+ * Fetch all experiments and bias audits linked to a model inventory record.
+ * Reads from llm_evals_* tables (same Postgres, verifywise schema).
+ */
+export async function getEvaluationsByModelInventoryId(
+  modelInventoryId: number,
+  organizationId: number
+) {
+  const experiments = await sequelize.query(
+    `SELECT id, name, status, config, results, error_message,
+            started_at, completed_at, created_at, created_by,
+            'experiment' AS eval_type
+     FROM llm_evals_experiments
+     WHERE model_inventory_id = :modelInventoryId
+       AND organization_id = :organizationId
+     ORDER BY created_at DESC`,
+    {
+      replacements: { modelInventoryId, organizationId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  const biasAudits = await sequelize.query(
+    `SELECT id, preset_name AS name, status, config, results, error,
+            completed_at, created_at, created_by,
+            'bias_audit' AS eval_type
+     FROM llm_evals_bias_audits
+     WHERE model_inventory_id = :modelInventoryId
+       AND organization_id = :organizationId
+     ORDER BY created_at DESC`,
+    {
+      replacements: { modelInventoryId, organizationId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  return { experiments, biasAudits };
+}
+```
+
+- [ ] **Step 2: Create the controller**
+
+Create `Servers/controllers/modelEvaluations.ctrl.ts`:
+
+```typescript
+import { Request, Response } from "express";
+import { getEvaluationsByModelInventoryId } from "../utils/modelEvaluations.utils";
+import { logProcessing, logSuccess, logFailure } from "../utils/logger/logHelper";
+
+export async function getModelEvaluations(req: Request, res: Response) {
+  const source = "getModelEvaluations";
+  logProcessing(source, req);
+
+  try {
+    const modelInventoryId = parseInt(req.params.id, 10);
+    const organizationId = req.organizationId;
+
+    if (isNaN(modelInventoryId)) {
+      return res.status(400).json({ error: "Invalid model inventory ID" });
+    }
+
+    const data = await getEvaluationsByModelInventoryId(
+      modelInventoryId,
+      organizationId
+    );
+
+    logSuccess(source, req);
+    return res.status(200).json(data);
+  } catch (error) {
+    logFailure(source, req, error);
+    return res.status(500).json({ error: "Failed to fetch evaluations" });
+  }
+}
+```
+
+- [ ] **Step 3: Add route**
+
+In `Servers/routes/modelInventory.route.ts`, add:
+
+Import at top:
+```typescript
+import { getModelEvaluations } from "../controllers/modelEvaluations.ctrl";
+```
+
+Add route (before the POST route, after GET routes):
+```typescript
+router.get("/:id/evaluations", authenticateJWT, getModelEvaluations);
+```
+
+- [ ] **Step 4: Verify Servers build**
+
+Run: `cd Servers && npm run build`
+Expected: Build succeeds with no TypeScript errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Servers/utils/modelEvaluations.utils.ts Servers/controllers/modelEvaluations.ctrl.ts Servers/routes/modelInventory.route.ts
+git commit -m "feat(api): add GET /api/modelInventories/:id/evaluations endpoint
+
+Reads experiments and bias audits from llm_evals_* tables filtered by
+model_inventory_id. Returns { experiments, biasAudits } arrays."
+```
+
+---
+
+### Task 7: Frontend — "Evaluations" tab on Model Inventory detail page
+
+**Files:**
+- Create: `Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx`
+- Modify: `Clients/src/presentation/pages/ModelInventory/index.tsx`
+- Create: `Clients/src/application/repository/modelEvaluations.repository.ts`
+
+- [ ] **Step 1: Create the repository**
+
+Create `Clients/src/application/repository/modelEvaluations.repository.ts`:
+
+```typescript
+import apiServices from "../../infrastructure/api/customAxios";
+
+export interface ModelEvaluation {
+  id: string;
+  name: string;
+  status: string;
+  config: Record<string, any>;
+  results?: Record<string, any>;
+  error_message?: string;
+  error?: string;
+  completed_at?: string;
+  created_at: string;
+  created_by?: string;
+  eval_type: "experiment" | "bias_audit";
+}
+
+export interface ModelEvaluationsResponse {
+  experiments: ModelEvaluation[];
+  biasAudits: ModelEvaluation[];
+}
+
+export async function getModelEvaluations(
+  modelInventoryId: number
+): Promise<ModelEvaluationsResponse> {
+  const response = await apiServices.get(
+    `/modelInventories/${modelInventoryId}/evaluations`
+  );
+  return response.data;
+}
+```
+
+- [ ] **Step 2: Create the Evaluations tab component**
+
+Create `Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx`:
+
+```tsx
+import { useState, useEffect, useMemo } from "react";
+import { Box, Stack, Typography, Alert } from "@mui/material";
+import { FlaskConical, AlertTriangle } from "lucide-react";
+import Chip from "../../components/Chip";
+import CustomizableBasicTable from "../../components/Table/CustomizableBasicTable";
+import { palette } from "../../themes/palette";
+import {
+  getModelEvaluations,
+  type ModelEvaluation,
+  type ModelEvaluationsResponse,
+} from "../../../application/repository/modelEvaluations.repository";
+
+interface ModelEvaluationsTabProps {
+  modelInventoryId: number;
+}
+
+const statusColorMap: Record<string, string> = {
+  completed: "#4caf50",
+  running: "#ff9800",
+  pending: "#9e9e9e",
+  failed: "#f44336",
+};
+
+/**
+ * Check if an experiment has any failed metrics (score < threshold).
+ */
+function hasFailedMetrics(eval_: ModelEvaluation): boolean {
+  if (eval_.eval_type === "experiment") {
+    const results = eval_.results;
+    if (!results?.metric_results) return false;
+    const thresholds = eval_.config?.thresholds || eval_.config?.metric_thresholds || {};
+    for (const [metric, data] of Object.entries(results.metric_results)) {
+      const score = (data as any)?.average ?? (data as any)?.score;
+      const threshold = thresholds[metric];
+      if (score !== undefined && threshold !== undefined && score < threshold) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (eval_.eval_type === "bias_audit") {
+    const results = eval_.results;
+    if (!results?.categories) return false;
+    for (const cat of Object.values(results.categories) as any[]) {
+      if (cat?.groups) {
+        for (const group of cat.groups) {
+          if (group.flagged) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  return false;
+}
+
+function getKeyResult(eval_: ModelEvaluation): string {
+  if (eval_.eval_type === "experiment") {
+    const results = eval_.results?.metric_results;
+    if (!results) return "—";
+    const entries = Object.entries(results);
+    if (entries.length === 0) return "—";
+    const [metric, data] = entries[0];
+    const score = (data as any)?.average ?? (data as any)?.score;
+    return score !== undefined ? `${metric}: ${(score as number).toFixed(2)}` : "—";
+  }
+
+  if (eval_.eval_type === "bias_audit") {
+    const results = eval_.results;
+    if (!results?.categories) return "—";
+    const cats = Object.values(results.categories) as any[];
+    const totalGroups = cats.reduce((sum, c) => sum + (c?.groups?.length || 0), 0);
+    const flagged = cats.reduce(
+      (sum, c) => sum + (c?.groups?.filter((g: any) => g.flagged)?.length || 0),
+      0
+    );
+    return flagged > 0 ? `${flagged}/${totalGroups} flagged` : `${totalGroups} groups passed`;
+  }
+
+  return "—";
+}
+
+export default function ModelEvaluationsTab({ modelInventoryId }: ModelEvaluationsTabProps) {
+  const [data, setData] = useState<ModelEvaluationsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getModelEvaluations(modelInventoryId)
+      .then(setData)
+      .catch(() => setData({ experiments: [], biasAudits: [] }))
+      .finally(() => setLoading(false));
+  }, [modelInventoryId]);
+
+  const allEvals = useMemo(() => {
+    if (!data) return [];
+    return [...data.experiments, ...data.biasAudits].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+  }, [data]);
+
+  const flaggedCount = useMemo(
+    () => allEvals.filter(hasFailedMetrics).length,
+    [allEvals]
+  );
+
+  const columns = ["NAME", "TYPE", "STATUS", "KEY RESULT", "DATE"];
+
+  const rows = allEvals.map((e) => ({
+    id: e.id,
+    data: [
+      { text: e.name || e.id },
+      {
+        text: e.eval_type === "experiment" ? "Experiment" : "Bias audit",
+      },
+      {
+        text: (
+          <Chip
+            label={e.status}
+            sx={{
+              backgroundColor: `${statusColorMap[e.status] || "#9e9e9e"}20`,
+              color: statusColorMap[e.status] || "#9e9e9e",
+              fontSize: "11px",
+              height: "22px",
+            }}
+          />
+        ),
+      },
+      {
+        text: (
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            <Typography sx={{ fontSize: "13px" }}>{getKeyResult(e)}</Typography>
+            {hasFailedMetrics(e) && (
+              <AlertTriangle size={14} color="#f44336" strokeWidth={1.5} />
+            )}
+          </Stack>
+        ),
+      },
+      {
+        text: e.created_at
+          ? new Date(e.created_at).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })
+          : "—",
+      },
+    ],
+  }));
+
+  if (loading) {
+    return (
+      <Box sx={{ p: "24px", textAlign: "center" }}>
+        <Typography sx={{ fontSize: "13px", color: palette.text.secondary }}>
+          Loading evaluations...
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: "16px" }}>
+      {/* Risk nudge banner */}
+      {flaggedCount > 0 && (
+        <Alert
+          severity="warning"
+          icon={<AlertTriangle size={16} strokeWidth={1.5} />}
+          sx={{ mb: "16px", fontSize: "13px", borderRadius: "4px" }}
+        >
+          {flaggedCount} evaluation{flaggedCount !== 1 ? "s" : ""} flagged a potential risk.
+          Consider adding {flaggedCount !== 1 ? "these" : "this"} to the risk register.
+        </Alert>
+      )}
+
+      {allEvals.length === 0 ? (
+        <Box sx={{ textAlign: "center", py: "48px" }}>
+          <FlaskConical size={32} color={palette.text.secondary} strokeWidth={1.5} />
+          <Typography sx={{ mt: "8px", fontSize: "13px", color: palette.text.secondary }}>
+            No evaluations linked to this model yet
+          </Typography>
+        </Box>
+      ) : (
+        <CustomizableBasicTable
+          columns={columns}
+          rows={rows}
+          page={1}
+          setCurrentPagingation={() => {}}
+        />
+      )}
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 3: Add the tab to ModelInventory/index.tsx**
+
+In `Clients/src/presentation/pages/ModelInventory/index.tsx`:
+
+Add import near top:
+```typescript
+import ModelEvaluationsTab from "./ModelEvaluationsTab";
+```
+
+Add the tab definition in the TabBar `tabs` array (around line 2136, after the "model-risks" tab and before the pluginTabs spread):
+```typescript
+{
+  label: "Evaluations",
+  value: "evaluations",
+  icon: "Database" as const,
+  tooltip: "LLM evaluations and bias audits linked to models in your inventory",
+},
+```
+
+Update the `isBuiltInTab` check (line 720) to include "evaluations":
+```typescript
+const isBuiltInTab = ["models", "model-risks", "evidence-hub", "evaluations"].includes(newTab);
+```
+
+Update `getTabFromPath` (line 700) to detect the evaluations tab:
+```typescript
+if (pathname.includes("evaluations")) return "evaluations";
+```
+
+Add conditional rendering for the tab content (find where `activeTab === "models"` and `activeTab === "model-risks"` are rendered, and add after the model-risks block):
+
+```tsx
+{activeTab === "evaluations" && (
+  <Box sx={{ mt: "16px" }}>
+    <ModelEvaluationsTab
+      modelInventoryId={/* pass the current model ID if on a single-model view, or 0 for list view */}
+    />
+  </Box>
+)}
+```
+
+**Important**: The ModelInventory page appears to be a list view with tabs, not a single-model detail view. The evaluations tab needs to show evaluations across ALL models in the inventory. Adjust the component to accept an array of model IDs or fetch all linked evals for the org. Check how the page works — if it's a list page, the "Evaluations" tab should show all evals that are linked to any model, grouped by model.
+
+Alternatively, if the page does show individual model details (via selecting a row), pass the selected model's ID.
+
+Read the page more carefully to determine the correct approach. The key question: is there a "selected model" state, or is this purely a list view?
+
+- [ ] **Step 4: Verify Clients build**
+
+Run: `cd Clients && npm run build`
+Expected: Build succeeds with no TypeScript errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Clients/src/application/repository/modelEvaluations.repository.ts Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx Clients/src/presentation/pages/ModelInventory/index.tsx
+git commit -m "feat(ui): add Evaluations tab to model inventory page
+
+Shows linked experiments and bias audits in a table with status, key
+result, and date. Warning banner when evaluations have flagged results
+suggesting risk register consideration."
+```
+
+---
+
+### Task 8: Frontend — "Unlinked" indicator on experiment and bias audit lists
+
+**Files:**
+- Modify: `Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx`
+- Modify: `Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx`
+
+- [ ] **Step 1: Add "Linked model" column to experiments table**
+
+In `ProjectExperiments.tsx:484`, add "LINKED MODEL" to tableColumns:
+
+```typescript
+const tableColumns = ["EXPERIMENT NAME", "MODEL", "JUDGE/SCORER", "# PROMPTS", "DATASET", "LINKED MODEL", "DATE", "ACTION"];
+```
+
+In the `tableRows` mapping (line 486), add a cell for the linked model. The experiment data should now include `model_inventory_id` from the API. Add the cell:
+
+```typescript
+{
+  text: exp.model_inventory_id ? (
+    <Chip label="Linked" sx={{ backgroundColor: "#e8f5e9", color: "#2e7d32", fontSize: "11px", height: "22px" }} />
+  ) : (
+    <Typography sx={{ fontSize: "11px", color: palette.text.secondary }}>Unlinked</Typography>
+  ),
+},
+```
+
+Place this cell at the correct position in the row data array (after DATASET, before DATE).
+
+- [ ] **Step 2: Add "Linked model" column to bias audits list**
+
+In `BiasAuditsList.tsx`, follow the same pattern. Find the table columns definition and add "LINKED MODEL". In the row mapping, add a cell checking for `modelInventoryId` (camelCase, matching the _row_to_dict output).
+
+- [ ] **Step 3: Verify Clients build**
+
+Run: `cd Clients && npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx Clients/src/presentation/pages/EvalsDashboard/BiasAuditsList.tsx
+git commit -m "feat(ui): show linked/unlinked model indicator on eval lists
+
+Experiments and bias audits tables show a 'Linked' chip or 'Unlinked'
+text based on whether model_inventory_id is set."
+```
+
+---
+
+### Task 9: Build verification and manual testing
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run Servers build**
+
+Run: `cd Servers && npm run build`
+Expected: No TypeScript errors.
+
+- [ ] **Step 2: Run Clients build**
+
+Run: `cd Clients && npm run build`
+Expected: No TypeScript errors.
+
+- [ ] **Step 3: Start dev servers and test the flow**
+
+Start all services:
+```bash
+# Terminal 1
+cd Servers && npm run watch
+# Terminal 2
+cd Clients && npm run dev
+# Terminal 3
+cd EvalServer/src && alembic upgrade head && uvicorn app:app --port 8000 --workers 1
+```
+
+Test:
+1. Navigate to LLM Evals → create a new experiment
+2. Verify the "Link to model inventory" dropdown appears and is populated
+3. Select a model and create the experiment
+4. Navigate to Model Inventory → Evaluations tab
+5. Verify the linked experiment appears in the table
+6. Create an experiment WITHOUT selecting a model — verify it works (dropdown is optional)
+7. Check the experiment list — verify "Linked" / "Unlinked" indicators
+
+- [ ] **Step 4: Test bias audit flow**
+
+1. Navigate to LLM Evals → Bias Audits → create a new audit
+2. Verify the "Link to model inventory" dropdown appears in step 2
+3. Select a model and run the audit
+4. After completion, check Model Inventory → Evaluations tab
+5. Verify the bias audit appears with correct status and result summary
+
+- [ ] **Step 5: Final commit (if any fixes needed)**
+
+```bash
+git add -A
+git commit -m "fix(eval): address issues found during manual testing"
+```

--- a/docs/superpowers/specs/2026-04-12-eval-model-inventory-link-design.md
+++ b/docs/superpowers/specs/2026-04-12-eval-model-inventory-link-design.md
@@ -1,0 +1,142 @@
+# Eval → Model Inventory Linking
+
+> **Date:** 2026-04-12
+> **Branch:** `feat/eval-model-inventory-link`
+> **Status:** Design
+
+## Problem
+
+LLM evaluations (experiments and bias audits) run in EvalServer but have no connection to the Model Inventory in the governance system. A user runs an eval against GPT-4, gets results, then separately manages GPT-4 in the model inventory — with no link between the two. Eval results that surface risks (bias flags, toxicity failures, low relevancy scores) don't flow into the governance view of the model.
+
+## Solution
+
+Add an optional "Which model in your inventory are you testing?" dropdown to both experiment and bias audit creation forms. When linked, the model's detail page shows evaluation history. If an eval flags a risk, the user is nudged to add it to the risk register — but the system never auto-creates risks.
+
+## Design decisions
+
+1. **Optional linking only.** The dropdown is never required. Users who just want to run a quick eval skip it with zero friction.
+2. **User-driven risk creation.** When eval results flag something (bias threshold exceeded, metric failed), the UI surfaces a nudge: "This evaluation flagged a potential risk. Add to risk register?" The user decides. No auto-writes to `model_risks`.
+3. **Both entity types.** Experiments and bias audits both get the dropdown. Bias audits already have `systemName`/`systemVersion` free-text fields — the dropdown supplements (does not replace) those.
+4. **No cross-service writes.** EvalServer stores the `model_inventory_id` FK. Servers reads `llm_evals_*` tables (same Postgres instance) to display eval history on the model detail page. Neither service writes to the other's tables.
+
+## Scope
+
+### In scope
+
+- Alembic migration: add nullable `model_inventory_id` (INTEGER) to `llm_evals_experiments` and `llm_evals_bias_audits`
+- Frontend: optional model inventory dropdown on `NewExperimentModal.tsx` and `NewBiasAuditModal.tsx`
+- Frontend: "Evaluations" tab on model inventory detail page showing linked experiments and bias audits
+- Frontend: risk nudge banner when a linked eval has flagged/failed results
+- Frontend: "Unlinked" badge on evals list for experiments/audits not linked to a model
+- Backend: update EvalServer CRUD to accept and store `model_inventory_id`
+- Backend: Servers endpoint to fetch evals by `model_inventory_id` (read from `llm_evals_*` tables)
+
+### Out of scope
+
+- Auto-creating risks from eval results
+- Auto-creating use cases from evals (evals link to models; models already link to use cases)
+- Match-score suggestions or fuzzy matching (v1 is a manual dropdown)
+- Backfill existing evals to models (future: surface "you have N past evals that match this model's provider")
+
+## Architecture
+
+### Data flow
+
+```
+[Eval Creation Form] — user picks model from inventory dropdown (optional)
+        |
+        v
+[EvalServer] — stores model_inventory_id on experiment/bias_audit row
+        |
+        v
+[Servers] — reads llm_evals_experiments + llm_evals_bias_audits
+            WHERE model_inventory_id = :id (direct DB read, same Postgres)
+        |
+        v
+[Model Detail Page] — "Evaluations" tab shows linked results
+        |
+        v
+[Risk Nudge] — if any eval has failed metrics, show banner:
+               "This evaluation flagged a potential risk. Add to risk register?"
+               → opens existing Add Risk form, pre-filled with eval context
+```
+
+### Database changes
+
+**EvalServer — Alembic migration:**
+
+```sql
+ALTER TABLE verifywise.llm_evals_experiments
+  ADD COLUMN model_inventory_id INTEGER NULL;
+
+ALTER TABLE verifywise.llm_evals_bias_audits
+  ADD COLUMN model_inventory_id INTEGER NULL;
+```
+
+No foreign key constraint (cross-schema reference to `verifywise.model_inventories`). Application-level validation only — if the model is deleted, the eval retains the stale ID but the UI shows "Model removed" gracefully.
+
+### API changes
+
+**EvalServer (Python/FastAPI):**
+
+- `POST /evaluate` — accept optional `model_inventory_id` in payload
+- `POST /deepeval/bias-audits/run` — accept optional `model_inventory_id` in form data
+- `GET /deepeval/experiments?model_inventory_id=X` — filter experiments by model (new query param)
+- `GET /deepeval/bias-audits?model_inventory_id=X` — filter bias audits by model (new query param)
+
+**Servers (Node/Express):**
+
+- `GET /api/modelInventories/:id/evaluations` — new endpoint that reads from `llm_evals_experiments` and `llm_evals_bias_audits` WHERE `model_inventory_id = :id`, returns combined list sorted by `completed_at DESC`
+
+### Frontend changes
+
+**NewExperimentModal.tsx:**
+
+- Add optional `Select` dropdown labeled "Link to model inventory (optional)"
+- Populated via `GET /api/modelInventories` (already available through CustomAxios)
+- Each option shows: `{provider} — {model} (v{version})` with status chip (Approved/Pending/Restricted)
+- Default: empty (no model selected)
+- Selected value stored as `model_inventory_id` in the experiment config payload
+
+**NewBiasAuditModal.tsx:**
+
+- Same dropdown pattern as experiments
+- Placed near existing `systemName`/`systemVersion` fields
+- Does not replace those fields — supplements them
+
+**Model Inventory Detail Page (new "Evaluations" tab):**
+
+- Tab added alongside existing tabs on the model detail page
+- Table columns: Date | Type (Experiment/Bias Audit) | Name | Status | Key Result | Actions
+- "Key Result" shows: primary metric score for experiments, overall pass/fail + flagged count for bias audits
+- If any eval has failed metrics or flagged bias categories: amber banner at top of tab
+  - "1 evaluation flagged a potential risk. Add to risk register?"
+  - Click opens existing AddNewRiskForm pre-filled with:
+    - `risk_category`: "Performance" (for experiment failures) or "Bias" (for bias audit flags)
+    - `description`: auto-generated from eval results (e.g., "Answer relevancy scored 0.62, below threshold 0.80")
+    - `model_inventory_id`: current model
+  - User reviews, edits, and submits — standard risk creation flow
+
+**Evals List Pages (ExperimentsList / BiasAuditsList):**
+
+- New column or badge: "Linked model" showing model name, or "Unlinked" in muted text
+- Optional filter: "Show unlinked only" toggle
+
+## Risk nudge logic
+
+An eval is considered "flagged" when:
+
+- **Experiment:** any metric in `results` has `score < threshold` (thresholds stored in `config.metric_thresholds`)
+- **Bias audit:** any category in `results` has `flagged: true`
+
+The nudge banner appears on the model detail "Evaluations" tab only. It does not appear on the evals list page (that would be too noisy). The nudge is dismissible per-eval (stored in component state, not persisted — it reappears on page reload, which is fine since it's informational).
+
+## Testing considerations
+
+- Verify eval creation works with and without model selection (optional field)
+- Verify model detail "Evaluations" tab shows correct linked evals
+- Verify risk nudge appears only when eval results contain failures/flags
+- Verify "Add to risk register" pre-fills the risk form correctly
+- Verify unlinked badge displays on evals list
+- Verify graceful handling when a linked model is deleted (show "Model removed")
+- Verify dropdown filters by organization (multi-tenancy)


### PR DESCRIPTION
## Summary

- Adds optional "Link to model inventory" dropdown on both experiment and bias audit creation modals
- New "Evaluations" tab on model inventory page showing all linked experiments and bias audits with risk nudge banner
- "Linked/Unlinked" indicator column on experiment and bias audit list tables
- Alembic migration adds nullable `model_inventory_id` column to `llm_evals_experiments` and `llm_evals_bias_audits`
- New `GET /api/modelInventory/evaluations` endpoint (Servers reads from `llm_evals_*` tables, no cross-service writes)
- EvalServer CRUD and API layer updated to accept and return `model_inventory_id`

## Design decisions

- **Optional only** — dropdown defaults to "None", zero friction for users who don't want to link
- **User-driven risk awareness** — flagged evals show a warning banner ("Consider adding to risk register"), no auto-creation of risks
- **No cross-service writes** — EvalServer stores the FK, Servers reads `llm_evals_*` tables directly (same Postgres)
- **No FK constraint** — application-level validation only; graceful "Model removed" handling if a linked model is deleted