### PR TITLE
Hide leaderboard from LLM Evals sidebar

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsSidebar.tsx
@@ -6,7 +6,7 @@ import {
   Settings,
   KeyRound,
   Swords,
-  Trophy,
+  // Trophy,
   Cpu,
   MessageSquare,
   Scale,
@@ -133,13 +133,13 @@ export default function EvalsSidebar({
       count: arenaCount,
       disabled: false, // Always enabled - org-scoped
     },
-    {
-      id: "leaderboard",
-      label: "Leaderboard",
-      value: "leaderboard",
-      icon: <Trophy size={16} strokeWidth={1.5} />,
-      disabled: false,
-    },
+    // {
+    //   id: "leaderboard",
+    //   label: "Leaderboard",
+    //   value: "leaderboard",
+    //   icon: <Trophy size={16} strokeWidth={1.5} />,
+    //   disabled: false,
+    // },
     {
       id: "reports",
       label: "Reports",


### PR DESCRIPTION
## Summary

- Commented out the leaderboard sidebar item in LLM Evals since it has no page implementation yet
- Removed unused Trophy icon import