### PR TITLE
docs(api): comprehensive API documentation audit and schema enrichment

### DIFF
--- a/Servers/docs/api/ai-detection-trust-incidents-openapi.yaml
+++ b/Servers/docs/api/ai-detection-trust-incidents-openapi.yaml
@@ -1,0 +1,2553 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise - AI Detection, Trust Centre & Incident Management APIs
+  description: |
+    OpenAPI specification for three API domains:
+    1. AI Detection - Repository scanning for AI/ML components
+    2. AI Trust Centre - Public trust page management
+    3. AI Incident Management - Incident lifecycle management
+  version: 1.0.0
+
+servers:
+  - url: /ai-detection
+    description: AI Detection endpoints
+  - url: /ai-trust-centre
+    description: AI Trust Centre endpoints
+  - url: /ai-incident-management
+    description: AI Incident Management endpoints
+
+tags:
+  - name: AI Detection - Scans
+  - name: AI Detection - Repositories
+  - name: AI Detection - Risk Scoring
+  - name: AI Trust Centre
+  - name: AI Incident Management
+
+paths:
+  # ===========================================================================
+  # AI DETECTION - SCANS
+  # ===========================================================================
+
+  /ai-detection/scans:
+    post:
+      tags: [AI Detection - Scans]
+      summary: Start a new repository scan
+      description: |
+        Starts a new AI detection scan for the given repository URL.
+        Rate limited to 30 requests per 15 minutes per IP.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartScanRequest'
+      responses:
+        '201':
+          description: Scan created and queued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          description: Validation error (missing/invalid fields)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Business logic error (e.g., scan already in progress)
+        '502':
+          description: External service error (e.g., GitHub unreachable)
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get scan history list
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/ScanStatus'
+      responses:
+        '200':
+          description: Paginated scan list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ScansResponse'
+
+  /ai-detection/scans/active:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get the most recent active scan
+      description: Returns the most recent scan with status pending, cloning, or scanning. Returns null data if none active.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Active scan or null
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /ai-detection/scans/{scanId}:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get scan details with summary
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Scan details with findings summary
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ScanResponse'
+        '404':
+          description: Scan not found
+    delete:
+      tags: [AI Detection - Scans]
+      summary: Delete a completed/failed/cancelled scan
+      description: Admin only. Cascades to findings.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Scan deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/DeleteScanResponse'
+        '404':
+          description: Scan not found
+
+  /ai-detection/scans/{scanId}/status:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get scan status for polling
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Scan status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ScanStatusResponse'
+
+  /ai-detection/scans/{scanId}/findings:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get findings for a scan
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            maximum: 100
+        - name: confidence
+          in: query
+          schema:
+            $ref: '#/components/schemas/ConfidenceLevel'
+        - name: finding_type
+          in: query
+          schema:
+            $ref: '#/components/schemas/FindingType'
+      responses:
+        '200':
+          description: Paginated findings
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/FindingsResponse'
+
+  /ai-detection/scans/{scanId}/security-findings:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get security findings for a scan
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            maximum: 100
+        - name: severity
+          in: query
+          schema:
+            type: string
+            enum: [critical, high, medium, low]
+      responses:
+        '200':
+          description: Paginated security findings
+
+  /ai-detection/scans/{scanId}/security-summary:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get security summary for a scan
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Security summary
+
+  /ai-detection/scans/{scanId}/cancel:
+    post:
+      tags: [AI Detection - Scans]
+      summary: Cancel an in-progress scan
+      description: Admin or Editor. Ownership check in service layer.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Scan cancelled
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/CancelScanResponse'
+        '404':
+          description: Scan not found
+        '422':
+          description: Scan not in cancellable state
+
+  /ai-detection/scans/{scanId}/findings/{findingId}/governance:
+    patch:
+      tags: [AI Detection - Scans]
+      summary: Update governance status for a finding
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+        - name: findingId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGovernanceStatusRequest'
+      responses:
+        '200':
+          description: Governance status updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/UpdateGovernanceStatusResponse'
+
+  /ai-detection/scans/{scanId}/governance-summary:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get governance summary for a scan
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Governance summary
+
+  /ai-detection/stats:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get overall AI Detection statistics
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Statistics object
+
+  /ai-detection/scans/{scanId}/export/ai-bom:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Export scan results as AI Bill of Materials
+      description: Returns JSON file attachment with AI-BOM format.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: AI-BOM JSON file
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: 'attachment; filename="ai-bom-owner-repo-1.json"'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /ai-detection/scans/{scanId}/dependency-graph:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get dependency graph data for visualization
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Graph nodes, edges, and metadata
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/DependencyGraphResponse'
+
+  /ai-detection/scans/{scanId}/compliance:
+    get:
+      tags: [AI Detection - Scans]
+      summary: Get EU AI Act compliance mapping for scan findings
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Compliance mappings, checklist, and summary
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ComplianceMappingResponse'
+
+  # ===========================================================================
+  # AI DETECTION - RISK SCORING
+  # ===========================================================================
+
+  /ai-detection/scans/{scanId}/risk-score:
+    get:
+      tags: [AI Detection - Risk Scoring]
+      summary: Get risk score with dimension breakdown
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Risk score data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/RiskScoreResponse'
+
+  /ai-detection/scans/{scanId}/risk-score/recalculate:
+    post:
+      tags: [AI Detection - Risk Scoring]
+      summary: Recalculate risk score for a completed scan
+      description: Admin or Editor only. Scan must be in completed status.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/scanId'
+      responses:
+        '200':
+          description: Recalculated risk score
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/RiskScoreResponse'
+        '422':
+          description: Scan not in completed status
+
+  /ai-detection/risk-scoring/config:
+    get:
+      tags: [AI Detection - Risk Scoring]
+      summary: Get risk scoring configuration
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Risk scoring config (or defaults if none set)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/RiskScoringConfig'
+    patch:
+      tags: [AI Detection - Risk Scoring]
+      summary: Update risk scoring configuration
+      description: Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRiskScoringConfigRequest'
+      responses:
+        '200':
+          description: Updated config
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/RiskScoringConfig'
+        '400':
+          description: Validation error (invalid weights, unknown keys)
+
+  # ===========================================================================
+  # AI DETECTION - REPOSITORIES
+  # ===========================================================================
+
+  /ai-detection/repositories:
+    get:
+      tags: [AI Detection - Repositories]
+      summary: List all registered repositories
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+      responses:
+        '200':
+          description: Paginated repository list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/RepositoryListResponse'
+    post:
+      tags: [AI Detection - Repositories]
+      summary: Register a new repository
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRepositoryRequest'
+      responses:
+        '201':
+          description: Repository registered
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Repository'
+        '400':
+          description: Validation error
+        '409':
+          description: Repository already registered
+
+  /ai-detection/repositories/{id}:
+    get:
+      tags: [AI Detection - Repositories]
+      summary: Get a single repository by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/repositoryId'
+      responses:
+        '200':
+          description: Repository details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Repository'
+        '404':
+          description: Repository not found
+    patch:
+      tags: [AI Detection - Repositories]
+      summary: Update a repository
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/repositoryId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRepositoryRequest'
+      responses:
+        '200':
+          description: Repository updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Repository'
+        '404':
+          description: Repository not found
+    delete:
+      tags: [AI Detection - Repositories]
+      summary: Remove a repository from registry
+      description: Admin only. Blocked if a scan is in progress.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/repositoryId'
+      responses:
+        '200':
+          description: Repository deleted
+        '404':
+          description: Repository not found
+        '409':
+          description: Scan in progress, cannot delete
+
+  /ai-detection/repositories/{id}/scan:
+    post:
+      tags: [AI Detection - Repositories]
+      summary: Trigger a manual scan for a registered repository
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/repositoryId'
+      responses:
+        '201':
+          description: Scan triggered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: Repository not found
+        '409':
+          description: Scan already in progress for this repository
+
+  /ai-detection/repositories/{id}/webhook-secret:
+    post:
+      tags: [AI Detection - Repositories]
+      summary: Generate a new webhook secret for CI/CD integration
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/repositoryId'
+      responses:
+        '200':
+          description: New webhook secret generated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          webhook_secret:
+                            type: string
+        '404':
+          description: Repository not found
+
+  /ai-detection/repositories/{id}/scans:
+    get:
+      tags: [AI Detection - Repositories]
+      summary: Get scan history for a specific repository
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/repositoryId'
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+      responses:
+        '200':
+          description: Paginated scan history for this repository
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ScansResponse'
+
+  # ===========================================================================
+  # AI TRUST CENTRE
+  # ===========================================================================
+
+  /ai-trust-centre/overview:
+    get:
+      tags: [AI Trust Centre]
+      summary: Get AI Trust Centre overview (all sections)
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Full overview object with intro, compliance_badges, company_description, terms_and_contact, info
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          overview:
+                            $ref: '#/components/schemas/AITrustCentreOverview'
+    put:
+      tags: [AI Trust Centre]
+      summary: Update AI Trust Centre overview
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AITrustCentreOverview'
+      responses:
+        '200':
+          description: Overview updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          overview:
+                            $ref: '#/components/schemas/AITrustCentreOverview'
+        '503':
+          description: Database operation failed
+
+  /ai-trust-centre/resources:
+    get:
+      tags: [AI Trust Centre]
+      summary: Get all AI Trust Centre resources
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: List of resources with file info
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          resources:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/AITrustCentreResource'
+    post:
+      tags: [AI Trust Centre]
+      summary: Create an AI Trust Centre resource
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file, name]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                name:
+                  type: string
+                description:
+                  type: string
+                visible:
+                  type: string
+                  enum: ['true', 'false']
+      responses:
+        '201':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          resource:
+                            $ref: '#/components/schemas/AITrustCentreResource'
+        '400':
+          description: File upload failed
+
+  /ai-trust-centre/resources/{id}:
+    put:
+      tags: [AI Trust Centre]
+      summary: Update an AI Trust Centre resource
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                name:
+                  type: string
+                description:
+                  type: string
+                visible:
+                  type: string
+                  enum: ['true', 'false']
+                delete:
+                  type: string
+                  description: File ID to delete (required when uploading replacement)
+      responses:
+        '200':
+          description: Resource updated
+        '400':
+          description: File validation error
+    delete:
+      tags: [AI Trust Centre]
+      summary: Delete an AI Trust Centre resource
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Resource deleted
+        '503':
+          description: Deletion failed
+
+  /ai-trust-centre/subprocessors:
+    get:
+      tags: [AI Trust Centre]
+      summary: Get all AI Trust Centre subprocessors
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Subprocessor list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          subprocessors:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/AITrustCentreSubprocessor'
+    post:
+      tags: [AI Trust Centre]
+      summary: Create an AI Trust Centre subprocessor
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSubprocessorRequest'
+      responses:
+        '201':
+          description: Subprocessor created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          subprocessor:
+                            $ref: '#/components/schemas/AITrustCentreSubprocessor'
+
+  /ai-trust-centre/subprocessors/{id}:
+    put:
+      tags: [AI Trust Centre]
+      summary: Update an AI Trust Centre subprocessor
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSubprocessorRequest'
+      responses:
+        '200':
+          description: Subprocessor updated
+    delete:
+      tags: [AI Trust Centre]
+      summary: Delete an AI Trust Centre subprocessor
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Subprocessor deleted
+        '503':
+          description: Deletion failed
+
+  /ai-trust-centre/logo:
+    post:
+      tags: [AI Trust Centre]
+      summary: Upload company logo
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [logo]
+              properties:
+                logo:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Logo uploaded
+        '400':
+          description: File upload failed
+    delete:
+      tags: [AI Trust Centre]
+      summary: Delete company logo
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Logo deleted
+        '503':
+          description: Deletion failed
+
+  /ai-trust-centre/{hash}:
+    get:
+      tags: [AI Trust Centre]
+      summary: Get public trust centre page by organization hash
+      description: No authentication required. Validated by visibility middleware.
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Organization tenant hash
+      responses:
+        '200':
+          description: Public trust centre page data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          trustCentre:
+                            $ref: '#/components/schemas/AITrustCentrePublicPage'
+        '404':
+          description: Organization not found
+
+  /ai-trust-centre/{hash}/logo:
+    get:
+      tags: [AI Trust Centre]
+      summary: Get company logo for public page
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Logo data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                          logo:
+                            type: object
+                            properties:
+                              content:
+                                type: string
+                                format: byte
+                              type:
+                                type: string
+        '404':
+          description: Logo not found
+
+  /ai-trust-centre/{hash}/resources/{id}:
+    get:
+      tags: [AI Trust Centre]
+      summary: Download a public resource file
+      description: Returns the file binary with appropriate Content-Type and Content-Disposition headers.
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: File binary
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Resource not found
+
+  # ===========================================================================
+  # AI INCIDENT MANAGEMENT
+  # ===========================================================================
+
+  /ai-incident-management:
+    get:
+      tags: [AI Incident Management]
+      summary: Get all incidents
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Array of incidents
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Incident'
+    post:
+      tags: [AI Incident Management]
+      summary: Create a new incident
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIncidentRequest'
+      responses:
+        '201':
+          description: Incident created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Incident'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: error
+                  message:
+                    type: string
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        field:
+                          type: string
+                        message:
+                          type: string
+                        code:
+                          type: string
+
+  /ai-incident-management/{id}:
+    get:
+      tags: [AI Incident Management]
+      summary: Get incident by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/incidentId'
+      responses:
+        '200':
+          description: Incident details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Incident'
+        '204':
+          description: Incident not found (no content)
+        '400':
+          description: Invalid ID parameter
+    patch:
+      tags: [AI Incident Management]
+      summary: Update incident by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/incidentId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIncidentRequest'
+      responses:
+        '200':
+          description: Incident updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Incident'
+        '400':
+          description: Validation error
+        '404':
+          description: Incident not found
+    delete:
+      tags: [AI Incident Management]
+      summary: Delete incident by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/incidentId'
+      responses:
+        '200':
+          description: Incident deleted
+        '400':
+          description: Invalid ID parameter
+        '404':
+          description: Incident not found
+
+  /ai-incident-management/{id}/archive:
+    patch:
+      tags: [AI Incident Management]
+      summary: Archive incident by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/incidentId'
+      responses:
+        '200':
+          description: Incident archived
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/Incident'
+        '400':
+          description: Invalid ID parameter
+        '404':
+          description: Incident not found
+
+# =============================================================================
+# COMPONENTS
+# =============================================================================
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    scanId:
+      name: scanId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Scan ID
+    repositoryId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Repository ID
+    incidentId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Incident ID
+
+  schemas:
+    # =========================================================================
+    # Common
+    # =========================================================================
+
+    ApiResponse:
+      type: object
+      properties:
+        statusCode:
+          type: integer
+        data:
+          description: Response payload (varies by endpoint)
+
+    ErrorResponse:
+      type: object
+      properties:
+        statusCode:
+          type: integer
+        data:
+          type: string
+          description: Error message
+
+    Pagination:
+      type: object
+      properties:
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+        total_pages:
+          type: integer
+
+    # =========================================================================
+    # AI Detection - Enums
+    # =========================================================================
+
+    ScanStatus:
+      type: string
+      enum: [pending, cloning, scanning, completed, failed, cancelled]
+
+    ScanMode:
+      type: string
+      enum: [full, incremental]
+
+    FindingStatus:
+      type: string
+      enum: [active, fixed, carried_forward]
+
+    FindingType:
+      type: string
+      enum:
+        - library
+        - dependency
+        - api_call
+        - secret
+        - model_ref
+        - rag_component
+        - agent
+        - prompt_injection
+        - pii_exposure
+        - excessive_agency
+        - jailbreak_risk
+        - training_data_poisoning
+        - model_dos
+        - supply_chain
+        - insecure_plugin
+        - overreliance
+        - model_theft
+
+    ConfidenceLevel:
+      type: string
+      enum: [high, medium, low]
+
+    RiskLevel:
+      type: string
+      enum: [high, medium, low]
+
+    GovernanceStatus:
+      type: string
+      enum: [reviewed, approved, flagged]
+      nullable: true
+
+    LicenseRiskLevel:
+      type: string
+      enum: [high, medium, low, unknown]
+
+    # =========================================================================
+    # AI Detection - Scan Schemas
+    # =========================================================================
+
+    StartScanRequest:
+      type: object
+      required: [repository_url]
+      properties:
+        repository_url:
+          type: string
+          description: GitHub repository URL
+          example: https://github.com/owner/repo
+        scan_mode:
+          $ref: '#/components/schemas/ScanMode'
+        base_commit_sha:
+          type: string
+          pattern: '^[0-9a-fA-F]{7,40}$'
+          description: Required for incremental scans
+        head_commit_sha:
+          type: string
+          pattern: '^[0-9a-fA-F]{7,40}$'
+          description: Required for incremental scans
+
+    ScanStatusResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        status:
+          $ref: '#/components/schemas/ScanStatus'
+        progress:
+          type: number
+          format: float
+        current_file:
+          type: string
+        files_scanned:
+          type: integer
+        total_files:
+          type: integer
+          nullable: true
+        findings_count:
+          type: integer
+        error_message:
+          type: string
+          nullable: true
+
+    TriggeredByUser:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        surname:
+          type: string
+
+    ScanResponse:
+      type: object
+      properties:
+        scan:
+          type: object
+          properties:
+            id:
+              type: integer
+            repository_url:
+              type: string
+            repository_owner:
+              type: string
+            repository_name:
+              type: string
+            status:
+              $ref: '#/components/schemas/ScanStatus'
+            findings_count:
+              type: integer
+            files_scanned:
+              type: integer
+            started_at:
+              type: string
+              format: date-time
+              nullable: true
+            completed_at:
+              type: string
+              format: date-time
+              nullable: true
+            duration_ms:
+              type: integer
+              nullable: true
+            error_message:
+              type: string
+              nullable: true
+            triggered_by:
+              $ref: '#/components/schemas/TriggeredByUser'
+            risk_score:
+              type: number
+              nullable: true
+            risk_score_grade:
+              type: string
+              nullable: true
+            risk_score_details:
+              type: object
+              nullable: true
+            risk_score_calculated_at:
+              type: string
+              format: date-time
+              nullable: true
+            scan_mode:
+              $ref: '#/components/schemas/ScanMode'
+            base_commit_sha:
+              type: string
+              nullable: true
+            head_commit_sha:
+              type: string
+              nullable: true
+            baseline_scan_id:
+              type: integer
+              nullable: true
+            changed_files_count:
+              type: integer
+              nullable: true
+            created_at:
+              type: string
+              format: date-time
+        summary:
+          $ref: '#/components/schemas/ScanSummary'
+
+    ScanSummary:
+      type: object
+      properties:
+        total:
+          type: integer
+        by_confidence:
+          type: object
+          properties:
+            high:
+              type: integer
+            medium:
+              type: integer
+            low:
+              type: integer
+        by_provider:
+          type: object
+          additionalProperties:
+            type: integer
+
+    ScanListItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        repository_url:
+          type: string
+        repository_owner:
+          type: string
+        repository_name:
+          type: string
+        status:
+          $ref: '#/components/schemas/ScanStatus'
+        findings_count:
+          type: integer
+        files_scanned:
+          type: integer
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        duration_ms:
+          type: integer
+          nullable: true
+        triggered_by:
+          $ref: '#/components/schemas/TriggeredByUser'
+        risk_score:
+          type: number
+          nullable: true
+        risk_score_grade:
+          type: string
+          nullable: true
+        scan_mode:
+          $ref: '#/components/schemas/ScanMode'
+        baseline_scan_id:
+          type: integer
+          nullable: true
+        changed_files_count:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    ScansResponse:
+      type: object
+      properties:
+        scans:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScanListItem'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    CancelScanResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        status:
+          type: string
+          enum: [cancelled]
+        message:
+          type: string
+
+    DeleteScanResponse:
+      type: object
+      properties:
+        message:
+          type: string
+
+    # =========================================================================
+    # AI Detection - Finding Schemas
+    # =========================================================================
+
+    FilePath:
+      type: object
+      properties:
+        path:
+          type: string
+        line_number:
+          type: integer
+          nullable: true
+        matched_text:
+          type: string
+
+    Finding:
+      type: object
+      properties:
+        id:
+          type: integer
+        finding_type:
+          $ref: '#/components/schemas/FindingType'
+        category:
+          type: string
+        name:
+          type: string
+        provider:
+          type: string
+        confidence:
+          $ref: '#/components/schemas/ConfidenceLevel'
+        risk_level:
+          $ref: '#/components/schemas/RiskLevel'
+        description:
+          type: string
+          nullable: true
+        documentation_url:
+          type: string
+          nullable: true
+        file_count:
+          type: integer
+        file_paths:
+          type: array
+          items:
+            $ref: '#/components/schemas/FilePath'
+        governance_status:
+          $ref: '#/components/schemas/GovernanceStatus'
+        governance_updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        governance_updated_by:
+          type: integer
+          nullable: true
+        license_id:
+          type: string
+          nullable: true
+        license_name:
+          type: string
+          nullable: true
+        license_risk:
+          $ref: '#/components/schemas/LicenseRiskLevel'
+        license_source:
+          type: string
+          enum: [package, huggingface, pypi, npm, manual]
+          nullable: true
+        mitigation:
+          type: string
+          nullable: true
+        data_flow_summary:
+          type: string
+          nullable: true
+        vulnerability_details:
+          type: object
+          nullable: true
+        finding_status:
+          $ref: '#/components/schemas/FindingStatus'
+
+    FindingsResponse:
+      type: object
+      properties:
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Finding'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    UpdateGovernanceStatusRequest:
+      type: object
+      properties:
+        governance_status:
+          type: string
+          enum: [reviewed, approved, flagged]
+          nullable: true
+          description: Set to null to clear governance status
+
+    UpdateGovernanceStatusResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        governance_status:
+          type: string
+          nullable: true
+        governance_updated_at:
+          type: string
+          format: date-time
+        governance_updated_by:
+          type: integer
+
+    # =========================================================================
+    # AI Detection - Risk Scoring
+    # =========================================================================
+
+    RiskScoreResponse:
+      type: object
+      properties:
+        score:
+          type: number
+          nullable: true
+        grade:
+          type: string
+          nullable: true
+        details:
+          type: object
+          nullable: true
+        calculated_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    DimensionWeights:
+      type: object
+      properties:
+        data_sovereignty:
+          type: number
+          minimum: 0
+          maximum: 1
+        transparency:
+          type: number
+          minimum: 0
+          maximum: 1
+        security:
+          type: number
+          minimum: 0
+          maximum: 1
+        autonomy:
+          type: number
+          minimum: 0
+          maximum: 1
+        supply_chain:
+          type: number
+          minimum: 0
+          maximum: 1
+      description: All values must sum to 1.0
+
+    VulnerabilityTypesEnabled:
+      type: object
+      properties:
+        prompt_injection:
+          type: boolean
+        pii_exposure:
+          type: boolean
+        excessive_agency:
+          type: boolean
+        jailbreak_risk:
+          type: boolean
+        training_data_poisoning:
+          type: boolean
+        model_dos:
+          type: boolean
+        supply_chain:
+          type: boolean
+        insecure_plugin:
+          type: boolean
+        overreliance:
+          type: boolean
+        model_theft:
+          type: boolean
+
+    RiskScoringConfig:
+      type: object
+      properties:
+        id:
+          type: integer
+          nullable: true
+        llm_enabled:
+          type: boolean
+        llm_key_id:
+          type: integer
+          nullable: true
+        dimension_weights:
+          $ref: '#/components/schemas/DimensionWeights'
+        vulnerability_scan_enabled:
+          type: boolean
+        vulnerability_types_enabled:
+          $ref: '#/components/schemas/VulnerabilityTypesEnabled'
+        updated_by:
+          type: integer
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    UpdateRiskScoringConfigRequest:
+      type: object
+      properties:
+        llm_enabled:
+          type: boolean
+        llm_key_id:
+          type: integer
+          nullable: true
+        dimension_weights:
+          $ref: '#/components/schemas/DimensionWeights'
+        vulnerability_scan_enabled:
+          type: boolean
+        vulnerability_types_enabled:
+          $ref: '#/components/schemas/VulnerabilityTypesEnabled'
+
+    # =========================================================================
+    # AI Detection - Dependency Graph & Compliance
+    # =========================================================================
+
+    DependencyGraphResponse:
+      type: object
+      properties:
+        nodes:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              label:
+                type: string
+              type:
+                type: string
+              metadata:
+                type: object
+        edges:
+          type: array
+          items:
+            type: object
+            properties:
+              source:
+                type: string
+              target:
+                type: string
+              relationship:
+                type: string
+        metadata:
+          type: object
+
+    ComplianceMappingResponse:
+      type: object
+      properties:
+        mappings:
+          type: array
+          items:
+            type: object
+        checklist:
+          type: array
+          items:
+            type: object
+        summary:
+          type: object
+
+    # =========================================================================
+    # AI Detection - Repository Schemas
+    # =========================================================================
+
+    Repository:
+      type: object
+      properties:
+        id:
+          type: integer
+        repository_url:
+          type: string
+        repository_owner:
+          type: string
+        repository_name:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        default_branch:
+          type: string
+        github_token_id:
+          type: integer
+          nullable: true
+        schedule_enabled:
+          type: boolean
+        schedule_frequency:
+          type: string
+          enum: [daily, weekly, monthly]
+          nullable: true
+        schedule_day_of_week:
+          type: integer
+          minimum: 0
+          maximum: 6
+          nullable: true
+        schedule_day_of_month:
+          type: integer
+          minimum: 1
+          maximum: 31
+          nullable: true
+        schedule_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+        schedule_minute:
+          type: integer
+          minimum: 0
+          maximum: 59
+        webhook_secret:
+          type: string
+          nullable: true
+        ci_enabled:
+          type: boolean
+        ci_min_score:
+          type: number
+        ci_max_critical:
+          type: integer
+        ci_post_comments:
+          type: boolean
+        ci_status_checks:
+          type: boolean
+        last_scan_id:
+          type: integer
+          nullable: true
+        last_scan_status:
+          type: string
+          nullable: true
+        last_scan_at:
+          type: string
+          format: date-time
+          nullable: true
+        next_scan_at:
+          type: string
+          format: date-time
+          nullable: true
+        is_enabled:
+          type: boolean
+        created_by:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateRepositoryRequest:
+      type: object
+      required: [repository_url]
+      properties:
+        repository_url:
+          type: string
+          description: GitHub repository URL
+          example: https://github.com/owner/repo
+        display_name:
+          type: string
+          nullable: true
+        default_branch:
+          type: string
+          default: main
+        github_token_id:
+          type: integer
+          nullable: true
+        schedule_enabled:
+          type: boolean
+          default: false
+        schedule_frequency:
+          type: string
+          enum: [daily, weekly, monthly]
+          description: Required when schedule_enabled is true
+        schedule_day_of_week:
+          type: integer
+          minimum: 0
+          maximum: 6
+          description: Required for weekly schedule (0=Sunday)
+        schedule_day_of_month:
+          type: integer
+          minimum: 1
+          maximum: 31
+          description: Required for monthly schedule
+        schedule_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+          default: 2
+        schedule_minute:
+          type: integer
+          minimum: 0
+          maximum: 59
+          default: 0
+
+    UpdateRepositoryRequest:
+      type: object
+      properties:
+        display_name:
+          type: string
+          nullable: true
+        default_branch:
+          type: string
+        github_token_id:
+          type: integer
+          nullable: true
+        schedule_enabled:
+          type: boolean
+        schedule_frequency:
+          type: string
+          enum: [daily, weekly, monthly]
+        schedule_day_of_week:
+          type: integer
+          minimum: 0
+          maximum: 6
+        schedule_day_of_month:
+          type: integer
+          minimum: 1
+          maximum: 31
+        schedule_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+        schedule_minute:
+          type: integer
+          minimum: 0
+          maximum: 59
+        is_enabled:
+          type: boolean
+        ci_enabled:
+          type: boolean
+        ci_min_score:
+          type: number
+        ci_max_critical:
+          type: integer
+        ci_post_comments:
+          type: boolean
+        ci_status_checks:
+          type: boolean
+
+    RepositoryListResponse:
+      type: object
+      properties:
+        repositories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Repository'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    # =========================================================================
+    # AI Trust Centre Schemas
+    # =========================================================================
+
+    AITrustCentreOverview:
+      type: object
+      description: Full overview with all sections
+      properties:
+        intro:
+          type: object
+          properties:
+            id:
+              type: integer
+            purpose_visible:
+              type: boolean
+            purpose_text:
+              type: string
+            our_statement_visible:
+              type: boolean
+            our_statement_text:
+              type: string
+            our_mission_visible:
+              type: boolean
+            our_mission_text:
+              type: string
+        compliance_badges:
+          type: object
+          properties:
+            id:
+              type: integer
+            soc2_type_i:
+              type: boolean
+            soc2_type_ii:
+              type: boolean
+            iso_27001:
+              type: boolean
+            iso_42001:
+              type: boolean
+            ccpa:
+              type: boolean
+            gdpr:
+              type: boolean
+            hipaa:
+              type: boolean
+            eu_ai_act:
+              type: boolean
+        company_description:
+          type: object
+          properties:
+            id:
+              type: integer
+            background_visible:
+              type: boolean
+            background_text:
+              type: string
+            core_benefits_visible:
+              type: boolean
+            core_benefits_text:
+              type: string
+            compliance_doc_visible:
+              type: boolean
+            compliance_doc_text:
+              type: string
+        terms_and_contact:
+          type: object
+          properties:
+            id:
+              type: integer
+            terms_visible:
+              type: boolean
+            terms_text:
+              type: string
+            privacy_visible:
+              type: boolean
+            privacy_text:
+              type: string
+            email_visible:
+              type: boolean
+            email_text:
+              type: string
+        info:
+          type: object
+          properties:
+            id:
+              type: integer
+            title:
+              type: string
+            header_color:
+              type: string
+            visible:
+              type: boolean
+            intro_visible:
+              type: boolean
+            compliance_badges_visible:
+              type: boolean
+            company_description_visible:
+              type: boolean
+            terms_and_contact_visible:
+              type: boolean
+            resources_visible:
+              type: boolean
+            subprocessor_visible:
+              type: boolean
+            updated_at:
+              type: string
+              format: date-time
+
+    AITrustCentreResource:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        file_id:
+          type: integer
+        visible:
+          type: boolean
+        filename:
+          type: string
+
+    AITrustCentreSubprocessor:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        name:
+          type: string
+        purpose:
+          type: string
+        location:
+          type: string
+        url:
+          type: string
+
+    CreateSubprocessorRequest:
+      type: object
+      required: [name, purpose, location]
+      properties:
+        name:
+          type: string
+        purpose:
+          type: string
+        location:
+          type: string
+        url:
+          type: string
+
+    UpdateSubprocessorRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        purpose:
+          type: string
+        location:
+          type: string
+        url:
+          type: string
+
+    AITrustCentrePublicPage:
+      type: object
+      description: Conditionally includes sections based on visibility settings
+      properties:
+        info:
+          type: object
+          properties:
+            title:
+              type: string
+            header_color:
+              type: string
+            logo:
+              type: integer
+              nullable: true
+        intro:
+          type: object
+          nullable: true
+          properties:
+            purpose:
+              type: string
+              nullable: true
+            statement:
+              type: string
+              nullable: true
+            mission:
+              type: string
+              nullable: true
+        compliance_badges:
+          type: object
+          nullable: true
+          properties:
+            soc2_type_i:
+              type: boolean
+            soc2_type_ii:
+              type: boolean
+            iso_27001:
+              type: boolean
+            iso_42001:
+              type: boolean
+            ccpa:
+              type: boolean
+            gdpr:
+              type: boolean
+            hipaa:
+              type: boolean
+            eu_ai_act:
+              type: boolean
+        company_description:
+          type: object
+          nullable: true
+          properties:
+            background:
+              type: string
+              nullable: true
+            core_benefits:
+              type: string
+              nullable: true
+            compliance_doc:
+              type: string
+              nullable: true
+        terms_and_contact:
+          type: object
+          nullable: true
+          properties:
+            terms:
+              type: string
+              nullable: true
+            privacy:
+              type: string
+              nullable: true
+            email:
+              type: string
+              nullable: true
+        resources:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              description:
+                type: string
+              file_id:
+                type: integer
+              visible:
+                type: boolean
+        subprocessors:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              purpose:
+                type: string
+              location:
+                type: string
+              url:
+                type: string
+
+    # =========================================================================
+    # AI Incident Management Schemas
+    # =========================================================================
+
+    IncidentType:
+      type: string
+      enum:
+        - Malfunction
+        - Unexpected behavior
+        - Model drift
+        - Misuse
+        - Data corruption
+        - Security breach
+        - Performance degradation
+
+    IncidentSeverity:
+      type: string
+      enum:
+        - Minor
+        - Serious
+        - Very serious
+
+    IncidentStatus:
+      type: string
+      enum:
+        - Open
+        - Investigating
+        - Mitigated
+        - Closed
+
+    IncidentApprovalStatus:
+      type: string
+      enum:
+        - Approved
+        - Rejected
+        - Pending
+        - Not required
+
+    Incident:
+      type: object
+      properties:
+        id:
+          type: integer
+        incident_id:
+          type: string
+          nullable: true
+        ai_project:
+          type: string
+        type:
+          $ref: '#/components/schemas/IncidentType'
+        severity:
+          $ref: '#/components/schemas/IncidentSeverity'
+        status:
+          $ref: '#/components/schemas/IncidentStatus'
+        occurred_date:
+          type: string
+          format: date-time
+        date_detected:
+          type: string
+          format: date-time
+        reporter:
+          type: string
+        categories_of_harm:
+          type: array
+          items:
+            type: string
+        affected_persons_groups:
+          type: string
+          nullable: true
+        description:
+          type: string
+        relationship_causality:
+          type: string
+          nullable: true
+        immediate_mitigations:
+          type: string
+          nullable: true
+        planned_corrective_actions:
+          type: string
+          nullable: true
+        model_system_version:
+          type: string
+          nullable: true
+        interim_report:
+          type: boolean
+        archived:
+          type: boolean
+        approval_status:
+          $ref: '#/components/schemas/IncidentApprovalStatus'
+        approved_by:
+          type: string
+          nullable: true
+        approval_date:
+          type: string
+          format: date-time
+          nullable: true
+        approval_notes:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateIncidentRequest:
+      type: object
+      required:
+        - ai_project
+        - type
+        - severity
+        - status
+        - occurred_date
+        - date_detected
+        - reporter
+        - approval_status
+        - categories_of_harm
+        - description
+        - relationship_causality
+      properties:
+        ai_project:
+          type: string
+        type:
+          $ref: '#/components/schemas/IncidentType'
+        severity:
+          $ref: '#/components/schemas/IncidentSeverity'
+        status:
+          $ref: '#/components/schemas/IncidentStatus'
+        occurred_date:
+          type: string
+          format: date-time
+        date_detected:
+          type: string
+          format: date-time
+        reporter:
+          type: string
+        approval_status:
+          $ref: '#/components/schemas/IncidentApprovalStatus'
+        approved_by:
+          type: string
+        categories_of_harm:
+          oneOf:
+            - type: array
+              items:
+                type: string
+            - type: string
+              description: Comma-separated string (will be split)
+        affected_persons_groups:
+          type: string
+        description:
+          type: string
+        relationship_causality:
+          type: string
+        immediate_mitigations:
+          type: string
+        planned_corrective_actions:
+          type: string
+        model_system_version:
+          type: string
+        interim_report:
+          type: boolean
+          default: false
+        archived:
+          type: boolean
+          default: false
+        approval_date:
+          type: string
+          format: date-time
+        approval_notes:
+          type: string
+
+    UpdateIncidentRequest:
+      type: object
+      description: All fields are optional; only provided fields are updated.
+      properties:
+        ai_project:
+          type: string
+        type:
+          $ref: '#/components/schemas/IncidentType'
+        severity:
+          $ref: '#/components/schemas/IncidentSeverity'
+        status:
+          $ref: '#/components/schemas/IncidentStatus'
+        occurred_date:
+          type: string
+          format: date-time
+        date_detected:
+          type: string
+          format: date-time
+        reporter:
+          type: string
+        approval_status:
+          $ref: '#/components/schemas/IncidentApprovalStatus'
+        approved_by:
+          type: string
+        categories_of_harm:
+          oneOf:
+            - type: array
+              items:
+                type: string
+            - type: string
+        affected_persons_groups:
+          type: string
+        description:
+          type: string
+        relationship_causality:
+          type: string
+        immediate_mitigations:
+          type: string
+        planned_corrective_actions:
+          type: string
+        model_system_version:
+          type: string
+        interim_report:
+          type: boolean
+        archived:
+          type: boolean
+        approval_date:
+          type: string
+          format: date-time
+        approval_notes:
+          type: string

--- a/Servers/docs/api/compliance-frameworks-openapi.yaml
+++ b/Servers/docs/api/compliance-frameworks-openapi.yaml
@@ -1,0 +1,2089 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise Compliance Frameworks API
+  description: API endpoints for compliance framework management including ISO 27001, ISO 42001, NIST AI RMF, and compliance scoring.
+  version: 1.0.0
+
+servers:
+  - url: /
+    description: Local server
+
+security:
+  - bearerAuth: []
+
+paths:
+  # ==================== Frameworks ====================
+  /frameworks:
+    get:
+      tags: [Frameworks]
+      summary: Get all frameworks
+      description: Retrieves all compliance frameworks for the authenticated user's organization.
+      responses:
+        "200":
+          description: Frameworks retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "204":
+          description: No frameworks found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /frameworks/{id}:
+    get:
+      tags: [Frameworks]
+      summary: Get framework by ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Framework found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /frameworks/toProject:
+    post:
+      tags: [Frameworks]
+      summary: Add framework to project
+      description: Associates a framework with a project. Fails if the project has a pending approval request.
+      parameters:
+        - name: frameworkId
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: projectId
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Framework added to project
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          description: Project has pending approval request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /frameworks/fromProject:
+    delete:
+      tags: [Frameworks]
+      summary: Remove framework from project
+      description: Removes a framework association from a project. Fails if the project has a pending approval request.
+      parameters:
+        - name: frameworkId
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: projectId
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Framework removed from project
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          description: Project has pending approval request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ==================== ISO 27001 ====================
+  /iso27001/clauses:
+    get:
+      tags: [ISO 27001]
+      summary: Get all ISO 27001 clauses
+      description: Returns all ISO 27001 clause structure records for the organization.
+      responses:
+        "200":
+          description: Clauses retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ISO27001Clause"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/clauses/struct/byProjectId/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get clauses structure for project
+      description: Returns clauses with nested sub-clauses for a specific project framework ID.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Clauses structure retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ISO27001ClauseWithSubClauses"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/annexes:
+    get:
+      tags: [ISO 27001]
+      summary: Get all ISO 27001 annexes
+      description: Returns all ISO 27001 annex structure records for the organization.
+      responses:
+        "200":
+          description: Annexes retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ISO27001Annex"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/annexes/struct/byProjectId/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get annexes structure for project
+      description: Returns annexes with nested controls for a specific project framework ID.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annexes structure retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ISO27001AnnexWithControls"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/clauses/byProjectId/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get clauses by project framework ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Clauses retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/annexes/byProjectId/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get annexes by project framework ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annexes retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/subClauses/byClauseId/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get sub-clauses by clause ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Sub-clauses retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: No sub-clauses found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/annexControls/byAnnexId/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get annex controls by annex ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annex controls retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: No annex controls found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/subClause/byId/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get sub-clause by ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+        - name: projectFrameworkId
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Sub-clause retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: No sub-clause found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/annexControl/byId/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get annex control by ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+        - name: projectFrameworkId
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Annex control retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: No annex control found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/clauses/progress/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get project clauses progress
+      description: Returns total and completed sub-clauses count for a project framework.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Progress data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProgressResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/annexes/progress/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get project annexes progress
+      description: Returns total and completed annex controls count for a project framework.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Progress data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProgressResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/all/clauses/progress:
+    get:
+      tags: [ISO 27001]
+      summary: Get all projects clauses progress
+      description: Returns clauses progress across all projects in the organization.
+      responses:
+        "200":
+          description: Progress data for all projects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/all/annexes/progress:
+    get:
+      tags: [ISO 27001]
+      summary: Get all projects annexes progress
+      description: Returns annexes progress across all projects in the organization.
+      responses:
+        "200":
+          description: Progress data for all projects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/clauses/assignments/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get project clauses assignments
+      description: Returns total and assigned sub-clauses count for a project framework.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Assignment data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssignmentResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/annexes/assignments/{id}:
+    get:
+      tags: [ISO 27001]
+      summary: Get project annexes assignments
+      description: Returns total and assigned annex controls count for a project framework.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Assignment data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssignmentResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/saveClauses/{id}:
+    patch:
+      tags: [ISO 27001]
+      summary: Save/update a sub-clause
+      description: Updates a sub-clause with new data, file uploads, file unlinking, and risk associations. Accepts multipart/form-data.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/ISO27001SaveClauseRequest"
+      responses:
+        "200":
+          description: Sub-clause updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/saveAnnexes/{id}:
+    patch:
+      tags: [ISO 27001]
+      summary: Save/update an annex control
+      description: Updates an annex control with new data, file uploads, file unlinking, and risk associations. Accepts multipart/form-data.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/ISO27001SaveAnnexRequest"
+      responses:
+        "200":
+          description: Annex control updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/clauses/byProjectId/{id}:
+    delete:
+      tags: [ISO 27001]
+      summary: Delete management system clauses by project ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Clauses deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso27001/annexes/byProjectId/{id}:
+    delete:
+      tags: [ISO 27001]
+      summary: Delete reference controls by project ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annex controls deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ==================== ISO 42001 ====================
+  /iso42001/clauses:
+    get:
+      tags: [ISO 42001]
+      summary: Get all ISO 42001 clauses
+      responses:
+        "200":
+          description: Clauses retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ISO42001Clause"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/clauses/struct/byProjectId/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get clauses structure for project
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Clauses structure with sub-clauses
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ISO42001ClauseWithSubClauses"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexes:
+    get:
+      tags: [ISO 42001]
+      summary: Get all ISO 42001 annexes
+      responses:
+        "200":
+          description: Annexes retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ISO42001Annex"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexes/struct/byProjectId/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get annexes structure for project
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annexes structure with categories
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ISO42001AnnexWithCategories"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/clauses/byProjectId/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get clauses by project framework ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Clauses retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexes/byProjectId/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get annexes by project framework ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annexes retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/subClauses/byClauseId/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get sub-clauses by clause ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Sub-clauses retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: No sub-clauses found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexCategories/byAnnexId/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get annex categories by annex ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annex categories retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: No annex categories found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/subClause/byId/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get sub-clause by ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+        - name: projectFrameworkId
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Sub-clause retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: No sub-clause found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/subclauses/{id}/risks:
+    get:
+      tags: [ISO 42001]
+      summary: Get risks linked to a sub-clause
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Linked risks retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RisksResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexCategories/{id}/risks:
+    get:
+      tags: [ISO 42001]
+      summary: Get risks linked to an annex category
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Linked risks retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RisksResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexCategory/byId/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get annex category by ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+        - name: projectFrameworkId
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Annex category retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: No annex category found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/clauses/progress/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get project clauses progress
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Progress data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProgressResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexes/progress/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get project annexes progress
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Progress data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProgressResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/all/clauses/progress:
+    get:
+      tags: [ISO 42001]
+      summary: Get all projects clauses progress
+      responses:
+        "200":
+          description: Progress data for all projects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/all/annexes/progress:
+    get:
+      tags: [ISO 42001]
+      summary: Get all projects annexes progress
+      responses:
+        "200":
+          description: Progress data for all projects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/clauses/assignments/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get project clauses assignments
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Assignment data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssignmentResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexes/assignments/{id}:
+    get:
+      tags: [ISO 42001]
+      summary: Get project annexes assignments
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Assignment data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssignmentResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/saveClauses/{id}:
+    patch:
+      tags: [ISO 42001]
+      summary: Save/update a sub-clause
+      description: Updates a sub-clause with new data, file uploads, file unlinking, and risk associations.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/ISO42001SaveClauseRequest"
+      responses:
+        "200":
+          description: Sub-clause updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/saveAnnexes/{id}:
+    patch:
+      tags: [ISO 42001]
+      summary: Save/update an annex category
+      description: Updates an annex category with new data, file uploads, file unlinking, and risk associations.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/ISO42001SaveAnnexRequest"
+      responses:
+        "200":
+          description: Annex category updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/clauses/byProjectId/{id}:
+    delete:
+      tags: [ISO 42001]
+      summary: Delete management system clauses by project ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Clauses deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /iso42001/annexes/byProjectId/{id}:
+    delete:
+      tags: [ISO 42001]
+      summary: Delete reference controls by project ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annex controls deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ==================== NIST AI RMF ====================
+  /nist-ai-rmf/functions:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get all NIST AI RMF functions
+      description: Returns all NIST AI RMF functions (Govern, Map, Measure, Manage) for the organization.
+      responses:
+        "200":
+          description: Functions retrieved
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NISTFunction"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/functions/{id}:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get NIST AI RMF function by ID or name
+      description: The id parameter can be a function name (GOVERN, MAP, MEASURE, MANAGE) or a numeric ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Function name (GOVERN, MAP, MEASURE, MANAGE) or numeric ID
+      responses:
+        "200":
+          description: Function retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/categories/{title}:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get categories by function title
+      description: Returns all NIST AI RMF categories filtered by function title.
+      parameters:
+        - name: title
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Function title (e.g., GOVERN, MAP)
+      responses:
+        "200":
+          description: Categories retrieved
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NISTCategory"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/subcategories/byId/{id}:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get subcategory by ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Subcategory retrieved
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/NISTSubcategory"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/subcategories/{id}/risks:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get risks linked to a subcategory
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Risks retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Risks retrieved successfully"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Risk"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/subcategories/{categoryId}/{title}:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get subcategories by category ID and title
+      parameters:
+        - name: categoryId
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: title
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Function title for filtering
+      responses:
+        "200":
+          description: Subcategories retrieved
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NISTSubcategory"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/subcategories/{id}:
+    patch:
+      tags: [NIST AI RMF]
+      summary: Update subcategory by ID
+      description: Updates a NIST AI RMF subcategory with new data, file uploads, file unlinking, tag changes, and risk associations.
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/NISTSubcategoryUpdateRequest"
+      responses:
+        "200":
+          description: Subcategory updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/subcategories/{id}/status:
+    patch:
+      tags: [NIST AI RMF]
+      summary: Update subcategory status
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NISTSubcategoryStatusUpdate"
+      responses:
+        "200":
+          description: Status updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "400":
+          description: Status is required or invalid status value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/progress:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get overall NIST AI RMF progress
+      description: Returns total and completed subcategories count.
+      responses:
+        "200":
+          description: Progress data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/NISTProgress"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/progress-by-function:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get progress grouped by function
+      description: Returns progress for each function (Govern, Map, Measure, Manage).
+      responses:
+        "200":
+          description: Progress by function
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/assignments:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get overall NIST AI RMF assignments
+      description: Returns total and assigned subcategories count.
+      responses:
+        "200":
+          description: Assignment data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/NISTAssignments"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/assignments-by-function:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get assignments grouped by function
+      description: Returns assignments for each function (Govern, Map, Measure, Manage).
+      responses:
+        "200":
+          description: Assignments by function
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/status-breakdown:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get status breakdown
+      description: Returns count of subcategories by status.
+      responses:
+        "200":
+          description: Status breakdown
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /nist-ai-rmf/overview:
+    get:
+      tags: [NIST AI RMF]
+      summary: Get full NIST AI RMF overview
+      description: Returns all functions with categories and subcategories in a nested structure.
+      responses:
+        "200":
+          description: Full overview
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ==================== Compliance Score ====================
+  /compliance/score:
+    get:
+      tags: [Compliance Score]
+      summary: Get compliance score
+      description: Retrieves the AI compliance score for the authenticated user's organization.
+      responses:
+        "200":
+          description: Compliance score retrieved
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ComplianceScore"
+        "400":
+          description: Organization ID is required
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /compliance/score/{organizationId}:
+    get:
+      tags: [Compliance Score]
+      summary: Get compliance score by organization
+      description: Retrieves compliance score for a specific organization. Requires the user to belong to that organization.
+      parameters:
+        - name: organizationId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Compliance score retrieved
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ComplianceScore"
+        "400":
+          description: Invalid organization ID
+        "403":
+          description: Access denied
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /compliance/details/{organizationId}:
+    get:
+      tags: [Compliance Score]
+      summary: Get detailed compliance breakdown
+      description: Returns detailed compliance analysis with insights, strongest/weakest modules, improvement priority, and data quality indicators.
+      parameters:
+        - name: organizationId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Detailed compliance data retrieved
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ComplianceDetails"
+        "400":
+          description: Invalid organization ID
+        "403":
+          description: Access denied
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    IdPath:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Resource ID
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    InternalError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+  schemas:
+    # ---- Generic response wrappers ----
+    SuccessResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 200
+        data:
+          description: Response payload (varies by endpoint)
+
+    ErrorResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+        data:
+          type: string
+          description: Error message
+
+    # ---- Frameworks ----
+    Framework:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        organization_id:
+          type: integer
+
+    # ---- ISO 27001 ----
+    ISO27001Clause:
+      type: object
+      properties:
+        id:
+          type: integer
+        arrangement:
+          type: integer
+        title:
+          type: string
+
+    ISO27001ClauseWithSubClauses:
+      type: object
+      properties:
+        id:
+          type: integer
+        arrangement:
+          type: integer
+        title:
+          type: string
+        subClauses:
+          type: array
+          items:
+            $ref: "#/components/schemas/ISO27001SubClause"
+
+    ISO27001SubClause:
+      type: object
+      properties:
+        id:
+          type: integer
+        subclause_meta_id:
+          type: integer
+        projects_frameworks_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    ISO27001Annex:
+      type: object
+      properties:
+        id:
+          type: integer
+        arrangement:
+          type: string
+        order_no:
+          type: integer
+        title:
+          type: string
+
+    ISO27001AnnexWithControls:
+      type: object
+      properties:
+        id:
+          type: integer
+        arrangement:
+          type: string
+        order_no:
+          type: integer
+        title:
+          type: string
+        controls:
+          type: array
+          items:
+            $ref: "#/components/schemas/ISO27001AnnexControl"
+
+    ISO27001AnnexControl:
+      type: object
+      properties:
+        id:
+          type: integer
+        annexcontrol_meta_id:
+          type: integer
+        projects_frameworks_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    ISO27001SaveClauseRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: User ID for file upload attribution
+        project_id:
+          type: string
+          description: Project ID for file upload association
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+          description: Evidence files to upload
+
+    ISO27001SaveAnnexRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: User ID for file upload attribution
+        project_id:
+          type: string
+          description: Project ID for file upload association
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+          description: Evidence files to upload
+
+    # ---- ISO 42001 ----
+    ISO42001Clause:
+      type: object
+      properties:
+        id:
+          type: integer
+        clause_no:
+          type: integer
+        title:
+          type: string
+
+    ISO42001ClauseWithSubClauses:
+      type: object
+      properties:
+        id:
+          type: integer
+        clause_no:
+          type: integer
+        title:
+          type: string
+        subClauses:
+          type: array
+          items:
+            $ref: "#/components/schemas/ISO42001SubClause"
+
+    ISO42001SubClause:
+      type: object
+      properties:
+        id:
+          type: integer
+        subclause_meta_id:
+          type: integer
+        projects_frameworks_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    ISO42001Annex:
+      type: object
+      properties:
+        id:
+          type: integer
+        annex_no:
+          type: integer
+        title:
+          type: string
+
+    ISO42001AnnexWithCategories:
+      type: object
+      properties:
+        id:
+          type: integer
+        annex_no:
+          type: integer
+        title:
+          type: string
+        categories:
+          type: array
+          items:
+            $ref: "#/components/schemas/ISO42001AnnexCategory"
+
+    ISO42001AnnexCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        annexcategory_meta_id:
+          type: integer
+        projects_frameworks_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    ISO42001SaveClauseRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+        project_id:
+          type: string
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+
+    ISO42001SaveAnnexRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+        project_id:
+          type: string
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+
+    # ---- NIST AI RMF ----
+    NISTFunction:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+          example: GOVERN
+        description:
+          type: string
+        organization_id:
+          type: integer
+
+    NISTCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+        function_id:
+          type: integer
+        organization_id:
+          type: integer
+
+    NISTSubcategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        subcategory_meta_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    NISTSubcategoryUpdateRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: User ID for file upload attribution
+        project_id:
+          type: string
+          description: Project ID for file upload association
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+          description: Evidence files to upload
+
+    NISTSubcategoryStatusUpdate:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+          description: New status value
+
+    NISTProgress:
+      type: object
+      properties:
+        totalSubcategories:
+          type: integer
+        doneSubcategories:
+          type: integer
+
+    NISTAssignments:
+      type: object
+      properties:
+        totalSubcategories:
+          type: integer
+        assignedSubcategories:
+          type: integer
+
+    # ---- Compliance Score ----
+    ComplianceScore:
+      type: object
+      properties:
+        organizationId:
+          type: integer
+        overallScore:
+          type: integer
+          minimum: 0
+          maximum: 100
+        calculatedAt:
+          type: string
+          format: date-time
+        modules:
+          type: object
+          properties:
+            riskManagement:
+              $ref: "#/components/schemas/ModuleScore"
+            vendorManagement:
+              $ref: "#/components/schemas/ModuleScore"
+            projectGovernance:
+              $ref: "#/components/schemas/ModuleScore"
+            modelLifecycle:
+              $ref: "#/components/schemas/ModuleScore"
+            policyDocumentation:
+              $ref: "#/components/schemas/ModuleScore"
+        metadata:
+          $ref: "#/components/schemas/ComplianceMetadata"
+
+    ModuleScore:
+      type: object
+      properties:
+        score:
+          type: number
+          minimum: 0
+          maximum: 100
+        weight:
+          type: number
+          description: Module weight (sums to 1.0 across all modules)
+        components:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComponentScore"
+        totalDataPoints:
+          type: integer
+        qualityScore:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Data completeness indicator
+
+    ComponentScore:
+      type: object
+      properties:
+        name:
+          type: string
+        score:
+          type: number
+        weight:
+          type: number
+        dataPoints:
+          type: integer
+        details:
+          type: object
+          description: Module-specific details
+
+    ComplianceMetadata:
+      type: object
+      properties:
+        totalProjects:
+          type: integer
+        applicableProjects:
+          type: integer
+        lastUpdated:
+          type: string
+          format: date-time
+        dataFreshness:
+          type: object
+          properties:
+            risks:
+              type: string
+              format: date-time
+            vendors:
+              type: string
+              format: date-time
+            projects:
+              type: string
+              format: date-time
+            models:
+              type: string
+              format: date-time
+            policies:
+              type: string
+              format: date-time
+        calculationMethod:
+          type: string
+          enum: [balanced_weighted_average]
+        version:
+          type: string
+
+    ComplianceDetails:
+      allOf:
+        - $ref: "#/components/schemas/ComplianceScore"
+        - type: object
+          properties:
+            insights:
+              type: object
+              properties:
+                strongestModule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    score:
+                      type: number
+                weakestModule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    score:
+                      type: number
+                improvementPriority:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      module:
+                        type: string
+                      score:
+                        type: number
+                      weight:
+                        type: number
+                      impact:
+                        type: number
+                        description: "(100 - score) * weight"
+                overallTrend:
+                  type: string
+                  enum: [up, down, stable]
+                dataQuality:
+                  type: object
+                  properties:
+                    riskManagement:
+                      type: number
+                    vendorManagement:
+                      type: number
+                    projectGovernance:
+                      type: number
+                    modelLifecycle:
+                      type: number
+                    policyDocumentation:
+                      type: number
+
+    # ---- Shared ----
+    ProgressResponse:
+      type: object
+      properties:
+        total:
+          type: integer
+        done:
+          type: integer
+
+    AssignmentResponse:
+      type: object
+      properties:
+        total:
+          type: integer
+        assigned:
+          type: integer
+
+    RisksResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Risk"
+
+    Risk:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+        risk_level:
+          type: string
+        status:
+          type: string
+        organization_id:
+          type: integer

--- a/Servers/docs/api/evidence-datasets-automations-openapi.yaml
+++ b/Servers/docs/api/evidence-datasets-automations-openapi.yaml
@@ -1,0 +1,1245 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise API - Evidence Hub, Datasets, Automations
+  version: 1.0.0
+  description: API documentation for Evidence Hub, Datasets, and Automations domains.
+
+servers:
+  - url: /
+    description: Base URL (no /api prefix)
+
+security:
+  - bearerAuth: []
+
+paths:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Evidence Hub
+  # ─────────────────────────────────────────────────────────────────────────────
+  /evidences:
+    get:
+      tags: [Evidence Hub]
+      summary: Get all evidences
+      description: Returns all evidence records for the authenticated user's organization.
+      responses:
+        "200":
+          description: List of evidences (may be empty)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Evidence"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    post:
+      tags: [Evidence Hub]
+      summary: Create new evidence
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EvidenceCreateRequest"
+      responses:
+        "201":
+          description: Evidence created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Evidence"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /evidences/{id}:
+    parameters:
+      - $ref: "#/components/parameters/IdParam"
+
+    get:
+      tags: [Evidence Hub]
+      summary: Get evidence by ID
+      responses:
+        "200":
+          description: Evidence found
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Evidence"
+        "204":
+          description: No evidence found
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    patch:
+      tags: [Evidence Hub]
+      summary: Update evidence by ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EvidenceUpdateRequest"
+      responses:
+        "200":
+          description: Evidence updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Evidence"
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "404":
+          description: Evidence not found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      tags: [Evidence Hub]
+      summary: Delete evidence by ID
+      responses:
+        "200":
+          description: Evidence deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: string
+                        example: Evidence deleted successfully
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "404":
+          description: Evidence not found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Datasets
+  # ─────────────────────────────────────────────────────────────────────────────
+  /datasets:
+    get:
+      tags: [Datasets]
+      summary: Get all datasets
+      description: Returns all datasets for the authenticated user's organization.
+      responses:
+        "200":
+          description: List of datasets
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Dataset"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    post:
+      tags: [Datasets]
+      summary: Create a new dataset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DatasetCreateRequest"
+      responses:
+        "201":
+          description: Dataset created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Dataset"
+        "400":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /datasets/{id}:
+    parameters:
+      - $ref: "#/components/parameters/IdParam"
+
+    get:
+      tags: [Datasets]
+      summary: Get dataset by ID
+      responses:
+        "200":
+          description: Dataset found
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Dataset"
+        "204":
+          description: No dataset found
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    patch:
+      tags: [Datasets]
+      summary: Update dataset by ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DatasetUpdateRequest"
+      responses:
+        "200":
+          description: Dataset updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Dataset"
+        "400":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorResponse"
+        "404":
+          description: Dataset not found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      tags: [Datasets]
+      summary: Delete dataset by ID
+      responses:
+        "200":
+          description: Dataset deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: string
+                        example: Dataset deleted successfully
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "404":
+          description: Dataset not found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /datasets/by-model/{modelId}:
+    parameters:
+      - name: modelId
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Model inventory ID
+    get:
+      tags: [Datasets]
+      summary: Get datasets by model ID
+      responses:
+        "200":
+          description: Datasets for the given model
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Dataset"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /datasets/by-project/{projectId}:
+    parameters:
+      - name: projectId
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Project ID
+    get:
+      tags: [Datasets]
+      summary: Get datasets by project ID
+      responses:
+        "200":
+          description: Datasets for the given project
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Dataset"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /datasets/{id}/history:
+    parameters:
+      - $ref: "#/components/parameters/IdParam"
+    get:
+      tags: [Datasets]
+      summary: Get dataset change history
+      responses:
+        "200":
+          description: Change history entries
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/DatasetChangeHistoryEntry"
+        "400":
+          $ref: "#/components/responses/InvalidParameter"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Automations
+  # ─────────────────────────────────────────────────────────────────────────────
+  /automations:
+    get:
+      tags: [Automations]
+      summary: Get all automations
+      description: Returns all automations for the authenticated user's organization.
+      responses:
+        "200":
+          description: List of automations
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Automation"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    post:
+      tags: [Automations]
+      summary: Create a new automation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AutomationCreateRequest"
+      responses:
+        "201":
+          description: Automation created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/AutomationWithActions"
+        "400":
+          description: Missing required fields
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /automations/triggers:
+    get:
+      tags: [Automations]
+      summary: Get all automation triggers
+      description: Returns the catalog of available automation triggers (not org-scoped).
+      responses:
+        "200":
+          description: List of triggers
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/AutomationTrigger"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /automations/actions/by-triggerId/{triggerId}:
+    parameters:
+      - name: triggerId
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Trigger ID
+    get:
+      tags: [Automations]
+      summary: Get available actions for a trigger
+      responses:
+        "200":
+          description: List of actions available for the trigger
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/AutomationAction"
+        "400":
+          description: Invalid trigger ID
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /automations/{id}:
+    parameters:
+      - $ref: "#/components/parameters/IdParam"
+
+    get:
+      tags: [Automations]
+      summary: Get automation by ID
+      responses:
+        "200":
+          description: Automation with actions
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/AutomationWithActions"
+        "400":
+          description: Invalid automation ID
+        "404":
+          description: Automation not found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    put:
+      tags: [Automations]
+      summary: Update automation by ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AutomationUpdateRequest"
+      responses:
+        "200":
+          description: Automation updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/AutomationWithActions"
+        "400":
+          description: Invalid automation ID
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      tags: [Automations]
+      summary: Delete automation by ID
+      responses:
+        "200":
+          description: Automation deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                            example: Automation deleted successfully
+        "400":
+          description: Invalid automation ID
+        "404":
+          description: Automation not found
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /automations/{id}/history:
+    parameters:
+      - $ref: "#/components/parameters/IdParam"
+    get:
+      tags: [Automations]
+      summary: Get automation execution history
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+          description: Number of records to return
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+          description: Number of records to skip
+      responses:
+        "200":
+          description: Paginated execution logs
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/AutomationHistoryResponse"
+        "400":
+          description: Invalid automation ID
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /automations/{id}/stats:
+    parameters:
+      - $ref: "#/components/parameters/IdParam"
+    get:
+      tags: [Automations]
+      summary: Get automation execution stats
+      responses:
+        "200":
+          description: Execution statistics
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/AutomationStats"
+        "400":
+          description: Invalid automation ID
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    IdParam:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Resource ID
+
+  responses:
+    InternalError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    InvalidParameter:
+      description: Invalid parameter
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                example: error
+              message:
+                type: string
+                example: Invalid ID
+              code:
+                type: string
+                example: INVALID_PARAMETER
+
+  schemas:
+    # ─── Generic wrappers ──────────────────────────────────────────────────────
+    SuccessResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+        data:
+          description: Response payload (type varies per endpoint)
+
+    ErrorResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: error
+        data:
+          type: string
+          description: Error message
+
+    ValidationErrorResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: error
+        message:
+          type: string
+          example: Dataset creation validation failed
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+              message:
+                type: string
+              code:
+                type: string
+
+    # ─── Evidence Hub ──────────────────────────────────────────────────────────
+    Evidence:
+      type: object
+      properties:
+        id:
+          type: integer
+        evidence_name:
+          type: string
+        evidence_type:
+          type: string
+        description:
+          type: string
+          nullable: true
+        evidence_files:
+          type: array
+          items:
+            $ref: "#/components/schemas/FileResponse"
+        expiry_date:
+          type: string
+          format: date-time
+          nullable: true
+        mapped_model_ids:
+          type: array
+          items:
+            type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    FileResponse:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+        filename:
+          type: string
+        size:
+          oneOf:
+            - type: number
+            - type: string
+        mimetype:
+          type: string
+        uploaded_by:
+          type: integer
+        upload_date:
+          type: string
+
+    EvidenceCreateRequest:
+      type: object
+      required:
+        - evidence_name
+        - evidence_type
+      properties:
+        evidence_name:
+          type: string
+          maxLength: 255
+        evidence_type:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          nullable: true
+        evidence_files:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                oneOf:
+                  - type: string
+                  - type: integer
+          description: Array of file references (by ID) to link
+        expiry_date:
+          type: string
+          format: date-time
+          nullable: true
+        mapped_model_ids:
+          type: array
+          items:
+            type: integer
+          description: Model inventory IDs to map this evidence to
+
+    EvidenceUpdateRequest:
+      type: object
+      properties:
+        evidence_name:
+          type: string
+          maxLength: 255
+        evidence_type:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          nullable: true
+        evidence_files:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                oneOf:
+                  - type: string
+                  - type: integer
+          description: New files to link
+        deleteFiles:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: integer
+          description: File IDs to unlink
+        expiry_date:
+          type: string
+          format: date-time
+          nullable: true
+        mapped_model_ids:
+          type: array
+          items:
+            type: integer
+
+    # ─── Datasets ──────────────────────────────────────────────────────────────
+    Dataset:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        version:
+          type: string
+        owner:
+          type: string
+        type:
+          type: string
+          enum: [training, validation, testing, production, reference, synthetic]
+        function:
+          type: string
+        source:
+          type: string
+        license:
+          type: string
+          nullable: true
+        format:
+          type: string
+          nullable: true
+        classification:
+          type: string
+          enum: [public, internal, confidential, restricted]
+        contains_pii:
+          type: boolean
+        pii_types:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [draft, active, deprecated, archived]
+        status_date:
+          type: string
+          format: date-time
+        known_biases:
+          type: string
+          nullable: true
+        bias_mitigation:
+          type: string
+          nullable: true
+        collection_method:
+          type: string
+          nullable: true
+        preprocessing_steps:
+          type: string
+          nullable: true
+        documentation_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentationFile"
+        is_demo:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        models:
+          type: array
+          items:
+            type: integer
+          description: Related model inventory IDs
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Related project IDs
+
+    DocumentationFile:
+      type: object
+      description: File metadata stored in JSONB documentation_data column
+      properties:
+        id:
+          type: string
+        filename:
+          type: string
+        size:
+          type: number
+        mimetype:
+          type: string
+
+    DatasetCreateRequest:
+      type: object
+      required:
+        - name
+        - description
+        - version
+        - owner
+        - type
+        - function
+        - source
+        - classification
+        - contains_pii
+        - status
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        version:
+          type: string
+          maxLength: 50
+        owner:
+          type: string
+          maxLength: 255
+        type:
+          type: string
+          enum: [training, validation, testing, production, reference, synthetic]
+        function:
+          type: string
+        source:
+          type: string
+          maxLength: 255
+        license:
+          type: string
+          maxLength: 255
+        format:
+          type: string
+          maxLength: 100
+        classification:
+          type: string
+          enum: [public, internal, confidential, restricted]
+        contains_pii:
+          type: boolean
+        pii_types:
+          type: string
+        status:
+          type: string
+          enum: [draft, active, deprecated, archived]
+        status_date:
+          type: string
+          format: date-time
+          description: Defaults to current time if omitted
+        known_biases:
+          type: string
+        bias_mitigation:
+          type: string
+        collection_method:
+          type: string
+        preprocessing_steps:
+          type: string
+        documentation_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentationFile"
+        is_demo:
+          type: boolean
+          default: false
+        models:
+          type: array
+          items:
+            type: integer
+          description: Model inventory IDs to associate
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Project IDs to associate
+
+    DatasetUpdateRequest:
+      type: object
+      description: All fields optional. Only provided fields are updated.
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        version:
+          type: string
+          maxLength: 50
+        owner:
+          type: string
+          maxLength: 255
+        type:
+          type: string
+          enum: [training, validation, testing, production, reference, synthetic]
+        function:
+          type: string
+        source:
+          type: string
+          maxLength: 255
+        license:
+          type: string
+          maxLength: 255
+        format:
+          type: string
+          maxLength: 100
+        classification:
+          type: string
+          enum: [public, internal, confidential, restricted]
+        contains_pii:
+          type: boolean
+        pii_types:
+          type: string
+        status:
+          type: string
+          enum: [draft, active, deprecated, archived]
+        status_date:
+          type: string
+          format: date-time
+        known_biases:
+          type: string
+        bias_mitigation:
+          type: string
+        collection_method:
+          type: string
+        preprocessing_steps:
+          type: string
+        documentation_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentationFile"
+        is_demo:
+          type: boolean
+        models:
+          type: array
+          items:
+            type: integer
+          description: Replace model associations (provide full list)
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Replace project associations (provide full list)
+        deleteModels:
+          type: boolean
+          description: If true, remove all model associations (even if models array is empty)
+        deleteProjects:
+          type: boolean
+          description: If true, remove all project associations (even if projects array is empty)
+
+    DatasetChangeHistoryEntry:
+      type: object
+      properties:
+        id:
+          type: integer
+        dataset_id:
+          type: integer
+        change_type:
+          type: string
+          description: "e.g. created, deleted, field_change"
+        field_name:
+          type: string
+          nullable: true
+        old_value:
+          type: string
+          nullable: true
+        new_value:
+          type: string
+          nullable: true
+        changed_by:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    # ─── Automations ───────────────────────────────────────────────────────────
+    AutomationTrigger:
+      type: object
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+          description: Machine-readable trigger identifier
+        label:
+          type: string
+          description: Human-readable name
+        event_name:
+          type: string
+        description:
+          type: string
+          nullable: true
+
+    AutomationAction:
+      type: object
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+          description: Machine-readable action identifier
+        label:
+          type: string
+          description: Human-readable name
+        description:
+          type: string
+          nullable: true
+        default_params:
+          type: object
+          nullable: true
+          description: Default parameters for this action type
+
+    Automation:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        trigger_id:
+          type: integer
+        params:
+          type: object
+          description: Trigger-specific parameters (JSON)
+        is_active:
+          type: boolean
+        created_by:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    AutomationWithActions:
+      allOf:
+        - $ref: "#/components/schemas/Automation"
+        - type: object
+          properties:
+            actions:
+              type: array
+              items:
+                $ref: "#/components/schemas/TenantAutomationAction"
+
+    TenantAutomationAction:
+      type: object
+      properties:
+        id:
+          type: integer
+        automation_id:
+          type: integer
+        action_type_id:
+          type: integer
+        params:
+          type: object
+          nullable: true
+          description: Action-specific parameters (JSON)
+        order:
+          type: integer
+          description: Execution order (1-based)
+
+    AutomationCreateRequest:
+      type: object
+      required:
+        - triggerId
+        - name
+        - actions
+      properties:
+        triggerId:
+          type: integer
+          description: ID of the automation trigger
+        name:
+          type: string
+          description: Automation name
+        params:
+          type: string
+          description: JSON-encoded trigger parameters (parsed server-side)
+          default: "{}"
+        actions:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+              - action_type_id
+            properties:
+              action_type_id:
+                type: integer
+                description: ID of the action type
+              params:
+                type: object
+                nullable: true
+                description: Action-specific parameters
+
+    AutomationUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        triggerId:
+          type: integer
+        params:
+          type: string
+          description: JSON-encoded trigger parameters
+          default: "{}"
+        is_active:
+          type: boolean
+        actions:
+          type: array
+          items:
+            type: object
+            required:
+              - action_type_id
+            properties:
+              action_type_id:
+                type: integer
+              params:
+                type: object
+                nullable: true
+          description: If provided, replaces all existing actions
+
+    AutomationHistoryResponse:
+      type: object
+      properties:
+        logs:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              automation_id:
+                type: integer
+              status:
+                type: string
+              triggered_at:
+                type: string
+                format: date-time
+              completed_at:
+                type: string
+                format: date-time
+                nullable: true
+              actions:
+                type: array
+                items:
+                  type: object
+                description: Per-action execution results
+        total:
+          type: integer
+          description: Total number of log entries
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    AutomationStats:
+      type: object
+      description: Aggregated execution statistics for an automation
+      properties:
+        total_executions:
+          type: integer
+        successful:
+          type: integer
+        failed:
+          type: integer
+        last_executed_at:
+          type: string
+          format: date-time
+          nullable: true

--- a/Servers/docs/api/files-plugins-shadow-pmm-openapi.yaml
+++ b/Servers/docs/api/files-plugins-shadow-pmm-openapi.yaml
@@ -1,0 +1,2774 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise - File Manager, Virtual Folders, Plugins, Shadow AI & Post-Market Monitoring
+  version: 1.0.0
+  description: |
+    OpenAPI specification for File Manager, Virtual Folders, Plugins, Shadow AI,
+    and Post-Market Monitoring API domains.
+
+servers:
+  - url: /
+    description: Relative to API root
+
+security:
+  - BearerAuth: []
+
+paths:
+  # ===========================================================================
+  # FILE MANAGER
+  # ===========================================================================
+  /file-manager:
+    post:
+      tags: [File Manager]
+      summary: Upload a file
+      description: Upload a file to the organization's file manager. Max 30MB.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: File to upload (PDF, DOC, DOCX, XLS, XLSX, CSV, MD, JPEG, PNG, GIF, WEBP, SVG, BMP, TIFF, MP4, MPEG, MOV, AVI, WMV, WEBM, MKV)
+                model_id:
+                  type: integer
+                  description: Optional model inventory ID to associate
+                approval_workflow_id:
+                  type: integer
+                  description: Optional approval workflow ID to trigger
+                source:
+                  type: string
+                  description: File source label
+                  default: File Manager
+      responses:
+        '201':
+          description: File uploaded successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/FileUploadResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '413':
+          description: File size exceeds 30MB
+        '415':
+          description: Unsupported file type
+    get:
+      tags: [File Manager]
+      summary: List all files
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          description: Paginated file list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/FileListResponse'
+
+  /file-manager/search:
+    get:
+      tags: [File Manager]
+      summary: Full-text search over file contents
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Search query
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          description: Search results with snippets
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/FileSearchResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /file-manager/with-metadata:
+    get:
+      tags: [File Manager]
+      summary: List files with full metadata
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          description: Files with metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /file-manager/highlighted:
+    get:
+      tags: [File Manager]
+      summary: Get highlighted files (due for update, pending approval, recently modified)
+      parameters:
+        - name: daysUntilExpiry
+          in: query
+          schema:
+            type: integer
+            default: 30
+        - name: recentDays
+          in: query
+          schema:
+            type: integer
+            default: 7
+      responses:
+        '200':
+          description: Categorized file IDs
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/HighlightedFiles'
+
+  /file-manager/{id}:
+    get:
+      tags: [File Manager]
+      summary: Download a file
+      description: Admin only. Returns file binary with download headers.
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      responses:
+        '200':
+          description: File binary content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [File Manager]
+      summary: Delete a file
+      description: Admin, Reviewer, or Editor only.
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      responses:
+        '200':
+          description: File deleted
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /file-manager/{id}/metadata:
+    get:
+      tags: [File Manager]
+      summary: Get file metadata
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      responses:
+        '200':
+          description: File metadata
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/FileMetadata'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [File Manager]
+      summary: Update file metadata
+      description: Admin, Reviewer, or Editor only.
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFileMetadataRequest'
+      responses:
+        '200':
+          description: Updated metadata
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/FileMetadata'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /file-manager/{id}/versions:
+    get:
+      tags: [File Manager]
+      summary: Get file version history
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      responses:
+        '200':
+          description: List of file versions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /file-manager/{id}/preview:
+    get:
+      tags: [File Manager]
+      summary: Preview file content (limited to 5MB)
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      responses:
+        '200':
+          description: File content for inline display
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '413':
+          description: File too large for preview
+
+  # ===========================================================================
+  # VIRTUAL FOLDERS
+  # ===========================================================================
+  /virtual-folders:
+    get:
+      tags: [Virtual Folders]
+      summary: Get all folders (flat list with file counts)
+      responses:
+        '200':
+          description: List of folders
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/VirtualFolder'
+    post:
+      tags: [Virtual Folders]
+      summary: Create a new folder
+      description: Admin or Editor only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFolderRequest'
+      responses:
+        '201':
+          description: Folder created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/VirtualFolder'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: Duplicate folder name in same parent
+
+  /virtual-folders/tree:
+    get:
+      tags: [Virtual Folders]
+      summary: Get folder tree (hierarchical structure)
+      responses:
+        '200':
+          description: Hierarchical folder tree
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /virtual-folders/uncategorized:
+    get:
+      tags: [Virtual Folders]
+      summary: Get files not assigned to any folder
+      responses:
+        '200':
+          description: List of uncategorized files
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /virtual-folders/{id}:
+    get:
+      tags: [Virtual Folders]
+      summary: Get folder by ID
+      parameters:
+        - $ref: '#/components/parameters/FolderId'
+      responses:
+        '200':
+          description: Folder details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/VirtualFolder'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Virtual Folders]
+      summary: Update a folder
+      description: Admin or Editor only. System folders cannot be modified.
+      parameters:
+        - $ref: '#/components/parameters/FolderId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFolderRequest'
+      responses:
+        '200':
+          description: Folder updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/VirtualFolder'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Duplicate folder name
+    delete:
+      tags: [Virtual Folders]
+      summary: Delete a folder (cascades children and mappings)
+      description: Admin or Editor only. System folders cannot be deleted.
+      parameters:
+        - $ref: '#/components/parameters/FolderId'
+      responses:
+        '200':
+          description: Folder deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          deleted:
+                            type: boolean
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /virtual-folders/{id}/path:
+    get:
+      tags: [Virtual Folders]
+      summary: Get folder breadcrumb path (root to folder)
+      parameters:
+        - $ref: '#/components/parameters/FolderId'
+      responses:
+        '200':
+          description: Array of folder path segments
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /virtual-folders/{id}/files:
+    get:
+      tags: [Virtual Folders]
+      summary: Get files in a folder
+      parameters:
+        - $ref: '#/components/parameters/FolderId'
+      responses:
+        '200':
+          description: List of files in the folder
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags: [Virtual Folders]
+      summary: Assign files to a folder
+      description: Admin or Editor only.
+      parameters:
+        - $ref: '#/components/parameters/FolderId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignFilesRequest'
+      responses:
+        '200':
+          description: Files assigned
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          assigned:
+                            type: integer
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /virtual-folders/{id}/files/{fileId}:
+    delete:
+      tags: [Virtual Folders]
+      summary: Remove a file from a folder
+      description: Admin or Editor only.
+      parameters:
+        - $ref: '#/components/parameters/FolderId'
+        - name: fileId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: File removed from folder
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          removed:
+                            type: boolean
+
+  /files/{id}/folders:
+    get:
+      tags: [Virtual Folders]
+      summary: Get all folders a file belongs to
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      responses:
+        '200':
+          description: List of folders for the file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    patch:
+      tags: [Virtual Folders]
+      summary: Bulk update file folder assignments
+      description: Admin or Editor only.
+      parameters:
+        - $ref: '#/components/parameters/FileId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [folder_ids]
+              properties:
+                folder_ids:
+                  type: array
+                  items:
+                    type: integer
+                  description: Complete set of folder IDs to assign (replaces existing)
+      responses:
+        '200':
+          description: Updated folder assignments
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  # ===========================================================================
+  # PLUGINS
+  # ===========================================================================
+  /plugins/marketplace:
+    get:
+      tags: [Plugins]
+      summary: Get all available plugins from marketplace
+      parameters:
+        - name: category
+          in: query
+          schema:
+            type: string
+          description: Filter by category
+      responses:
+        '200':
+          description: List of plugins
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Plugin'
+
+  /plugins/marketplace/search:
+    get:
+      tags: [Plugins]
+      summary: Search plugins
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Search query
+      responses:
+        '200':
+          description: Matching plugins
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Plugin'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /plugins/marketplace/{key}:
+    get:
+      tags: [Plugins]
+      summary: Get plugin by key
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-z0-9-]+$'
+      responses:
+        '200':
+          description: Plugin details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/Plugin'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /plugins/categories:
+    get:
+      tags: [Plugins]
+      summary: Get plugin categories
+      responses:
+        '200':
+          description: List of categories
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          type: string
+
+  /plugins/install:
+    post:
+      tags: [Plugins]
+      summary: Install a plugin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [pluginKey]
+              properties:
+                pluginKey:
+                  type: string
+                  pattern: '^[a-z0-9-]+$'
+                  description: Plugin key to install
+      responses:
+        '201':
+          description: Plugin installed
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PluginInstallation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /plugins/installations:
+    get:
+      tags: [Plugins]
+      summary: Get installed plugins for organization
+      responses:
+        '200':
+          description: List of installed plugins
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/PluginInstallation'
+
+  /plugins/installations/{id}:
+    delete:
+      tags: [Plugins]
+      summary: Uninstall a plugin
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Installation ID
+      responses:
+        '200':
+          description: Plugin uninstalled
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /plugins/installations/{id}/configuration:
+    put:
+      tags: [Plugins]
+      summary: Update plugin configuration
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Installation ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [configuration]
+              properties:
+                configuration:
+                  type: object
+                  additionalProperties: true
+                  description: Plugin-specific configuration key-value pairs
+      responses:
+        '200':
+          description: Configuration updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /plugins/{key}/test-connection:
+    post:
+      tags: [Plugins]
+      summary: Test plugin connection with provided configuration
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-z0-9-]+$'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [configuration]
+              properties:
+                configuration:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Connection test result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/ConnectionTestResult'
+
+  # ===========================================================================
+  # SHADOW AI
+  # ===========================================================================
+  /shadow-ai/api-keys:
+    post:
+      tags: [Shadow AI - API Keys]
+      summary: Create a new API key (Admin only)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                label:
+                  type: string
+                  description: Optional label for the key
+      responses:
+        '201':
+          description: API key created (full key shown only once)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/ApiKeyCreateResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    get:
+      tags: [Shadow AI - API Keys]
+      summary: List all API keys (Admin only)
+      responses:
+        '200':
+          description: List of API keys (no full key values)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ApiKeyRecord'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /shadow-ai/api-keys/{id}:
+    delete:
+      tags: [Shadow AI - API Keys]
+      summary: Revoke an API key (Admin only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Key revoked
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /shadow-ai/api-keys/{id}/permanent:
+    delete:
+      tags: [Shadow AI - API Keys]
+      summary: Permanently delete a revoked API key (Admin only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Key permanently deleted
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /shadow-ai/insights/summary:
+    get:
+      tags: [Shadow AI - Insights]
+      summary: Get insights summary
+      parameters:
+        - $ref: '#/components/parameters/Period'
+      responses:
+        '200':
+          description: Summary statistics
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/InsightsSummary'
+
+  /shadow-ai/insights/tools-by-events:
+    get:
+      tags: [Shadow AI - Insights]
+      summary: Get tools ranked by event count
+      parameters:
+        - $ref: '#/components/parameters/Period'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 6
+      responses:
+        '200':
+          description: Tools by events
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shadow-ai/insights/tools-by-users:
+    get:
+      tags: [Shadow AI - Insights]
+      summary: Get tools ranked by unique user count
+      parameters:
+        - $ref: '#/components/parameters/Period'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 6
+      responses:
+        '200':
+          description: Tools by users
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shadow-ai/insights/users-by-department:
+    get:
+      tags: [Shadow AI - Insights]
+      summary: Get user counts by department
+      parameters:
+        - $ref: '#/components/parameters/Period'
+      responses:
+        '200':
+          description: Users by department
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shadow-ai/insights/trend:
+    get:
+      tags: [Shadow AI - Insights]
+      summary: Get usage trend data
+      parameters:
+        - $ref: '#/components/parameters/Period'
+        - name: granularity
+          in: query
+          schema:
+            type: string
+            enum: [daily, weekly, monthly]
+            default: daily
+      responses:
+        '200':
+          description: Trend data points
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shadow-ai/users:
+    get:
+      tags: [Shadow AI - Users]
+      summary: Get user activity list
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: sort
+          in: query
+          schema:
+            type: string
+          description: Sort field
+        - name: department
+          in: query
+          schema:
+            type: string
+          description: Filter by department
+      responses:
+        '200':
+          description: Paginated user activity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shadow-ai/users/{email}/activity:
+    get:
+      tags: [Shadow AI - Users]
+      summary: Get detailed activity for a specific user
+      parameters:
+        - name: email
+          in: path
+          required: true
+          schema:
+            type: string
+            format: email
+        - $ref: '#/components/parameters/Period'
+      responses:
+        '200':
+          description: User detail with tool usage
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/UserDetail'
+
+  /shadow-ai/departments:
+    get:
+      tags: [Shadow AI - Users]
+      summary: Get department activity summary
+      responses:
+        '200':
+          description: Department activity data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shadow-ai/tools:
+    get:
+      tags: [Shadow AI - Tools]
+      summary: Get detected AI tools
+      parameters:
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/ShadowAiToolStatus'
+        - name: sort
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/Page'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+      responses:
+        '200':
+          description: Paginated tool list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shadow-ai/tools/{id}:
+    get:
+      tags: [Shadow AI - Tools]
+      summary: Get tool details including departments and top users
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Tool details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/ShadowAiToolDetail'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /shadow-ai/tools/{id}/status:
+    patch:
+      tags: [Shadow AI - Tools]
+      summary: Update tool status (Admin/Editor only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  $ref: '#/components/schemas/ShadowAiToolStatus'
+      responses:
+        '200':
+          description: Status updated
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /shadow-ai/tools/{id}/start-governance:
+    post:
+      tags: [Shadow AI - Tools]
+      summary: Start governance for a tool (create model inventory entry)
+      description: Admin/Editor only. Creates a model inventory entry and links it to the tool.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartGovernanceRequest'
+      responses:
+        '201':
+          description: Governance started
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/StartGovernanceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /shadow-ai/rules:
+    get:
+      tags: [Shadow AI - Rules]
+      summary: Get all rules
+      responses:
+        '200':
+          description: List of rules
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ShadowAiRule'
+    post:
+      tags: [Shadow AI - Rules]
+      summary: Create a rule (Admin/Editor only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRuleRequest'
+      responses:
+        '201':
+          description: Rule created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/ShadowAiRule'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /shadow-ai/rules/alert-history:
+    get:
+      tags: [Shadow AI - Rules]
+      summary: Get alert history
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: ruleId
+          in: query
+          schema:
+            type: integer
+          description: Filter by rule ID
+      responses:
+        '200':
+          description: Paginated alert history
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
+  /shadow-ai/rules/{id}:
+    patch:
+      tags: [Shadow AI - Rules]
+      summary: Update a rule (Admin/Editor only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRuleRequest'
+      responses:
+        '200':
+          description: Rule updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/ShadowAiRule'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [Shadow AI - Rules]
+      summary: Delete a rule (Admin/Editor only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Rule deleted
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /shadow-ai/config/syslog:
+    get:
+      tags: [Shadow AI - Configuration]
+      summary: Get syslog configurations (Admin only)
+      responses:
+        '200':
+          description: Syslog configs
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/SyslogConfig'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Shadow AI - Configuration]
+      summary: Create syslog configuration (Admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSyslogConfigRequest'
+      responses:
+        '201':
+          description: Config created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/SyslogConfig'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /shadow-ai/config/syslog/{id}:
+    patch:
+      tags: [Shadow AI - Configuration]
+      summary: Update syslog configuration (Admin only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSyslogConfigRequest'
+      responses:
+        '200':
+          description: Config updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/SyslogConfig'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [Shadow AI - Configuration]
+      summary: Delete syslog configuration (Admin only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Config deleted
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /shadow-ai/settings:
+    get:
+      tags: [Shadow AI - Configuration]
+      summary: Get settings (rate limiting & data retention)
+      responses:
+        '200':
+          description: Current settings
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/ShadowAiSettings'
+    patch:
+      tags: [Shadow AI - Configuration]
+      summary: Update settings (Admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSettingsRequest'
+      responses:
+        '200':
+          description: Settings updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/ShadowAiSettings'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  # ===========================================================================
+  # POST-MARKET MONITORING
+  # ===========================================================================
+  /pmm/config/{projectId}:
+    get:
+      tags: [Post-Market Monitoring]
+      summary: Get PMM config for a project
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: PMM configuration
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMConfig'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /pmm/config:
+    post:
+      tags: [Post-Market Monitoring]
+      summary: Create new PMM config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PMMConfigCreateRequest'
+      responses:
+        '201':
+          description: Config created with default questions
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMConfig'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '409':
+          description: Configuration already exists for this project
+
+  /pmm/config/{configId}:
+    put:
+      tags: [Post-Market Monitoring]
+      summary: Update PMM config
+      parameters:
+        - name: configId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PMMConfigUpdateRequest'
+      responses:
+        '200':
+          description: Config updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMConfig'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [Post-Market Monitoring]
+      summary: Delete PMM config
+      parameters:
+        - name: configId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Config deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /pmm/config/{configId}/questions:
+    get:
+      tags: [Post-Market Monitoring]
+      summary: Get questions for a config
+      parameters:
+        - name: configId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of questions
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/PMMQuestion'
+    post:
+      tags: [Post-Market Monitoring]
+      summary: Add a question to config
+      parameters:
+        - name: configId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PMMQuestionCreate'
+      responses:
+        '201':
+          description: Question added
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMQuestion'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /pmm/org/questions:
+    get:
+      tags: [Post-Market Monitoring]
+      summary: Get global organization questions (config_id = null)
+      responses:
+        '200':
+          description: Organization-level questions
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/PMMQuestion'
+
+  /pmm/questions/{questionId}:
+    put:
+      tags: [Post-Market Monitoring]
+      summary: Update a question
+      parameters:
+        - name: questionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PMMQuestionUpdate'
+      responses:
+        '200':
+          description: Question updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMQuestion'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [Post-Market Monitoring]
+      summary: Delete a question
+      parameters:
+        - name: questionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Question deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /pmm/questions/reorder:
+    post:
+      tags: [Post-Market Monitoring]
+      summary: Reorder questions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [orders]
+              properties:
+                orders:
+                  type: array
+                  items:
+                    type: object
+                    required: [id, display_order]
+                    properties:
+                      id:
+                        type: integer
+                      display_order:
+                        type: integer
+      responses:
+        '200':
+          description: Questions reordered
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /pmm/active-cycle/{projectId}:
+    get:
+      tags: [Post-Market Monitoring]
+      summary: Get active cycle for a project
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Active cycle details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMCycle'
+        '404':
+          description: No active monitoring cycle
+
+  /pmm/cycles/{cycleId}:
+    get:
+      tags: [Post-Market Monitoring]
+      summary: Get cycle details
+      parameters:
+        - name: cycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Cycle details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMCycle'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /pmm/cycles/{cycleId}/responses:
+    get:
+      tags: [Post-Market Monitoring]
+      summary: Get saved responses for a cycle
+      parameters:
+        - name: cycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of responses
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/PMMResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags: [Post-Market Monitoring]
+      summary: Save responses (partial save)
+      parameters:
+        - name: cycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PMMSaveResponsesRequest'
+      responses:
+        '200':
+          description: Responses saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Cycle is already completed
+
+  /pmm/cycles/{cycleId}/submit:
+    post:
+      tags: [Post-Market Monitoring]
+      summary: Submit cycle (final submission, generates report)
+      parameters:
+        - name: cycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PMMSaveResponsesRequest'
+      responses:
+        '200':
+          description: Cycle submitted and report generated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMSubmitCycleResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Cycle is already completed
+
+  /pmm/cycles/{cycleId}/flag:
+    post:
+      tags: [Post-Market Monitoring]
+      summary: Flag a concern (immediate notification)
+      parameters:
+        - name: cycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [question_id]
+              properties:
+                question_id:
+                  type: integer
+                response_value:
+                  type: string
+      responses:
+        '200':
+          description: Concern flagged
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /pmm/cycles/{cycleId}/reassign:
+    post:
+      tags: [Post-Market Monitoring]
+      summary: Reassign stakeholder for a cycle
+      parameters:
+        - name: cycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [stakeholder_id]
+              properties:
+                stakeholder_id:
+                  type: integer
+      responses:
+        '200':
+          description: Stakeholder reassigned
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /pmm/reports:
+    get:
+      tags: [Post-Market Monitoring]
+      summary: List reports with filters
+      parameters:
+        - name: project_id
+          in: query
+          schema:
+            type: integer
+        - name: start_date
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: end_date
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: completed_by
+          in: query
+          schema:
+            type: integer
+        - name: flagged_only
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - $ref: '#/components/parameters/Page'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+            maximum: 100
+      responses:
+        '200':
+          description: Paginated reports
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMReportsResponse'
+
+  /pmm/reports/{reportId}/download:
+    get:
+      tags: [Post-Market Monitoring]
+      summary: Download report PDF
+      parameters:
+        - name: reportId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '302':
+          description: Redirect to file download endpoint
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /pmm/projects/{projectId}/start-cycle:
+    post:
+      tags: [Post-Market Monitoring]
+      summary: Manually start a new monitoring cycle
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '201':
+          description: New cycle started
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - properties:
+                      data:
+                        $ref: '#/components/schemas/PMMCycle'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    Page:
+      name: page
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    PageSize:
+      name: pageSize
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    FileId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    FolderId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    Period:
+      name: period
+      in: query
+      schema:
+        type: string
+        pattern: '^\d+d$'
+        default: 30d
+      description: Time period in days (e.g., "30d", "7d", "90d")
+
+  responses:
+    BadRequest:
+      description: Validation or input error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Forbidden:
+      description: Insufficient permissions
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    ApiResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+        data:
+          description: Response payload
+
+    ErrorResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+        data:
+          type: string
+
+    # ─── File Manager Schemas ───────────────────────────────────────────────
+    FileUploadResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        filename:
+          type: string
+        size:
+          type: integer
+        mimetype:
+          type: string
+        upload_date:
+          type: string
+          format: date-time
+        uploaded_by:
+          type: integer
+        modelId:
+          type: integer
+          nullable: true
+        review_status:
+          type: string
+          enum: [draft, pending_review]
+        approval_workflow_id:
+          type: integer
+          nullable: true
+        approval_request_id:
+          type: integer
+          nullable: true
+
+    FileListResponse:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileListItem'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    FileListItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        filename:
+          type: string
+        size:
+          type: integer
+        formattedSize:
+          type: string
+        mimetype:
+          type: string
+        upload_date:
+          type: string
+          format: date-time
+        uploaded_by:
+          type: integer
+        uploader_name:
+          type: string
+        uploader_surname:
+          type: string
+        review_status:
+          type: string
+        approval_workflow_id:
+          type: integer
+          nullable: true
+
+    FileSearchResponse:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              filename:
+                type: string
+              snippet:
+                type: string
+                description: Highlighted text snippet matching the query
+              rank:
+                type: number
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    FileMetadata:
+      type: object
+      properties:
+        id:
+          type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        review_status:
+          type: string
+          enum: [draft, pending_review, approved, rejected, expired]
+        version:
+          type: string
+        expiry_date:
+          type: string
+          format: date-time
+          nullable: true
+        description:
+          type: string
+          nullable: true
+
+    UpdateFileMetadataRequest:
+      type: object
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+          maxItems: 50
+          description: Each tag max 100 chars, alphanumeric/spaces/hyphens/underscores only
+        review_status:
+          type: string
+          enum: [draft, pending_review, approved, rejected, expired]
+        version:
+          type: string
+        expiry_date:
+          type: string
+          format: date-time
+        description:
+          type: string
+
+    HighlightedFiles:
+      type: object
+      properties:
+        due_for_update:
+          type: array
+          items:
+            type: integer
+        pending_approval:
+          type: array
+          items:
+            type: integer
+        recently_modified:
+          type: array
+          items:
+            type: integer
+
+    Pagination:
+      type: object
+      properties:
+        total:
+          type: integer
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        totalPages:
+          type: integer
+
+    # ─── Virtual Folder Schemas ─────────────────────────────────────────────
+    VirtualFolder:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        parent_id:
+          type: integer
+          nullable: true
+        color:
+          type: string
+          nullable: true
+        icon:
+          type: string
+          nullable: true
+        is_system:
+          type: boolean
+        file_count:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateFolderRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        parent_id:
+          type: integer
+          nullable: true
+          description: Parent folder ID (null for root)
+        color:
+          type: string
+          description: Hex color code
+        icon:
+          type: string
+          description: Icon identifier
+
+    UpdateFolderRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        parent_id:
+          type: integer
+          nullable: true
+          description: New parent (null to move to root). Cannot create circular refs.
+        color:
+          type: string
+        icon:
+          type: string
+
+    AssignFilesRequest:
+      type: object
+      required: [file_ids]
+      properties:
+        file_ids:
+          type: array
+          items:
+            type: integer
+          minItems: 1
+
+    # ─── Plugin Schemas ─────────────────────────────────────────────────────
+    Plugin:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        version:
+          type: string
+        author:
+          type: string
+        icon_url:
+          type: string
+        documentation_url:
+          type: string
+
+    PluginInstallation:
+      type: object
+      properties:
+        id:
+          type: integer
+        plugin_key:
+          type: string
+        organization_id:
+          type: integer
+        installed_by:
+          type: integer
+        installed_at:
+          type: string
+          format: date-time
+        configuration:
+          type: object
+          additionalProperties: true
+        status:
+          type: string
+
+    ConnectionTestResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        details:
+          type: object
+
+    # ─── Shadow AI Schemas ──────────────────────────────────────────────────
+    ShadowAiToolStatus:
+      type: string
+      enum: [detected, under_review, approved, restricted, blocked, dismissed]
+
+    ApiKeyCreateResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+          description: Full API key (shown only on creation)
+        key_prefix:
+          type: string
+        label:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    ApiKeyRecord:
+      type: object
+      properties:
+        id:
+          type: integer
+        key_prefix:
+          type: string
+        label:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        revoked_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    InsightsSummary:
+      type: object
+      properties:
+        total_events:
+          type: integer
+        total_users:
+          type: integer
+        total_tools:
+          type: integer
+        total_departments:
+          type: integer
+
+    UserDetail:
+      type: object
+      properties:
+        email:
+          type: string
+        department:
+          type: string
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              tool_name:
+                type: string
+              event_count:
+                type: integer
+        total_prompts:
+          type: integer
+
+    ShadowAiToolDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        domain:
+          type: string
+        status:
+          $ref: '#/components/schemas/ShadowAiToolStatus'
+        first_seen:
+          type: string
+          format: date-time
+        last_seen:
+          type: string
+          format: date-time
+        event_count:
+          type: integer
+        user_count:
+          type: integer
+        departments:
+          type: array
+          items:
+            type: object
+            properties:
+              department:
+                type: string
+              user_count:
+                type: integer
+        top_users:
+          type: array
+          items:
+            type: object
+            properties:
+              email:
+                type: string
+              event_count:
+                type: integer
+
+    StartGovernanceRequest:
+      type: object
+      required: [model_inventory, governance_owner_id]
+      properties:
+        model_inventory:
+          type: object
+          required: [provider, model]
+          properties:
+            provider:
+              type: string
+            model:
+              type: string
+            version:
+              type: string
+            status:
+              type: string
+              enum: [Approved, Restricted, Pending, Blocked]
+        governance_owner_id:
+          type: integer
+          minimum: 1
+        start_lifecycle:
+          type: boolean
+          default: false
+
+    StartGovernanceResponse:
+      type: object
+      properties:
+        model_inventory_id:
+          type: integer
+        tool_id:
+          type: integer
+        lifecycle_initialized:
+          type: boolean
+
+    ShadowAiRule:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+        trigger_type:
+          type: string
+        trigger_config:
+          type: object
+        actions:
+          type: array
+          items:
+            type: object
+        cooldown_minutes:
+          type: integer
+          nullable: true
+        notification_user_ids:
+          type: array
+          items:
+            type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    CreateRuleRequest:
+      type: object
+      required: [name, trigger_type, actions]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        is_active:
+          type: boolean
+          default: true
+        trigger_type:
+          type: string
+        trigger_config:
+          type: object
+          default: {}
+        actions:
+          type: array
+          items:
+            type: object
+        cooldown_minutes:
+          type: integer
+        notification_user_ids:
+          type: array
+          items:
+            type: integer
+
+    UpdateRuleRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        is_active:
+          type: boolean
+        trigger_type:
+          type: string
+        trigger_config:
+          type: object
+        actions:
+          type: array
+          items:
+            type: object
+        cooldown_minutes:
+          type: integer
+        notification_user_ids:
+          type: array
+          items:
+            type: integer
+
+    SyslogConfig:
+      type: object
+      properties:
+        id:
+          type: integer
+        source_identifier:
+          type: string
+        parser_type:
+          type: string
+          enum: [zscaler, netskope, squid, generic_kv]
+        is_active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    CreateSyslogConfigRequest:
+      type: object
+      required: [source_identifier, parser_type]
+      properties:
+        source_identifier:
+          type: string
+        parser_type:
+          type: string
+          enum: [zscaler, netskope, squid, generic_kv]
+        is_active:
+          type: boolean
+          default: true
+
+    UpdateSyslogConfigRequest:
+      type: object
+      properties:
+        source_identifier:
+          type: string
+        parser_type:
+          type: string
+          enum: [zscaler, netskope, squid, generic_kv]
+        is_active:
+          type: boolean
+
+    ShadowAiSettings:
+      type: object
+      properties:
+        rate_limit_max_events_per_hour:
+          type: integer
+        retention_events_days:
+          type: integer
+        retention_daily_rollups_days:
+          type: integer
+        retention_alert_history_days:
+          type: integer
+
+    UpdateSettingsRequest:
+      type: object
+      properties:
+        rate_limit_max_events_per_hour:
+          type: integer
+        retention_events_days:
+          type: integer
+        retention_daily_rollups_days:
+          type: integer
+        retention_alert_history_days:
+          type: integer
+
+    # ─── Post-Market Monitoring Schemas ─────────────────────────────────────
+    PMMConfig:
+      type: object
+      properties:
+        id:
+          type: integer
+        project_id:
+          type: integer
+        frequency:
+          type: string
+          description: Monitoring frequency (e.g., "monthly", "quarterly")
+        stakeholder_id:
+          type: integer
+          nullable: true
+        is_active:
+          type: boolean
+        questions_count:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    PMMConfigCreateRequest:
+      type: object
+      required: [project_id]
+      properties:
+        project_id:
+          type: integer
+        frequency:
+          type: string
+        stakeholder_id:
+          type: integer
+        is_active:
+          type: boolean
+          default: true
+
+    PMMConfigUpdateRequest:
+      type: object
+      properties:
+        frequency:
+          type: string
+        stakeholder_id:
+          type: integer
+        is_active:
+          type: boolean
+
+    PMMQuestion:
+      type: object
+      properties:
+        id:
+          type: integer
+        config_id:
+          type: integer
+          nullable: true
+        question_text:
+          type: string
+        question_type:
+          type: string
+          enum: [yes_no, multi_select, multi_line_text]
+        options:
+          type: array
+          items:
+            type: string
+          nullable: true
+        is_required:
+          type: boolean
+        is_default:
+          type: boolean
+        display_order:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    PMMQuestionCreate:
+      type: object
+      required: [question_text, question_type]
+      properties:
+        config_id:
+          type: integer
+          nullable: true
+        question_text:
+          type: string
+        question_type:
+          type: string
+          enum: [yes_no, multi_select, multi_line_text]
+        options:
+          type: array
+          items:
+            type: string
+        is_required:
+          type: boolean
+          default: false
+        display_order:
+          type: integer
+
+    PMMQuestionUpdate:
+      type: object
+      properties:
+        question_text:
+          type: string
+        question_type:
+          type: string
+          enum: [yes_no, multi_select, multi_line_text]
+        options:
+          type: array
+          items:
+            type: string
+        is_required:
+          type: boolean
+        display_order:
+          type: integer
+
+    PMMCycle:
+      type: object
+      properties:
+        id:
+          type: integer
+        config_id:
+          type: integer
+        project_id:
+          type: integer
+        project_title:
+          type: string
+        cycle_number:
+          type: integer
+        status:
+          type: string
+          enum: [active, completed]
+        assigned_stakeholder_id:
+          type: integer
+          nullable: true
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    PMMResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        cycle_id:
+          type: integer
+        question_id:
+          type: integer
+        response_value:
+          type: string
+        is_flagged:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    PMMSaveResponsesRequest:
+      type: object
+      required: [responses]
+      properties:
+        responses:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required: [question_id, response_value]
+            properties:
+              question_id:
+                type: integer
+              response_value:
+                type: string
+              is_flagged:
+                type: boolean
+                default: false
+
+    PMMSubmitCycleResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        report_generated:
+          type: boolean
+        report_filename:
+          type: string
+          nullable: true
+
+    PMMReportsResponse:
+      type: object
+      properties:
+        reports:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              cycle_id:
+                type: integer
+              file_id:
+                type: integer
+                nullable: true
+              completed_by:
+                type: integer
+              created_at:
+                type: string
+                format: date-time
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer

--- a/Servers/docs/api/fria-openapi.yaml
+++ b/Servers/docs/api/fria-openapi.yaml
@@ -1,0 +1,1112 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise FRIA API
+  description: >
+    Fundamental Rights Impact Assessment (FRIA) endpoints for managing
+    EU AI Act Article 27 assessments, rights matrices, risk items, model
+    links, evidence attachments, and version snapshots.
+  version: 1.0.0
+
+tags:
+  - name: FRIA Assessment
+    description: Core assessment CRUD and auto-creation
+  - name: FRIA Rights
+    description: Fundamental rights matrix (10 EU Charter rights)
+  - name: FRIA Risk Items
+    description: Risk items within an assessment
+  - name: FRIA Model Links
+    description: Link/unlink model inventory entries to an assessment
+  - name: FRIA Evidence
+    description: Evidence file attachments per assessment section
+  - name: FRIA Versions
+    description: Submission and version snapshot management
+
+paths:
+  # ── Assessment CRUD ────────────────────────────────────────────────
+  /fria/{projectId}:
+    get:
+      tags: [FRIA Assessment]
+      summary: Get FRIA for a project
+      description: >
+        Returns the FRIA assessment for the given project. If no assessment
+        exists, one is auto-created in draft status with all 10 rights
+        rows initialized.
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "200":
+          description: Assessment with related rights, risk items, and model links
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/FriaFullResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    put:
+      tags: [FRIA Assessment]
+      summary: Update FRIA assessment fields
+      description: >
+        Partially updates assessment fields. Scores (risk_score,
+        risk_level, completion_pct, rights_flagged) are recomputed
+        automatically after every update. Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FriaUpdateRequest"
+      responses:
+        "200":
+          description: Updated assessment
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/FriaAssessment"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  # ── Rights matrix ──────────────────────────────────────────────────
+  /fria/{friaId}/rights:
+    put:
+      tags: [FRIA Rights]
+      summary: Bulk upsert all rights for a FRIA
+      description: >
+        Accepts an array of up to 10 rights (keyed by right_key) and
+        upserts each one. Scores are recomputed after the update.
+        Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FriaRightsUpdateRequest"
+      responses:
+        "200":
+          description: Updated rights array
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/FriaRight"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  # ── Risk items ─────────────────────────────────────────────────────
+  /fria/{friaId}/risk-items:
+    get:
+      tags: [FRIA Risk Items]
+      summary: List risk items for a FRIA
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+      responses:
+        "200":
+          description: Array of risk items
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/FriaRiskItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    post:
+      tags: [FRIA Risk Items]
+      summary: Add a risk item to a FRIA
+      description: >
+        Creates a new risk item. Scores are recomputed after creation.
+        Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FriaRiskItemCreateRequest"
+      responses:
+        "201":
+          description: Created risk item
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/FriaRiskItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /fria/{friaId}/risk-items/{itemId}:
+    patch:
+      tags: [FRIA Risk Items]
+      summary: Update a risk item
+      description: >
+        Partially updates risk item fields. Scores are recomputed after
+        the update. Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+        - $ref: "#/components/parameters/ItemId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FriaRiskItemUpdateRequest"
+      responses:
+        "200":
+          description: Updated risk item
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/FriaRiskItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    delete:
+      tags: [FRIA Risk Items]
+      summary: Delete a risk item
+      description: >
+        Removes a risk item. Scores are recomputed after deletion.
+        Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+        - $ref: "#/components/parameters/ItemId"
+      responses:
+        "200":
+          description: Deletion confirmed
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/DeletedResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  # ── Model links ────────────────────────────────────────────────────
+  /fria/{friaId}/models:
+    get:
+      tags: [FRIA Model Links]
+      summary: List linked models for a FRIA
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+      responses:
+        "200":
+          description: Array of model links with model inventory details
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/FriaModelLink"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /fria/{friaId}/models/{modelId}:
+    post:
+      tags: [FRIA Model Links]
+      summary: Link a model to a FRIA
+      description: >
+        Creates an association between a model inventory entry and the
+        FRIA. Duplicate links are silently ignored (ON CONFLICT DO
+        NOTHING). Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+        - $ref: "#/components/parameters/ModelId"
+      responses:
+        "201":
+          description: Created model link
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/FriaModelLink"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    delete:
+      tags: [FRIA Model Links]
+      summary: Unlink a model from a FRIA
+      description: Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+        - $ref: "#/components/parameters/ModelId"
+      responses:
+        "200":
+          description: Deletion confirmed
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/DeletedResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  # ── Evidence attachments ───────────────────────────────────────────
+  /fria/{friaId}/evidence:
+    get:
+      tags: [FRIA Evidence]
+      summary: Get evidence files for a FRIA
+      description: >
+        If the section query parameter is provided, returns evidence for
+        that section only. Otherwise returns evidence for all 8 sections
+        grouped by entity type (section_1 through section_8).
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+        - name: section
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - section_1
+              - section_2
+              - section_3
+              - section_4
+              - section_5
+              - section_6
+              - section_7
+              - section_8
+          description: Filter evidence by a specific section
+      responses:
+        "200":
+          description: Evidence files (single section array or grouped object)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        description: >
+                          When section param is provided, an array of
+                          evidence file objects. When omitted, an object
+                          keyed by section type with arrays of evidence
+                          file objects.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+    post:
+      tags: [FRIA Evidence]
+      summary: Link a file as evidence to a FRIA section
+      description: Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FriaEvidenceLinkRequest"
+      responses:
+        "201":
+          description: Evidence linked
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          linked:
+                            type: boolean
+                            example: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /fria/{friaId}/evidence/{linkId}:
+    delete:
+      tags: [FRIA Evidence]
+      summary: Unlink an evidence file from a FRIA
+      description: Requires Admin or Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+        - name: linkId
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: ID of the file-entity link to remove
+      responses:
+        "200":
+          description: Evidence unlinked
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/DeletedResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  # ── Submit & versioning ────────────────────────────────────────────
+  /fria/{friaId}/submit:
+    post:
+      tags: [FRIA Versions]
+      summary: Submit FRIA for review
+      description: >
+        Creates a full snapshot of the current assessment state (assessment,
+        rights, risk items, model links) and changes the status to
+        submitted. The version number is incremented. Requires Admin or
+        Editor role.
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FriaSubmitRequest"
+      responses:
+        "200":
+          description: Submission confirmed
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          submitted:
+                            type: boolean
+                            example: true
+                          version:
+                            type: integer
+                            description: The version number that was snapshotted
+                            example: 1
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /fria/{friaId}/versions:
+    get:
+      tags: [FRIA Versions]
+      summary: List all version snapshots for a FRIA
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+      responses:
+        "200":
+          description: Array of snapshots ordered by version descending
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/FriaSnapshot"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+  /fria/{friaId}/versions/{version}:
+    get:
+      tags: [FRIA Versions]
+      summary: Get a specific version snapshot
+      parameters:
+        - $ref: "#/components/parameters/FriaId"
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Version number of the snapshot
+      responses:
+        "200":
+          description: Snapshot data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiEnvelope"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/FriaSnapshot"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+# ════════════════════════════════════════════════════════════════════
+# COMPONENTS
+# ════════════════════════════════════════════════════════════════════
+components:
+  # ── Security ─────────────────────────────────────────────────────
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  # ── Parameters ───────────────────────────────────────────────────
+  parameters:
+    ProjectId:
+      name: projectId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: ID of the project
+
+    FriaId:
+      name: friaId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: ID of the FRIA assessment
+
+    ItemId:
+      name: itemId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: ID of the risk item
+
+    ModelId:
+      name: modelId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: ID of the model inventory entry
+
+  # ── Reusable responses ──────────────────────────────────────────
+  responses:
+    BadRequest:
+      description: Invalid or missing parameters
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+
+    ServerError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+
+  # ── Schemas ─────────────────────────────────────────────────────
+  schemas:
+    # -- Envelope wrappers --
+    ApiEnvelope:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 200
+        data:
+          description: Response payload (varies per endpoint)
+
+    ErrorEnvelope:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 400
+        data:
+          type: string
+          example: "Invalid project ID"
+
+    DeletedResponse:
+      type: object
+      properties:
+        deleted:
+          type: boolean
+          example: true
+
+    # -- Enums --
+    FriaStatus:
+      type: string
+      enum: [draft, submitted, approved, rejected]
+
+    FriaRiskLevel:
+      type: string
+      enum: [Low, Medium, High]
+
+    FriaLikelihood:
+      type: string
+      enum: [Low, Medium, High]
+
+    FriaSeverity:
+      type: string
+      enum: [Low, Medium, High]
+
+    # -- Assessment --
+    FriaAssessment:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        project_id:
+          type: integer
+        version:
+          type: integer
+        status:
+          $ref: "#/components/schemas/FriaStatus"
+        # Section 1: Organisation & system profile
+        assessment_owner:
+          type: string
+          nullable: true
+        assessment_date:
+          type: string
+          nullable: true
+          description: ISO 8601 date string
+        operational_context:
+          type: string
+          nullable: true
+        # Section 2: Applicability & scope
+        is_high_risk:
+          type: string
+          nullable: true
+        high_risk_basis:
+          type: string
+          nullable: true
+        deployer_type:
+          type: string
+          nullable: true
+        annex_iii_category:
+          type: string
+          nullable: true
+        first_use_date:
+          type: string
+          nullable: true
+        review_cycle:
+          type: string
+          nullable: true
+        period_frequency:
+          type: string
+          nullable: true
+        fria_rationale:
+          type: string
+          nullable: true
+        # Section 3: Affected persons
+        affected_groups:
+          type: string
+          nullable: true
+        vulnerability_context:
+          type: string
+          nullable: true
+        group_flags:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: JSON array of group flag identifiers
+        # Section 5: Specific risks context
+        risk_scenarios:
+          type: string
+          nullable: true
+        provider_info_used:
+          type: string
+          nullable: true
+        # Section 6: Oversight
+        human_oversight:
+          type: string
+          nullable: true
+        transparency_measures:
+          type: string
+          nullable: true
+        redress_process:
+          type: string
+          nullable: true
+        data_governance:
+          type: string
+          nullable: true
+        # Section 7: Consultation
+        legal_review:
+          type: string
+          nullable: true
+        dpo_review:
+          type: string
+          nullable: true
+        owner_approval:
+          type: string
+          nullable: true
+        stakeholders_consulted:
+          type: string
+          nullable: true
+        consultation_notes:
+          type: string
+          nullable: true
+        # Section 8: Summary
+        deployment_decision:
+          type: string
+          nullable: true
+        decision_conditions:
+          type: string
+          nullable: true
+        # Computed scores (cached on save)
+        completion_pct:
+          type: integer
+          description: 0-100 completion percentage
+        risk_score:
+          type: integer
+          description: 0-100 computed risk score
+        risk_level:
+          $ref: "#/components/schemas/FriaRiskLevel"
+        rights_flagged:
+          type: integer
+          description: Count of flagged rights (0-10)
+        # Metadata
+        created_by:
+          type: integer
+        updated_by:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        # Joined fields
+        project_title:
+          type: string
+          nullable: true
+        organization_name:
+          type: string
+          nullable: true
+        created_by_name:
+          type: string
+          nullable: true
+        updated_by_name:
+          type: string
+          nullable: true
+
+    FriaUpdateRequest:
+      type: object
+      description: >
+        All fields are optional. Only provided fields are updated.
+        Scores are recomputed automatically.
+      properties:
+        status:
+          $ref: "#/components/schemas/FriaStatus"
+        assessment_owner:
+          type: string
+        assessment_date:
+          type: string
+        operational_context:
+          type: string
+        is_high_risk:
+          type: string
+        high_risk_basis:
+          type: string
+        deployer_type:
+          type: string
+        annex_iii_category:
+          type: string
+        first_use_date:
+          type: string
+        review_cycle:
+          type: string
+        period_frequency:
+          type: string
+        fria_rationale:
+          type: string
+        affected_groups:
+          type: string
+        vulnerability_context:
+          type: string
+        group_flags:
+          type: array
+          items:
+            type: string
+        risk_scenarios:
+          type: string
+        provider_info_used:
+          type: string
+        human_oversight:
+          type: string
+        transparency_measures:
+          type: string
+        redress_process:
+          type: string
+        data_governance:
+          type: string
+        legal_review:
+          type: string
+        dpo_review:
+          type: string
+        owner_approval:
+          type: string
+        stakeholders_consulted:
+          type: string
+        consultation_notes:
+          type: string
+        deployment_decision:
+          type: string
+        decision_conditions:
+          type: string
+
+    FriaFullResponse:
+      type: object
+      properties:
+        assessment:
+          $ref: "#/components/schemas/FriaAssessment"
+        rights:
+          type: array
+          items:
+            $ref: "#/components/schemas/FriaRight"
+        riskItems:
+          type: array
+          items:
+            $ref: "#/components/schemas/FriaRiskItem"
+        modelLinks:
+          type: array
+          items:
+            $ref: "#/components/schemas/FriaModelLink"
+
+    # -- Rights --
+    FriaRight:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        fria_id:
+          type: integer
+        right_key:
+          type: string
+          description: >
+            One of: dignity, privacy, data, equality, child, worker,
+            education, effective, accessibility, freedom
+        right_title:
+          type: string
+          description: Human-readable right name (e.g. "Human dignity")
+        charter_ref:
+          type: string
+          description: EU Charter article reference (e.g. "Article 1")
+        flagged:
+          type: boolean
+          description: Whether this right is flagged as impacted
+        severity:
+          type: integer
+          description: Severity rating (0-5 scale)
+        confidence:
+          type: integer
+          description: Confidence rating (0-5 scale)
+        impact_pathway:
+          type: string
+          nullable: true
+          description: Description of how the right may be impacted
+        mitigation:
+          type: string
+          nullable: true
+          description: Planned mitigation measures
+
+    FriaRightsUpdateRequest:
+      type: object
+      required:
+        - rights
+      properties:
+        rights:
+          type: array
+          items:
+            type: object
+            required:
+              - right_key
+            properties:
+              right_key:
+                type: string
+                description: >
+                  One of: dignity, privacy, data, equality, child,
+                  worker, education, effective, accessibility, freedom
+              flagged:
+                type: boolean
+              severity:
+                type: integer
+              confidence:
+                type: integer
+              impact_pathway:
+                type: string
+              mitigation:
+                type: string
+
+    # -- Risk items --
+    FriaRiskItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        fria_id:
+          type: integer
+        risk_description:
+          type: string
+        likelihood:
+          $ref: "#/components/schemas/FriaLikelihood"
+        severity:
+          $ref: "#/components/schemas/FriaSeverity"
+        existing_controls:
+          type: string
+          nullable: true
+        further_action:
+          type: string
+          nullable: true
+        linked_project_risk_id:
+          type: integer
+          nullable: true
+          description: Optional link to a project risk register entry
+        sort_order:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        # Joined fields
+        linked_risk_name:
+          type: string
+          nullable: true
+        linked_risk_description:
+          type: string
+          nullable: true
+
+    FriaRiskItemCreateRequest:
+      type: object
+      required:
+        - risk_description
+      properties:
+        risk_description:
+          type: string
+        likelihood:
+          $ref: "#/components/schemas/FriaLikelihood"
+        severity:
+          $ref: "#/components/schemas/FriaSeverity"
+        existing_controls:
+          type: string
+        further_action:
+          type: string
+        linked_project_risk_id:
+          type: integer
+        sort_order:
+          type: integer
+
+    FriaRiskItemUpdateRequest:
+      type: object
+      description: All fields are optional. Only provided fields are updated.
+      properties:
+        risk_description:
+          type: string
+        likelihood:
+          $ref: "#/components/schemas/FriaLikelihood"
+        severity:
+          $ref: "#/components/schemas/FriaSeverity"
+        existing_controls:
+          type: string
+        further_action:
+          type: string
+        linked_project_risk_id:
+          type: integer
+        sort_order:
+          type: integer
+
+    # -- Model links --
+    FriaModelLink:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        fria_id:
+          type: integer
+        model_id:
+          type: integer
+        # Joined fields from model_inventories
+        provider:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        version:
+          type: string
+          nullable: true
+        model_status:
+          type: string
+          nullable: true
+
+    # -- Evidence --
+    FriaEvidenceLinkRequest:
+      type: object
+      required:
+        - file_id
+        - entity_type
+      properties:
+        file_id:
+          type: integer
+          description: ID of an already-uploaded file in the evidence hub
+        entity_type:
+          type: string
+          description: >
+            Section identifier, e.g. "section_1" through "section_8",
+            or a right key like "right_dignity"
+
+    # -- Snapshots --
+    FriaSnapshot:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        fria_id:
+          type: integer
+        version:
+          type: integer
+        snapshot_data:
+          type: object
+          description: >
+            Full JSON snapshot containing assessment, rights, riskItems,
+            and modelLinks at the time of submission
+          properties:
+            assessment:
+              $ref: "#/components/schemas/FriaAssessment"
+            rights:
+              type: array
+              items:
+                $ref: "#/components/schemas/FriaRight"
+            riskItems:
+              type: array
+              items:
+                $ref: "#/components/schemas/FriaRiskItem"
+            modelLinks:
+              type: array
+              items:
+                $ref: "#/components/schemas/FriaModelLink"
+        snapshot_reason:
+          type: string
+          nullable: true
+        created_by:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        # Joined field
+        created_by_name:
+          type: string
+          nullable: true
+
+    FriaSubmitRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: >
+            Optional reason for submission. Defaults to
+            "Submitted for review" if omitted.
+
+security:
+  - BearerAuth: []

--- a/Servers/docs/api/integrations-openapi.yaml
+++ b/Servers/docs/api/integrations-openapi.yaml
@@ -1,0 +1,963 @@
+openapi: "3.0.3"
+info:
+  title: VerifyWise Integrations & Webhooks API
+  description: |
+    API endpoints for managing Slack integrations, GitHub token management,
+    and incoming GitHub webhooks.
+  version: "1.0.0"
+
+tags:
+  - name: Slack Webhooks
+    description: Manage Slack OAuth integrations and send messages
+  - name: GitHub Integration
+    description: Manage GitHub Personal Access Token for private repository access (Admin only)
+  - name: Webhooks
+    description: Incoming webhook endpoints (public, HMAC-secured)
+
+paths:
+  # ===========================================================================
+  # Slack Webhooks — /slackWebhooks
+  # ===========================================================================
+  /slackWebhooks:
+    get:
+      tags: [Slack Webhooks]
+      summary: List Slack webhooks for a user
+      description: |
+        Returns all Slack webhook integrations for the given user.
+        Optionally filters by channel name.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          description: Numeric user ID whose webhooks to retrieve
+          schema:
+            type: string
+        - name: channel
+          in: query
+          required: false
+          description: Filter by Slack channel name
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of Slack webhooks
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse_SlackWebhookArray"
+        "400":
+          description: Missing userId query parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse400"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+    post:
+      tags: [Slack Webhooks]
+      summary: Create a new Slack webhook via OAuth
+      description: |
+        Exchanges a Slack OAuth authorization code for tokens, creates the
+        webhook record, and invites the bot to the channel.
+        Rate-limited to 10 requests per hour per IP.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSlackWebhookRequest"
+      responses:
+        "201":
+          description: Slack webhook created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResponse_SlackWebhookFull"
+        "400":
+          description: Validation error or creation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse400"
+        "403":
+          description: Business logic error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse403"
+        "429":
+          description: Rate limit exceeded (10 per hour)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Too many webhook creation requests from this IP, please try again after an hour."
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+  /slackWebhooks/{id}:
+    get:
+      tags: [Slack Webhooks]
+      summary: Get a Slack webhook by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/SlackWebhookId"
+      responses:
+        "200":
+          description: Slack webhook found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse_SlackWebhookJSON"
+        "400":
+          description: Invalid ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse400"
+        "404":
+          description: Webhook not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse404"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+    patch:
+      tags: [Slack Webhooks]
+      summary: Update a Slack webhook
+      description: |
+        Updates the routing_type and/or is_active fields of an existing
+        Slack webhook.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/SlackWebhookId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateSlackWebhookRequest"
+      responses:
+        "202":
+          description: Webhook updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AcceptedResponse_SlackWebhookFull"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse400"
+        "403":
+          description: Business logic error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse403"
+        "404":
+          description: Webhook not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse404"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+    delete:
+      tags: [Slack Webhooks]
+      summary: Delete a Slack webhook
+      description: |
+        Deletes a Slack webhook. Only the user who created it (user_id match)
+        can delete it.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/SlackWebhookId"
+      responses:
+        "204":
+          description: Webhook deleted (no content)
+        "403":
+          description: Unauthorized (user_id mismatch)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse403"
+        "404":
+          description: Webhook not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse404"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+  /slackWebhooks/{id}/send:
+    post:
+      tags: [Slack Webhooks]
+      summary: Send a Slack message via a webhook
+      description: |
+        Sends a message to the Slack channel associated with the webhook.
+        The webhook must be active (is_active = true).
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/SlackWebhookId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SendSlackMessageRequest"
+      responses:
+        "200":
+          description: Message sent successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse_SlackMessageSent"
+        "400":
+          description: Validation error (invalid ID)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse400"
+        "404":
+          description: Webhook not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse404"
+        "500":
+          description: Internal server error or channel inactive/archived
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "This slack channel is no longer active"
+
+  # ===========================================================================
+  # GitHub Integration — /integrations/github
+  # ===========================================================================
+  /integrations/github/token:
+    get:
+      tags: [GitHub Integration]
+      summary: Get GitHub token status
+      description: |
+        Returns whether a GitHub PAT is configured for the organization.
+        Does NOT return the actual token. Admin role required.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Token status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse_GitHubTokenStatus"
+        "403":
+          description: Forbidden (non-Admin role)
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+    post:
+      tags: [GitHub Integration]
+      summary: Save or update GitHub token
+      description: |
+        Saves (or replaces) the GitHub Personal Access Token for the
+        organization. The token is encrypted at rest with AES-256-CBC.
+        Admin role required.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SaveGitHubTokenRequest"
+      responses:
+        "201":
+          description: Token saved, returns updated status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreatedResponse_GitHubTokenStatus"
+        "400":
+          description: |
+            Token missing or format invalid. Accepted formats:
+            - Classic PAT: `ghp_` prefix, >= 40 chars
+            - Fine-grained PAT: `github_pat_` prefix, >= 30 chars
+            - Legacy OAuth: 40-char hex string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse400"
+        "403":
+          description: Forbidden (non-Admin role)
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+    delete:
+      tags: [GitHub Integration]
+      summary: Delete GitHub token
+      description: |
+        Removes the GitHub PAT for the organization. Admin role required.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Token deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse_GitHubTokenDeleted"
+        "403":
+          description: Forbidden (non-Admin role)
+        "404":
+          description: No token found for organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse404"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+  /integrations/github/token/test:
+    post:
+      tags: [GitHub Integration]
+      summary: Test a GitHub token
+      description: |
+        Validates the token format and tests it against the GitHub API
+        (GET /user). Returns validity, scopes, and rate limit info.
+        Admin role required.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestGitHubTokenRequest"
+      responses:
+        "200":
+          description: Test result (may be valid or invalid)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse_GitHubTokenTest"
+        "400":
+          description: Token missing or format invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse400"
+        "403":
+          description: Forbidden (non-Admin role)
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse500"
+
+  # ===========================================================================
+  # Incoming Webhooks — /webhooks
+  # ===========================================================================
+  /webhooks/github:
+    post:
+      tags: [Webhooks]
+      summary: Receive GitHub webhook events
+      description: |
+        Public endpoint for GitHub webhook delivery. Security is via HMAC
+        signature verification (X-Hub-Signature-256 header) against the
+        per-repository webhook_secret.
+
+        Supported events: `ping`, `push`, `pull_request`.
+        Unsupported events return 200 with `triggered: false`.
+
+        The endpoint always returns 200 (even on internal errors) to prevent
+        GitHub from retrying.
+      security: []
+      parameters:
+        - name: X-Hub-Signature-256
+          in: header
+          required: true
+          description: HMAC-SHA256 signature of the raw request body
+          schema:
+            type: string
+            example: "sha256=abc123..."
+        - name: X-GitHub-Event
+          in: header
+          required: true
+          description: GitHub event type
+          schema:
+            type: string
+            enum: [ping, push, pull_request]
+        - name: X-GitHub-Delivery
+          in: header
+          required: false
+          description: Unique delivery ID from GitHub
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GitHubWebhookPayload"
+      responses:
+        "200":
+          description: |
+            Webhook processed. Check `triggered` field to see if a scan
+            was initiated.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/GitHubWebhookResult"
+                  - $ref: "#/components/schemas/GitHubWebhookPong"
+                  - $ref: "#/components/schemas/GitHubWebhookSkipped"
+        "400":
+          description: Missing event header, invalid JSON, or missing repo info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse400"
+        "401":
+          description: Missing or invalid HMAC signature
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse401"
+
+# =============================================================================
+# Components
+# =============================================================================
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT access token from /auth/login
+
+  parameters:
+    SlackWebhookId:
+      name: id
+      in: path
+      required: true
+      description: Numeric Slack webhook ID
+      schema:
+        type: integer
+        minimum: 1
+
+  schemas:
+    # -------------------------------------------------------------------------
+    # Shared response wrappers
+    # -------------------------------------------------------------------------
+    StandardResponse:
+      type: object
+      description: |
+        All responses use STATUS_CODE wrapper: `{ message: "<status text>", data: <payload> }`.
+        5xx errors use `error` instead of `data`.
+      properties:
+        message:
+          type: string
+        data:
+          description: Response payload (present on 1xx-4xx)
+        error:
+          description: Error detail (present on 5xx)
+          type: string
+
+    ErrorResponse400:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Bad Request"
+        data:
+          type: string
+          example: "userId query parameter is required"
+
+    ErrorResponse401:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Unauthorized"
+        data:
+          type: string
+
+    ErrorResponse403:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Forbidden"
+        data:
+          type: string
+
+    ErrorResponse404:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Not Found"
+        data:
+          type: string
+
+    ErrorResponse500:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Internal Server Error"
+        error:
+          type: string
+
+    # -------------------------------------------------------------------------
+    # Slack Webhook schemas
+    # -------------------------------------------------------------------------
+    SlackNotificationRoutingType:
+      type: string
+      enum:
+        - "Membership and roles"
+        - "Projects and organizations"
+        - "Policy reminders and status"
+        - "Evidence and task alerts"
+        - "Control or policy changes"
+
+    SlackWebhookFull:
+      type: object
+      description: Full Slack webhook record as stored in the database
+      properties:
+        id:
+          type: integer
+          example: 1
+        access_token:
+          type: string
+          description: Encrypted access token (stored, not returned in toJSON)
+        access_token_iv:
+          type: string
+          description: AES IV for access_token
+        scope:
+          type: string
+          example: "incoming-webhook,chat:write"
+        user_id:
+          type: integer
+          example: 5
+        team_name:
+          type: string
+          example: "Acme Corp"
+        team_id:
+          type: string
+          example: "T01234ABC"
+        channel:
+          type: string
+          example: "#general"
+        channel_id:
+          type: string
+          example: "C01234ABC"
+        configuration_url:
+          type: string
+          format: uri
+          example: "https://acme.slack.com/services/B01234"
+        url:
+          type: string
+          description: Encrypted webhook URL
+        url_iv:
+          type: string
+          description: AES IV for url
+        is_active:
+          type: boolean
+          example: true
+        routing_type:
+          type: array
+          items:
+            $ref: "#/components/schemas/SlackNotificationRoutingType"
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    SlackWebhookJSON:
+      type: object
+      description: Slack webhook as returned by toJSON() (sensitive fields stripped)
+      properties:
+        id:
+          type: integer
+        scope:
+          type: string
+        user_id:
+          type: integer
+        team_name:
+          type: string
+        team_id:
+          type: string
+        channel:
+          type: string
+        channel_id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        is_active:
+          type: boolean
+        routing_type:
+          type: array
+          items:
+            $ref: "#/components/schemas/SlackNotificationRoutingType"
+          nullable: true
+
+    CreateSlackWebhookRequest:
+      type: object
+      required:
+        - code
+        - userId
+      properties:
+        code:
+          type: string
+          description: Slack OAuth authorization code (exchanged for tokens server-side)
+          example: "1234567890.abcdef"
+        userId:
+          type: integer
+          description: ID of the user creating this integration
+          example: 5
+
+    UpdateSlackWebhookRequest:
+      type: object
+      description: At least one field should be provided
+      properties:
+        is_active:
+          type: boolean
+          description: Enable or disable the webhook
+          example: false
+        routing_type:
+          type: array
+          description: Notification categories to route to this channel
+          items:
+            $ref: "#/components/schemas/SlackNotificationRoutingType"
+          example:
+            - "Membership and roles"
+            - "Evidence and task alerts"
+
+    SendSlackMessageRequest:
+      type: object
+      required:
+        - title
+        - message
+      properties:
+        title:
+          type: string
+          description: Message header text (plain_text block)
+          example: "New policy update"
+        message:
+          type: string
+          description: Message body (mrkdwn block)
+          example: "Policy *Data Retention* has been updated."
+
+    SlackMessageSentResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        messageId:
+          type: string
+          description: Slack message timestamp ID
+          example: "1234567890.123456"
+        channel:
+          type: string
+          description: Channel ID the message was posted to
+          example: "C01234ABC"
+
+    # -------------------------------------------------------------------------
+    # GitHub Integration schemas
+    # -------------------------------------------------------------------------
+    GitHubTokenStatus:
+      type: object
+      properties:
+        configured:
+          type: boolean
+          description: Whether a GitHub PAT is stored for this organization
+          example: true
+        token_name:
+          type: string
+          description: Friendly name (only present when configured = true)
+          example: "GitHub Personal Access Token"
+        last_used_at:
+          type: string
+          format: date-time
+          description: Last time the token was used (only present when configured = true)
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          description: When the token was first saved (only present when configured = true)
+
+    SaveGitHubTokenRequest:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: |
+            GitHub Personal Access Token. Accepted formats:
+            - Classic: starts with `ghp_`, >= 40 characters
+            - Fine-grained: starts with `github_pat_`, >= 30 characters
+            - Legacy OAuth: 40-character hexadecimal string
+          example: "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        token_name:
+          type: string
+          description: Optional friendly name for the token
+          default: "GitHub Personal Access Token"
+          example: "CI/CD Scanner Token"
+
+    TestGitHubTokenRequest:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: Plain-text GitHub PAT to test against the GitHub API
+          example: "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+    GitHubTokenTestResult:
+      type: object
+      properties:
+        valid:
+          type: boolean
+          example: true
+        scopes:
+          type: array
+          description: OAuth scopes granted (only present when valid = true)
+          items:
+            type: string
+          example: ["repo", "read:org"]
+        rate_limit:
+          type: object
+          description: GitHub API rate limit info (only present when valid = true)
+          properties:
+            limit:
+              type: integer
+              example: 5000
+            remaining:
+              type: integer
+              example: 4999
+            reset:
+              type: string
+              format: date-time
+              description: When the rate limit resets
+        error:
+          type: string
+          description: Error message (only present when valid = false)
+          example: "Invalid or expired token"
+
+    # -------------------------------------------------------------------------
+    # GitHub Webhook (incoming) schemas
+    # -------------------------------------------------------------------------
+    GitHubWebhookPayload:
+      type: object
+      description: |
+        Standard GitHub webhook payload. Only `repository` is required
+        for routing; the full payload structure depends on X-GitHub-Event.
+      required:
+        - repository
+      properties:
+        repository:
+          type: object
+          required:
+            - owner
+            - name
+          properties:
+            owner:
+              type: object
+              required:
+                - login
+              properties:
+                login:
+                  type: string
+                  example: "verifywise-ai"
+            name:
+              type: string
+              example: "verifywise"
+        ref:
+          type: string
+          description: Git ref (push events)
+          example: "refs/heads/main"
+        action:
+          type: string
+          description: Action type (pull_request events)
+          example: "opened"
+        pull_request:
+          type: object
+          description: Pull request object (pull_request events)
+
+    GitHubWebhookResult:
+      type: object
+      properties:
+        triggered:
+          type: boolean
+          description: Whether a scan was triggered
+        reason:
+          type: string
+          description: Human-readable explanation
+          example: "Scan triggered for push to main"
+
+    GitHubWebhookPong:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "pong"
+
+    GitHubWebhookSkipped:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Repository not registered or CI not enabled"
+
+    # -------------------------------------------------------------------------
+    # Wrapped response types
+    # -------------------------------------------------------------------------
+    SuccessResponse_SlackWebhookArray:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/SlackWebhookFull"
+
+    SuccessResponse_SlackWebhookJSON:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          $ref: "#/components/schemas/SlackWebhookJSON"
+
+    CreatedResponse_SlackWebhookFull:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Created"
+        data:
+          $ref: "#/components/schemas/SlackWebhookFull"
+
+    AcceptedResponse_SlackWebhookFull:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Accepted"
+        data:
+          $ref: "#/components/schemas/SlackWebhookFull"
+
+    SuccessResponse_SlackMessageSent:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          $ref: "#/components/schemas/SlackMessageSentResult"
+
+    SuccessResponse_GitHubTokenStatus:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          $ref: "#/components/schemas/GitHubTokenStatus"
+
+    CreatedResponse_GitHubTokenStatus:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Created"
+        data:
+          $ref: "#/components/schemas/GitHubTokenStatus"
+
+    SuccessResponse_GitHubTokenDeleted:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          type: object
+          properties:
+            message:
+              type: string
+              example: "GitHub token deleted successfully"
+
+    SuccessResponse_GitHubTokenTest:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          $ref: "#/components/schemas/GitHubTokenTestResult"

--- a/Servers/docs/api/model-inventory-paths.yaml
+++ b/Servers/docs/api/model-inventory-paths.yaml
@@ -1,0 +1,672 @@
+# Model Inventory API — OpenAPI 3.0 Path Definitions
+# Paste into the `paths:` section of swagger.yaml
+# Base path: /api/model-inventories
+
+/model-inventories:
+  get:
+    tags:
+      - Model Inventory
+    summary: Get all model inventories
+    description: >
+      Returns every model inventory record belonging to the caller's organization,
+      ordered by created_at DESC, id ASC. Each record includes its associated
+      project and framework IDs.
+    security:
+      - bearerAuth: []
+    responses:
+      "200":
+        description: List of model inventories (may be empty)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/ModelInventoryResponse"
+      "401":
+        description: Missing or invalid JWT
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServerError"
+
+  post:
+    tags:
+      - Model Inventory
+    summary: Create a new model inventory
+    description: >
+      Creates a model inventory record, links it to the supplied project and
+      framework IDs, records a change-history entry, fires any "model_added"
+      automations, and notifies the approver (if set).
+    security:
+      - bearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelInventoryCreateRequest"
+    responses:
+      "201":
+        description: Model inventory created
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Created
+                data:
+                  $ref: "#/components/schemas/ModelInventoryResponse"
+      "401":
+        description: Missing or invalid JWT
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServerError"
+
+/model-inventories/{id}:
+  get:
+    tags:
+      - Model Inventory
+    summary: Get a model inventory by ID
+    description: >
+      Returns a single model inventory record with its associated project and
+      framework IDs. Returns 204 if the record does not exist.
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Model inventory ID
+        schema:
+          type: integer
+    responses:
+      "200":
+        description: Model inventory found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  $ref: "#/components/schemas/ModelInventoryResponse"
+      "204":
+        description: No model inventory found for the given ID
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: No Content
+                data:
+                  nullable: true
+      "401":
+        description: Missing or invalid JWT
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServerError"
+
+  patch:
+    tags:
+      - Model Inventory
+    summary: Update a model inventory by ID
+    description: >
+      Partially updates a model inventory record. All body fields are optional;
+      only provided fields are changed. Project and framework associations can be
+      replaced or cleared. Fires "model_updated" automations and notifies a new
+      approver if changed.
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Model inventory ID
+        schema:
+          type: integer
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ModelInventoryUpdateRequest"
+    responses:
+      "200":
+        description: Model inventory updated
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  $ref: "#/components/schemas/ModelInventoryResponse"
+      "401":
+        description: Missing or invalid JWT
+      "404":
+        description: Model inventory not found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Not Found
+                data:
+                  type: string
+                  example: Model inventory not found
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServerError"
+
+  delete:
+    tags:
+      - Model Inventory
+    summary: Delete a model inventory by ID
+    description: >
+      Deletes a model inventory record and its project/framework associations.
+      Optionally deletes linked model risks when deleteRisks=true.
+      Records deletion in change history and fires "model_deleted" automations.
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Model inventory ID
+        schema:
+          type: integer
+      - name: deleteRisks
+        in: query
+        required: false
+        description: >
+          When "true", also deletes associated rows from the model_risks table.
+        schema:
+          type: string
+          enum:
+            - "true"
+            - "false"
+          default: "false"
+    responses:
+      "200":
+        description: Model inventory deleted
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: string
+                  example: Model inventory deleted successfully
+      "401":
+        description: Missing or invalid JWT
+      "404":
+        description: Model inventory not found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Not Found
+                data:
+                  type: string
+                  example: Model inventory not found
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServerError"
+
+/model-inventories/by-projectId/{projectId}:
+  get:
+    tags:
+      - Model Inventory
+    summary: Get model inventories by project ID
+    description: >
+      Returns all model inventories associated with a project (via the
+      model_inventories_projects_frameworks join table where framework_id IS NULL).
+      Non-numeric project IDs (e.g. plugin-sourced) return an empty array.
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: projectId
+        in: path
+        required: true
+        description: Project ID (integer). Non-numeric values return an empty array.
+        schema:
+          type: integer
+    responses:
+      "200":
+        description: List of model inventories for the project (may be empty)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/ModelInventoryResponse"
+      "401":
+        description: Missing or invalid JWT
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServerError"
+
+/model-inventories/by-frameworkId/{frameworkId}:
+  get:
+    tags:
+      - Model Inventory
+    summary: Get model inventories by framework ID
+    description: >
+      Returns all model inventories associated with a framework (via the
+      model_inventories_projects_frameworks join table where framework_id matches).
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: frameworkId
+        in: path
+        required: true
+        description: Framework ID
+        schema:
+          type: integer
+    responses:
+      "200":
+        description: List of model inventories for the framework (may be empty)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/ModelInventoryResponse"
+      "401":
+        description: Missing or invalid JWT
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServerError"
+
+# ---------------------------------------------------------------------------
+# Schema Definitions — paste into components.schemas
+# ---------------------------------------------------------------------------
+components:
+  schemas:
+    ModelInventoryStatus:
+      type: string
+      enum:
+        - Approved
+        - Restricted
+        - Pending
+        - Blocked
+        - Rejected
+      description: Current approval/review status of the model
+
+    Filedata:
+      type: object
+      description: Metadata for an uploaded security-assessment file
+      properties:
+        id:
+          type: integer
+          description: File record ID
+        filename:
+          type: string
+          description: Original file name
+        size:
+          type: integer
+          description: File size in bytes
+        mimetype:
+          type: string
+          description: MIME type (e.g. application/pdf)
+        upload_date:
+          type: string
+          format: date-time
+          description: ISO 8601 upload timestamp
+        uploaded_by:
+          type: integer
+          description: User ID who uploaded the file
+      required:
+        - id
+        - filename
+        - size
+        - mimetype
+        - upload_date
+        - uploaded_by
+
+    ModelInventoryResponse:
+      type: object
+      description: Model inventory record as returned by the API
+      properties:
+        id:
+          type: integer
+          description: Auto-generated primary key
+          example: 42
+        provider_model:
+          type: string
+          nullable: true
+          description: Legacy combined provider+model field (backward compatibility)
+          example: "OpenAI / GPT-4"
+        provider:
+          type: string
+          description: Model provider name
+          example: OpenAI
+        model:
+          type: string
+          description: Model name
+          example: GPT-4
+        version:
+          type: string
+          description: Model version identifier
+          example: "turbo-2024-04-09"
+        approver:
+          type: integer
+          nullable: true
+          description: User ID of the assigned approver
+          example: 7
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: >
+            List of capability strings. Stored as comma-separated text in the DB,
+            returned as an array.
+          example: ["Text Generation", "Code Generation", "Reasoning"]
+        security_assessment:
+          type: boolean
+          description: Whether a security assessment has been completed
+          example: false
+        status:
+          $ref: "#/components/schemas/ModelInventoryStatus"
+        status_date:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of the last status change
+          example: "2026-04-15T10:30:00.000Z"
+        reference_link:
+          type: string
+          nullable: true
+          description: URL to external model documentation or model card
+          example: "https://platform.openai.com/docs/models/gpt-4"
+        biases:
+          type: string
+          description: Known biases of the model
+          example: "May reflect biases present in training data"
+        limitations:
+          type: string
+          description: Known limitations of the model
+          example: "Knowledge cutoff, potential hallucinations"
+        hosting_provider:
+          type: string
+          description: Where the model is hosted
+          example: "Azure OpenAI"
+        security_assessment_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Filedata"
+          description: Uploaded security assessment file metadata
+        is_demo:
+          type: boolean
+          description: Whether this is a demo/sample record
+          example: false
+        created_at:
+          type: string
+          format: date-time
+          description: ISO 8601 creation timestamp
+          example: "2026-04-10T08:00:00.000Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: ISO 8601 last-updated timestamp
+          example: "2026-04-15T10:30:00.000Z"
+        projects:
+          type: array
+          items:
+            type: integer
+          description: IDs of projects this model is associated with
+          example: [1, 3]
+        frameworks:
+          type: array
+          items:
+            type: integer
+          description: IDs of frameworks this model is associated with
+          example: [5]
+
+    ModelInventoryCreateRequest:
+      type: object
+      description: Request body for creating a new model inventory record
+      required:
+        - provider
+        - model
+        - version
+        - capabilities
+        - status
+        - status_date
+        - reference_link
+        - biases
+        - limitations
+        - hosting_provider
+      properties:
+        provider_model:
+          type: string
+          description: Legacy combined provider+model field (optional, backward compatibility)
+          example: "OpenAI / GPT-4"
+        provider:
+          type: string
+          description: Model provider name
+          example: OpenAI
+        model:
+          type: string
+          description: Model name
+          example: GPT-4
+        version:
+          type: string
+          description: Model version identifier
+          example: "turbo-2024-04-09"
+        approver:
+          type: integer
+          nullable: true
+          description: User ID of the assigned approver
+          example: 7
+        capabilities:
+          oneOf:
+            - type: string
+              description: Comma-separated capabilities
+            - type: array
+              items:
+                type: string
+              description: Array of capability strings
+          description: >
+            Accepted as either a comma-separated string or an array of strings.
+            Arrays are joined with ", " before storage.
+          example: ["Text Generation", "Code Generation"]
+        security_assessment:
+          type: boolean
+          description: Whether a security assessment has been completed
+          default: false
+        status:
+          $ref: "#/components/schemas/ModelInventoryStatus"
+        status_date:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp for the status
+          example: "2026-04-15T10:30:00.000Z"
+        reference_link:
+          type: string
+          description: URL to external model documentation or model card
+          example: "https://platform.openai.com/docs/models/gpt-4"
+        biases:
+          type: string
+          description: Known biases of the model
+          example: "May reflect biases present in training data"
+        limitations:
+          type: string
+          description: Known limitations of the model
+          example: "Knowledge cutoff, potential hallucinations"
+        hosting_provider:
+          type: string
+          description: Where the model is hosted
+          example: "Azure OpenAI"
+        security_assessment_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Filedata"
+          description: Uploaded security assessment file metadata
+          default: []
+        is_demo:
+          type: boolean
+          description: Whether this is a demo/sample record
+          default: false
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Project IDs to associate with this model
+          default: []
+          example: [1, 3]
+        frameworks:
+          type: array
+          items:
+            type: integer
+          description: Framework IDs to associate with this model
+          default: []
+          example: [5]
+
+    ModelInventoryUpdateRequest:
+      type: object
+      description: >
+        Request body for updating a model inventory record. All fields are
+        optional; only provided fields are modified.
+      properties:
+        provider_model:
+          type: string
+          description: Legacy combined provider+model field
+        provider:
+          type: string
+          description: Model provider name
+        model:
+          type: string
+          description: Model name
+        version:
+          type: string
+          description: Model version identifier
+        approver:
+          type: integer
+          nullable: true
+          description: User ID of the assigned approver
+        capabilities:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          description: Capabilities (string or array)
+        security_assessment:
+          type: boolean
+          description: Whether a security assessment has been completed
+        status:
+          $ref: "#/components/schemas/ModelInventoryStatus"
+        status_date:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp for the status
+        reference_link:
+          type: string
+          description: URL to external model documentation
+        biases:
+          type: string
+          description: Known biases of the model
+        limitations:
+          type: string
+          description: Known limitations of the model
+        hosting_provider:
+          type: string
+          description: Where the model is hosted
+        security_assessment_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Filedata"
+          description: Uploaded security assessment file metadata
+        is_demo:
+          type: boolean
+          description: Whether this is a demo/sample record
+        projects:
+          type: array
+          items:
+            type: integer
+          description: >
+            Project IDs to associate. When provided (even empty), replaces all
+            existing project associations.
+        frameworks:
+          type: array
+          items:
+            type: integer
+          description: >
+            Framework IDs to associate. When provided (even empty), replaces all
+            existing framework associations.
+        deleteProjects:
+          type: boolean
+          description: >
+            When true, clears all project associations even if projects array is
+            empty. Used to force-delete associations without providing replacements.
+          default: false
+        deleteFrameworks:
+          type: boolean
+          description: >
+            When true, clears all framework associations even if frameworks array
+            is empty. Used to force-delete associations without providing replacements.
+          default: false
+
+    ServerError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Internal Server Error
+        error:
+          type: string
+          description: Error message from the caught exception

--- a/Servers/docs/api/notifications-openapi.yaml
+++ b/Servers/docs/api/notifications-openapi.yaml
@@ -1,0 +1,531 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise Notifications API
+  version: 1.0.0
+  description: >
+    Real-time and REST endpoints for the VerifyWise notification system.
+    All endpoints require JWT authentication via the Authorization header.
+    Responses are wrapped in `{ message: string, data: T }`.
+
+paths:
+  /notifications/stream:
+    get:
+      summary: SSE stream for real-time notifications
+      operationId: streamNotifications
+      tags: [Notifications]
+      security:
+        - bearerAuth: []
+      description: >
+        Establishes a persistent Server-Sent Events connection.
+        The server sends an initial `{ "type": "connected" }` event,
+        followed by heartbeat comments every 30 seconds.
+        New notifications arrive as `IRealtimeNotification` events.
+        Stale connections are cleaned up after 1 hour.
+        Only one connection per user is allowed; opening a new one closes the previous.
+      responses:
+        "200":
+          description: SSE stream established
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: >
+                  Initial event: `data: {"type":"connected"}\n\n`.
+                  Notification events: `data: <IRealtimeNotification JSON>\n\n`.
+                  Heartbeats: `: heartbeat\n\n` (comment, every 30s).
+        "401":
+          description: Missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /notifications:
+    get:
+      summary: List notifications for the current user
+      operationId: getNotifications
+      tags: [Notifications]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: is_read
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["true", "false"]
+          description: Filter by read status. Omit to return all.
+        - name: type
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/NotificationType"
+          description: Filter by notification type.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+          description: Maximum number of notifications to return.
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+          description: Number of notifications to skip (for pagination).
+      responses:
+        "200":
+          description: List of notifications
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message, data]
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/NotificationJSON"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /notifications/summary:
+    get:
+      summary: Get notification summary for bell icon badge
+      operationId: getNotificationSummary
+      tags: [Notifications]
+      security:
+        - bearerAuth: []
+      description: >
+        Returns unread count, total count, and the 10 most recent notifications
+        in a single atomic query.
+      responses:
+        "200":
+          description: Notification summary
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message, data]
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/NotificationSummary"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /notifications/unread-count:
+    get:
+      summary: Get unread notification count
+      operationId: getUnreadCount
+      tags: [Notifications]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Unread count
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message, data]
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: object
+                    required: [unread_count]
+                    properties:
+                      unread_count:
+                        type: integer
+                        example: 5
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /notifications/read-all:
+    patch:
+      summary: Mark all notifications as read
+      operationId: markAllAsRead
+      tags: [Notifications]
+      security:
+        - bearerAuth: []
+      description: >
+        Marks every unread notification for the current user as read.
+        Returns the count of notifications that were updated.
+      responses:
+        "200":
+          description: All notifications marked as read
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message, data]
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: object
+                    required: [marked_count]
+                    properties:
+                      marked_count:
+                        type: integer
+                        description: Number of notifications that were marked as read.
+                        example: 12
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /notifications/{id}/read:
+    patch:
+      summary: Mark a single notification as read
+      operationId: markAsRead
+      tags: [Notifications]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: The notification ID.
+      responses:
+        "200":
+          description: Notification marked as read
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message, data]
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/NotificationJSON"
+        "400":
+          description: Invalid notification ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Notification not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /notifications/{id}:
+    delete:
+      summary: Delete a notification
+      operationId: deleteNotification
+      tags: [Notifications]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: The notification ID.
+      responses:
+        "200":
+          description: Notification deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message, data]
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: object
+                    required: [deleted]
+                    properties:
+                      deleted:
+                        type: boolean
+                        example: true
+        "400":
+          description: Invalid notification ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Notification not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >
+        JWT token obtained from the auth endpoints.
+        Payload includes id, email, organizationId, tenantId, roleName, expire.
+
+  schemas:
+    NotificationType:
+      type: string
+      enum:
+        - task_assigned
+        - task_updated
+        - task_completed
+        - review_requested
+        - review_approved
+        - review_rejected
+        - approval_requested
+        - approval_approved
+        - approval_rejected
+        - approval_complete
+        - policy_due_soon
+        - policy_overdue
+        - training_assigned
+        - training_completed
+        - vendor_review_due
+        - file_uploaded
+        - comment_added
+        - mention
+        - shadow_ai_alert
+        - ai_gateway_budget_warning
+        - ai_gateway_budget_exhausted
+        - ai_gateway_guardrail_spike
+        - ai_gateway_config_change
+        - ai_gateway_virtual_key_budget_exhausted
+        - system
+        - assignment_owner
+        - assignment_reviewer
+        - assignment_approver
+        - assignment_member
+        - assignment_assignee
+        - assignment_action_owner
+
+    NotificationEntityType:
+      type: string
+      enum:
+        - project
+        - task
+        - policy
+        - vendor
+        - model
+        - training
+        - file
+        - use_case
+        - risk
+        - assessment
+        - comment
+        - user
+        - shadow_ai_tool
+        - ai_gateway
+
+    NotificationJSON:
+      type: object
+      description: Notification record as returned by the API.
+      required:
+        - id
+        - user_id
+        - type
+        - title
+        - message
+        - is_read
+        - created_at
+      properties:
+        id:
+          type: integer
+          description: Unique notification ID.
+          example: 42
+        user_id:
+          type: integer
+          description: ID of the user who receives this notification.
+          example: 7
+        type:
+          $ref: "#/components/schemas/NotificationType"
+        title:
+          type: string
+          description: Short notification title.
+          example: "Task assigned to you"
+        message:
+          type: string
+          description: Notification body text.
+          example: "You have been assigned to task 'Review vendor contract'."
+        entity_type:
+          allOf:
+            - $ref: "#/components/schemas/NotificationEntityType"
+          nullable: true
+          description: Type of entity the notification relates to.
+        entity_id:
+          type: integer
+          nullable: true
+          description: ID of the related entity.
+          example: 15
+        entity_name:
+          type: string
+          nullable: true
+          description: Display name of the related entity.
+          example: "Review vendor contract"
+        action_url:
+          type: string
+          nullable: true
+          description: Deep-link URL for the notification action.
+          example: "/projects/3/tasks/15"
+        is_read:
+          type: boolean
+          description: Whether the notification has been read.
+          example: false
+        read_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO 8601 timestamp of when the notification was read.
+          example: "2026-04-20T14:30:00.000Z"
+        created_at:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of when the notification was created.
+          example: "2026-04-20T10:00:00.000Z"
+        created_by:
+          type: integer
+          nullable: true
+          description: ID of the user who triggered the notification.
+          example: 3
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Arbitrary key-value metadata attached to the notification.
+          example: { "old_status": "in_progress", "new_status": "completed" }
+
+    NotificationSummary:
+      type: object
+      description: Summary payload for the bell icon badge.
+      required:
+        - unread_count
+        - total_count
+        - recent_notifications
+      properties:
+        unread_count:
+          type: integer
+          description: Number of unread notifications.
+          example: 3
+        total_count:
+          type: integer
+          description: Total number of notifications.
+          example: 47
+        recent_notifications:
+          type: array
+          description: The 10 most recent notifications (read and unread).
+          maxItems: 10
+          items:
+            $ref: "#/components/schemas/NotificationJSON"
+
+    ErrorResponse:
+      type: object
+      required: [message, data]
+      properties:
+        message:
+          type: string
+          description: HTTP status text.
+          example: Not Found
+        data:
+          type: string
+          description: Error detail message.
+          example: "Notification not found"
+
+    RealtimeNotification:
+      type: object
+      description: Payload sent over the SSE stream when a new notification arrives.
+      required:
+        - type
+        - data
+      properties:
+        type:
+          type: string
+          enum: [notification]
+        data:
+          $ref: "#/components/schemas/NotificationJSON"

--- a/Servers/docs/api/organizations-openapi.yaml
+++ b/Servers/docs/api/organizations-openapi.yaml
@@ -1,0 +1,450 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise Organizations API
+  description: RESTful API for organization management with multi-tenant architecture.
+  version: 1.0.0
+
+paths:
+  /organizations/exists:
+    get:
+      summary: Check if any organizations exist
+      description: >
+        Public endpoint used for setup/initialization flows to determine if this
+        is a fresh installation requiring initial organization setup.
+      operationId: getOrganizationsExists
+      tags:
+        - Organizations
+      security: []
+      responses:
+        "200":
+          description: Boolean result indicating whether organizations exist.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/OrganizationExistsResult"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /organizations/{id}:
+    get:
+      summary: Get organization by ID
+      description: Retrieves detailed information about a single organization.
+      operationId: getOrganizationById
+      tags:
+        - Organizations
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+      responses:
+        "200":
+          description: Organization found.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/Organization"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    patch:
+      summary: Update organization by ID
+      description: >
+        Updates an existing organization's name and/or logo. Uses a database
+        transaction for atomicity. Only provided fields are updated.
+      operationId: updateOrganizationById
+      tags:
+        - Organizations
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateOrganizationRequest"
+      responses:
+        "200":
+          description: Organization updated successfully.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/Organization"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/BusinessLogicError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /organizations:
+    post:
+      summary: Create a new organization
+      description: >
+        Creates a new organization with complete onboarding flow: organization
+        record creation, tenant hash provisioning, admin user creation, and JWT
+        token generation. Requires super-admin privileges. All operations are
+        wrapped in a database transaction.
+      operationId: createOrganization
+      tags:
+        - Organizations
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrganizationRequest"
+      responses:
+        "201":
+          description: Organization and admin user created successfully.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CreatedEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/CreateOrganizationResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "403":
+          $ref: "#/components/responses/BusinessLogicError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /organizations/{id}/onboarding-status:
+    patch:
+      summary: Update onboarding status to completed
+      description: >
+        Sets the organization's onboarding_status to "completed". Called after
+        the user selects demo data, a blank dashboard, or dismisses the setup
+        modal. The requesting user must belong to the target organization.
+      operationId: updateOnboardingStatus
+      tags:
+        - Organizations
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+      responses:
+        "200":
+          description: Onboarding status updated to completed.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/SuccessEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/OnboardingStatusResponse"
+        "403":
+          description: Access denied - user does not belong to this organization.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >
+        JWT access token. Payload includes id, email, organizationId,
+        tenantId, roleName, and expire.
+
+  parameters:
+    OrganizationId:
+      name: id
+      in: path
+      required: true
+      description: Unique numeric identifier of the organization.
+      schema:
+        type: integer
+        minimum: 1
+        example: 1
+
+  schemas:
+    # ---------- Request schemas ----------
+
+    CreateOrganizationRequest:
+      type: object
+      required:
+        - name
+        - userEmail
+        - userName
+        - userSurname
+        - userPassword
+      properties:
+        name:
+          type: string
+          minLength: 2
+          maxLength: 255
+          description: Organization name.
+          example: Acme Corp
+        logo:
+          type: string
+          format: uri
+          nullable: true
+          description: URL of the organization logo. Optional.
+          example: https://example.com/logo.png
+        userEmail:
+          type: string
+          format: email
+          description: Email address for the initial admin user.
+          example: admin@acme.com
+        userName:
+          type: string
+          description: First name of the initial admin user.
+          example: John
+        userSurname:
+          type: string
+          description: Last name of the initial admin user.
+          example: Doe
+        userPassword:
+          type: string
+          format: password
+          description: Password for the initial admin user.
+          example: SecurePassword123!
+
+    UpdateOrganizationRequest:
+      type: object
+      description: >
+        Partial update - only provided fields are changed. At least one field
+        should be provided.
+      properties:
+        name:
+          type: string
+          minLength: 2
+          maxLength: 255
+          description: New organization name.
+          example: Acme Corporation
+        logo:
+          type: string
+          format: uri
+          nullable: true
+          description: New logo URL. Pass null to clear.
+          example: https://example.com/new-logo.png
+
+    # ---------- Response schemas ----------
+
+    Organization:
+      type: object
+      description: Full organization record as returned from the database.
+      properties:
+        id:
+          type: integer
+          description: Auto-incrementing primary key.
+          example: 1
+        name:
+          type: string
+          description: Organization name.
+          example: Acme Corp
+        logo:
+          type: string
+          nullable: true
+          description: Logo URL or empty string if not set.
+          example: https://example.com/logo.png
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the organization was created.
+          example: "2025-01-15T10:30:00.000Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of the last update.
+          example: "2025-01-15T12:00:00.000Z"
+        onboarding_status:
+          type: string
+          enum:
+            - pending
+            - completed
+          description: Whether the organization has completed onboarding.
+          example: pending
+        tenant_id:
+          type: string
+          nullable: true
+          description: SHA-256 derived hash used for tenant identification.
+          example: a1b2c3d4e5
+        risk_assessment_mode:
+          type: string
+          enum:
+            - qualitative
+            - quantitative
+          description: Risk assessment methodology for the organization.
+          example: qualitative
+        ageInDays:
+          type: integer
+          description: Computed age of the organization in days (present in toJSON output).
+          example: 45
+
+    OrganizationExistsResult:
+      type: object
+      properties:
+        exists:
+          type: boolean
+          description: True if at least one organization exists, false otherwise.
+          example: true
+
+    CreateOrganizationResponse:
+      type: object
+      properties:
+        user:
+          $ref: "#/components/schemas/SafeUser"
+        organization:
+          type: object
+          properties:
+            id:
+              type: integer
+              example: 1
+            name:
+              type: string
+              example: Acme Corp
+        token:
+          type: string
+          description: JWT access token for the newly created admin user.
+          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+
+    SafeUser:
+      type: object
+      description: User object with sensitive fields (password hash) omitted.
+      properties:
+        id:
+          type: integer
+          example: 1
+        email:
+          type: string
+          format: email
+          example: admin@acme.com
+        name:
+          type: string
+          example: John
+        surname:
+          type: string
+          example: Doe
+        role_id:
+          type: integer
+          description: "Role identifier (1=Admin, 2=Reviewer, 3=Editor, 4=Auditor)."
+          example: 1
+        organization_id:
+          type: integer
+          example: 1
+
+    OnboardingStatusResponse:
+      type: object
+      properties:
+        onboarding_status:
+          type: string
+          enum:
+            - completed
+          example: completed
+
+    # ---------- Envelope schemas ----------
+
+    SuccessEnvelope:
+      type: object
+      properties:
+        message:
+          type: string
+          example: OK
+        data:
+          description: Response payload.
+
+    CreatedEnvelope:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Created
+        data:
+          description: Response payload.
+
+    ErrorEnvelope:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Forbidden
+        data:
+          type: string
+          description: Error detail message.
+          example: Access denied
+
+  responses:
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorEnvelope"
+              - type: object
+                properties:
+                  message:
+                    example: Not Found
+
+    ValidationError:
+      description: Request validation failed.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorEnvelope"
+              - type: object
+                properties:
+                  message:
+                    example: Bad Request
+
+    BusinessLogicError:
+      description: Business rule violation.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorEnvelope"
+              - type: object
+                properties:
+                  message:
+                    example: Forbidden
+
+    InternalServerError:
+      description: Unexpected server error.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorEnvelope"
+              - type: object
+                properties:
+                  message:
+                    example: Internal Server Error

--- a/Servers/docs/api/projects-openapi.yaml
+++ b/Servers/docs/api/projects-openapi.yaml
@@ -1,0 +1,1116 @@
+# Projects API — OpenAPI 3.0 path definitions
+# Paste into the `paths:` section of swagger.yaml
+# All endpoints are prefixed with /api/projects (set via app.use in index.ts)
+
+paths:
+  /api/projects:
+    get:
+      summary: Get all projects
+      description: >
+        Returns all projects visible to the authenticated user. Admins and SuperAdmins
+        see all projects in the organization; other roles see only projects they own or
+        are members of. Includes approval status and any plugin-sourced use cases.
+      operationId: getAllProjects
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of projects retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectListItem"
+        "401":
+          description: Unauthorized — missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+    post:
+      summary: Create a new project (use case)
+      description: >
+        Creates a new project with associated members and frameworks. If an
+        approval_workflow_id is provided, framework creation is deferred until
+        the approval request is approved. Triggers automation actions and
+        notifications on success.
+      operationId: createProject
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateProjectRequest"
+      responses:
+        "201":
+          description: Project created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Created
+                  data:
+                    type: object
+                    properties:
+                      project:
+                        $ref: "#/components/schemas/Project"
+                      frameworks:
+                        type: object
+                        description: >
+                          Map of framework key to framework data. Keys are
+                          "eu", "iso42001", "iso27001", "nist_ai_rmf".
+                          Empty object when approval workflow defers creation.
+                        additionalProperties: true
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Business logic error (e.g. framework not allowed)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+        "503":
+          description: Service unavailable — project creation returned null
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/projects/{id}:
+    get:
+      summary: Get a project by ID
+      description: >
+        Returns a single project with its frameworks, owner name, members,
+        and approval status fields.
+      operationId: getProjectById
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "200":
+          description: Project found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ProjectDetail"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+    patch:
+      summary: Update a project by ID
+      description: >
+        Partially updates a project and its member list. Only provided fields
+        are updated. Tracks changes in use case change history. Triggers
+        automation actions and member notifications on success.
+      operationId: updateProjectById
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateProjectRequest"
+      responses:
+        "202":
+          description: Project updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    $ref: "#/components/schemas/ProjectWithMembers"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Business logic error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+    delete:
+      summary: Delete a project by ID
+      description: >
+        Deletes a project and all dependent entities (files, risks, members,
+        framework data). Withdraws any pending approval request. Records
+        deletion in change history before removing the project.
+      operationId: deleteProjectById
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "202":
+          description: Project deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    type: boolean
+                    example: true
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/{id}/status:
+    patch:
+      summary: Update project status
+      description: >
+        Updates only the status field of a project. Records the status change
+        in use case change history.
+      operationId: updateProjectStatus
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - status
+              properties:
+                status:
+                  $ref: "#/components/schemas/ProjectStatus"
+      responses:
+        "200":
+          description: Project status updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ProjectWithMembers"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/stats/{id}:
+    get:
+      summary: Get project statistics by ID
+      description: >
+        Returns owner details and last-updated metadata for a project.
+      operationId: getProjectStatsById
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "202":
+          description: Project stats retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    $ref: "#/components/schemas/ProjectStats"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/calculateProjectRisks/{id}:
+    get:
+      summary: Calculate project risk distribution
+      description: >
+        Returns the count of risks grouped by auto-calculated risk level for
+        a given project.
+      operationId: getProjectRisksCalculations
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "200":
+          description: Risk calculations returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectRiskCount"
+        "204":
+          description: No risk data available
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: No Content
+                  data:
+                    nullable: true
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/calculateVendorRisks/{id}:
+    get:
+      summary: Calculate vendor risk distribution
+      description: >
+        Returns the count of vendor risks grouped by risk level for a given project.
+      operationId: getVendorRisksCalculations
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "200":
+          description: Vendor risk calculations returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/VendorRiskCount"
+        "204":
+          description: No vendor risk data available
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: No Content
+                  data:
+                    nullable: true
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/complainces/{projid}:
+    get:
+      summary: Get compliance data for a project
+      description: >
+        Returns all control categories with their controls and sub-controls
+        for a given project. Each control includes sub-control counts and
+        completion status.
+      operationId: getCompliances
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: projid
+          in: path
+          required: true
+          description: The project ID
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Compliance data returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ControlCategory"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/compliance/progress/{id}:
+    get:
+      summary: Get compliance progress for a single project
+      description: >
+        Returns the total number of sub-controls and how many are marked as
+        "Done" for a specific project.
+      operationId: projectComplianceProgress
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "200":
+          description: Compliance progress returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ComplianceProgress"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/assessment/progress/{id}:
+    get:
+      summary: Get assessment progress for a single project
+      description: >
+        Returns the total number of assessment questions and how many have
+        been answered (status = "Done") for a specific project.
+      operationId: projectAssessmentProgress
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "200":
+          description: Assessment progress returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/AssessmentProgress"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/all/compliance/progress:
+    get:
+      summary: Get compliance progress across all projects
+      description: >
+        Aggregates compliance progress (total and done sub-controls) across
+        all projects visible to the authenticated user.
+      operationId: allProjectsComplianceProgress
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Aggregated compliance progress returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ComplianceProgress"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No projects found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+  /api/projects/all/assessment/progress:
+    get:
+      summary: Get assessment progress across all projects
+      description: >
+        Aggregates assessment progress (total and answered questions) across
+        all projects visible to the authenticated user.
+      operationId: allProjectsAssessmentProgress
+      tags: [Projects]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Aggregated assessment progress returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/AssessmentProgress"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No projects found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >
+        JWT token obtained from /api/auth/login. Token payload includes
+        id, email, organizationId, tenantId, roleName, and expire fields.
+
+  parameters:
+    ProjectId:
+      name: id
+      in: path
+      required: true
+      description: The numeric project ID
+      schema:
+        type: integer
+        example: 1
+
+  schemas:
+    # --- Enums ---
+    AiRiskClassification:
+      type: string
+      enum:
+        - Prohibited
+        - High risk
+        - Limited risk
+        - Minimal risk
+      description: EU AI Act risk classification level
+
+    HighRiskRole:
+      type: string
+      enum:
+        - Deployer
+        - Provider
+        - Distributor
+        - Importer
+        - Product manufacturer
+        - Authorized representative
+      description: Role of the organization under the EU AI Act for high-risk systems
+
+    ProjectStatus:
+      type: string
+      enum:
+        - Not started
+        - In progress
+        - Under review
+        - Completed
+        - Closed
+        - On hold
+        - Rejected
+      description: Current lifecycle status of the project
+
+    # --- Request Schemas ---
+    CreateProjectRequest:
+      type: object
+      required:
+        - project_title
+        - owner
+        - start_date
+        - framework
+      properties:
+        project_title:
+          type: string
+          description: Display name of the project / use case
+          example: Customer Support Chatbot
+        owner:
+          type: integer
+          description: User ID of the project owner
+          example: 1
+        start_date:
+          type: string
+          format: date-time
+          description: Project start date
+          example: "2026-01-15T00:00:00.000Z"
+        geography:
+          type: integer
+          description: Geography identifier (defaults to 1)
+          default: 1
+          example: 1
+        ai_risk_classification:
+          $ref: "#/components/schemas/AiRiskClassification"
+        type_of_high_risk_role:
+          $ref: "#/components/schemas/HighRiskRole"
+        goal:
+          type: string
+          nullable: true
+          description: Project goal or objective
+          example: Automate tier-1 support queries
+        target_industry:
+          type: string
+          nullable: true
+          description: Target industry for the AI system
+          example: Financial Services
+        description:
+          type: string
+          nullable: true
+          description: Detailed project description
+          example: An LLM-powered chatbot for handling customer inquiries
+        status:
+          $ref: "#/components/schemas/ProjectStatus"
+        is_organizational:
+          type: boolean
+          default: false
+          description: >
+            Whether this is an organizational-level project. Determines
+            which frameworks are allowed (organizational vs. non-organizational).
+        members:
+          type: array
+          items:
+            type: integer
+          description: List of user IDs to add as project members
+          example: [2, 3, 5]
+        framework:
+          type: array
+          items:
+            type: integer
+          description: >
+            List of framework IDs to associate with the project.
+            Known IDs: 1 = EU AI Act, 2 = ISO 42001, 3 = ISO 27001, 4 = NIST AI RMF.
+          example: [1, 2]
+        approval_workflow_id:
+          type: integer
+          nullable: true
+          description: >
+            ID of an approval workflow to assign. When set, framework creation
+            is deferred until the approval request is approved.
+          example: null
+        enable_ai_data_insertion:
+          type: boolean
+          default: false
+          description: >
+            Whether to enable AI-assisted data insertion when creating
+            framework structures. Only used when approval_workflow_id is not set
+            (or after approval).
+
+    UpdateProjectRequest:
+      type: object
+      description: >
+        Partial update — only provided fields are modified. Members array
+        replaces the full member list (add/remove is computed by diff).
+      properties:
+        project_title:
+          type: string
+          description: Display name of the project
+        owner:
+          type: integer
+          description: User ID of the project owner
+        start_date:
+          type: string
+          format: date-time
+          description: Project start date
+        geography:
+          type: integer
+          description: Geography identifier
+        ai_risk_classification:
+          $ref: "#/components/schemas/AiRiskClassification"
+        type_of_high_risk_role:
+          $ref: "#/components/schemas/HighRiskRole"
+        goal:
+          type: string
+          nullable: true
+        target_industry:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        status:
+          $ref: "#/components/schemas/ProjectStatus"
+        last_updated:
+          type: string
+          format: date-time
+          description: Timestamp of last update (auto-set if not provided)
+        last_updated_by:
+          type: integer
+          description: User ID who last updated the project
+        members:
+          type: array
+          items:
+            type: integer
+          description: >
+            Full replacement list of member user IDs. Members not in this
+            list are removed; new IDs are added.
+          example: [2, 3, 5]
+
+    # --- Response Schemas ---
+    ProjectFramework:
+      type: object
+      properties:
+        project_framework_id:
+          type: integer
+          description: ID of the projects_frameworks join record
+        framework_id:
+          type: integer
+          description: Framework ID (1=EU AI Act, 2=ISO 42001, 3=ISO 27001, 4=NIST AI RMF)
+        name:
+          type: string
+          description: Framework display name
+          example: EU AI Act
+
+    Project:
+      type: object
+      description: Base project record as stored in the database
+      properties:
+        id:
+          type: integer
+          example: 42
+        uc_id:
+          type: string
+          description: Auto-generated use case ID
+          example: UC-7
+        project_title:
+          type: string
+          example: Customer Support Chatbot
+        owner:
+          type: integer
+          description: User ID of the project owner
+          example: 1
+        start_date:
+          type: string
+          format: date-time
+        geography:
+          type: integer
+          example: 1
+        ai_risk_classification:
+          $ref: "#/components/schemas/AiRiskClassification"
+        type_of_high_risk_role:
+          $ref: "#/components/schemas/HighRiskRole"
+        goal:
+          type: string
+          nullable: true
+        target_industry:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        status:
+          $ref: "#/components/schemas/ProjectStatus"
+        last_updated:
+          type: string
+          format: date-time
+        last_updated_by:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        is_organizational:
+          type: boolean
+        is_demo:
+          type: boolean
+        approval_workflow_id:
+          type: integer
+          nullable: true
+        pending_frameworks:
+          type: string
+          nullable: true
+          description: JSON-encoded array of framework IDs pending approval
+        enable_ai_data_insertion:
+          type: boolean
+        organization_id:
+          type: integer
+        framework:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectFramework"
+          description: Associated frameworks
+        members:
+          type: array
+          items:
+            type: integer
+          description: User IDs of project members
+
+    ProjectListItem:
+      allOf:
+        - $ref: "#/components/schemas/Project"
+        - type: object
+          properties:
+            has_pending_approval:
+              type: boolean
+              description: Whether the project has a pending approval request
+            approval_status:
+              type: string
+              nullable: true
+              description: Current approval status (pending, rejected, or null)
+              enum:
+                - pending
+                - rejected
+                - null
+            _source:
+              type: string
+              nullable: true
+              description: Plugin source identifier for externally-sourced use cases
+              example: jira-assets
+
+    ProjectDetail:
+      allOf:
+        - $ref: "#/components/schemas/Project"
+        - type: object
+          properties:
+            owner_name:
+              type: string
+              description: Full name of the project owner
+              example: John Doe
+            has_pending_approval:
+              type: boolean
+            approval_status:
+              type: string
+              nullable: true
+              enum:
+                - pending
+                - rejected
+                - null
+
+    ProjectWithMembers:
+      allOf:
+        - $ref: "#/components/schemas/Project"
+        - type: object
+          properties:
+            members:
+              type: array
+              items:
+                type: integer
+              description: Updated list of member user IDs
+
+    ProjectStats:
+      type: object
+      properties:
+        user:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Owner first name
+            surname:
+              type: string
+              description: Owner surname
+            email:
+              type: string
+              format: email
+              description: Owner email address
+            project_last_updated:
+              type: string
+              format: date-time
+              description: Timestamp of last project update
+            userWhoUpdated:
+              type: object
+              description: User object of the person who last updated the project
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+                surname:
+                  type: string
+                email:
+                  type: string
+                  format: email
+
+    ProjectRiskCount:
+      type: object
+      properties:
+        risk_level_autocalculated:
+          type: string
+          description: Auto-calculated risk level label
+          example: High
+        count:
+          type: string
+          description: Number of risks at this level (returned as string from SQL COUNT)
+          example: "3"
+
+    VendorRiskCount:
+      type: object
+      properties:
+        risk_level:
+          type: string
+          description: Vendor risk level label
+          example: Critical
+        count:
+          type: string
+          description: Number of vendor risks at this level
+          example: "2"
+
+    ComplianceProgress:
+      type: object
+      properties:
+        allsubControls:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Total number of sub-controls
+          example: "45"
+        allDonesubControls:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Number of sub-controls with status "Done"
+          example: "12"
+
+    AssessmentProgress:
+      type: object
+      properties:
+        totalQuestions:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Total number of assessment questions
+          example: "80"
+        answeredQuestions:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Number of questions with status "Done"
+          example: "35"
+
+    ControlCategory:
+      type: object
+      description: A control category with nested controls and sub-controls
+      properties:
+        id:
+          type: integer
+        project_id:
+          type: integer
+        name:
+          type: string
+        organization_id:
+          type: integer
+        controls:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              control_category_id:
+                type: integer
+              title:
+                type: string
+              description:
+                type: string
+              status:
+                type: string
+              numberOfSubcontrols:
+                type: integer
+                description: Total sub-controls under this control
+              numberOfDoneSubcontrols:
+                type: integer
+                description: Sub-controls with status "Done"
+              subControls:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    control_id:
+                      type: integer
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    status:
+                      type: string
+                      enum: [Draft, In progress, Done]
+                    organization_id:
+                      type: integer
+
+    # --- Error Schemas ---
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: HTTP status text
+          example: Not Found
+        data:
+          description: Error details or empty object
+          example: {}
+
+    ServerError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Internal Server Error
+        error:
+          type: string
+          description: Error message string
+          example: "Unexpected error occurred"

--- a/Servers/docs/api/risk-management-openapi.yaml
+++ b/Servers/docs/api/risk-management-openapi.yaml
@@ -1,0 +1,1270 @@
+# Risk Management API — OpenAPI 3.0 Path Definitions
+# Ready to paste into swagger.yaml under the `paths:` section.
+# Covers: Project Risks, Vendor Risks, Model Risks
+
+# ─────────────────────────────────────────────────────
+# SCHEMAS (paste under components.schemas)
+# ─────────────────────────────────────────────────────
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    # ── Shared envelope ──
+    SuccessResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: OK
+        data: {}
+
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Internal Server Error
+        error:
+          type: string
+
+    # ── Project Risk ──
+    ProjectRiskInput:
+      type: object
+      required:
+        - risk_name
+        - risk_owner
+        - risk_description
+      properties:
+        risk_name:
+          type: string
+          description: Name/title of the risk.
+        risk_owner:
+          type: integer
+          description: User ID of the risk owner (must be >= 1).
+        ai_lifecycle_phase:
+          type: string
+          enum:
+            - Problem definition & planning
+            - Data collection & processing
+            - Model development & training
+            - Model validation & testing
+            - Deployment & integration
+            - Monitoring & maintenance
+            - Decommissioning & retirement
+        risk_description:
+          type: string
+          description: Detailed description of the risk.
+        risk_category:
+          type: array
+          items:
+            type: string
+          description: Array of category labels.
+        impact:
+          type: string
+        assessment_mapping:
+          type: string
+        controls_mapping:
+          type: string
+        likelihood:
+          type: string
+          enum: [Rare, Unlikely, Possible, Likely, Almost Certain]
+        severity:
+          type: string
+          enum: [Negligible, Minor, Moderate, Major, Catastrophic]
+        risk_level_autocalculated:
+          type: string
+          enum: [No risk, Very low risk, Low risk, Medium risk, High risk, Very high risk]
+        review_notes:
+          type: string
+        mitigation_status:
+          type: string
+          enum: [Not Started, In Progress, Completed, On Hold, Deferred, Canceled, Requires review]
+        current_risk_level:
+          type: string
+          enum: [Very Low risk, Low risk, Medium risk, High risk, Very high risk]
+        deadline:
+          type: string
+          format: date-time
+        mitigation_plan:
+          type: string
+        implementation_strategy:
+          type: string
+        mitigation_evidence_document:
+          type: string
+        likelihood_mitigation:
+          type: string
+          enum: [Rare, Unlikely, Possible, Likely, Almost Certain]
+        risk_severity:
+          type: string
+          enum: [Negligible, Minor, Moderate, Major, Critical]
+        final_risk_level:
+          type: string
+        risk_approval:
+          type: integer
+          description: User ID of the approver.
+        approval_status:
+          type: string
+        date_of_assessment:
+          type: string
+          format: date-time
+        is_demo:
+          type: boolean
+          default: false
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Array of project IDs to link this risk to.
+        frameworks:
+          type: array
+          items:
+            type: integer
+          description: Array of framework IDs to link this risk to.
+        # FAIR Quantitative fields (all optional)
+        event_frequency_min:
+          type: number
+          nullable: true
+        event_frequency_likely:
+          type: number
+          nullable: true
+        event_frequency_max:
+          type: number
+          nullable: true
+        loss_regulatory_min:
+          type: number
+          nullable: true
+        loss_regulatory_likely:
+          type: number
+          nullable: true
+        loss_regulatory_max:
+          type: number
+          nullable: true
+        loss_operational_min:
+          type: number
+          nullable: true
+        loss_operational_likely:
+          type: number
+          nullable: true
+        loss_operational_max:
+          type: number
+          nullable: true
+        loss_litigation_min:
+          type: number
+          nullable: true
+        loss_litigation_likely:
+          type: number
+          nullable: true
+        loss_litigation_max:
+          type: number
+          nullable: true
+        loss_reputational_min:
+          type: number
+          nullable: true
+        loss_reputational_likely:
+          type: number
+          nullable: true
+        loss_reputational_max:
+          type: number
+          nullable: true
+        control_effectiveness:
+          type: number
+          nullable: true
+          description: Percentage 0-100.
+        mitigation_cost_annual:
+          type: number
+          nullable: true
+        benchmark_id:
+          type: integer
+          nullable: true
+        currency:
+          type: string
+          nullable: true
+          default: USD
+          maxLength: 3
+
+    ProjectRiskResponse:
+      allOf:
+        - $ref: '#/components/schemas/ProjectRiskInput'
+        - type: object
+          properties:
+            id:
+              type: integer
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+            # Computed FAIR fields (server-derived)
+            total_loss_likely:
+              type: number
+              nullable: true
+            ale_estimate:
+              type: number
+              nullable: true
+            residual_ale:
+              type: number
+              nullable: true
+            roi_percentage:
+              type: number
+              nullable: true
+            # Relationship arrays (populated on list endpoints)
+            projects:
+              type: array
+              items:
+                type: integer
+            frameworks:
+              type: array
+              items:
+                type: integer
+            # Relationship arrays (populated only on single-risk GET)
+            subClauses:
+              type: array
+              items:
+                type: object
+            annexCategories:
+              type: array
+              items:
+                type: object
+            controls:
+              type: array
+              items:
+                type: object
+            assessments:
+              type: array
+              items:
+                type: object
+            annexControls_27001:
+              type: array
+              items:
+                type: object
+            subClauses_27001:
+              type: array
+              items:
+                type: object
+
+    # ── Vendor Risk ──
+    VendorRiskInput:
+      type: object
+      required:
+        - vendor_id
+        - risk_description
+        - impact_description
+        - likelihood
+        - risk_severity
+        - action_plan
+        - action_owner
+        - risk_level
+      properties:
+        vendor_id:
+          type: integer
+          description: ID of the vendor this risk belongs to.
+        order_no:
+          type: integer
+          nullable: true
+          description: Optional ordering number.
+        risk_description:
+          type: string
+        impact_description:
+          type: string
+        likelihood:
+          type: string
+          enum: [Rare, Unlikely, Possible, Likely, Almost certain]
+        risk_severity:
+          type: string
+          enum: [Negligible, Minor, Moderate, Major, Catastrophic]
+        action_plan:
+          type: string
+        action_owner:
+          type: integer
+          description: User ID of the action owner.
+        risk_level:
+          type: string
+          description: Free-text risk level.
+        is_demo:
+          type: boolean
+          default: false
+
+    VendorRiskResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        vendor_id:
+          type: integer
+        order_no:
+          type: integer
+          nullable: true
+        risk_description:
+          type: string
+        impact_description:
+          type: string
+        impact:
+          type: string
+          nullable: true
+        likelihood:
+          type: string
+          enum: [Rare, Unlikely, Possible, Likely, Almost certain]
+        risk_severity:
+          type: string
+          enum: [Negligible, Minor, Moderate, Major, Catastrophic]
+        action_plan:
+          type: string
+        action_owner:
+          type: integer
+        risk_level:
+          type: string
+        is_demo:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    VendorRiskAllProjectsResponse:
+      description: Extended vendor risk with joined vendor/project info.
+      type: object
+      properties:
+        risk_id:
+          type: integer
+        vendor_id:
+          type: integer
+        order_no:
+          type: integer
+          nullable: true
+        risk_description:
+          type: string
+        impact_description:
+          type: string
+        likelihood:
+          type: string
+        risk_severity:
+          type: string
+        action_plan:
+          type: string
+        action_owner:
+          type: integer
+        risk_level:
+          type: string
+        is_demo:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        is_deleted:
+          type: boolean
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        vendor_name:
+          type: string
+        project_id:
+          type: integer
+          nullable: true
+        project_title:
+          type: string
+          nullable: true
+
+    # ── Model Risk ──
+    ModelRiskInput:
+      type: object
+      required:
+        - risk_name
+        - risk_category
+        - risk_level
+        - owner
+        - target_date
+      properties:
+        risk_name:
+          type: string
+        risk_category:
+          type: string
+          enum: [Performance, Bias & Fairness, Security, Data Quality, Compliance]
+        risk_level:
+          type: string
+          enum: [Low, Medium, High, Critical]
+        status:
+          type: string
+          enum: [Open, In Progress, Resolved, Accepted]
+          default: Open
+        owner:
+          type: string
+          description: Name or identifier of the risk owner.
+        target_date:
+          type: string
+          format: date
+          description: Next review / target date.
+        description:
+          type: string
+        mitigation_plan:
+          type: string
+        impact:
+          type: string
+        likelihood:
+          type: string
+        key_metrics:
+          type: string
+        current_values:
+          type: string
+        threshold:
+          type: string
+        model_id:
+          type: integer
+          nullable: true
+          description: ID of the model inventory entry this risk is linked to.
+        is_demo:
+          type: boolean
+          default: false
+
+    ModelRiskResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        risk_name:
+          type: string
+        risk_category:
+          type: string
+          enum: [Performance, Bias & Fairness, Security, Data Quality, Compliance]
+        risk_level:
+          type: string
+          enum: [Low, Medium, High, Critical]
+        status:
+          type: string
+          enum: [Open, In Progress, Resolved, Accepted]
+        owner:
+          type: string
+        target_date:
+          type: string
+          format: date
+        description:
+          type: string
+        mitigation_plan:
+          type: string
+        impact:
+          type: string
+        likelihood:
+          type: string
+        key_metrics:
+          type: string
+        current_values:
+          type: string
+        threshold:
+          type: string
+        model_id:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+# ─────────────────────────────────────────────────────
+# PATHS (paste under paths:)
+# ─────────────────────────────────────────────────────
+paths:
+
+  # ═══════════════════════════════════════════════════
+  # PROJECT RISKS  (mounted at /api/projectRisks)
+  # ═══════════════════════════════════════════════════
+
+  /api/projectRisks:
+    get:
+      tags: [Project Risks]
+      summary: Get all project risks
+      description: Returns all project risks for the authenticated user's organization. Includes linked project and framework IDs. Relationship arrays (subClauses, assessments, etc.) are empty on the list endpoint for performance — use the single-risk GET for full relationships.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+          description: Filter by soft-delete state.
+      responses:
+        '200':
+          description: Array of project risks.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProjectRiskResponse'
+        '204':
+          description: No project risks found.
+        '401':
+          description: Unauthorized — missing or invalid JWT.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    post:
+      tags: [Project Risks]
+      summary: Create a new project risk
+      description: Creates a project risk. Requires `risk_name`, `risk_owner` (user ID >= 1), and `risk_description`. Optionally accepts FAIR quantitative fields (event_frequency_*, loss_*_*, control_effectiveness, mitigation_cost_annual) which trigger server-side auto-computation of derived fields (total_loss_likely, ale_estimate, residual_ale, roi_percentage). Pass `projects` and `frameworks` arrays to link the risk to projects/frameworks.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRiskInput'
+      responses:
+        '201':
+          description: Project risk created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Created
+                  data:
+                    $ref: '#/components/schemas/ProjectRiskResponse'
+        '400':
+          description: Validation error or quantitative risk validation failed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Bad Request
+                  data:
+                    oneOf:
+                      - type: string
+                      - type: object
+                        properties:
+                          message:
+                            type: string
+                          errors:
+                            type: array
+                            items:
+                              type: string
+        '401':
+          description: Unauthorized.
+        '403':
+          description: Business logic violation.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  /api/projectRisks/by-projid/{id}:
+    get:
+      tags: [Project Risks]
+      summary: Get project risks by project ID
+      description: Returns project risks linked to a specific project. Non-numeric IDs (e.g. plugin-sourced) return an empty array.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Project ID (integer). Non-numeric values return `[]`.
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+      responses:
+        '200':
+          description: Array of project risks.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProjectRiskResponse'
+        '204':
+          description: No risks found for this project.
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  /api/projectRisks/by-frameworkid/{id}:
+    get:
+      tags: [Project Risks]
+      summary: Get project risks by framework ID
+      description: Returns project risks linked to a specific framework.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Framework ID.
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+      responses:
+        '200':
+          description: Array of project risks.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProjectRiskResponse'
+        '204':
+          description: No risks found for this framework.
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  /api/projectRisks/{id}:
+    get:
+      tags: [Project Risks]
+      summary: Get a project risk by ID
+      description: Returns a single project risk with full relationship data (subClauses, annexCategories, controls, assessments, annexControls_27001, subClauses_27001).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Project risk ID.
+      responses:
+        '200':
+          description: Project risk found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: '#/components/schemas/ProjectRiskResponse'
+        '204':
+          description: Project risk not found.
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    put:
+      tags: [Project Risks]
+      summary: Update a project risk by ID
+      description: Partially updates a project risk. Any field in ProjectRiskInput can be sent; only provided fields are updated. FAIR fields trigger auto-recomputation merged with existing values. Pass `projects` and `frameworks` arrays to update linked entities.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Project risk ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectRiskInput'
+      responses:
+        '200':
+          description: Project risk updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: '#/components/schemas/ProjectRiskResponse'
+        '400':
+          description: Validation error.
+        '401':
+          description: Unauthorized.
+        '403':
+          description: Business logic violation.
+        '404':
+          description: Project risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      tags: [Project Risks]
+      summary: Soft-delete a project risk
+      description: Sets `is_deleted = true` and `deleted_at = NOW()` on the risk. Returns the deleted risk object.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Project risk ID.
+      responses:
+        '200':
+          description: Project risk soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: '#/components/schemas/ProjectRiskResponse'
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Project risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  # ═══════════════════════════════════════════════════
+  # VENDOR RISKS  (mounted at /api/vendorRisks)
+  # ═══════════════════════════════════════════════════
+
+  /api/vendorRisks:
+    post:
+      tags: [Vendor Risks]
+      summary: Create a new vendor risk
+      description: Creates a vendor risk. Sends an in-app notification to the `action_owner` if assigned.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VendorRiskInput'
+      responses:
+        '201':
+          description: Vendor risk created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Created
+                  data:
+                    $ref: '#/components/schemas/VendorRiskResponse'
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable — creation returned null.
+
+  /api/vendorRisks/all:
+    get:
+      tags: [Vendor Risks]
+      summary: Get all vendor risks across all projects
+      description: Returns vendor risks joined with vendor name, project ID, and project title.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+      responses:
+        '200':
+          description: Array of vendor risks with vendor/project metadata.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/VendorRiskAllProjectsResponse'
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  /api/vendorRisks/by-projid/{id}:
+    get:
+      tags: [Vendor Risks]
+      summary: Get vendor risks by project ID
+      description: Returns vendor risks for vendors linked to the given project. Non-numeric IDs return an empty array.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Project ID (integer). Non-numeric values return `[]`.
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+      responses:
+        '200':
+          description: Array of vendor risks.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/VendorRiskResponse'
+        '204':
+          description: No vendor risks found.
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  /api/vendorRisks/by-vendorid/{id}:
+    get:
+      tags: [Vendor Risks]
+      summary: Get vendor risks by vendor ID
+      description: Returns all risks for a specific vendor.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Vendor ID.
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+      responses:
+        '200':
+          description: Array of vendor risks.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/VendorRiskResponse'
+        '204':
+          description: No vendor risks found.
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  /api/vendorRisks/{id}:
+    get:
+      tags: [Vendor Risks]
+      summary: Get a vendor risk by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Vendor risk ID.
+      responses:
+        '200':
+          description: Vendor risk found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: '#/components/schemas/VendorRiskResponse'
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Vendor risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    patch:
+      tags: [Vendor Risks]
+      summary: Update a vendor risk by ID
+      description: Partially updates a vendor risk. Only non-null/non-undefined fields in the body are applied. Updatable fields are vendor_id, risk_description, impact_description, likelihood, risk_severity, action_plan, action_owner, risk_level. Notifies new action_owner if changed.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Vendor risk ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                vendor_id:
+                  type: integer
+                risk_description:
+                  type: string
+                impact_description:
+                  type: string
+                likelihood:
+                  type: string
+                  enum: [Rare, Unlikely, Possible, Likely, Almost certain]
+                risk_severity:
+                  type: string
+                  enum: [Negligible, Minor, Moderate, Major, Catastrophic]
+                action_plan:
+                  type: string
+                action_owner:
+                  type: integer
+                risk_level:
+                  type: string
+      responses:
+        '202':
+          description: Vendor risk updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    $ref: '#/components/schemas/VendorRiskResponse'
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Vendor risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      tags: [Vendor Risks]
+      summary: Soft-delete a vendor risk
+      description: Sets `is_deleted = true` and `deleted_at = NOW()`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Vendor risk ID.
+      responses:
+        '202':
+          description: Vendor risk soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    $ref: '#/components/schemas/VendorRiskResponse'
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Vendor risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  # ═══════════════════════════════════════════════════
+  # MODEL RISKS  (mounted at /api/modelRisks)
+  # ═══════════════════════════════════════════════════
+
+  /api/modelRisks:
+    get:
+      tags: [Model Risks]
+      summary: Get all model risks
+      description: Returns all model risks for the authenticated user's organization.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+      responses:
+        '200':
+          description: Array of model risks (empty array if none found).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ModelRiskResponse'
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    post:
+      tags: [Model Risks]
+      summary: Create a new model risk
+      description: Creates a model risk entry. Required fields are risk_name, risk_category, risk_level, owner, and target_date. Status defaults to "Open".
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelRiskInput'
+      responses:
+        '201':
+          description: Model risk created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Created
+                  data:
+                    $ref: '#/components/schemas/ModelRiskResponse'
+        '400':
+          description: Validation error.
+        '401':
+          description: Unauthorized.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+  /api/modelRisks/{id}:
+    get:
+      tags: [Model Risks]
+      summary: Get a model risk by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Model risk ID.
+      responses:
+        '200':
+          description: Model risk found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: '#/components/schemas/ModelRiskResponse'
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Model risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    put:
+      tags: [Model Risks]
+      summary: Update a model risk by ID
+      description: Partially updates a model risk. Only provided fields are updated. Updatable fields are risk_name, risk_category, risk_level, status, owner, target_date, description, mitigation_plan, impact, likelihood, key_metrics, current_values, threshold, model_id. If no fields are provided, the current state is returned unchanged.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Model risk ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelRiskInput'
+      responses:
+        '200':
+          description: Model risk updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: '#/components/schemas/ModelRiskResponse'
+        '400':
+          description: Validation error.
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Model risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    patch:
+      tags: [Model Risks]
+      summary: Update a model risk by ID (alternative)
+      description: Identical to PUT. Both methods route to the same handler.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Model risk ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModelRiskInput'
+      responses:
+        '200':
+          description: Model risk updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: '#/components/schemas/ModelRiskResponse'
+        '400':
+          description: Validation error.
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Model risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      tags: [Model Risks]
+      summary: Soft-delete a model risk
+      description: Sets `is_deleted = true` and `deleted_at = NOW()`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Model risk ID.
+      responses:
+        '200':
+          description: Model risk deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: string
+                    example: Model risk deleted successfully.
+        '401':
+          description: Unauthorized.
+        '404':
+          description: Model risk not found.
+        '500':
+          $ref: '#/components/schemas/ErrorResponse'

--- a/Servers/docs/api/small-apis-openapi.yaml
+++ b/Servers/docs/api/small-apis-openapi.yaml
@@ -1,0 +1,1850 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise Small APIs
+  description: >
+    OpenAPI specification for smaller API domains: Share Links, Notes, Search,
+    Reporting, Dashboard, CE Marking, Roles, Subscriptions, Tiers, API Tokens,
+    LLM Keys, and User Preferences.
+  version: 1.0.0
+
+servers:
+  - url: /api
+
+security:
+  - BearerAuth: []
+
+paths:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # SHARE LINKS
+  # ─────────────────────────────────────────────────────────────────────────────
+  /shares:
+    post:
+      tags: [Share Links]
+      summary: Create a new share link
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ShareLinkCreateRequest"
+      responses:
+        "201":
+          description: Share link created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/ShareLinkResponse"
+        "400":
+          description: Validation error
+        "500":
+          description: Server error
+
+  /shares/{resourceType}/{resourceId}:
+    get:
+      tags: [Share Links]
+      summary: Get all share links for a specific resource
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: resourceType
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [model, vendor, project, policy, risk]
+        - name: resourceId
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+            description: Use 0 for table/list view sharing
+      responses:
+        "200":
+          description: Array of share links
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ShareLinkListItem"
+        "400":
+          description: Invalid resource type or ID
+        "500":
+          description: Server error
+
+  /shares/token/{token}:
+    get:
+      tags: [Share Links]
+      summary: Get share link metadata by token (public, no auth)
+      security: []
+      parameters:
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+            description: 64-character hex share token
+      responses:
+        "200":
+          description: Share link metadata
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/ShareLinkMetadata"
+        "400":
+          description: Invalid token format
+        "403":
+          description: Share link disabled or expired
+        "404":
+          description: Share link not found
+        "500":
+          description: Server error
+
+  /shares/view/{token}:
+    get:
+      tags: [Share Links]
+      summary: Get shared resource data by token (public, no auth)
+      security: []
+      parameters:
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+            description: 64-character hex share token
+      responses:
+        "200":
+          description: Shared resource data with permissions
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/SharedDataResponse"
+        "400":
+          description: Invalid token or unsupported resource type
+        "403":
+          description: Share link disabled or expired
+        "404":
+          description: Share link or resource not found
+        "500":
+          description: Server error
+
+  /shares/{id}:
+    patch:
+      tags: [Share Links]
+      summary: Update a share link
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ShareLinkUpdateRequest"
+      responses:
+        "200":
+          description: Updated share link
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/ShareLinkListItem"
+        "400":
+          description: No fields to update
+        "403":
+          description: Unauthorized (not the creator)
+        "404":
+          description: Share link not found
+        "500":
+          description: Server error
+    delete:
+      tags: [Share Links]
+      summary: Delete a share link
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Share link deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                            example: Share link deleted successfully
+        "403":
+          description: Unauthorized (not the creator)
+        "404":
+          description: Share link not found
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # NOTES
+  # ─────────────────────────────────────────────────────────────────────────────
+  /notes:
+    post:
+      tags: [Notes]
+      summary: Create a new note
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NoteCreateRequest"
+      responses:
+        "201":
+          description: Note created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Note"
+        "400":
+          description: Validation error (missing content, attached_to, or attached_to_id)
+        "500":
+          description: Server error
+    get:
+      tags: [Notes]
+      summary: Fetch notes for an entity
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: attachedTo
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [project, vendor, model, risk, policy, task, incident]
+            description: Entity type the notes are attached to
+        - name: attachedToId
+          in: query
+          required: true
+          schema:
+            type: string
+            description: ID of the entity
+      responses:
+        "200":
+          description: Array of notes (may be empty)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Note"
+        "400":
+          description: Missing query parameters
+        "500":
+          description: Server error
+
+  /notes/{id}:
+    put:
+      tags: [Notes]
+      summary: Update note content
+      description: Only the author or admins can update a note
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [content]
+              properties:
+                content:
+                  type: string
+                  maxLength: 5000
+      responses:
+        "200":
+          description: Updated note
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Note"
+        "400":
+          description: Validation or permission error
+        "500":
+          description: Server error
+    delete:
+      tags: [Notes]
+      summary: Delete a note
+      description: Only the author or admins can delete a note
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Note deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: string
+                        example: Note deleted successfully
+        "400":
+          description: Permission error
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # SEARCH
+  # ─────────────────────────────────────────────────────────────────────────────
+  /search:
+    get:
+      tags: [Search]
+      summary: Global search across all entities
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 3
+          description: Search query (minimum 3 characters unless reviewStatus is set)
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+          description: Maximum results per entity type
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+          description: Pagination offset
+        - name: reviewStatus
+          in: query
+          schema:
+            type: string
+          description: Filter by review status (bypasses min query length)
+      responses:
+        "200":
+          description: Grouped search results
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/SearchResponse"
+        "401":
+          description: Unauthorized
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # REPORTING
+  # ─────────────────────────────────────────────────────────────────────────────
+  /reporting/generate-report:
+    post:
+      tags: [Reporting]
+      summary: Generate a report (legacy, redirects to v2)
+      description: Admin only. Generates compliance/assessment reports as DOCX/PDF.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportGenerateRequest"
+      responses:
+        "200":
+          description: Report file binary
+          content:
+            application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+              schema:
+                type: string
+                format: binary
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: User not found
+        "500":
+          description: Generation or upload failed
+    get:
+      tags: [Reporting]
+      summary: Get all previously generated reports
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Array of report metadata
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/GeneratedReport"
+        "401":
+          description: Unauthorized
+        "500":
+          description: Server error
+
+  /reporting/v2/generate-report:
+    post:
+      tags: [Reporting]
+      summary: Generate report v2 (HTML/EJS-based, supports PDF and DOCX)
+      description: Admin only. Rich formatting with optional AI enhancement.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportGenerateRequest"
+      responses:
+        "200":
+          description: Report file binary with Content-Disposition header
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: attachment; filename="report.docx"
+          content:
+            application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+              schema:
+                type: string
+                format: binary
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: User not found
+        "500":
+          description: Generation or upload failed
+
+  /reporting/{id}:
+    delete:
+      tags: [Reporting]
+      summary: Delete a generated report by ID
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Deleted report data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/GeneratedReport"
+        "204":
+          description: No report to delete
+        "404":
+          description: Report not found
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # DASHBOARD
+  # ─────────────────────────────────────────────────────────────────────────────
+  /dashboard:
+    get:
+      tags: [Dashboard]
+      summary: Get dashboard overview data
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Dashboard data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/DashboardData"
+        "204":
+          description: No data available
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CE MARKING
+  # ─────────────────────────────────────────────────────────────────────────────
+  /ce-marking/{projectId}:
+    get:
+      tags: [CE Marking]
+      summary: Get CE Marking data for a project
+      description: Creates default record with 7 conformity steps if none exists.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: CE Marking data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CEMarkingResponse"
+        "404":
+          description: Project not found or no access
+        "500":
+          description: Server error
+    put:
+      tags: [CE Marking]
+      summary: Update CE Marking data for a project
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CEMarkingUpdateRequest"
+      responses:
+        "200":
+          description: Updated CE Marking data (same shape as GET response)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CEMarkingResponse"
+        "404":
+          description: Project or CE Marking record not found
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # ROLES
+  # ─────────────────────────────────────────────────────────────────────────────
+  /roles:
+    get:
+      tags: [Roles]
+      summary: List all roles
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Array of roles
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Role"
+        "204":
+          description: No roles found
+        "500":
+          description: Server error
+
+  /roles/{id}:
+    get:
+      tags: [Roles]
+      summary: Get role by ID
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Role object
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Role"
+        "404":
+          description: Role not found
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # SUBSCRIPTIONS
+  # ─────────────────────────────────────────────────────────────────────────────
+  /subscriptions:
+    get:
+      tags: [Subscriptions]
+      summary: Get all subscriptions
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Array of subscriptions
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Subscription"
+        "404":
+          description: No subscriptions found
+        "500":
+          description: Server error
+    post:
+      tags: [Subscriptions]
+      summary: Create a new subscription
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubscriptionCreateRequest"
+      responses:
+        "201":
+          description: Subscription created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Subscription"
+        "400":
+          description: Creation failed
+        "500":
+          description: Server error
+
+  /subscriptions/{id}:
+    put:
+      tags: [Subscriptions]
+      summary: Update a subscription
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubscriptionUpdateRequest"
+      responses:
+        "200":
+          description: Subscription updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/Subscription"
+        "404":
+          description: Subscription not found
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # TIERS
+  # ─────────────────────────────────────────────────────────────────────────────
+  /tiers/features/{id}:
+    get:
+      tags: [Tiers]
+      summary: Get features for a specific tier
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Tier ID
+      responses:
+        "200":
+          description: Tier features
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/TierFeatures"
+        "404":
+          description: Tier features not found
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # API TOKENS
+  # ─────────────────────────────────────────────────────────────────────────────
+  /tokens:
+    get:
+      tags: [API Tokens]
+      summary: List all API tokens for the organization
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Array of API tokens
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ApiToken"
+        "500":
+          description: Server error
+    post:
+      tags: [API Tokens]
+      summary: Create a new API token
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApiTokenCreateRequest"
+      responses:
+        "201":
+          description: API token created (includes full token value, shown only once)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/ApiTokenCreated"
+        "400":
+          description: Validation error
+        "500":
+          description: Server error
+
+  /tokens/{id}:
+    delete:
+      tags: [API Tokens]
+      summary: Delete an API token
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Token deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                            example: API token deleted successfully
+        "404":
+          description: Token not found
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # LLM KEYS
+  # ─────────────────────────────────────────────────────────────────────────────
+  /llm-keys:
+    get:
+      tags: [LLM Keys]
+      summary: List all LLM keys for the organization
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Array of LLM keys (key values are masked)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/LLMKey"
+        "500":
+          description: Server error
+    post:
+      tags: [LLM Keys]
+      summary: Create a new LLM key
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LLMKeyCreateRequest"
+      responses:
+        "201":
+          description: LLM key created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/LLMKey"
+        "400":
+          description: Validation error or duplicate key
+        "500":
+          description: Server error
+
+  /llm-keys/status:
+    get:
+      tags: [LLM Keys]
+      summary: Get LLM key configuration status
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Key status summary
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/LLMKeyStatus"
+        "500":
+          description: Server error
+
+  /llm-keys/{name}:
+    get:
+      tags: [LLM Keys]
+      summary: Get LLM key by provider name
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [Anthropic, OpenAI, OpenRouter, Custom]
+      responses:
+        "200":
+          description: LLM key for provider
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/LLMKey"
+        "500":
+          description: Server error
+
+  /llm-keys/{id}:
+    patch:
+      tags: [LLM Keys]
+      summary: Update an LLM key
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LLMKeyUpdateRequest"
+      responses:
+        "200":
+          description: LLM key updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/LLMKey"
+        "400":
+          description: Validation error or duplicate key
+        "404":
+          description: LLM key not found
+        "500":
+          description: Server error
+    delete:
+      tags: [LLM Keys]
+      summary: Delete an LLM key
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: LLM key deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                            example: LLM Key deleted successfully
+        "404":
+          description: LLM key not found
+        "500":
+          description: Server error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # USER PREFERENCES
+  # ─────────────────────────────────────────────────────────────────────────────
+  /user-preferences/{userId}:
+    get:
+      tags: [User Preferences]
+      summary: Get preferences for a user
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: User preferences (null if none exist)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        oneOf:
+                          - $ref: "#/components/schemas/UserPreference"
+                          - type: "null"
+        "500":
+          description: Server error
+    patch:
+      tags: [User Preferences]
+      summary: Update user preferences
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserPreferenceUpdateRequest"
+      responses:
+        "200":
+          description: Updated preferences
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/UserPreference"
+        "400":
+          description: Update failed or validation error
+        "404":
+          description: User preferences not found
+        "500":
+          description: Server error
+
+  /user-preferences:
+    post:
+      tags: [User Preferences]
+      summary: Create user preferences
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserPreferenceCreateRequest"
+      responses:
+        "201":
+          description: Preferences created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/StatusCodeWrapper"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/UserPreference"
+        "400":
+          description: Missing fields, invalid user_id, or preferences already exist
+        "500":
+          description: Server error
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    # ─── Generic wrapper ────────────────────────────────────────────────────────
+    StatusCodeWrapper:
+      type: object
+      properties:
+        code:
+          type: integer
+        data:
+          description: Response payload
+
+    # ─── Share Links ────────────────────────────────────────────────────────────
+    ShareLinkSettings:
+      type: object
+      properties:
+        shareAllFields:
+          type: boolean
+          default: false
+        allowDataExport:
+          type: boolean
+          default: true
+        allowViewersToOpenRecords:
+          type: boolean
+          default: false
+        displayToolbar:
+          type: boolean
+          default: true
+
+    ShareLinkCreateRequest:
+      type: object
+      required: [resource_type, resource_id]
+      properties:
+        resource_type:
+          type: string
+          enum: [model, vendor, project, policy, risk]
+        resource_id:
+          type: integer
+          minimum: 0
+          description: Use 0 for sharing the entire table/list view
+        settings:
+          $ref: "#/components/schemas/ShareLinkSettings"
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    ShareLinkUpdateRequest:
+      type: object
+      properties:
+        settings:
+          $ref: "#/components/schemas/ShareLinkSettings"
+        is_enabled:
+          type: boolean
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    ShareLinkResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        share_token:
+          type: string
+        resource_type:
+          type: string
+        resource_id:
+          type: integer
+        settings:
+          $ref: "#/components/schemas/ShareLinkSettings"
+        is_enabled:
+          type: boolean
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        shareable_url:
+          type: string
+          format: uri
+
+    ShareLinkListItem:
+      allOf:
+        - $ref: "#/components/schemas/ShareLinkResponse"
+        - properties:
+            is_valid:
+              type: boolean
+              description: Whether the link is currently active and not expired
+
+    ShareLinkMetadata:
+      type: object
+      properties:
+        id:
+          type: integer
+        share_token:
+          type: string
+        resource_type:
+          type: string
+        resource_id:
+          type: integer
+        settings:
+          $ref: "#/components/schemas/ShareLinkSettings"
+        is_enabled:
+          type: boolean
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        is_valid:
+          type: boolean
+
+    SharedDataResponse:
+      type: object
+      properties:
+        share_link:
+          type: object
+          properties:
+            resource_type:
+              type: string
+            settings:
+              $ref: "#/components/schemas/ShareLinkSettings"
+        data:
+          description: Resource data (object for single record, array for table view)
+          oneOf:
+            - type: object
+            - type: array
+              items:
+                type: object
+        permissions:
+          type: object
+          properties:
+            allowDataExport:
+              type: boolean
+            allowViewersToOpenRecords:
+              type: boolean
+
+    # ─── Notes ──────────────────────────────────────────────────────────────────
+    NoteCreateRequest:
+      type: object
+      required: [content, attached_to, attached_to_id]
+      properties:
+        content:
+          type: string
+          maxLength: 5000
+        attached_to:
+          type: string
+          enum: [project, vendor, model, risk, policy, task, incident]
+        attached_to_id:
+          type: string
+
+    Note:
+      type: object
+      properties:
+        id:
+          type: integer
+        content:
+          type: string
+        author_id:
+          type: integer
+        attached_to:
+          type: string
+        attached_to_id:
+          type: string
+        organization_id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    # ─── Search ─────────────────────────────────────────────────────────────────
+    SearchResponse:
+      type: object
+      properties:
+        results:
+          type: object
+          description: Results grouped by entity type (projects, vendors, models, etc.)
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: Entity-specific result object
+        totalCount:
+          type: integer
+        query:
+          type: string
+        message:
+          type: string
+          description: Present when query is too short
+
+    # ─── Reporting ──────────────────────────────────────────────────────────────
+    ReportGenerateRequest:
+      type: object
+      required: [projectId, frameworkId, projectFrameworkId, reportType]
+      properties:
+        projectId:
+          type: integer
+        frameworkId:
+          type: integer
+        projectFrameworkId:
+          type: integer
+        reportType:
+          oneOf:
+            - type: string
+              enum:
+                - projectRisks
+                - vendorRisks
+                - modelRisks
+                - compliance
+                - assessment
+                - clausesAndAnnexes
+                - nistSubcategories
+                - vendors
+                - models
+                - trainingRegistry
+                - policyManager
+                - incidentManagement
+                - all
+            - type: array
+              items:
+                type: string
+        reportName:
+          type: string
+        format:
+          type: string
+          enum: [pdf, docx]
+          default: docx
+        aiEnhanced:
+          type: boolean
+          default: false
+        llmKeyId:
+          type: integer
+          description: LLM key ID for AI-enhanced reports
+
+    GeneratedReport:
+      type: object
+      properties:
+        id:
+          type: integer
+        filename:
+          type: string
+        project_id:
+          type: integer
+        report_type:
+          type: string
+        created_by:
+          type: integer
+        organization_id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    # ─── Dashboard ──────────────────────────────────────────────────────────────
+    DashboardData:
+      type: object
+      properties:
+        projects:
+          type: integer
+          description: Total project count
+        trainings:
+          type: integer
+          description: Total training records
+        models:
+          type: integer
+          description: Total model count
+        reports:
+          type: integer
+          description: Total report count
+        task_radar:
+          type: object
+          properties:
+            overdue:
+              type: integer
+            due:
+              type: integer
+            upcoming:
+              type: integer
+        projects_list:
+          type: array
+          items:
+            type: object
+            description: Project summary objects
+
+    # ─── CE Marking ────────────────────────────────────────────────────────────
+    ConformityStep:
+      type: object
+      properties:
+        id:
+          type: integer
+        step:
+          type: string
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [Not started, In progress, Completed, Not needed]
+        owner:
+          type: string
+          nullable: true
+        dueDate:
+          type: string
+          format: date
+          nullable: true
+        completedDate:
+          type: string
+          format: date
+          nullable: true
+
+    CEMarkingResponse:
+      type: object
+      properties:
+        isHighRiskAISystem:
+          type: boolean
+        roleInProduct:
+          type: string
+          enum: [standalone, safety_component, product_itself]
+        annexIIICategory:
+          type: string
+        controlsCompleted:
+          type: integer
+        controlsTotal:
+          type: integer
+        assessmentsCompleted:
+          type: integer
+        assessmentsTotal:
+          type: integer
+        conformitySteps:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConformityStep"
+        completedStepsCount:
+          type: integer
+        totalStepsCount:
+          type: integer
+        declarationStatus:
+          type: string
+          enum: [draft, ready, signed]
+        signedOn:
+          type: string
+          format: date
+          nullable: true
+        signatory:
+          type: string
+          nullable: true
+        declarationDocument:
+          type: string
+          nullable: true
+        registrationStatus:
+          type: string
+          enum: [not_registered, pending, registered]
+        euRegistrationId:
+          type: string
+          nullable: true
+        registrationDate:
+          type: string
+          format: date
+          nullable: true
+        euRecordUrl:
+          type: string
+          format: uri
+          nullable: true
+        policiesLinked:
+          type: integer
+        evidenceLinked:
+          type: integer
+        linkedPolicies:
+          type: array
+          items:
+            type: integer
+        linkedEvidences:
+          type: array
+          items:
+            type: integer
+        totalIncidents:
+          type: integer
+        aiActReportableIncidents:
+          type: integer
+        lastIncident:
+          type: string
+          format: date-time
+          nullable: true
+        linkedIncidents:
+          type: array
+          items:
+            type: integer
+
+    CEMarkingUpdateRequest:
+      type: object
+      properties:
+        isHighRiskAISystem:
+          type: boolean
+        roleInProduct:
+          type: string
+        annexIIICategory:
+          type: string
+        declarationStatus:
+          type: string
+        signedOn:
+          type: string
+          format: date
+        signatory:
+          type: string
+        declarationDocument:
+          type: string
+        registrationStatus:
+          type: string
+        euRegistrationId:
+          type: string
+        registrationDate:
+          type: string
+          format: date
+        euRecordUrl:
+          type: string
+        linkedPolicies:
+          type: array
+          items:
+            type: integer
+        linkedEvidences:
+          type: array
+          items:
+            type: integer
+        linkedIncidents:
+          type: array
+          items:
+            type: integer
+        conformitySteps:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              description:
+                type: string
+              status:
+                type: string
+                enum: [Not started, In progress, Completed, Not needed]
+              owner:
+                type: string
+              dueDate:
+                type: string
+                format: date
+              completedDate:
+                type: string
+                format: date
+
+    # ─── Roles ──────────────────────────────────────────────────────────────────
+    Role:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          enum: [Admin, Reviewer, Editor, Auditor]
+        description:
+          type: string
+
+    # ─── Subscriptions ──────────────────────────────────────────────────────────
+    SubscriptionCreateRequest:
+      type: object
+      required: [organization_id, tier_id, status, start_date]
+      properties:
+        organization_id:
+          type: integer
+        tier_id:
+          type: integer
+        stripe_sub_id:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [active, cancelled, past_due, trialing]
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+
+    SubscriptionUpdateRequest:
+      type: object
+      properties:
+        tier_id:
+          type: integer
+        stripe_sub_id:
+          type: string
+        status:
+          type: string
+          enum: [active, cancelled, past_due, trialing]
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+
+    Subscription:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        tier_id:
+          type: integer
+        stripe_sub_id:
+          type: string
+          nullable: true
+        status:
+          type: string
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    # ─── Tiers ──────────────────────────────────────────────────────────────────
+    TierFeatures:
+      type: object
+      description: Tier details with associated feature flags
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        features:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              enabled:
+                type: boolean
+
+    # ─── API Tokens ─────────────────────────────────────────────────────────────
+    ApiTokenCreateRequest:
+      type: object
+      required: [name, expires_in_days]
+      properties:
+        name:
+          type: string
+          description: Descriptive name for the token
+        expires_in_days:
+          type: integer
+          minimum: 1
+          description: Number of days until token expires
+
+    ApiToken:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        expires_at:
+          type: string
+          format: date-time
+        created_by:
+          type: integer
+        organization_id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    ApiTokenCreated:
+      allOf:
+        - $ref: "#/components/schemas/ApiToken"
+        - properties:
+            token:
+              type: string
+              description: Full JWT token value (only shown on creation)
+
+    # ─── LLM Keys ──────────────────────────────────────────────────────────────
+    LLMKeyCreateRequest:
+      type: object
+      required: [name, key]
+      properties:
+        name:
+          type: string
+          enum: [Anthropic, OpenAI, OpenRouter, Custom]
+          description: LLM provider name
+        key:
+          type: string
+          description: API key value
+        model:
+          type: string
+          description: Default model to use with this key
+        url:
+          type: string
+          format: uri
+          description: Required for Custom provider; auto-populated for others
+        custom_headers:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+          description: Optional custom headers (string key-value pairs)
+
+    LLMKeyUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          enum: [Anthropic, OpenAI, OpenRouter, Custom]
+        key:
+          type: string
+        model:
+          type: string
+        url:
+          type: string
+          format: uri
+        custom_headers:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+
+    LLMKey:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        key:
+          type: string
+          description: Masked key value
+        url:
+          type: string
+        model:
+          type: string
+          nullable: true
+        custom_headers:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+        organization_id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    LLMKeyStatus:
+      type: object
+      properties:
+        hasKeys:
+          type: boolean
+        keyCount:
+          type: integer
+        providers:
+          type: array
+          items:
+            type: string
+
+    # ─── User Preferences ───────────────────────────────────────────────────────
+    UserPreferenceCreateRequest:
+      type: object
+      required: [user_id, date_format]
+      properties:
+        user_id:
+          type: integer
+          minimum: 1
+        date_format:
+          type: string
+          description: "Preferred date format (e.g., YYYY-MM-DD, DD/MM/YYYY)"
+
+    UserPreferenceUpdateRequest:
+      type: object
+      properties:
+        date_format:
+          type: string
+
+    UserPreference:
+      type: object
+      properties:
+        id:
+          type: integer
+        user_id:
+          type: integer
+        date_format:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time

--- a/Servers/docs/api/tasks-openapi.yaml
+++ b/Servers/docs/api/tasks-openapi.yaml
@@ -1,0 +1,865 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise Tasks API
+  description: Task management endpoints for VerifyWise platform.
+  version: 1.0.0
+
+paths:
+  /tasks:
+    get:
+      summary: List all tasks
+      description: >
+        Retrieve tasks with filtering, sorting, and pagination.
+        Visibility is role-based: Admins see all tasks in the organization;
+        non-admins see only tasks they created or are assigned to.
+        Soft-deleted tasks are excluded unless `include_archived=true`.
+      operationId: getAllTasks
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          description: Filter by one or more task statuses.
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/TaskStatus"
+          style: form
+          explode: true
+        - name: priority
+          in: query
+          description: Filter by one or more priorities.
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/TaskPriority"
+          style: form
+          explode: true
+        - name: due_date_start
+          in: query
+          description: Return tasks with due_date on or after this date (ISO 8601).
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: due_date_end
+          in: query
+          description: Return tasks with due_date on or before this date (ISO 8601).
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: category
+          in: query
+          description: Filter by one or more category strings stored in the task's categories array.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: assignee
+          in: query
+          description: Filter by one or more assignee user IDs.
+          required: false
+          schema:
+            type: array
+            items:
+              type: integer
+          style: form
+          explode: true
+        - name: search
+          in: query
+          description: Case-insensitive substring search across title and description.
+          required: false
+          schema:
+            type: string
+        - name: include_archived
+          in: query
+          description: When `true`, includes soft-deleted (archived) tasks in results.
+          required: false
+          schema:
+            type: string
+            enum: ["true", "false"]
+            default: "false"
+        - name: sort_by
+          in: query
+          description: Field to sort by.
+          required: false
+          schema:
+            type: string
+            enum: [due_date, priority, created_at]
+            default: created_at
+        - name: sort_order
+          in: query
+          description: Sort direction.
+          required: false
+          schema:
+            type: string
+            enum: [ASC, DESC]
+            default: DESC
+        - name: page
+          in: query
+          description: Page number (1-based).
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: page_size
+          in: query
+          description: Number of items per page (max 100).
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 25
+      responses:
+        "200":
+          description: Paginated list of tasks.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          tasks:
+                            type: array
+                            items:
+                              $ref: "#/components/schemas/TaskWithRelations"
+                          pagination:
+                            $ref: "#/components/schemas/Pagination"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    post:
+      summary: Create a task
+      description: >
+        Create a new task. The authenticated user becomes the creator.
+        Priority defaults to Medium, status defaults to Open.
+        Assignees receive in-app and email notifications.
+      operationId: createTask
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTaskRequest"
+      responses:
+        "201":
+          description: Task created.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TaskWithAssignees"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /tasks/{id}:
+    get:
+      summary: Get a task by ID
+      description: >
+        Retrieve a single task including assignees, assignee names,
+        creator name, and entity links. Visibility rules apply.
+      operationId: getTaskById
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TaskId"
+      responses:
+        "200":
+          description: Task details.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TaskDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    put:
+      summary: Update a task
+      description: >
+        Partially update a task. Only provided fields are changed.
+        Permission rules:
+        - Only admins and the task creator can update `due_date` and `priority`.
+        - Creator, assignee, or admin can update `status`.
+        - Newly assigned users receive a TASK_ASSIGNED notification;
+          existing assignees receive a TASK_UPDATED notification.
+      operationId: updateTask
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TaskId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateTaskRequest"
+      responses:
+        "200":
+          description: Task updated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TaskWithAssignees"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      summary: Soft-delete (archive) a task
+      description: >
+        Sets the task status to "Deleted". Only the task creator or an admin
+        can perform this action. The task can be restored later.
+      operationId: deleteTask
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TaskId"
+      responses:
+        "200":
+          description: Task archived.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                            example: Task deleted successfully
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /tasks/{id}/restore:
+    put:
+      summary: Restore an archived task
+      description: >
+        Restores a soft-deleted task by setting its status back to "Open".
+        Only the task creator or an admin can restore.
+        The task must currently have status "Deleted".
+      operationId: restoreTask
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TaskId"
+      responses:
+        "200":
+          description: Task restored.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TaskWithAssignees"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /tasks/{id}/hard:
+    delete:
+      summary: Permanently delete a task
+      description: >
+        Permanently removes the task and its assignee records from the database.
+        This action cannot be undone. Only the task creator or an admin can perform this.
+      operationId: hardDeleteTask
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TaskId"
+      responses:
+        "200":
+          description: Task permanently deleted.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                            example: Task permanently deleted
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /tasks/{id}/entities:
+    get:
+      summary: Get entity links for a task
+      description: >
+        Returns all entities linked to the specified task, enriched with
+        entity names resolved from their respective tables.
+      operationId: getTaskEntityLinks
+      tags: [Task Entity Links]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TaskId"
+      responses:
+        "200":
+          description: List of entity links.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/TaskEntityLink"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    post:
+      summary: Add an entity link to a task
+      description: >
+        Links an entity (vendor, model, policy, compliance control, etc.)
+        to the specified task. Validates that both the task and entity exist
+        and that the link is not a duplicate.
+      operationId: addTaskEntityLink
+      tags: [Task Entity Links]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TaskId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddEntityLinkRequest"
+      responses:
+        "201":
+          description: Entity link created.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TaskEntityLink"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Duplicate link.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEnvelope"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /tasks/{id}/entities/{linkId}:
+    delete:
+      summary: Remove an entity link from a task
+      description: Removes a specific entity link by its ID from the specified task.
+      operationId: removeTaskEntityLink
+      tags: [Task Entity Links]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TaskId"
+        - name: linkId
+          in: path
+          required: true
+          description: ID of the entity link to remove.
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Entity link removed.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ResponseEnvelope"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                            example: Entity link removed successfully
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >
+        JWT access token. Payload contains `id` (user ID), `email`,
+        `organizationId`, `tenantId`, `roleName`, and `expire`.
+
+  parameters:
+    TaskId:
+      name: id
+      in: path
+      required: true
+      description: Task ID.
+      schema:
+        type: integer
+
+  schemas:
+    # ---------- Enums ----------
+
+    TaskPriority:
+      type: string
+      enum: [Low, Medium, High]
+      description: Task priority level.
+
+    TaskStatus:
+      type: string
+      enum: [Open, In Progress, Completed, Overdue, Deleted]
+      description: >
+        Task lifecycle status. "Deleted" represents a soft-deleted (archived) task.
+
+    EntityType:
+      type: string
+      enum:
+        - vendor
+        - model
+        - policy
+        - nist_subcategory
+        - iso42001_subclause
+        - iso42001_annexcategory
+        - iso27001_subclause
+        - iso27001_annexcontrol
+        - eu_control
+        - eu_subcontrol
+      description: Type of entity that can be linked to a task.
+
+    # ---------- Request Bodies ----------
+
+    CreateTaskRequest:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+          description: Task title.
+          example: Review vendor risk assessment
+        description:
+          type: string
+          nullable: true
+          description: Detailed task description.
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Due date in ISO 8601 format.
+          example: "2026-05-15T00:00:00.000Z"
+        priority:
+          $ref: "#/components/schemas/TaskPriority"
+          default: Medium
+        status:
+          $ref: "#/components/schemas/TaskStatus"
+          default: Open
+        categories:
+          type: array
+          items:
+            type: string
+          description: Free-form category tags.
+          example: ["compliance", "vendor"]
+        assignees:
+          type: array
+          items:
+            oneOf:
+              - type: integer
+                description: User ID directly.
+              - type: object
+                properties:
+                  user_id:
+                    type: integer
+                required:
+                  - user_id
+          description: >
+            Users to assign. Accepts an array of user IDs (integers)
+            or objects with a `user_id` property.
+          example: [1, 2, 3]
+        entity_links:
+          type: array
+          items:
+            type: object
+            properties:
+              entity_id:
+                type: integer
+              entity_type:
+                $ref: "#/components/schemas/EntityType"
+              entity_name:
+                type: string
+                description: Display name for the entity (optional, used in notifications).
+          description: >
+            Entity links passed for notification purposes only.
+            These are NOT persisted as entity links during task creation;
+            use POST /tasks/{id}/entities to persist links.
+
+    UpdateTaskRequest:
+      type: object
+      description: >
+        All fields are optional. Only provided fields are updated.
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+          nullable: true
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Set to null to clear the due date.
+        priority:
+          $ref: "#/components/schemas/TaskPriority"
+        status:
+          $ref: "#/components/schemas/TaskStatus"
+        categories:
+          type: array
+          items:
+            type: string
+        assignees:
+          type: array
+          items:
+            type: integer
+          description: >
+            Full replacement of the assignee list. Pass the complete
+            set of user IDs; previous assignees not in the list are removed.
+        entity_links:
+          type: array
+          items:
+            type: object
+            properties:
+              entity_id:
+                type: integer
+              entity_type:
+                $ref: "#/components/schemas/EntityType"
+              entity_name:
+                type: string
+          description: Entity links passed for notification purposes only.
+
+    AddEntityLinkRequest:
+      type: object
+      required:
+        - entity_id
+        - entity_type
+      properties:
+        entity_id:
+          type: integer
+          description: ID of the entity to link.
+          example: 42
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        entity_name:
+          type: string
+          description: Optional display name stored on the link for quick access.
+          example: Acme Corp
+
+    # ---------- Response Schemas ----------
+
+    ResponseEnvelope:
+      type: object
+      properties:
+        message:
+          type: string
+          description: HTTP status text.
+          example: OK
+        data:
+          description: Response payload (varies by endpoint).
+
+    Task:
+      type: object
+      description: Core task fields as stored in the database.
+      properties:
+        id:
+          type: integer
+          example: 1
+        title:
+          type: string
+          example: Review vendor risk assessment
+        description:
+          type: string
+          nullable: true
+        creator_id:
+          type: integer
+          description: User ID of the task creator.
+        organization_id:
+          type: integer
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
+        priority:
+          $ref: "#/components/schemas/TaskPriority"
+        status:
+          $ref: "#/components/schemas/TaskStatus"
+        categories:
+          type: array
+          items:
+            type: string
+          description: JSONB array of free-form category strings.
+        is_demo:
+          type: boolean
+          description: Whether this is demo/seed data.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    TaskWithAssignees:
+      description: Task with the assignees array appended.
+      allOf:
+        - $ref: "#/components/schemas/Task"
+        - type: object
+          properties:
+            assignees:
+              type: array
+              items:
+                type: integer
+              description: Array of assigned user IDs.
+
+    TaskWithRelations:
+      description: Task with assignees and entity links (returned by list endpoint).
+      allOf:
+        - $ref: "#/components/schemas/Task"
+        - type: object
+          properties:
+            assignees:
+              type: array
+              items:
+                type: integer
+              description: Array of assigned user IDs.
+            entity_links:
+              type: array
+              items:
+                $ref: "#/components/schemas/EntityLinkSummary"
+
+    TaskDetail:
+      description: >
+        Full task detail returned by the get-by-ID endpoint. Includes
+        creator name, assignee names, and entity links.
+      allOf:
+        - $ref: "#/components/schemas/Task"
+        - type: object
+          properties:
+            assignees:
+              type: array
+              items:
+                type: integer
+              description: Array of assigned user IDs.
+            creator_name:
+              type: string
+              description: Full name of the task creator.
+              example: Jane Smith
+            assignee_names:
+              type: array
+              items:
+                type: string
+              description: Full names of assignees in the same order.
+              example: ["John Doe", "Alice Johnson"]
+            entity_links:
+              type: array
+              items:
+                $ref: "#/components/schemas/EntityLinkSummary"
+
+    EntityLinkSummary:
+      type: object
+      description: Abbreviated entity link included in task responses.
+      properties:
+        id:
+          type: integer
+        entity_id:
+          type: integer
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        entity_name:
+          type: string
+          description: Resolved display name of the linked entity.
+
+    TaskEntityLink:
+      type: object
+      description: Full entity link record.
+      properties:
+        id:
+          type: integer
+        task_id:
+          type: integer
+        entity_id:
+          type: integer
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        entity_name:
+          type: string
+          nullable: true
+          description: Display name, resolved from entity table or stored directly.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    Pagination:
+      type: object
+      properties:
+        page:
+          type: integer
+          example: 1
+        pageSize:
+          type: integer
+          example: 25
+        total:
+          type: integer
+          description: Total number of tasks returned (current page count).
+          example: 25
+        totalPages:
+          type: integer
+          example: 4
+        hasNext:
+          type: boolean
+        hasPrev:
+          type: boolean
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid JWT token.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: Unauthorized
+
+    ValidationError:
+      description: Request validation failed.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ResponseEnvelope"
+
+    Forbidden:
+      description: Insufficient permissions for this action.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ResponseEnvelope"
+
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ResponseEnvelope"
+
+    InternalError:
+      description: Unexpected server error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ResponseEnvelope"

--- a/Servers/docs/api/training-openapi.yaml
+++ b/Servers/docs/api/training-openapi.yaml
@@ -1,0 +1,627 @@
+openapi: 3.0.3
+info:
+  title: VerifyWise Training API
+  description: >
+    Training Registry and Training Change History endpoints.
+    All endpoints require JWT authentication via Bearer token.
+    All responses are wrapped in a standard envelope: `{ message, data }` for
+    2xx/4xx and `{ message, error }` for 5xx.
+  version: 1.0.0
+
+paths:
+  # ---------------------------------------------------------------------------
+  # Training Registry
+  # ---------------------------------------------------------------------------
+  /training:
+    get:
+      summary: List all training records
+      description: >
+        Returns every training record belonging to the authenticated user's
+        organization, ordered by id ascending.
+      operationId: getAllTrainingRegistar
+      tags: [Training Registry]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Training records found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrainingListResponse"
+        "204":
+          description: No training records exist for this organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeEmpty"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    post:
+      summary: Create a new training record
+      operationId: createNewTrainingRegistar
+      tags: [Training Registry]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TrainingCreateRequest"
+      responses:
+        "201":
+          description: Training record created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrainingSingleResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          description: Service unavailable — creation failed without error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeError"
+
+  /training/training-id/{id}:
+    get:
+      summary: Get a training record by ID
+      operationId: getTrainingRegistarById
+      tags: [Training Registry]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TrainingId"
+      responses:
+        "200":
+          description: Training record found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrainingSingleResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Training record not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeNotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /training/{id}:
+    patch:
+      summary: Update a training record by ID
+      description: >
+        Accepts a partial or full update body. The `numberOfPeople` field is
+        mapped to the `people` database column internally. Only provided fields
+        are updated.
+      operationId: updateTrainingRegistarById
+      tags: [Training Registry]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TrainingId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TrainingUpdateRequest"
+      responses:
+        "202":
+          description: Training record updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrainingSingleResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Training record not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeNotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    delete:
+      summary: Delete a training record by ID
+      operationId: deleteTrainingRegistarById
+      tags: [Training Registry]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TrainingId"
+      responses:
+        "202":
+          description: Training record deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/EnvelopeBase"
+                  - type: object
+                    properties:
+                      data:
+                        type: boolean
+                        example: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: Training record not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeNotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  # ---------------------------------------------------------------------------
+  # Training Change History
+  # ---------------------------------------------------------------------------
+  /training-change-history/{id}:
+    get:
+      summary: Get change history for a training record
+      description: >
+        Returns a paginated list of field-level change history entries for the
+        specified training record, ordered newest-first.
+      operationId: getTrainingChangeHistoryById
+      tags: [Training Change History]
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/TrainingId"
+        - name: limit
+          in: query
+          required: false
+          description: >
+            Maximum number of history entries to return. Clamped to 1-500.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          description: Number of entries to skip (for pagination). Minimum 0.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: Change history retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChangeHistoryResponse"
+        "400":
+          description: Invalid training ID (not a positive integer)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeBadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+components:
+  # -------------------------------------------------------------------------
+  # Security
+  # -------------------------------------------------------------------------
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT access token obtained from `/api/users/login`
+
+  # -------------------------------------------------------------------------
+  # Parameters
+  # -------------------------------------------------------------------------
+  parameters:
+    TrainingId:
+      name: id
+      in: path
+      required: true
+      description: Numeric ID of the training record
+      schema:
+        type: integer
+        minimum: 1
+        example: 42
+
+  # -------------------------------------------------------------------------
+  # Reusable Responses
+  # -------------------------------------------------------------------------
+  responses:
+    Unauthorized:
+      description: Missing or invalid JWT token
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: Unauthorized
+
+    InternalServerError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EnvelopeError"
+
+  # -------------------------------------------------------------------------
+  # Schemas
+  # -------------------------------------------------------------------------
+  schemas:
+    # -- Envelope wrappers --------------------------------------------------
+    EnvelopeBase:
+      type: object
+      properties:
+        message:
+          type: string
+          description: HTTP status text
+      required:
+        - message
+
+    EnvelopeEmpty:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: No Content
+            data:
+              type: array
+              items: {}
+              example: []
+
+    EnvelopeNotFound:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: Not Found
+            data:
+              nullable: true
+              example: null
+
+    EnvelopeBadRequest:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: Bad Request
+            data:
+              type: string
+              example: Invalid training ID
+
+    EnvelopeError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Internal Server Error
+        error:
+          type: string
+          description: Error message string
+      required:
+        - message
+        - error
+
+    # -- Training entity ----------------------------------------------------
+    Training:
+      type: object
+      description: >
+        Training record as returned by the API. The `toJSON()` method on the
+        model produces this shape, mapping the DB `people` column to
+        `numberOfPeople`.
+      properties:
+        id:
+          type: integer
+          description: Auto-generated primary key
+          example: 42
+        training_name:
+          type: string
+          description: Name of the training programme
+          minLength: 2
+          maxLength: 255
+          example: AI Governance Fundamentals
+        duration:
+          type: string
+          description: Human-readable duration (e.g. "2 hours", "3 days")
+          maxLength: 1000
+          example: 2 hours
+        provider:
+          type: string
+          description: Training provider name or type
+          maxLength: 255
+          example: Internal
+        department:
+          type: string
+          description: Target department
+          maxLength: 100
+          example: Compliance
+        status:
+          type: string
+          enum:
+            - Planned
+            - In Progress
+            - Completed
+          description: Current status of the training
+          example: Planned
+        numberOfPeople:
+          type: integer
+          description: Number of participants
+          minimum: 1
+          maximum: 1000
+          example: 25
+        description:
+          type: string
+          description: Free-text description of the training (optional)
+          maxLength: 2000
+          example: Introductory course on EU AI Act compliance
+        progressPercentage:
+          type: integer
+          description: >
+            Derived progress value — 0 for Planned, 50 for In Progress, 100
+            for Completed. Computed by the model's `toJSON()`.
+          enum: [0, 50, 100]
+          example: 0
+        createdAt:
+          type: string
+          format: date-time
+          description: Record creation timestamp
+          example: "2026-04-18T10:30:00.000Z"
+        updatedAt:
+          type: string
+          format: date-time
+          description: Last update timestamp
+          example: "2026-04-19T14:15:00.000Z"
+      required:
+        - id
+        - training_name
+        - duration
+        - provider
+        - department
+        - status
+        - numberOfPeople
+        - description
+        - progressPercentage
+
+    # -- Request bodies -----------------------------------------------------
+    TrainingCreateRequest:
+      type: object
+      description: Request body for creating a new training record
+      properties:
+        training_name:
+          type: string
+          description: Name of the training programme
+          minLength: 2
+          maxLength: 255
+          example: AI Governance Fundamentals
+        duration:
+          type: string
+          description: >
+            Human-readable duration. Should contain time units such as "hours",
+            "days", "weeks", etc.
+          minLength: 1
+          maxLength: 1000
+          example: 2 hours
+        provider:
+          type: string
+          description: Training provider name or type
+          minLength: 1
+          maxLength: 255
+          example: Internal
+        department:
+          type: string
+          description: Target department
+          minLength: 1
+          maxLength: 100
+          example: Compliance
+        status:
+          type: string
+          enum:
+            - Planned
+            - In Progress
+            - Completed
+          description: Initial status of the training
+          example: Planned
+        numberOfPeople:
+          type: integer
+          description: Number of participants (mapped to `people` column in DB)
+          minimum: 1
+          maximum: 1000
+          example: 25
+        description:
+          type: string
+          description: Free-text description (optional)
+          maxLength: 2000
+          example: Introductory course on EU AI Act compliance
+        is_demo:
+          type: boolean
+          description: Mark as demo/sample data. Defaults to false.
+          default: false
+      required:
+        - training_name
+        - duration
+        - provider
+        - department
+        - status
+        - numberOfPeople
+
+    TrainingUpdateRequest:
+      type: object
+      description: >
+        Request body for updating a training record. All fields are accepted;
+        only fields with non-null, non-undefined values are applied.
+        `numberOfPeople` is mapped to the `people` DB column.
+      properties:
+        training_name:
+          type: string
+          minLength: 2
+          maxLength: 255
+          example: Advanced AI Risk Management
+        duration:
+          type: string
+          minLength: 1
+          maxLength: 1000
+          example: 3 days
+        provider:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: External
+        department:
+          type: string
+          minLength: 1
+          maxLength: 100
+          example: Engineering
+        status:
+          type: string
+          enum:
+            - Planned
+            - In Progress
+            - Completed
+          example: In Progress
+        numberOfPeople:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          example: 30
+        description:
+          type: string
+          maxLength: 2000
+          example: Updated scope to cover ISO 42001
+
+    # -- Response wrappers --------------------------------------------------
+    TrainingListResponse:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: OK
+            data:
+              type: array
+              items:
+                $ref: "#/components/schemas/Training"
+
+    TrainingSingleResponse:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: OK
+            data:
+              $ref: "#/components/schemas/Training"
+
+    # -- Change History -----------------------------------------------------
+    ChangeHistoryEntry:
+      type: object
+      description: A single field-level change record
+      properties:
+        id:
+          type: integer
+          description: Change history entry ID
+          example: 101
+        entity_type:
+          type: string
+          description: Always "training" for this endpoint
+          example: training
+        entity_id:
+          type: integer
+          description: ID of the training record
+          example: 42
+        field_name:
+          type: string
+          description: Name of the changed field
+          example: status
+        old_value:
+          type: string
+          nullable: true
+          description: Previous value (null for creation entries)
+          example: Planned
+        new_value:
+          type: string
+          nullable: true
+          description: New value (null for deletion entries)
+          example: In Progress
+        change_type:
+          type: string
+          description: Type of change
+          enum:
+            - created
+            - updated
+            - deleted
+          example: updated
+        changed_by:
+          type: integer
+          description: User ID of the person who made the change
+          example: 5
+        user_name:
+          type: string
+          description: First name of the user who made the change
+          example: Gorkem
+        user_surname:
+          type: string
+          description: Last name of the user who made the change
+          example: Cetin
+        organization_id:
+          type: integer
+          description: Organization ID
+          example: 1
+        created_at:
+          type: string
+          format: date-time
+          description: When the change was recorded
+          example: "2026-04-19T14:15:00.000Z"
+
+    ChangeHistoryData:
+      type: object
+      description: Paginated change history result
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChangeHistoryEntry"
+        hasMore:
+          type: boolean
+          description: Whether more entries exist beyond the current page
+          example: false
+        total:
+          type: integer
+          description: Total number of change history entries for this training
+          example: 5
+      required:
+        - data
+        - hasMore
+        - total
+
+    ChangeHistoryResponse:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: OK
+            data:
+              $ref: "#/components/schemas/ChangeHistoryData"

--- a/Servers/docs/api/users-api-paths.yaml
+++ b/Servers/docs/api/users-api-paths.yaml
@@ -1,0 +1,842 @@
+# Users API - OpenAPI 3.0 Path Definitions
+# Ready to paste into the paths section of swagger.yaml
+#
+# Base path: /api/users
+# Response envelope: { "message": "<status text>", "data": <payload> }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    UserSafe:
+      type: object
+      description: User object with password_hash excluded
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: "John"
+        surname:
+          type: string
+          example: "Doe"
+        email:
+          type: string
+          format: email
+          example: "john@example.com"
+        role_id:
+          type: integer
+          description: "1=Admin, 2=Reviewer, 3=Editor, 4=Auditor, 5=SuperAdmin"
+          example: 1
+        created_at:
+          type: string
+          format: date-time
+        last_login:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        is_demo:
+          type: boolean
+          default: false
+        organization_id:
+          type: integer
+          nullable: true
+          example: 1
+        profile_photo_id:
+          type: integer
+          nullable: true
+      required:
+        - id
+        - name
+        - surname
+        - email
+        - role_id
+        - created_at
+
+    StatusEnvelope:
+      type: object
+      properties:
+        message:
+          type: string
+          description: HTTP status text (e.g. "OK", "Created", "Accepted")
+        data:
+          description: Response payload (varies by endpoint)
+
+    ErrorEnvelope:
+      type: object
+      properties:
+        message:
+          type: string
+          description: HTTP status text or error category
+        data:
+          type: string
+          description: Error detail message
+
+    ProgressResponse:
+      type: object
+      properties:
+        assessmentsMetadata:
+          type: array
+          items:
+            type: object
+            properties:
+              projectId:
+                type: integer
+              totalAssessments:
+                type: integer
+              doneAssessments:
+                type: integer
+        controlsMetadata:
+          type: array
+          items:
+            type: object
+            properties:
+              projectId:
+                type: integer
+              totalSubControls:
+                type: integer
+              doneSubControls:
+                type: integer
+        allTotalAssessments:
+          type: integer
+        allDoneAssessments:
+          type: integer
+        allTotalSubControls:
+          type: integer
+        allDoneSubControls:
+          type: integer
+
+paths:
+  # ─────────────────────────────────────────────────────────
+  # POST /api/users/login
+  # ─────────────────────────────────────────────────────────
+  /api/users/login:
+    post:
+      summary: Authenticate user
+      description: |
+        Validates email/password credentials via bcrypt. Returns a JWT access token
+        in the response body and sets a refresh token in an HTTP-only cookie.
+        Rate-limited to 5 requests per minute per IP.
+      tags: [Users - Authentication]
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: "user@example.com"
+                password:
+                  type: string
+                  format: password
+                  example: "SecurePassword123!"
+      responses:
+        "202":
+          description: Authentication successful
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+              description: "refresh_token=<jwt>; Path=/api/users; HttpOnly; Secure (prod); SameSite=none (prod) / lax (dev)"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Accepted"
+                  data:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                        description: JWT access token
+                      isSuperAdmin:
+                        type: boolean
+                        description: Only present when user is super-admin (role_id=5)
+                      onboarding_status:
+                        type: string
+                        description: Organization onboarding status (not present for super-admin)
+                        example: "completed"
+                      is_org_creator:
+                        type: boolean
+                        description: Whether user is the first admin of the org (not present for super-admin)
+        "401":
+          description: Invalid email or password
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "429":
+          description: Too many login attempts
+        "500":
+          description: Internal server error
+
+  # ─────────────────────────────────────────────────────────
+  # POST /api/users/refresh-token
+  # ─────────────────────────────────────────────────────────
+  /api/users/refresh-token:
+    post:
+      summary: Refresh access token
+      description: |
+        Reads the refresh_token from an HTTP-only cookie and issues a new
+        JWT access token if the refresh token is still valid.
+      tags: [Users - Authentication]
+      security: []
+      parameters:
+        - in: cookie
+          name: refresh_token
+          required: true
+          schema:
+            type: string
+          description: JWT refresh token set during login
+      responses:
+        "200":
+          description: New access token issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                        description: New JWT access token
+        "400":
+          description: Refresh token missing from cookie
+        "401":
+          description: Invalid refresh token
+        "406":
+          description: Refresh token expired
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        example: "Token expired"
+        "500":
+          description: Internal server error
+
+  # ─────────────────────────────────────────────────────────
+  # POST /api/users/register
+  # ─────────────────────────────────────────────────────────
+  /api/users/register:
+    post:
+      summary: Register a new user
+      description: |
+        Creates a new user account. Requires a valid registration JWT (set by registerJWT middleware).
+        Validates email uniqueness, password strength, and required fields.
+        Marks any pending invitation as accepted after successful creation.
+      tags: [Users - Registration]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, surname, email, password, roleId, organizationId]
+              properties:
+                name:
+                  type: string
+                  description: User's first name
+                  example: "John"
+                surname:
+                  type: string
+                  description: User's last name
+                  example: "Doe"
+                email:
+                  type: string
+                  format: email
+                  example: "john@example.com"
+                password:
+                  type: string
+                  format: password
+                  description: "Must be 8+ chars with uppercase, lowercase, and digit"
+                  example: "SecurePassword123!"
+                roleId:
+                  type: integer
+                  description: "1=Admin, 2=Reviewer, 3=Editor, 4=Auditor"
+                  example: 3
+                organizationId:
+                  type: integer
+                  description: Organization to assign the user to
+                  example: 1
+      responses:
+        "201":
+          description: User created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Created"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "400":
+          description: Validation error (missing fields, weak password, invalid email)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          description: Business logic error
+        "409":
+          description: User with this email already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "500":
+          description: Internal server error
+
+  # ─────────────────────────────────────────────────────────
+  # GET /api/users
+  # ─────────────────────────────────────────────────────────
+  /api/users:
+    get:
+      summary: List all users in organization
+      description: |
+        Returns all users belonging to the authenticated user's organization,
+        ordered by created_at DESC, id ASC. Password hashes are excluded.
+      tags: [Users - CRUD]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Users found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/UserSafe"
+        "204":
+          description: No users found (empty organization)
+        "500":
+          description: Internal server error
+
+  # ─────────────────────────────────────────────────────────
+  # GET /api/users/check/exists
+  # ─────────────────────────────────────────────────────────
+  /api/users/check/exists:
+    get:
+      summary: Check if any user exists
+      description: |
+        Returns a boolean indicating whether any user record exists in the database.
+        Used during initial setup flow to determine if onboarding is needed.
+      tags: [Users - Utility]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Check result
+          content:
+            application/json:
+              schema:
+                type: boolean
+                example: true
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Internal server error"
+
+  # ─────────────────────────────────────────────────────────
+  # GET /api/users/{id}
+  # ─────────────────────────────────────────────────────────
+  /api/users/{id}:
+    get:
+      summary: Get user by ID
+      description: |
+        Retrieves a single user by their numeric ID. Super-admins can access
+        any user; regular users can only access users within their organization
+        (or their own record).
+      tags: [Users - CRUD]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: User ID
+      responses:
+        "200":
+          description: User found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "403":
+          description: Access denied (user belongs to different organization)
+        "404":
+          description: User not found
+        "500":
+          description: Internal server error
+
+    # ─────────────────────────────────────────────────────────
+    # PATCH /api/users/{id}
+    # ─────────────────────────────────────────────────────────
+    patch:
+      summary: Update user by ID
+      description: |
+        Updates user fields (name, surname, email, roleId, last_login).
+        Only provided fields are updated. Organization isolation enforced.
+        Sends Slack notification on role change. Sends email notification
+        when role changes from Editor (3) to Admin (1).
+      tags: [Users - CRUD]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: User ID to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: First name
+                  example: "Jane"
+                surname:
+                  type: string
+                  description: Last name
+                  example: "Smith"
+                email:
+                  type: string
+                  format: email
+                  example: "jane@example.com"
+                roleId:
+                  type: integer
+                  description: "New role ID (1=Admin, 2=Reviewer, 3=Editor, 4=Auditor). Can be sent as string."
+                  example: 1
+                last_login:
+                  type: string
+                  format: date-time
+                  description: Override last login timestamp
+              description: All fields are optional; only provided fields are updated
+      responses:
+        "202":
+          description: User updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Accepted"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "400":
+          description: Validation error
+        "403":
+          description: Access denied or business logic error
+        "404":
+          description: User not found
+        "500":
+          description: Internal server error
+
+    # ─────────────────────────────────────────────────────────
+    # DELETE /api/users/{id}
+    # ─────────────────────────────────────────────────────────
+    delete:
+      summary: Delete user by ID
+      description: |
+        Deletes a user and nullifies all their foreign key references across
+        projects, vendors, risks, vendor risks, files, automations, and invitations.
+        Also removes the user from projects_members. Demo users and super-admins
+        cannot be deleted.
+      tags: [Users - CRUD]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: User ID to delete
+      responses:
+        "202":
+          description: User deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Accepted"
+                  data:
+                    type: boolean
+                    description: true if deletion succeeded
+        "403":
+          description: "Forbidden: demo user, super-admin, or wrong organization"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: User not found
+        "500":
+          description: Internal server error
+
+  # ─────────────────────────────────────────────────────────
+  # POST /api/users/reset-password
+  # ─────────────────────────────────────────────────────────
+  /api/users/reset-password:
+    post:
+      summary: Reset user password
+      description: |
+        Resets the password for a user identified by email. Protected by
+        resetPasswordMiddleware (validates reset token/permission).
+        Password is hashed via bcrypt before storage.
+      tags: [Users - Password]
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, newPassword]
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: "user@example.com"
+                newPassword:
+                  type: string
+                  format: password
+                  description: "Must be 8+ chars with uppercase, lowercase, and digit"
+                  example: "NewSecure123!"
+      responses:
+        "202":
+          description: Password reset successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Accepted"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "400":
+          description: Validation error (weak password)
+        "403":
+          description: Business logic error
+        "404":
+          description: User not found
+        "500":
+          description: Internal server error
+
+  # ─────────────────────────────────────────────────────────
+  # PATCH /api/users/chng-pass/{id}
+  # ─────────────────────────────────────────────────────────
+  /api/users/chng-pass/{id}:
+    patch:
+      summary: Change password (authenticated)
+      description: |
+        Changes the password for the authenticated user. Requires the current
+        password for verification. Protected by selfOnly middleware (users can
+        only change their own password). Rate-limited.
+      tags: [Users - Password]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: User ID (must match authenticated user via selfOnly middleware)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id, currentPassword, newPassword]
+              properties:
+                id:
+                  type: integer
+                  description: User ID (must match path parameter)
+                  example: 1
+                currentPassword:
+                  type: string
+                  format: password
+                  description: Current password for verification
+                  example: "OldPassword123!"
+                newPassword:
+                  type: string
+                  format: password
+                  description: "Must be 8+ chars with uppercase, lowercase, and digit"
+                  example: "NewPassword456!"
+      responses:
+        "202":
+          description: Password changed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Password updated successfully"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "400":
+          description: Validation error (weak password, missing fields)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "403":
+          description: Business logic error (wrong current password)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "User not found"
+        "500":
+          description: Internal server error
+
+  # ─────────────────────────────────────────────────────────
+  # GET /api/users/{id}/calculate-progress
+  # ─────────────────────────────────────────────────────────
+  /api/users/{id}/calculate-progress:
+    get:
+      summary: Calculate user project progress
+      description: |
+        Computes completion metrics across all projects the user is a member of.
+        Calculates subcontrol completion (status="Done") and assessment question
+        completion (has answer) per project and as aggregated totals.
+      tags: [Users - Analytics]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: User ID to calculate progress for
+      responses:
+        "200":
+          description: Progress calculated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProgressResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Internal server error"
+
+  # ─────────────────────────────────────────────────────────
+  # POST /api/users/{id}/profile-photo
+  # ─────────────────────────────────────────────────────────
+  /api/users/{id}/profile-photo:
+    post:
+      summary: Upload profile photo
+      description: |
+        Uploads a profile photo for the specified user. The file is stored in the
+        tenant-scoped files table. If the user already has a profile photo, the old
+        one is deleted and replaced. Uses multer for multipart file handling.
+      tags: [Users - Profile Photo]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: User ID
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [photo]
+              properties:
+                photo:
+                  type: string
+                  format: binary
+                  description: Image file (JPEG, PNG, etc.)
+      responses:
+        "200":
+          description: Profile photo uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: object
+                    properties:
+                      profile_photo_id:
+                        type: integer
+                        description: ID of the new file record
+        "400":
+          description: No file provided
+        "403":
+          description: Access denied (wrong organization)
+        "500":
+          description: Internal server error
+
+    get:
+      summary: Get profile photo
+      description: |
+        Returns the profile photo binary content for the specified user.
+        The response includes the raw file content and its MIME type.
+      tags: [Users - Profile Photo]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: User ID
+      responses:
+        "200":
+          description: Profile photo returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: object
+                    properties:
+                      content:
+                        type: string
+                        format: byte
+                        description: Base64-encoded file content
+                      type:
+                        type: string
+                        description: MIME type
+                        example: "image/png"
+        "404":
+          description: No profile photo found
+        "500":
+          description: Internal server error
+
+    delete:
+      summary: Delete profile photo
+      description: |
+        Removes the profile photo from the user record and deletes the associated
+        file from the files table.
+      tags: [Users - Profile Photo]
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: User ID
+      responses:
+        "200":
+          description: Profile photo deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: boolean
+                    description: true if photo was deleted
+        "500":
+          description: Internal server error

--- a/Servers/docs/api/vendors-openapi-paths.yaml
+++ b/Servers/docs/api/vendors-openapi-paths.yaml
@@ -1,0 +1,722 @@
+# Vendors API - OpenAPI 3.0 Path Definitions
+# Paste into the `paths:` section of swagger.yaml
+# Paste Vendor / VendorInput / VendorUpdate into `components.schemas:`
+
+# ---------------------------------------------------------------------------
+# Reusable schemas (add under components.schemas)
+# ---------------------------------------------------------------------------
+# components:
+#   schemas:
+#     Vendor:
+#       type: object
+#       properties:
+#         id:
+#           type: integer
+#           description: Auto-generated primary key
+#           example: 42
+#         order_no:
+#           type: integer
+#           nullable: true
+#           description: Display order number
+#         vendor_name:
+#           type: string
+#           description: Name of the vendor
+#           example: "Acme Corp"
+#         vendor_provides:
+#           type: string
+#           description: What the vendor provides
+#           example: "Cloud hosting services"
+#         assignee:
+#           type: integer
+#           description: User ID of the assigned owner
+#           example: 5
+#         website:
+#           type: string
+#           description: Vendor website URL
+#           example: "https://acme.example.com"
+#         vendor_contact_person:
+#           type: string
+#           description: Name of the vendor contact
+#           example: "Jane Doe"
+#         review_result:
+#           type: string
+#           nullable: true
+#           description: Free-text review result summary
+#         review_status:
+#           type: string
+#           nullable: true
+#           enum:
+#             - Not started
+#             - In review
+#             - Reviewed
+#             - Requires follow-up
+#           default: Not started
+#           description: Current review lifecycle status
+#         reviewer:
+#           type: integer
+#           nullable: true
+#           description: User ID of the reviewer
+#         review_date:
+#           type: string
+#           format: date-time
+#           nullable: true
+#           description: Date the review was performed (ISO 8601)
+#         is_demo:
+#           type: boolean
+#           default: false
+#           description: Whether this is a demo vendor (read-only after creation)
+#         projects:
+#           type: array
+#           items:
+#             type: integer
+#           description: Array of associated project IDs
+#         data_sensitivity:
+#           type: string
+#           nullable: true
+#           enum:
+#             - None
+#             - Internal only
+#             - "Personally identifiable information (PII)"
+#             - Financial data
+#             - "Health data (e.g. HIPAA)"
+#             - Model weights or AI assets
+#             - Other sensitive data
+#           description: Scorecard — type of data the vendor accesses
+#         business_criticality:
+#           type: string
+#           nullable: true
+#           enum:
+#             - "Low (vendor supports non-core functions)"
+#             - "Medium (affects operations but is replaceable)"
+#             - "High (critical to core services or products)"
+#           description: Scorecard — how critical the vendor is to operations
+#         past_issues:
+#           type: string
+#           nullable: true
+#           enum:
+#             - None
+#             - "Minor incident (e.g. small delay, minor bug)"
+#             - "Major incident (e.g. data breach, legal issue)"
+#           description: Scorecard — history of past incidents
+#         regulatory_exposure:
+#           type: string
+#           nullable: true
+#           enum:
+#             - None
+#             - "GDPR (EU)"
+#             - "HIPAA (US)"
+#             - SOC 2
+#             - ISO 27001
+#             - EU AI act
+#             - "CCPA (california)"
+#             - Other
+#           description: Scorecard — applicable regulatory framework
+#         risk_score:
+#           type: integer
+#           nullable: true
+#           description: Computed risk score for the vendor
+#         created_at:
+#           type: string
+#           format: date-time
+#           description: Creation timestamp (ISO 8601)
+#         updated_at:
+#           type: string
+#           format: date-time
+#           description: Last update timestamp (ISO 8601)
+#       required:
+#         - vendor_name
+#         - vendor_provides
+#         - assignee
+#         - website
+#         - vendor_contact_person
+#
+#     VendorWithReviewerName:
+#       allOf:
+#         - $ref: '#/components/schemas/Vendor'
+#         - type: object
+#           properties:
+#             reviewer_name:
+#               type: string
+#               description: Full name of the reviewer (joined from users table)
+#               example: "John Smith"
+#
+#     VendorInput:
+#       type: object
+#       required:
+#         - vendor_name
+#         - vendor_provides
+#         - assignee
+#         - website
+#         - vendor_contact_person
+#       properties:
+#         vendor_name:
+#           type: string
+#           description: Name of the vendor (required, non-empty)
+#         vendor_provides:
+#           type: string
+#           description: What the vendor provides (required, non-empty)
+#         assignee:
+#           type: integer
+#           minimum: 1
+#           description: User ID of the assigned owner (required, >= 1)
+#         website:
+#           type: string
+#           description: Vendor website URL (required, non-empty)
+#         vendor_contact_person:
+#           type: string
+#           description: Name of the vendor contact (required, non-empty)
+#         review_result:
+#           type: string
+#           description: Free-text review result summary
+#         review_status:
+#           type: string
+#           enum:
+#             - Not started
+#             - In review
+#             - Reviewed
+#             - Requires follow-up
+#           description: Current review lifecycle status
+#         reviewer:
+#           type: integer
+#           minimum: 1
+#           description: User ID of the reviewer
+#         review_date:
+#           type: string
+#           format: date-time
+#           description: Date of the review (ISO 8601)
+#         order_no:
+#           type: integer
+#           description: Display order number
+#         is_demo:
+#           type: boolean
+#           default: false
+#           description: Mark as demo vendor
+#         projects:
+#           type: array
+#           items:
+#             type: integer
+#           description: Array of project IDs to associate
+#         data_sensitivity:
+#           type: string
+#           enum:
+#             - None
+#             - Internal only
+#             - "Personally identifiable information (PII)"
+#             - Financial data
+#             - "Health data (e.g. HIPAA)"
+#             - Model weights or AI assets
+#             - Other sensitive data
+#         business_criticality:
+#           type: string
+#           enum:
+#             - "Low (vendor supports non-core functions)"
+#             - "Medium (affects operations but is replaceable)"
+#             - "High (critical to core services or products)"
+#         past_issues:
+#           type: string
+#           enum:
+#             - None
+#             - "Minor incident (e.g. small delay, minor bug)"
+#             - "Major incident (e.g. data breach, legal issue)"
+#         regulatory_exposure:
+#           type: string
+#           enum:
+#             - None
+#             - "GDPR (EU)"
+#             - "HIPAA (US)"
+#             - SOC 2
+#             - ISO 27001
+#             - EU AI act
+#             - "CCPA (california)"
+#             - Other
+#         risk_score:
+#           type: integer
+#           description: Computed risk score
+#
+#     VendorUpdate:
+#       type: object
+#       description: All fields are optional. Only provided fields are updated. Review and scorecard fields can be set to null to clear them.
+#       properties:
+#         vendor_name:
+#           type: string
+#         vendor_provides:
+#           type: string
+#         assignee:
+#           type: integer
+#           minimum: 1
+#         website:
+#           type: string
+#         vendor_contact_person:
+#           type: string
+#         review_result:
+#           type: string
+#           nullable: true
+#         review_status:
+#           type: string
+#           nullable: true
+#           enum:
+#             - Not started
+#             - In review
+#             - Reviewed
+#             - Requires follow-up
+#         reviewer:
+#           type: integer
+#           nullable: true
+#         review_date:
+#           type: string
+#           format: date-time
+#           nullable: true
+#         order_no:
+#           type: integer
+#         projects:
+#           type: array
+#           items:
+#             type: integer
+#         data_sensitivity:
+#           type: string
+#           nullable: true
+#           enum:
+#             - None
+#             - Internal only
+#             - "Personally identifiable information (PII)"
+#             - Financial data
+#             - "Health data (e.g. HIPAA)"
+#             - Model weights or AI assets
+#             - Other sensitive data
+#         business_criticality:
+#           type: string
+#           nullable: true
+#           enum:
+#             - "Low (vendor supports non-core functions)"
+#             - "Medium (affects operations but is replaceable)"
+#             - "High (critical to core services or products)"
+#         past_issues:
+#           type: string
+#           nullable: true
+#           enum:
+#             - None
+#             - "Minor incident (e.g. small delay, minor bug)"
+#             - "Major incident (e.g. data breach, legal issue)"
+#         regulatory_exposure:
+#           type: string
+#           nullable: true
+#           enum:
+#             - None
+#             - "GDPR (EU)"
+#             - "HIPAA (US)"
+#             - SOC 2
+#             - ISO 27001
+#             - EU AI act
+#             - "CCPA (california)"
+#             - Other
+#         risk_score:
+#           type: integer
+#           nullable: true
+
+# ---------------------------------------------------------------------------
+# Path definitions (add under paths:)
+# ---------------------------------------------------------------------------
+
+/vendors:
+  get:
+    tags:
+      - Vendors
+    summary: Get all vendors
+    description: Retrieves all vendors for the authenticated user's organization, ordered by creation date descending. Each vendor includes its associated project IDs and the reviewer's full name.
+    security:
+      - bearerAuth: []
+    responses:
+      "200":
+        description: Vendors retrieved successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/VendorWithReviewerName"
+      "204":
+        description: No vendors found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: No Content
+                data:
+                  type: "null"
+      "401":
+        description: Unauthorized — missing or invalid JWT
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Internal Server Error
+                error:
+                  type: string
+
+  post:
+    tags:
+      - Vendors
+    summary: Create a vendor
+    description: |
+      Creates a new vendor in the authenticated user's organization.
+      Validates required fields, checks demo restrictions, associates
+      projects via the vendors_projects join table, records creation
+      in change history, fires automation triggers (`vendor_added`),
+      and sends in-app assignment notifications to assignee and reviewer.
+    security:
+      - bearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/VendorInput"
+    responses:
+      "201":
+        description: Vendor created successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Created
+                data:
+                  $ref: "#/components/schemas/Vendor"
+      "400":
+        description: Validation error (missing or invalid required fields)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Bad Request
+                data:
+                  type: string
+                  description: Validation error message
+      "401":
+        description: Unauthorized — missing or invalid JWT
+      "403":
+        description: Business logic error (e.g. demo vendor restriction)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Forbidden
+                data:
+                  type: string
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Internal Server Error
+                error:
+                  type: string
+      "503":
+        description: Service unavailable — vendor creation returned null
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Service Unavailable
+                error:
+                  type: object
+
+/vendors/project-id/{id}:
+  get:
+    tags:
+      - Vendors
+    summary: Get vendors by project ID
+    description: Retrieves all vendors associated with a specific project. Returns 404 if the project does not exist.
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Project ID
+    responses:
+      "200":
+        description: Vendors retrieved successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Vendor"
+      "401":
+        description: Unauthorized — missing or invalid JWT
+      "404":
+        description: Project not found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Not Found
+                data:
+                  type: array
+                  items: {}
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Internal Server Error
+                error:
+                  type: string
+
+/vendors/{id}:
+  get:
+    tags:
+      - Vendors
+    summary: Get vendor by ID
+    description: Retrieves a single vendor by its ID, including associated project IDs.
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Vendor ID
+    responses:
+      "200":
+        description: Vendor retrieved successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  $ref: "#/components/schemas/Vendor"
+      "401":
+        description: Unauthorized — missing or invalid JWT
+      "404":
+        description: Vendor not found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Not Found
+                data:
+                  type: "null"
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Internal Server Error
+                error:
+                  type: string
+
+  patch:
+    tags:
+      - Vendors
+    summary: Update a vendor
+    description: |
+      Partially updates an existing vendor. Only provided fields are updated.
+      Review and scorecard fields can be explicitly set to null to clear them.
+      Required fields (vendor_name, vendor_provides, website, vendor_contact_person)
+      are only updated if they have a non-empty value.
+      Records field-level changes in change history, fires automation triggers
+      (`vendor_updated`), and sends in-app notifications when assignee or reviewer changes.
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Vendor ID
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/VendorUpdate"
+    responses:
+      "202":
+        description: Vendor updated successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Accepted
+                data:
+                  $ref: "#/components/schemas/Vendor"
+      "400":
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Bad Request
+                data:
+                  type: string
+      "401":
+        description: Unauthorized — missing or invalid JWT, or missing userId/role
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Unauthorized
+      "403":
+        description: Business logic error (e.g. demo vendor restriction)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Forbidden
+                data:
+                  type: string
+      "404":
+        description: Vendor not found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Not Found
+                data:
+                  type: object
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Internal Server Error
+                error:
+                  type: string
+
+  delete:
+    tags:
+      - Vendors
+    summary: Delete a vendor
+    description: |
+      Deletes a vendor and all associated data in a transaction:
+      1. Deletes vendor risks (vendor_risks table)
+      2. Deletes project associations (vendors_projects table)
+      3. Deletes the vendor record itself
+      Fires automation triggers (`vendor_deleted`).
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Vendor ID
+    responses:
+      "202":
+        description: Vendor deleted successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Accepted
+                data:
+                  type: boolean
+                  example: true
+      "401":
+        description: Unauthorized — missing or invalid JWT
+      "404":
+        description: Vendor not found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Not Found
+                data:
+                  type: object
+      "500":
+        description: Internal server error
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Internal Server Error
+                error:
+                  type: string

--- a/Servers/docs/policies-api-paths.yaml
+++ b/Servers/docs/policies-api-paths.yaml
@@ -1,0 +1,728 @@
+# Policies API — OpenAPI 3.0 Path Definitions
+# Paste into the `paths:` section of swagger.yaml
+
+/api/policies:
+  get:
+    tags:
+      - Policies
+    summary: Get all policies
+    description: Returns all policies for the authenticated user's organization, including assigned reviewer IDs.
+    operationId: getAllPolicies
+    security:
+      - bearerAuth: []
+    responses:
+      "200":
+        description: List of policies retrieved successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/PolicyWithReviewers"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+  post:
+    tags:
+      - Policies
+    summary: Create a new policy
+    description: Creates a new policy. The `author_id` and `last_updated_by` are set from the JWT token automatically.
+    operationId: createPolicy
+    security:
+      - bearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PolicyCreateRequest"
+    responses:
+      "201":
+        description: Policy created successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Created
+                data:
+                  $ref: "#/components/schemas/PolicyWithReviewers"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+      "503":
+        description: Service unavailable — policy creation failed
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"
+
+/api/policies/tags:
+  get:
+    tags:
+      - Policies
+    summary: Get available policy tags
+    description: Returns the static list of allowed policy tags.
+    operationId: getPolicyTags
+    security:
+      - bearerAuth: []
+    responses:
+      "200":
+        description: List of available tags
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - AI ethics
+                      - Fairness
+                      - Transparency
+                      - Explainability
+                      - Bias mitigation
+                      - Privacy
+                      - Data governance
+                      - Model risk
+                      - Accountability
+                      - Security
+                      - LLM
+                      - Human oversight
+                      - EU AI Act
+                      - ISO 42001
+                      - NIST RMF
+                      - Red teaming
+                      - Audit
+                      - Monitoring
+                      - Vendor management
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+/api/policies/import/docx:
+  post:
+    tags:
+      - Policies
+    summary: Import DOCX and convert to HTML
+    description: >
+      Uploads a `.docx` file (max 10 MB) and converts it to HTML suitable for
+      the policy content editor. Returns the converted HTML and any conversion warnings.
+    operationId: importDocx
+    security:
+      - bearerAuth: []
+    requestBody:
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            required:
+              - file
+            properties:
+              file:
+                type: string
+                format: binary
+                description: A `.docx` file (max 10 MB). Accepted MIME types are `application/vnd.openxmlformats-officedocument.wordprocessingml.document` and `application/octet-stream`.
+    responses:
+      "200":
+        description: DOCX converted to HTML successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  type: object
+                  properties:
+                    html:
+                      type: string
+                      description: The converted HTML content
+                    warnings:
+                      type: array
+                      items:
+                        type: string
+                      description: Conversion warnings (e.g., unsupported formatting)
+      "400":
+        description: Bad request — no file uploaded or invalid file type
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+/api/policies/{id}:
+  get:
+    tags:
+      - Policies
+    summary: Get policy by ID
+    description: Returns a single policy by its ID, including assigned reviewer IDs.
+    operationId: getPolicyById
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    responses:
+      "200":
+        description: Policy retrieved successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  $ref: "#/components/schemas/PolicyWithReviewers"
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+  put:
+    tags:
+      - Policies
+    summary: Update a policy
+    description: >
+      Updates an existing policy. Only provided fields are updated.
+      The `last_updated_by` and `last_updated_at` are set automatically from the JWT token.
+      If `assigned_reviewer_ids` is provided, the reviewer list is fully replaced.
+    operationId: updatePolicy
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PolicyUpdateRequest"
+    responses:
+      "202":
+        description: Policy updated successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Accepted
+                data:
+                  $ref: "#/components/schemas/PolicyWithReviewers"
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+  delete:
+    tags:
+      - Policies
+    summary: Delete a policy by ID
+    description: Permanently deletes a policy and its associated reviewer mappings (via CASCADE).
+    operationId: deletePolicyById
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    responses:
+      "202":
+        description: Policy deleted successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Accepted
+                data:
+                  type: boolean
+                  example: true
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+/api/policies/{id}/export/pdf:
+  get:
+    tags:
+      - Policies
+    summary: Export policy as PDF
+    description: Generates and downloads the policy as a PDF file.
+    operationId: exportPolicyPDF
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    responses:
+      "200":
+        description: PDF file stream
+        content:
+          application/pdf:
+            schema:
+              type: string
+              format: binary
+        headers:
+          Content-Disposition:
+            schema:
+              type: string
+              example: 'attachment; filename="AI_Ethics_Policy.pdf"'
+          Content-Length:
+            schema:
+              type: integer
+      "400":
+        description: Invalid policy ID
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+/api/policies/{id}/export/docx:
+  get:
+    tags:
+      - Policies
+    summary: Export policy as DOCX
+    description: Generates and downloads the policy as a DOCX file.
+    operationId: exportPolicyDOCX
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    responses:
+      "200":
+        description: DOCX file stream
+        content:
+          application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+            schema:
+              type: string
+              format: binary
+        headers:
+          Content-Disposition:
+            schema:
+              type: string
+              example: 'attachment; filename="AI_Ethics_Policy.docx"'
+          Content-Length:
+            schema:
+              type: integer
+      "400":
+        description: Invalid policy ID
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+/api/policies/{id}/review/request:
+  post:
+    tags:
+      - Policies
+    summary: Request review for a policy
+    description: >
+      Sets the policy review status to `pending_review` and sends in-app
+      notifications to each specified reviewer.
+    operationId: requestPolicyReview
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - reviewer_ids
+            properties:
+              reviewer_ids:
+                type: array
+                items:
+                  type: integer
+                description: List of user IDs to request review from
+                example: [2, 5, 8]
+              message:
+                type: string
+                description: Optional message to include in the review request notification
+                example: "Please review the updated data governance section."
+    responses:
+      "200":
+        description: Review requested successfully; returns the updated policy
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  $ref: "#/components/schemas/PolicyWithReviewers"
+      "400":
+        description: Invalid policy ID or missing reviewer_ids
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+/api/policies/{id}/review/approve:
+  put:
+    tags:
+      - Policies
+    summary: Approve a policy review
+    description: >
+      Sets the policy review status to `approved` and sends an in-app
+      notification to the policy author.
+    operationId: approvePolicyReview
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    requestBody:
+      required: false
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              comment:
+                type: string
+                description: Optional approval comment
+                example: "Looks good, approved."
+    responses:
+      "200":
+        description: Policy review approved; returns the updated policy
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  $ref: "#/components/schemas/PolicyWithReviewers"
+      "400":
+        description: Invalid policy ID
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+/api/policies/{id}/review/reject:
+  put:
+    tags:
+      - Policies
+    summary: Reject a policy review (request changes)
+    description: >
+      Sets the policy review status to `changes_requested` and sends an in-app
+      notification to the policy author. A comment is required.
+    operationId: rejectPolicyReview
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/PolicyId"
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - comment
+            properties:
+              comment:
+                type: string
+                description: Reason for requesting changes (required)
+                example: "Section 3 needs more detail on bias mitigation procedures."
+    responses:
+      "200":
+        description: Policy review rejected; returns the updated policy
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: OK
+                data:
+                  $ref: "#/components/schemas/PolicyWithReviewers"
+      "400":
+        description: Invalid policy ID or missing comment
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"
+      "404":
+        $ref: "#/components/responses/NotFound"
+      "500":
+        $ref: "#/components/responses/InternalServerError"
+
+# ---------------------------------------------------------------------------
+# Components — paste into the `components:` section of swagger.yaml
+# ---------------------------------------------------------------------------
+
+components:
+  parameters:
+    PolicyId:
+      name: id
+      in: path
+      required: true
+      description: Numeric ID of the policy
+      schema:
+        type: integer
+        example: 42
+
+  schemas:
+    PolicyWithReviewers:
+      type: object
+      description: A policy record with computed assigned reviewer IDs
+      properties:
+        id:
+          type: integer
+          description: Auto-generated primary key
+          example: 42
+        organization_id:
+          type: integer
+          description: Tenant organization ID
+          example: 1
+        title:
+          type: string
+          description: Policy title
+          example: "AI Ethics Policy"
+        content_html:
+          type: string
+          description: Full policy content as HTML
+          example: "<h1>AI Ethics Policy</h1><p>...</p>"
+        status:
+          type: string
+          description: Policy lifecycle status
+          example: "draft"
+        tags:
+          type: array
+          items:
+            type: string
+            enum:
+              - AI ethics
+              - Fairness
+              - Transparency
+              - Explainability
+              - Bias mitigation
+              - Privacy
+              - Data governance
+              - Model risk
+              - Accountability
+              - Security
+              - LLM
+              - Human oversight
+              - EU AI Act
+              - ISO 42001
+              - NIST RMF
+              - Red teaming
+              - Audit
+              - Monitoring
+              - Vendor management
+          description: Categorization tags
+        next_review_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Scheduled next review date
+        author_id:
+          type: integer
+          description: User ID of the policy creator
+          example: 1
+        last_updated_by:
+          type: integer
+          description: User ID of the last editor
+          example: 1
+        last_updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of last update
+        review_status:
+          type: string
+          nullable: true
+          enum:
+            - pending_review
+            - approved
+            - changes_requested
+            - null
+          description: Current review workflow status
+        review_comment:
+          type: string
+          nullable: true
+          description: Most recent review comment
+        reviewed_by:
+          type: integer
+          nullable: true
+          description: User ID of the last reviewer
+        reviewed_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp of last review action
+        is_demo:
+          type: boolean
+          description: Whether this is a demo/seed policy
+          default: false
+        created_at:
+          type: string
+          format: date-time
+          description: Row creation timestamp (set by database)
+        assigned_reviewer_ids:
+          type: array
+          items:
+            type: integer
+          description: User IDs of assigned reviewers (aggregated from mapping table)
+          example: [2, 5]
+
+    PolicyCreateRequest:
+      type: object
+      required:
+        - title
+        - content_html
+        - status
+      properties:
+        title:
+          type: string
+          description: Policy title
+          example: "Data Governance Policy"
+        content_html:
+          type: string
+          description: Full policy content as HTML
+          example: "<h1>Data Governance</h1><p>This policy outlines...</p>"
+        status:
+          type: string
+          description: Initial policy status
+          example: "draft"
+        tags:
+          type: array
+          items:
+            type: string
+          description: Categorization tags (must be from the allowed tag list)
+          example: ["Data governance", "Privacy"]
+        next_review_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Scheduled next review date
+          example: "2026-07-01T00:00:00.000Z"
+        assigned_reviewer_ids:
+          type: array
+          items:
+            type: integer
+          description: User IDs to assign as reviewers
+          example: [2, 5]
+        is_demo:
+          type: boolean
+          description: Mark as a demo policy
+          default: false
+
+    PolicyUpdateRequest:
+      type: object
+      description: All fields are optional. Only provided fields are updated.
+      properties:
+        title:
+          type: string
+          description: Updated policy title
+        content_html:
+          type: string
+          description: Updated policy content as HTML
+        status:
+          type: string
+          description: Updated policy status
+        tags:
+          type: array
+          items:
+            type: string
+          description: Replacement tag list (must be from the allowed tag list)
+        next_review_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Updated next review date
+        assigned_reviewer_ids:
+          type: array
+          items:
+            type: integer
+          description: Replacement reviewer list (fully replaces existing reviewers)
+
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Bad Request"
+        data:
+          type: string
+          example: "reviewer_ids is required"
+
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Not Found"
+              data:
+                nullable: true
+                example: null
+
+    InternalServerError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Internal Server Error"
+              error:
+                type: string
+                example: "Unexpected error message"
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT access token from /api/auth/login

--- a/Servers/scripts/generateSwagger.ts
+++ b/Servers/scripts/generateSwagger.ts
@@ -137,14 +137,18 @@ function parseRouteFile(filePath: string): {
     let handlerName = "unknown";
 
     // Known middleware patterns to skip
+    // Use word-boundary-aware matching for patterns that could be substrings of handler names
     const middlewarePatterns = [
       "authenticateJWT", "authorize", "superAdminOnly",
-      "multer", "upload", "express", "json", "raw", "proxy",
+      "multer", "upload.", "express", "jsonParser", "rawParser", "proxy",
       "validateId", "validateVisibility", "validate", "limiter",
-      "checkCache", "cacheResponse", "jsonParser",
+      "checkCache", "cacheResponse",
     ];
 
-    for (const arg of args) {
+    // The last non-middleware argument is typically the handler.
+    // Process in reverse to find the handler first, then collect middlewares.
+    for (let i = args.length - 1; i >= 0; i--) {
+      const arg = args[i];
       const isMiddleware = middlewarePatterns.some((mw) => arg.includes(mw));
 
       if (isMiddleware) {
@@ -152,11 +156,16 @@ function parseRouteFile(filePath: string): {
         if (arg.includes("authorize")) middlewares.push(arg);
         if (arg.includes("superAdminOnly")) middlewares.push("superAdminOnly");
         if (arg.includes("upload")) middlewares.push("fileUpload");
-      } else if (/^[a-zA-Z_]\w*$/.test(arg)) {
-        // Simple identifier — this is the handler
-        handlerName = arg;
+      } else if (handlerName === "unknown") {
+        // Try to identify the handler
+        if (/^[a-zA-Z_]\w*$/.test(arg)) {
+          // Simple identifier — this is the handler
+          handlerName = arg;
+        } else if (arg.includes("=>") || arg.includes("function")) {
+          // Inline/anonymous handler — try to derive name from route path
+          handlerName = "anonymous";
+        }
       }
-      // Skip anything with parens/brackets that isn't a known middleware
     }
 
     endpoints.push({ method, routePath, handlerName, middlewares });

--- a/Servers/swagger.generated.yaml
+++ b/Servers/swagger.generated.yaml
@@ -1166,8 +1166,8 @@ paths:
     post:
       tags:
         - AI Trust Centre
-      summary: Unknown
-      operationId: unknown
+      summary: Upload Company Logo
+      operationId: uploadCompanyLogo
       security:
         - bearerAuth: []
       requestBody:
@@ -1591,8 +1591,8 @@ paths:
     post:
       tags:
         - Approval Workflows
-      summary: Unknown
-      operationId: approval_requests_unknown
+      summary: Withdraw Request
+      operationId: withdrawRequest
       security:
         - bearerAuth: []
       parameters:
@@ -2286,8 +2286,8 @@ paths:
     post:
       tags:
         - Datasets
-      summary: Handle Multer Error
-      operationId: handleMulterError
+      summary: Upload Dataset File
+      operationId: uploadDatasetFile
       security:
         - bearerAuth: []
       description: "Requires role: Admin or Editor"
@@ -3201,8 +3201,8 @@ paths:
     post:
       tags:
         - Files
-      summary: Handle Multer Error
-      operationId: file_manager_handleMulterError
+      summary: Upload File
+      operationId: uploadFile
       security:
         - bearerAuth: []
       description: "Requires role: Admin or Reviewer or Editor"
@@ -4885,8 +4885,8 @@ paths:
     post:
       tags:
         - Internal
-      summary: Unknown
-      operationId: internal_unknown
+      summary: Anonymous
+      operationId: anonymous
       requestBody:
         content:
           application/json:
@@ -5968,8 +5968,8 @@ paths:
     post:
       tags:
         - Mail
-      summary: Invite Limiter
-      operationId: inviteLimiter
+      summary: Anonymous
+      operationId: mail_anonymous
       security:
         - bearerAuth: []
       requestBody:
@@ -5988,8 +5988,8 @@ paths:
     post:
       tags:
         - Mail
-      summary: Email
-      operationId: email
+      summary: Anonymous
+      operationId: mail_anonymous
       requestBody:
         content:
           application/json:
@@ -6097,6 +6097,21 @@ paths:
           description: Unauthorized
         "500":
           description: Internal server error
+  /modelInventory/evaluations:
+    get:
+      tags:
+        - Model Inventory
+      summary: Get All Model Evaluations
+      operationId: getAllModelEvaluations
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Success
+        "401":
+          description: Unauthorized
+        "500":
+          description: Internal server error
   /modelInventory/{id}:
     get:
       tags:
@@ -6159,6 +6174,27 @@ paths:
       responses:
         "200":
           description: Deleted successfully
+        "401":
+          description: Unauthorized
+        "500":
+          description: Internal server error
+  /modelInventory/{id}/evaluations:
+    get:
+      tags:
+        - Model Inventory
+      summary: Get Model Evaluations
+      operationId: getModelEvaluations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Success
         "401":
           description: Unauthorized
         "500":
@@ -7113,8 +7149,8 @@ paths:
     get:
       tags:
         - Plugins
-      summary: Unknown
-      operationId: plugins_unknown
+      summary: Anonymous
+      operationId: plugins_anonymous
       security:
         - bearerAuth: []
       parameters:
@@ -9659,7 +9695,53 @@ paths:
           description: Forbidden - insufficient role
         "500":
           description: Internal server error
+  /super-admin/users/count:
+    get:
+      tags:
+        - Super Admin
+      summary: Get User Count
+      operationId: getUserCount
+      security:
+        - bearerAuth: []
+      description: "Requires role: Super Admin"
+      responses:
+        "200":
+          description: Success
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden - insufficient role
+        "500":
+          description: Internal server error
   /super-admin/users/{id}:
+    patch:
+      tags:
+        - Super Admin
+      summary: Update User
+      operationId: updateUser
+      security:
+        - bearerAuth: []
+      description: "Requires role: Super Admin"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Success
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden - insufficient role
+        "500":
+          description: Internal server error
     delete:
       tags:
         - Super Admin
@@ -10436,8 +10518,8 @@ paths:
     post:
       tags:
         - Users
-      summary: Unknown
-      operationId: users_unknown
+      summary: Upload User Profile Photo
+      operationId: uploadUserProfilePhoto
       security:
         - bearerAuth: []
       parameters:
@@ -10824,8 +10906,8 @@ paths:
     get:
       tags:
         - System
-      summary: Unknown
-      operationId: version_unknown
+      summary: Anonymous
+      operationId: version_anonymous
       responses:
         "200":
           description: Success

--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -13,12 +13,7422 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  parameters:
+    ProjectId:
+      name: id
+      in: path
+      required: true
+      description: The numeric project ID
+      schema:
+        type: integer
+        example: 1
+    PolicyId:
+      name: id
+      in: path
+      required: true
+      description: Numeric ID of the policy
+      schema:
+        type: integer
+        example: 42
   schemas:
     Error:
       type: object
       properties:
         data:
           type: string
+    AiRiskClassification:
+      type: string
+      enum: [Prohibited, High risk, Limited risk, Minimal risk]
+      description: EU AI Act risk classification level
+    HighRiskRole:
+      type: string
+      enum: [Deployer, Provider, Distributor, Importer, Product manufacturer, Authorized representative]
+      description: Role of the organization under the EU AI Act for high-risk systems
+    ProjectStatus:
+      type: string
+      enum: [Not started, In progress, Under review, Completed, Closed, On hold, Rejected]
+      description: Current lifecycle status of the project
+    CreateProjectRequest:
+      type: object
+      required: [project_title, owner, start_date, framework]
+      properties:
+        project_title:
+          type: string
+          example: Customer Support Chatbot
+        owner:
+          type: integer
+          example: 1
+        start_date:
+          type: string
+          format: date-time
+          example: "2026-01-15T00:00:00.000Z"
+        geography:
+          type: integer
+          default: 1
+          example: 1
+        ai_risk_classification:
+          $ref: "#/components/schemas/AiRiskClassification"
+        type_of_high_risk_role:
+          $ref: "#/components/schemas/HighRiskRole"
+        goal:
+          type: string
+          nullable: true
+          example: Automate tier-1 support queries
+        target_industry:
+          type: string
+          nullable: true
+          example: Financial Services
+        description:
+          type: string
+          nullable: true
+          example: An LLM-powered chatbot for handling customer inquiries
+        status:
+          $ref: "#/components/schemas/ProjectStatus"
+        is_organizational:
+          type: boolean
+          default: false
+        members:
+          type: array
+          items:
+            type: integer
+          example: [2, 3, 5]
+        framework:
+          type: array
+          items:
+            type: integer
+          example: [1, 2]
+        approval_workflow_id:
+          type: integer
+          nullable: true
+          example: null
+        enable_ai_data_insertion:
+          type: boolean
+          default: false
+    UpdateProjectRequest:
+      type: object
+      properties:
+        project_title:
+          type: string
+        owner:
+          type: integer
+        start_date:
+          type: string
+          format: date-time
+        geography:
+          type: integer
+        ai_risk_classification:
+          $ref: "#/components/schemas/AiRiskClassification"
+        type_of_high_risk_role:
+          $ref: "#/components/schemas/HighRiskRole"
+        goal:
+          type: string
+          nullable: true
+        target_industry:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        status:
+          $ref: "#/components/schemas/ProjectStatus"
+        last_updated:
+          type: string
+          format: date-time
+        last_updated_by:
+          type: integer
+        members:
+          type: array
+          items:
+            type: integer
+          example: [2, 3, 5]
+    ProjectFramework:
+      type: object
+      properties:
+        project_framework_id:
+          type: integer
+        framework_id:
+          type: integer
+        name:
+          type: string
+          example: EU AI Act
+    Project:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 42
+        uc_id:
+          type: string
+          example: UC-7
+        project_title:
+          type: string
+          example: Customer Support Chatbot
+        owner:
+          type: integer
+          example: 1
+        start_date:
+          type: string
+          format: date-time
+        geography:
+          type: integer
+          example: 1
+        ai_risk_classification:
+          $ref: "#/components/schemas/AiRiskClassification"
+        type_of_high_risk_role:
+          $ref: "#/components/schemas/HighRiskRole"
+        goal:
+          type: string
+          nullable: true
+        target_industry:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        status:
+          $ref: "#/components/schemas/ProjectStatus"
+        last_updated:
+          type: string
+          format: date-time
+        last_updated_by:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        is_organizational:
+          type: boolean
+        is_demo:
+          type: boolean
+        approval_workflow_id:
+          type: integer
+          nullable: true
+        pending_frameworks:
+          type: string
+          nullable: true
+        enable_ai_data_insertion:
+          type: boolean
+        organization_id:
+          type: integer
+        framework:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectFramework"
+        members:
+          type: array
+          items:
+            type: integer
+    ProjectListItem:
+      allOf:
+        - $ref: "#/components/schemas/Project"
+        - type: object
+          properties:
+            has_pending_approval:
+              type: boolean
+            approval_status:
+              type: string
+              nullable: true
+              enum: [pending, rejected, null]
+            _source:
+              type: string
+              nullable: true
+              example: jira-assets
+    ProjectDetail:
+      allOf:
+        - $ref: "#/components/schemas/Project"
+        - type: object
+          properties:
+            owner_name:
+              type: string
+              example: John Doe
+            has_pending_approval:
+              type: boolean
+            approval_status:
+              type: string
+              nullable: true
+              enum: [pending, rejected, null]
+    ProjectWithMembers:
+      allOf:
+        - $ref: "#/components/schemas/Project"
+        - type: object
+          properties:
+            members:
+              type: array
+              items:
+                type: integer
+    ProjectStats:
+      type: object
+      properties:
+        user:
+          type: object
+          properties:
+            name:
+              type: string
+            surname:
+              type: string
+            email:
+              type: string
+              format: email
+            project_last_updated:
+              type: string
+              format: date-time
+            userWhoUpdated:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+                surname:
+                  type: string
+                email:
+                  type: string
+                  format: email
+    ProjectRiskCount:
+      type: object
+      properties:
+        risk_level_autocalculated:
+          type: string
+          example: High
+        count:
+          type: string
+          example: "3"
+    VendorRiskCount:
+      type: object
+      properties:
+        risk_level:
+          type: string
+          example: Critical
+        count:
+          type: string
+          example: "2"
+    ComplianceProgress:
+      type: object
+      properties:
+        allsubControls:
+          oneOf:
+            - type: string
+            - type: integer
+          example: "45"
+        allDonesubControls:
+          oneOf:
+            - type: string
+            - type: integer
+          example: "12"
+    AssessmentProgress:
+      type: object
+      properties:
+        totalQuestions:
+          oneOf:
+            - type: string
+            - type: integer
+          example: "80"
+        answeredQuestions:
+          oneOf:
+            - type: string
+            - type: integer
+          example: "35"
+    ControlCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        project_id:
+          type: integer
+        name:
+          type: string
+        organization_id:
+          type: integer
+        controls:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              control_category_id:
+                type: integer
+              title:
+                type: string
+              description:
+                type: string
+              status:
+                type: string
+              numberOfSubcontrols:
+                type: integer
+              numberOfDoneSubcontrols:
+                type: integer
+              subControls:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    control_id:
+                      type: integer
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    status:
+                      type: string
+                      enum: [Draft, In progress, Done]
+                    organization_id:
+                      type: integer
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Not Found
+        data:
+          example: {}
+    ServerError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Internal Server Error
+        error:
+          type: string
+          example: "Unexpected error occurred"
+    UserSafe:
+      type: object
+      description: User object with password_hash excluded
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: "John"
+        surname:
+          type: string
+          example: "Doe"
+        email:
+          type: string
+          format: email
+          example: "john@example.com"
+        role_id:
+          type: integer
+          description: "1=Admin, 2=Reviewer, 3=Editor, 4=Auditor, 5=SuperAdmin"
+          example: 1
+        created_at:
+          type: string
+          format: date-time
+        last_login:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        is_demo:
+          type: boolean
+          default: false
+        organization_id:
+          type: integer
+          nullable: true
+          example: 1
+        profile_photo_id:
+          type: integer
+          nullable: true
+      required:
+        - id
+        - name
+        - surname
+        - email
+        - role_id
+        - created_at
+    StatusEnvelope:
+      type: object
+      properties:
+        message:
+          type: string
+          description: HTTP status text (e.g. "OK", "Created", "Accepted")
+        data:
+          description: Response payload (varies by endpoint)
+    ErrorEnvelope:
+      type: object
+      properties:
+        message:
+          type: string
+          description: HTTP status text or error category
+        data:
+          type: string
+          description: Error detail message
+    ProgressResponse:
+      type: object
+      properties:
+        assessmentsMetadata:
+          type: array
+          items:
+            type: object
+            properties:
+              projectId:
+                type: integer
+              totalAssessments:
+                type: integer
+              doneAssessments:
+                type: integer
+        controlsMetadata:
+          type: array
+          items:
+            type: object
+            properties:
+              projectId:
+                type: integer
+              totalSubControls:
+                type: integer
+              doneSubControls:
+                type: integer
+        allTotalAssessments:
+          type: integer
+        allDoneAssessments:
+          type: integer
+        allTotalSubControls:
+          type: integer
+        allDoneSubControls:
+          type: integer
+
+    Vendor:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Auto-generated primary key
+          example: 42
+        order_no:
+          type: integer
+          nullable: true
+          description: Display order number
+        vendor_name:
+          type: string
+          description: Name of the vendor
+          example: "Acme Corp"
+        vendor_provides:
+          type: string
+          description: What the vendor provides
+          example: "Cloud hosting services"
+        assignee:
+          type: integer
+          description: User ID of the assigned owner
+          example: 5
+        website:
+          type: string
+          description: Vendor website URL
+          example: "https://acme.example.com"
+        vendor_contact_person:
+          type: string
+          description: Name of the vendor contact
+          example: "Jane Doe"
+        review_result:
+          type: string
+          nullable: true
+          description: Free-text review result summary
+        review_status:
+          type: string
+          nullable: true
+          enum:
+            - Not started
+            - In review
+            - Reviewed
+            - Requires follow-up
+          default: Not started
+          description: Current review lifecycle status
+        reviewer:
+          type: integer
+          nullable: true
+          description: User ID of the reviewer
+        review_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Date the review was performed (ISO 8601)
+        is_demo:
+          type: boolean
+          default: false
+          description: Whether this is a demo vendor (read-only after creation)
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Array of associated project IDs
+        data_sensitivity:
+          type: string
+          nullable: true
+          enum:
+            - None
+            - Internal only
+            - "Personally identifiable information (PII)"
+            - Financial data
+            - "Health data (e.g. HIPAA)"
+            - Model weights or AI assets
+            - Other sensitive data
+          description: Scorecard - type of data the vendor accesses
+        business_criticality:
+          type: string
+          nullable: true
+          enum:
+            - "Low (vendor supports non-core functions)"
+            - "Medium (affects operations but is replaceable)"
+            - "High (critical to core services or products)"
+          description: Scorecard - how critical the vendor is to operations
+        past_issues:
+          type: string
+          nullable: true
+          enum:
+            - None
+            - "Minor incident (e.g. small delay, minor bug)"
+            - "Major incident (e.g. data breach, legal issue)"
+          description: Scorecard - history of past incidents
+        regulatory_exposure:
+          type: string
+          nullable: true
+          enum:
+            - None
+            - "GDPR (EU)"
+            - "HIPAA (US)"
+            - SOC 2
+            - ISO 27001
+            - EU AI act
+            - "CCPA (california)"
+            - Other
+          description: Scorecard - applicable regulatory framework
+        risk_score:
+          type: integer
+          nullable: true
+          description: Computed risk score for the vendor
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp (ISO 8601)
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp (ISO 8601)
+      required:
+        - vendor_name
+        - vendor_provides
+        - assignee
+        - website
+        - vendor_contact_person
+    VendorWithReviewerName:
+      allOf:
+        - $ref: "#/components/schemas/Vendor"
+        - type: object
+          properties:
+            reviewer_name:
+              type: string
+              description: Full name of the reviewer (joined from users table)
+              example: "John Smith"
+    VendorInput:
+      type: object
+      required:
+        - vendor_name
+        - vendor_provides
+        - assignee
+        - website
+        - vendor_contact_person
+      properties:
+        vendor_name:
+          type: string
+          description: Name of the vendor (required, non-empty)
+        vendor_provides:
+          type: string
+          description: What the vendor provides (required, non-empty)
+        assignee:
+          type: integer
+          minimum: 1
+          description: User ID of the assigned owner (required, >= 1)
+        website:
+          type: string
+          description: Vendor website URL (required, non-empty)
+        vendor_contact_person:
+          type: string
+          description: Name of the vendor contact (required, non-empty)
+        review_result:
+          type: string
+          description: Free-text review result summary
+        review_status:
+          type: string
+          enum:
+            - Not started
+            - In review
+            - Reviewed
+            - Requires follow-up
+          description: Current review lifecycle status
+        reviewer:
+          type: integer
+          minimum: 1
+          description: User ID of the reviewer
+        review_date:
+          type: string
+          format: date-time
+          description: Date of the review (ISO 8601)
+        order_no:
+          type: integer
+          description: Display order number
+        is_demo:
+          type: boolean
+          default: false
+          description: Mark as demo vendor
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Array of project IDs to associate
+        data_sensitivity:
+          type: string
+          enum:
+            - None
+            - Internal only
+            - "Personally identifiable information (PII)"
+            - Financial data
+            - "Health data (e.g. HIPAA)"
+            - Model weights or AI assets
+            - Other sensitive data
+        business_criticality:
+          type: string
+          enum:
+            - "Low (vendor supports non-core functions)"
+            - "Medium (affects operations but is replaceable)"
+            - "High (critical to core services or products)"
+        past_issues:
+          type: string
+          enum:
+            - None
+            - "Minor incident (e.g. small delay, minor bug)"
+            - "Major incident (e.g. data breach, legal issue)"
+        regulatory_exposure:
+          type: string
+          enum:
+            - None
+            - "GDPR (EU)"
+            - "HIPAA (US)"
+            - SOC 2
+            - ISO 27001
+            - EU AI act
+            - "CCPA (california)"
+            - Other
+        risk_score:
+          type: integer
+          description: Computed risk score
+    VendorUpdate:
+      type: object
+      description: All fields are optional. Only provided fields are updated. Review and scorecard fields can be set to null to clear them.
+      properties:
+        vendor_name:
+          type: string
+        vendor_provides:
+          type: string
+        assignee:
+          type: integer
+          minimum: 1
+        website:
+          type: string
+        vendor_contact_person:
+          type: string
+        review_result:
+          type: string
+          nullable: true
+        review_status:
+          type: string
+          nullable: true
+          enum:
+            - Not started
+            - In review
+            - Reviewed
+            - Requires follow-up
+        reviewer:
+          type: integer
+          nullable: true
+        review_date:
+          type: string
+          format: date-time
+          nullable: true
+        order_no:
+          type: integer
+        projects:
+          type: array
+          items:
+            type: integer
+        data_sensitivity:
+          type: string
+          nullable: true
+          enum:
+            - None
+            - Internal only
+            - "Personally identifiable information (PII)"
+            - Financial data
+            - "Health data (e.g. HIPAA)"
+            - Model weights or AI assets
+            - Other sensitive data
+        business_criticality:
+          type: string
+          nullable: true
+          enum:
+            - "Low (vendor supports non-core functions)"
+            - "Medium (affects operations but is replaceable)"
+            - "High (critical to core services or products)"
+        past_issues:
+          type: string
+          nullable: true
+          enum:
+            - None
+            - "Minor incident (e.g. small delay, minor bug)"
+            - "Major incident (e.g. data breach, legal issue)"
+        regulatory_exposure:
+          type: string
+          nullable: true
+          enum:
+            - None
+            - "GDPR (EU)"
+            - "HIPAA (US)"
+            - SOC 2
+            - ISO 27001
+            - EU AI act
+            - "CCPA (california)"
+            - Other
+        risk_score:
+          type: integer
+          nullable: true
+    ModelInventoryStatus:
+      type: string
+      enum:
+        - Approved
+        - Restricted
+        - Pending
+        - Blocked
+        - Rejected
+      description: Current approval/review status of the model
+    Filedata:
+      type: object
+      description: Metadata for an uploaded security-assessment file
+      properties:
+        id:
+          type: integer
+          description: File record ID
+        filename:
+          type: string
+          description: Original file name
+        size:
+          type: integer
+          description: File size in bytes
+        mimetype:
+          type: string
+          description: MIME type (e.g. application/pdf)
+        upload_date:
+          type: string
+          format: date-time
+          description: ISO 8601 upload timestamp
+        uploaded_by:
+          type: integer
+          description: User ID who uploaded the file
+      required:
+        - id
+        - filename
+        - size
+        - mimetype
+        - upload_date
+        - uploaded_by
+    ModelInventoryResponse:
+      type: object
+      description: Model inventory record as returned by the API
+      properties:
+        id:
+          type: integer
+          description: Auto-generated primary key
+          example: 42
+        provider_model:
+          type: string
+          nullable: true
+          description: Legacy combined provider+model field (backward compatibility)
+          example: "OpenAI / GPT-4"
+        provider:
+          type: string
+          description: Model provider name
+          example: OpenAI
+        model:
+          type: string
+          description: Model name
+          example: GPT-4
+        version:
+          type: string
+          description: Model version identifier
+          example: "turbo-2024-04-09"
+        approver:
+          type: integer
+          nullable: true
+          description: User ID of the assigned approver
+          example: 7
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: >
+            List of capability strings. Stored as comma-separated text in the DB,
+            returned as an array.
+          example: ["Text Generation", "Code Generation", "Reasoning"]
+        security_assessment:
+          type: boolean
+          description: Whether a security assessment has been completed
+          example: false
+        status:
+          $ref: "#/components/schemas/ModelInventoryStatus"
+        status_date:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of the last status change
+          example: "2026-04-15T10:30:00.000Z"
+        reference_link:
+          type: string
+          nullable: true
+          description: URL to external model documentation or model card
+          example: "https://platform.openai.com/docs/models/gpt-4"
+        biases:
+          type: string
+          description: Known biases of the model
+          example: "May reflect biases present in training data"
+        limitations:
+          type: string
+          description: Known limitations of the model
+          example: "Knowledge cutoff, potential hallucinations"
+        hosting_provider:
+          type: string
+          description: Where the model is hosted
+          example: "Azure OpenAI"
+        security_assessment_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Filedata"
+          description: Uploaded security assessment file metadata
+        is_demo:
+          type: boolean
+          description: Whether this is a demo/sample record
+          example: false
+        created_at:
+          type: string
+          format: date-time
+          description: ISO 8601 creation timestamp
+          example: "2026-04-10T08:00:00.000Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: ISO 8601 last-updated timestamp
+          example: "2026-04-15T10:30:00.000Z"
+        projects:
+          type: array
+          items:
+            type: integer
+          description: IDs of projects this model is associated with
+          example: [1, 3]
+        frameworks:
+          type: array
+          items:
+            type: integer
+          description: IDs of frameworks this model is associated with
+          example: [5]
+    ModelInventoryCreateRequest:
+      type: object
+      description: Request body for creating a new model inventory record
+      required:
+        - provider
+        - model
+        - version
+        - capabilities
+        - status
+        - status_date
+        - reference_link
+        - biases
+        - limitations
+        - hosting_provider
+      properties:
+        provider_model:
+          type: string
+          description: Legacy combined provider+model field (optional, backward compatibility)
+          example: "OpenAI / GPT-4"
+        provider:
+          type: string
+          description: Model provider name
+          example: OpenAI
+        model:
+          type: string
+          description: Model name
+          example: GPT-4
+        version:
+          type: string
+          description: Model version identifier
+          example: "turbo-2024-04-09"
+        approver:
+          type: integer
+          nullable: true
+          description: User ID of the assigned approver
+          example: 7
+        capabilities:
+          oneOf:
+            - type: string
+              description: Comma-separated capabilities
+            - type: array
+              items:
+                type: string
+              description: Array of capability strings
+          description: >
+            Accepted as either a comma-separated string or an array of strings.
+            Arrays are joined with ", " before storage.
+          example: ["Text Generation", "Code Generation"]
+        security_assessment:
+          type: boolean
+          description: Whether a security assessment has been completed
+          default: false
+        status:
+          $ref: "#/components/schemas/ModelInventoryStatus"
+        status_date:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp for the status
+          example: "2026-04-15T10:30:00.000Z"
+        reference_link:
+          type: string
+          description: URL to external model documentation or model card
+          example: "https://platform.openai.com/docs/models/gpt-4"
+        biases:
+          type: string
+          description: Known biases of the model
+          example: "May reflect biases present in training data"
+        limitations:
+          type: string
+          description: Known limitations of the model
+          example: "Knowledge cutoff, potential hallucinations"
+        hosting_provider:
+          type: string
+          description: Where the model is hosted
+          example: "Azure OpenAI"
+        security_assessment_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Filedata"
+          description: Uploaded security assessment file metadata
+          default: []
+        is_demo:
+          type: boolean
+          description: Whether this is a demo/sample record
+          default: false
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Project IDs to associate with this model
+          default: []
+          example: [1, 3]
+        frameworks:
+          type: array
+          items:
+            type: integer
+          description: Framework IDs to associate with this model
+          default: []
+          example: [5]
+    ModelInventoryUpdateRequest:
+      type: object
+      description: >
+        Request body for updating a model inventory record. All fields are
+        optional; only provided fields are modified.
+      properties:
+        provider_model:
+          type: string
+          description: Legacy combined provider+model field
+        provider:
+          type: string
+          description: Model provider name
+        model:
+          type: string
+          description: Model name
+        version:
+          type: string
+          description: Model version identifier
+        approver:
+          type: integer
+          nullable: true
+          description: User ID of the assigned approver
+        capabilities:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          description: Capabilities (string or array)
+        security_assessment:
+          type: boolean
+          description: Whether a security assessment has been completed
+        status:
+          $ref: "#/components/schemas/ModelInventoryStatus"
+        status_date:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp for the status
+        reference_link:
+          type: string
+          description: URL to external model documentation
+        biases:
+          type: string
+          description: Known biases of the model
+        limitations:
+          type: string
+          description: Known limitations of the model
+        hosting_provider:
+          type: string
+          description: Where the model is hosted
+        security_assessment_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Filedata"
+          description: Uploaded security assessment file metadata
+        is_demo:
+          type: boolean
+          description: Whether this is a demo/sample record
+        projects:
+          type: array
+          items:
+            type: integer
+          description: >
+            Project IDs to associate. When provided (even empty), replaces all
+            existing project associations.
+        frameworks:
+          type: array
+          items:
+            type: integer
+          description: >
+            Framework IDs to associate. When provided (even empty), replaces all
+            existing framework associations.
+        deleteProjects:
+          type: boolean
+          description: >
+            When true, clears all project associations even if projects array is
+            empty. Used to force-delete associations without providing replacements.
+          default: false
+        deleteFrameworks:
+          type: boolean
+          description: >
+            When true, clears all framework associations even if frameworks array
+            is empty. Used to force-delete associations without providing replacements.
+          default: false
+
+    PolicyWithReviewers:
+      type: object
+      description: A policy record with computed assigned reviewer IDs
+      properties:
+        id:
+          type: integer
+          description: Auto-generated primary key
+          example: 42
+        organization_id:
+          type: integer
+          description: Tenant organization ID
+          example: 1
+        title:
+          type: string
+          description: Policy title
+          example: "AI Ethics Policy"
+        content_html:
+          type: string
+          description: Full policy content as HTML
+          example: "<h1>AI Ethics Policy</h1><p>...</p>"
+        status:
+          type: string
+          description: Policy lifecycle status
+          example: "draft"
+        tags:
+          type: array
+          items:
+            type: string
+            enum:
+              - AI ethics
+              - Fairness
+              - Transparency
+              - Explainability
+              - Bias mitigation
+              - Privacy
+              - Data governance
+              - Model risk
+              - Accountability
+              - Security
+              - LLM
+              - Human oversight
+              - EU AI Act
+              - ISO 42001
+              - NIST RMF
+              - Red teaming
+              - Audit
+              - Monitoring
+              - Vendor management
+          description: Categorization tags
+        next_review_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Scheduled next review date
+        author_id:
+          type: integer
+          description: User ID of the policy creator
+          example: 1
+        last_updated_by:
+          type: integer
+          description: User ID of the last editor
+          example: 1
+        last_updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of last update
+        review_status:
+          type: string
+          nullable: true
+          enum:
+            - pending_review
+            - approved
+            - changes_requested
+            - null
+          description: Current review workflow status
+        review_comment:
+          type: string
+          nullable: true
+          description: Most recent review comment
+        reviewed_by:
+          type: integer
+          nullable: true
+          description: User ID of the last reviewer
+        reviewed_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp of last review action
+        is_demo:
+          type: boolean
+          description: Whether this is a demo/seed policy
+          default: false
+        created_at:
+          type: string
+          format: date-time
+          description: Row creation timestamp (set by database)
+        assigned_reviewer_ids:
+          type: array
+          items:
+            type: integer
+          description: User IDs of assigned reviewers (aggregated from mapping table)
+          example: [2, 5]
+    PolicyCreateRequest:
+      type: object
+      required:
+        - title
+        - content_html
+        - status
+      properties:
+        title:
+          type: string
+          description: Policy title
+          example: "Data Governance Policy"
+        content_html:
+          type: string
+          description: Full policy content as HTML
+          example: "<h1>Data Governance</h1><p>This policy outlines...</p>"
+        status:
+          type: string
+          description: Initial policy status
+          example: "draft"
+        tags:
+          type: array
+          items:
+            type: string
+          description: Categorization tags (must be from the allowed tag list)
+          example: ["Data governance", "Privacy"]
+        next_review_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Scheduled next review date
+          example: "2026-07-01T00:00:00.000Z"
+        assigned_reviewer_ids:
+          type: array
+          items:
+            type: integer
+          description: User IDs to assign as reviewers
+          example: [2, 5]
+        is_demo:
+          type: boolean
+          description: Mark as a demo policy
+          default: false
+    PolicyUpdateRequest:
+      type: object
+      description: All fields are optional. Only provided fields are updated.
+      properties:
+        title:
+          type: string
+          description: Updated policy title
+        content_html:
+          type: string
+          description: Updated policy content as HTML
+        status:
+          type: string
+          description: Updated policy status
+        tags:
+          type: array
+          items:
+            type: string
+          description: Replacement tag list (must be from the allowed tag list)
+        next_review_date:
+          type: string
+          format: date-time
+          nullable: true
+          description: Updated next review date
+        assigned_reviewer_ids:
+          type: array
+          items:
+            type: integer
+          description: Replacement reviewer list (fully replaces existing reviewers)
+    # ── Project Risk ──
+    ProjectRiskInput:
+      type: object
+      required:
+        - risk_name
+        - risk_owner
+        - risk_description
+      properties:
+        risk_name:
+          type: string
+          description: Name/title of the risk.
+        risk_owner:
+          type: integer
+          description: User ID of the risk owner (must be >= 1).
+        ai_lifecycle_phase:
+          type: string
+          enum:
+            - Problem definition & planning
+            - Data collection & processing
+            - Model development & training
+            - Model validation & testing
+            - Deployment & integration
+            - Monitoring & maintenance
+            - Decommissioning & retirement
+        risk_description:
+          type: string
+          description: Detailed description of the risk.
+        risk_category:
+          type: array
+          items:
+            type: string
+          description: Array of category labels.
+        impact:
+          type: string
+        assessment_mapping:
+          type: string
+        controls_mapping:
+          type: string
+        likelihood:
+          type: string
+          enum: [Rare, Unlikely, Possible, Likely, Almost Certain]
+        severity:
+          type: string
+          enum: [Negligible, Minor, Moderate, Major, Catastrophic]
+        risk_level_autocalculated:
+          type: string
+          enum: [No risk, Very low risk, Low risk, Medium risk, High risk, Very high risk]
+        review_notes:
+          type: string
+        mitigation_status:
+          type: string
+          enum: [Not Started, In Progress, Completed, On Hold, Deferred, Canceled, Requires review]
+        current_risk_level:
+          type: string
+          enum: [Very Low risk, Low risk, Medium risk, High risk, Very high risk]
+        deadline:
+          type: string
+          format: date-time
+        mitigation_plan:
+          type: string
+        implementation_strategy:
+          type: string
+        mitigation_evidence_document:
+          type: string
+        likelihood_mitigation:
+          type: string
+          enum: [Rare, Unlikely, Possible, Likely, Almost Certain]
+        risk_severity:
+          type: string
+          enum: [Negligible, Minor, Moderate, Major, Critical]
+        final_risk_level:
+          type: string
+        risk_approval:
+          type: integer
+          description: User ID of the approver.
+        approval_status:
+          type: string
+        date_of_assessment:
+          type: string
+          format: date-time
+        is_demo:
+          type: boolean
+          default: false
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Array of project IDs to link this risk to.
+        frameworks:
+          type: array
+          items:
+            type: integer
+          description: Array of framework IDs to link this risk to.
+        event_frequency_min:
+          type: number
+          nullable: true
+        event_frequency_likely:
+          type: number
+          nullable: true
+        event_frequency_max:
+          type: number
+          nullable: true
+        loss_regulatory_min:
+          type: number
+          nullable: true
+        loss_regulatory_likely:
+          type: number
+          nullable: true
+        loss_regulatory_max:
+          type: number
+          nullable: true
+        loss_operational_min:
+          type: number
+          nullable: true
+        loss_operational_likely:
+          type: number
+          nullable: true
+        loss_operational_max:
+          type: number
+          nullable: true
+        loss_litigation_min:
+          type: number
+          nullable: true
+        loss_litigation_likely:
+          type: number
+          nullable: true
+        loss_litigation_max:
+          type: number
+          nullable: true
+        loss_reputational_min:
+          type: number
+          nullable: true
+        loss_reputational_likely:
+          type: number
+          nullable: true
+        loss_reputational_max:
+          type: number
+          nullable: true
+        control_effectiveness:
+          type: number
+          nullable: true
+          description: Percentage 0-100.
+        mitigation_cost_annual:
+          type: number
+          nullable: true
+        benchmark_id:
+          type: integer
+          nullable: true
+        currency:
+          type: string
+          nullable: true
+          default: USD
+          maxLength: 3
+    ProjectRiskResponse:
+      allOf:
+        - $ref: "#/components/schemas/ProjectRiskInput"
+        - type: object
+          properties:
+            id:
+              type: integer
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+            total_loss_likely:
+              type: number
+              nullable: true
+            ale_estimate:
+              type: number
+              nullable: true
+            residual_ale:
+              type: number
+              nullable: true
+            roi_percentage:
+              type: number
+              nullable: true
+            projects:
+              type: array
+              items:
+                type: integer
+            frameworks:
+              type: array
+              items:
+                type: integer
+            subClauses:
+              type: array
+              items:
+                type: object
+            annexCategories:
+              type: array
+              items:
+                type: object
+            controls:
+              type: array
+              items:
+                type: object
+            assessments:
+              type: array
+              items:
+                type: object
+            annexControls_27001:
+              type: array
+              items:
+                type: object
+            subClauses_27001:
+              type: array
+              items:
+                type: object
+    # ── Vendor Risk ──
+    VendorRiskInput:
+      type: object
+      required:
+        - vendor_id
+        - risk_description
+        - impact_description
+        - likelihood
+        - risk_severity
+        - action_plan
+        - action_owner
+        - risk_level
+      properties:
+        vendor_id:
+          type: integer
+          description: ID of the vendor this risk belongs to.
+        order_no:
+          type: integer
+          nullable: true
+          description: Optional ordering number.
+        risk_description:
+          type: string
+        impact_description:
+          type: string
+        likelihood:
+          type: string
+          enum: [Rare, Unlikely, Possible, Likely, Almost certain]
+        risk_severity:
+          type: string
+          enum: [Negligible, Minor, Moderate, Major, Catastrophic]
+        action_plan:
+          type: string
+        action_owner:
+          type: integer
+          description: User ID of the action owner.
+        risk_level:
+          type: string
+          description: Free-text risk level.
+        is_demo:
+          type: boolean
+          default: false
+    VendorRiskResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        vendor_id:
+          type: integer
+        order_no:
+          type: integer
+          nullable: true
+        risk_description:
+          type: string
+        impact_description:
+          type: string
+        impact:
+          type: string
+          nullable: true
+        likelihood:
+          type: string
+          enum: [Rare, Unlikely, Possible, Likely, Almost certain]
+        risk_severity:
+          type: string
+          enum: [Negligible, Minor, Moderate, Major, Catastrophic]
+        action_plan:
+          type: string
+        action_owner:
+          type: integer
+        risk_level:
+          type: string
+        is_demo:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    VendorRiskAllProjectsResponse:
+      description: Extended vendor risk with joined vendor/project info.
+      type: object
+      properties:
+        risk_id:
+          type: integer
+        vendor_id:
+          type: integer
+        order_no:
+          type: integer
+          nullable: true
+        risk_description:
+          type: string
+        impact_description:
+          type: string
+        likelihood:
+          type: string
+        risk_severity:
+          type: string
+        action_plan:
+          type: string
+        action_owner:
+          type: integer
+        risk_level:
+          type: string
+        is_demo:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        is_deleted:
+          type: boolean
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        vendor_name:
+          type: string
+        project_id:
+          type: integer
+          nullable: true
+        project_title:
+          type: string
+          nullable: true
+    # ── Model Risk ──
+    ModelRiskInput:
+      type: object
+      required:
+        - risk_name
+        - risk_category
+        - risk_level
+        - owner
+        - target_date
+      properties:
+        risk_name:
+          type: string
+        risk_category:
+          type: string
+          enum: [Performance, Bias & Fairness, Security, Data Quality, Compliance]
+        risk_level:
+          type: string
+          enum: [Low, Medium, High, Critical]
+        status:
+          type: string
+          enum: [Open, In Progress, Resolved, Accepted]
+          default: Open
+        owner:
+          type: string
+          description: Name or identifier of the risk owner.
+        target_date:
+          type: string
+          format: date
+          description: Next review / target date.
+        description:
+          type: string
+        mitigation_plan:
+          type: string
+        impact:
+          type: string
+        likelihood:
+          type: string
+        key_metrics:
+          type: string
+        current_values:
+          type: string
+        threshold:
+          type: string
+        model_id:
+          type: integer
+          nullable: true
+          description: ID of the model inventory entry this risk is linked to.
+        is_demo:
+          type: boolean
+          default: false
+    ModelRiskResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        risk_name:
+          type: string
+        risk_category:
+          type: string
+          enum: [Performance, Bias & Fairness, Security, Data Quality, Compliance]
+        risk_level:
+          type: string
+          enum: [Low, Medium, High, Critical]
+        status:
+          type: string
+          enum: [Open, In Progress, Resolved, Accepted]
+        owner:
+          type: string
+        target_date:
+          type: string
+          format: date
+        description:
+          type: string
+        mitigation_plan:
+          type: string
+        impact:
+          type: string
+        likelihood:
+          type: string
+        key_metrics:
+          type: string
+        current_values:
+          type: string
+        threshold:
+          type: string
+        model_id:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    SuccessResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+        data:
+          description: Response payload (type varies per endpoint)
+
+    ValidationErrorResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: error
+        message:
+          type: string
+          example: Dataset creation validation failed
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+              message:
+                type: string
+              code:
+                type: string
+
+    # ─── Evidence Hub ──────────────────────────────────────────────────────────
+
+    Evidence:
+      type: object
+      properties:
+        id:
+          type: integer
+        evidence_name:
+          type: string
+        evidence_type:
+          type: string
+        description:
+          type: string
+          nullable: true
+        evidence_files:
+          type: array
+          items:
+            $ref: "#/components/schemas/FileResponse"
+        expiry_date:
+          type: string
+          format: date-time
+          nullable: true
+        mapped_model_ids:
+          type: array
+          items:
+            type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    FileResponse:
+      type: object
+      properties:
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+        filename:
+          type: string
+        size:
+          oneOf:
+            - type: number
+            - type: string
+        mimetype:
+          type: string
+        uploaded_by:
+          type: integer
+        upload_date:
+          type: string
+
+    EvidenceCreateRequest:
+      type: object
+      required:
+        - evidence_name
+        - evidence_type
+      properties:
+        evidence_name:
+          type: string
+          maxLength: 255
+        evidence_type:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          nullable: true
+        evidence_files:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                oneOf:
+                  - type: string
+                  - type: integer
+          description: Array of file references (by ID) to link
+        expiry_date:
+          type: string
+          format: date-time
+          nullable: true
+        mapped_model_ids:
+          type: array
+          items:
+            type: integer
+          description: Model inventory IDs to map this evidence to
+
+    EvidenceUpdateRequest:
+      type: object
+      properties:
+        evidence_name:
+          type: string
+          maxLength: 255
+        evidence_type:
+          type: string
+          maxLength: 100
+        description:
+          type: string
+          nullable: true
+        evidence_files:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                oneOf:
+                  - type: string
+                  - type: integer
+          description: New files to link
+        deleteFiles:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: integer
+          description: File IDs to unlink
+        expiry_date:
+          type: string
+          format: date-time
+          nullable: true
+        mapped_model_ids:
+          type: array
+          items:
+            type: integer
+
+    # ─── Datasets ──────────────────────────────────────────────────────────────
+
+    Dataset:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        version:
+          type: string
+        owner:
+          type: string
+        type:
+          type: string
+          enum: [training, validation, testing, production, reference, synthetic]
+        function:
+          type: string
+        source:
+          type: string
+        license:
+          type: string
+          nullable: true
+        format:
+          type: string
+          nullable: true
+        classification:
+          type: string
+          enum: [public, internal, confidential, restricted]
+        contains_pii:
+          type: boolean
+        pii_types:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [draft, active, deprecated, archived]
+        status_date:
+          type: string
+          format: date-time
+        known_biases:
+          type: string
+          nullable: true
+        bias_mitigation:
+          type: string
+          nullable: true
+        collection_method:
+          type: string
+          nullable: true
+        preprocessing_steps:
+          type: string
+          nullable: true
+        documentation_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentationFile"
+        is_demo:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        models:
+          type: array
+          items:
+            type: integer
+          description: Related model inventory IDs
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Related project IDs
+
+    DocumentationFile:
+      type: object
+      description: File metadata stored in JSONB documentation_data column
+      properties:
+        id:
+          type: string
+        filename:
+          type: string
+        size:
+          type: number
+        mimetype:
+          type: string
+
+    DatasetCreateRequest:
+      type: object
+      required:
+        - name
+        - description
+        - version
+        - owner
+        - type
+        - function
+        - source
+        - classification
+        - contains_pii
+        - status
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        version:
+          type: string
+          maxLength: 50
+        owner:
+          type: string
+          maxLength: 255
+        type:
+          type: string
+          enum: [training, validation, testing, production, reference, synthetic]
+        function:
+          type: string
+        source:
+          type: string
+          maxLength: 255
+        license:
+          type: string
+          maxLength: 255
+        format:
+          type: string
+          maxLength: 100
+        classification:
+          type: string
+          enum: [public, internal, confidential, restricted]
+        contains_pii:
+          type: boolean
+        pii_types:
+          type: string
+        status:
+          type: string
+          enum: [draft, active, deprecated, archived]
+        status_date:
+          type: string
+          format: date-time
+          description: Defaults to current time if omitted
+        known_biases:
+          type: string
+        bias_mitigation:
+          type: string
+        collection_method:
+          type: string
+        preprocessing_steps:
+          type: string
+        documentation_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentationFile"
+        is_demo:
+          type: boolean
+          default: false
+        models:
+          type: array
+          items:
+            type: integer
+          description: Model inventory IDs to associate
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Project IDs to associate
+
+    DatasetUpdateRequest:
+      type: object
+      description: All fields optional. Only provided fields are updated.
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        version:
+          type: string
+          maxLength: 50
+        owner:
+          type: string
+          maxLength: 255
+        type:
+          type: string
+          enum: [training, validation, testing, production, reference, synthetic]
+        function:
+          type: string
+        source:
+          type: string
+          maxLength: 255
+        license:
+          type: string
+          maxLength: 255
+        format:
+          type: string
+          maxLength: 100
+        classification:
+          type: string
+          enum: [public, internal, confidential, restricted]
+        contains_pii:
+          type: boolean
+        pii_types:
+          type: string
+        status:
+          type: string
+          enum: [draft, active, deprecated, archived]
+        status_date:
+          type: string
+          format: date-time
+        known_biases:
+          type: string
+        bias_mitigation:
+          type: string
+        collection_method:
+          type: string
+        preprocessing_steps:
+          type: string
+        documentation_data:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentationFile"
+        is_demo:
+          type: boolean
+        models:
+          type: array
+          items:
+            type: integer
+          description: Replace model associations (provide full list)
+        projects:
+          type: array
+          items:
+            type: integer
+          description: Replace project associations (provide full list)
+        deleteModels:
+          type: boolean
+          description: If true, remove all model associations (even if models array is empty)
+        deleteProjects:
+          type: boolean
+          description: If true, remove all project associations (even if projects array is empty)
+
+    DatasetChangeHistoryEntry:
+      type: object
+      properties:
+        id:
+          type: integer
+        dataset_id:
+          type: integer
+        change_type:
+          type: string
+          description: "e.g. created, deleted, field_change"
+        field_name:
+          type: string
+          nullable: true
+        old_value:
+          type: string
+          nullable: true
+        new_value:
+          type: string
+          nullable: true
+        changed_by:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    # ─── Automations ───────────────────────────────────────────────────────────
+
+    AutomationTrigger:
+      type: object
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+          description: Machine-readable trigger identifier
+        label:
+          type: string
+          description: Human-readable name
+        event_name:
+          type: string
+        description:
+          type: string
+          nullable: true
+
+    AutomationAction:
+      type: object
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+          description: Machine-readable action identifier
+        label:
+          type: string
+          description: Human-readable name
+        description:
+          type: string
+          nullable: true
+        default_params:
+          type: object
+          nullable: true
+          description: Default parameters for this action type
+
+    Automation:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        trigger_id:
+          type: integer
+        params:
+          type: object
+          description: Trigger-specific parameters (JSON)
+        is_active:
+          type: boolean
+        created_by:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    AutomationWithActions:
+      allOf:
+        - $ref: "#/components/schemas/Automation"
+        - type: object
+          properties:
+            actions:
+              type: array
+              items:
+                $ref: "#/components/schemas/TenantAutomationAction"
+
+    TenantAutomationAction:
+      type: object
+      properties:
+        id:
+          type: integer
+        automation_id:
+          type: integer
+        action_type_id:
+          type: integer
+        params:
+          type: object
+          nullable: true
+          description: Action-specific parameters (JSON)
+        order:
+          type: integer
+          description: Execution order (1-based)
+
+    AutomationCreateRequest:
+      type: object
+      required:
+        - triggerId
+        - name
+        - actions
+      properties:
+        triggerId:
+          type: integer
+          description: ID of the automation trigger
+        name:
+          type: string
+          description: Automation name
+        params:
+          type: string
+          description: JSON-encoded trigger parameters (parsed server-side)
+          default: "{}"
+        actions:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+              - action_type_id
+            properties:
+              action_type_id:
+                type: integer
+                description: ID of the action type
+              params:
+                type: object
+                nullable: true
+                description: Action-specific parameters
+
+    AutomationUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        triggerId:
+          type: integer
+        params:
+          type: string
+          description: JSON-encoded trigger parameters
+          default: "{}"
+        is_active:
+          type: boolean
+        actions:
+          type: array
+          items:
+            type: object
+            required:
+              - action_type_id
+            properties:
+              action_type_id:
+                type: integer
+              params:
+                type: object
+                nullable: true
+          description: If provided, replaces all existing actions
+
+    AutomationHistoryResponse:
+      type: object
+      properties:
+        logs:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              automation_id:
+                type: integer
+              status:
+                type: string
+              triggered_at:
+                type: string
+                format: date-time
+              completed_at:
+                type: string
+                format: date-time
+                nullable: true
+              actions:
+                type: array
+                items:
+                  type: object
+                description: Per-action execution results
+        total:
+          type: integer
+          description: Total number of log entries
+        limit:
+          type: integer
+        offset:
+          type: integer
+
+    AutomationStats:
+      type: object
+      description: Aggregated execution statistics for an automation
+      properties:
+        total_executions:
+          type: integer
+        successful:
+          type: integer
+        failed:
+          type: integer
+        last_executed_at:
+          type: string
+          format: date-time
+    # =========================================================================
+    # Common
+    # =========================================================================
+
+    ApiResponse:
+      type: object
+      properties:
+        statusCode:
+          type: integer
+        data:
+          description: Response payload (varies by endpoint)
+
+    Pagination:
+      type: object
+      properties:
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+        total_pages:
+          type: integer
+
+    # =========================================================================
+    # AI Detection - Enums
+    # =========================================================================
+
+    ScanStatus:
+      type: string
+      enum: [pending, cloning, scanning, completed, failed, cancelled]
+
+    ScanMode:
+      type: string
+      enum: [full, incremental]
+
+    FindingStatus:
+      type: string
+      enum: [active, fixed, carried_forward]
+
+    FindingType:
+      type: string
+      enum:
+        - library
+        - dependency
+        - api_call
+        - secret
+        - model_ref
+        - rag_component
+        - agent
+        - prompt_injection
+        - pii_exposure
+        - excessive_agency
+        - jailbreak_risk
+        - training_data_poisoning
+        - model_dos
+        - supply_chain
+        - insecure_plugin
+        - overreliance
+        - model_theft
+
+    ConfidenceLevel:
+      type: string
+      enum: [high, medium, low]
+
+    RiskLevel:
+      type: string
+      enum: [high, medium, low]
+
+    GovernanceStatus:
+      type: string
+      enum: [reviewed, approved, flagged]
+      nullable: true
+
+    LicenseRiskLevel:
+      type: string
+      enum: [high, medium, low, unknown]
+
+    # =========================================================================
+    # AI Detection - Scan Schemas
+    # =========================================================================
+
+    StartScanRequest:
+      type: object
+      required: [repository_url]
+      properties:
+        repository_url:
+          type: string
+          description: GitHub repository URL
+          example: https://github.com/owner/repo
+        scan_mode:
+          $ref: '#/components/schemas/ScanMode'
+        base_commit_sha:
+          type: string
+          pattern: '^[0-9a-fA-F]{7,40}$'
+          description: Required for incremental scans
+        head_commit_sha:
+          type: string
+          pattern: '^[0-9a-fA-F]{7,40}$'
+          description: Required for incremental scans
+
+    ScanStatusResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        status:
+          $ref: '#/components/schemas/ScanStatus'
+        progress:
+          type: number
+          format: float
+        current_file:
+          type: string
+        files_scanned:
+          type: integer
+        total_files:
+          type: integer
+          nullable: true
+        findings_count:
+          type: integer
+        error_message:
+          type: string
+          nullable: true
+
+    TriggeredByUser:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        surname:
+          type: string
+
+    ScanResponse:
+      type: object
+      properties:
+        scan:
+          type: object
+          properties:
+            id:
+              type: integer
+            repository_url:
+              type: string
+            repository_owner:
+              type: string
+            repository_name:
+              type: string
+            status:
+              $ref: '#/components/schemas/ScanStatus'
+            findings_count:
+              type: integer
+            files_scanned:
+              type: integer
+            started_at:
+              type: string
+              format: date-time
+              nullable: true
+            completed_at:
+              type: string
+              format: date-time
+              nullable: true
+            duration_ms:
+              type: integer
+              nullable: true
+            error_message:
+              type: string
+              nullable: true
+            triggered_by:
+              $ref: '#/components/schemas/TriggeredByUser'
+            risk_score:
+              type: number
+              nullable: true
+            risk_score_grade:
+              type: string
+              nullable: true
+            risk_score_details:
+              type: object
+              nullable: true
+            risk_score_calculated_at:
+              type: string
+              format: date-time
+              nullable: true
+            scan_mode:
+              $ref: '#/components/schemas/ScanMode'
+            base_commit_sha:
+              type: string
+              nullable: true
+            head_commit_sha:
+              type: string
+              nullable: true
+            baseline_scan_id:
+              type: integer
+              nullable: true
+            changed_files_count:
+              type: integer
+              nullable: true
+            created_at:
+              type: string
+              format: date-time
+        summary:
+          $ref: '#/components/schemas/ScanSummary'
+
+    ScanSummary:
+      type: object
+      properties:
+        total:
+          type: integer
+        by_confidence:
+          type: object
+          properties:
+            high:
+              type: integer
+            medium:
+              type: integer
+            low:
+              type: integer
+        by_provider:
+          type: object
+          additionalProperties:
+            type: integer
+
+    ScanListItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        repository_url:
+          type: string
+        repository_owner:
+          type: string
+        repository_name:
+          type: string
+        status:
+          $ref: '#/components/schemas/ScanStatus'
+        findings_count:
+          type: integer
+        files_scanned:
+          type: integer
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        duration_ms:
+          type: integer
+          nullable: true
+        triggered_by:
+          $ref: '#/components/schemas/TriggeredByUser'
+        risk_score:
+          type: number
+          nullable: true
+        risk_score_grade:
+          type: string
+          nullable: true
+        scan_mode:
+          $ref: '#/components/schemas/ScanMode'
+        baseline_scan_id:
+          type: integer
+          nullable: true
+        changed_files_count:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    ScansResponse:
+      type: object
+      properties:
+        scans:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScanListItem'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    CancelScanResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        status:
+          type: string
+          enum: [cancelled]
+        message:
+          type: string
+
+    DeleteScanResponse:
+      type: object
+      properties:
+        message:
+          type: string
+
+    # =========================================================================
+    # AI Detection - Finding Schemas
+    # =========================================================================
+
+    FilePath:
+      type: object
+      properties:
+        path:
+          type: string
+        line_number:
+          type: integer
+          nullable: true
+        matched_text:
+          type: string
+
+    Finding:
+      type: object
+      properties:
+        id:
+          type: integer
+        finding_type:
+          $ref: '#/components/schemas/FindingType'
+        category:
+          type: string
+        name:
+          type: string
+        provider:
+          type: string
+        confidence:
+          $ref: '#/components/schemas/ConfidenceLevel'
+        risk_level:
+          $ref: '#/components/schemas/RiskLevel'
+        description:
+          type: string
+          nullable: true
+        documentation_url:
+          type: string
+          nullable: true
+        file_count:
+          type: integer
+        file_paths:
+          type: array
+          items:
+            $ref: '#/components/schemas/FilePath'
+        governance_status:
+          $ref: '#/components/schemas/GovernanceStatus'
+        governance_updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        governance_updated_by:
+          type: integer
+          nullable: true
+        license_id:
+          type: string
+          nullable: true
+        license_name:
+          type: string
+          nullable: true
+        license_risk:
+          $ref: '#/components/schemas/LicenseRiskLevel'
+        license_source:
+          type: string
+          enum: [package, huggingface, pypi, npm, manual]
+          nullable: true
+        mitigation:
+          type: string
+          nullable: true
+        data_flow_summary:
+          type: string
+          nullable: true
+        vulnerability_details:
+          type: object
+          nullable: true
+        finding_status:
+          $ref: '#/components/schemas/FindingStatus'
+
+    FindingsResponse:
+      type: object
+      properties:
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Finding'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    UpdateGovernanceStatusRequest:
+      type: object
+      properties:
+        governance_status:
+          type: string
+          enum: [reviewed, approved, flagged]
+          nullable: true
+          description: Set to null to clear governance status
+
+    UpdateGovernanceStatusResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        governance_status:
+          type: string
+          nullable: true
+        governance_updated_at:
+          type: string
+          format: date-time
+        governance_updated_by:
+          type: integer
+
+    # =========================================================================
+    # AI Detection - Risk Scoring
+    # =========================================================================
+
+    RiskScoreResponse:
+      type: object
+      properties:
+        score:
+          type: number
+          nullable: true
+        grade:
+          type: string
+          nullable: true
+        details:
+          type: object
+          nullable: true
+        calculated_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    DimensionWeights:
+      type: object
+      properties:
+        data_sovereignty:
+          type: number
+          minimum: 0
+          maximum: 1
+        transparency:
+          type: number
+          minimum: 0
+          maximum: 1
+        security:
+          type: number
+          minimum: 0
+          maximum: 1
+        autonomy:
+          type: number
+          minimum: 0
+          maximum: 1
+        supply_chain:
+          type: number
+          minimum: 0
+          maximum: 1
+      description: All values must sum to 1.0
+
+    VulnerabilityTypesEnabled:
+      type: object
+      properties:
+        prompt_injection:
+          type: boolean
+        pii_exposure:
+          type: boolean
+        excessive_agency:
+          type: boolean
+        jailbreak_risk:
+          type: boolean
+        training_data_poisoning:
+          type: boolean
+        model_dos:
+          type: boolean
+        supply_chain:
+          type: boolean
+        insecure_plugin:
+          type: boolean
+        overreliance:
+          type: boolean
+        model_theft:
+          type: boolean
+
+    RiskScoringConfig:
+      type: object
+      properties:
+        id:
+          type: integer
+          nullable: true
+        llm_enabled:
+          type: boolean
+        llm_key_id:
+          type: integer
+          nullable: true
+        dimension_weights:
+          $ref: '#/components/schemas/DimensionWeights'
+        vulnerability_scan_enabled:
+          type: boolean
+        vulnerability_types_enabled:
+          $ref: '#/components/schemas/VulnerabilityTypesEnabled'
+        updated_by:
+          type: integer
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    UpdateRiskScoringConfigRequest:
+      type: object
+      properties:
+        llm_enabled:
+          type: boolean
+        llm_key_id:
+          type: integer
+          nullable: true
+        dimension_weights:
+          $ref: '#/components/schemas/DimensionWeights'
+        vulnerability_scan_enabled:
+          type: boolean
+        vulnerability_types_enabled:
+          $ref: '#/components/schemas/VulnerabilityTypesEnabled'
+
+    # =========================================================================
+    # AI Detection - Dependency Graph & Compliance
+    # =========================================================================
+
+    DependencyGraphResponse:
+      type: object
+      properties:
+        nodes:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              label:
+                type: string
+              type:
+                type: string
+              metadata:
+                type: object
+        edges:
+          type: array
+          items:
+            type: object
+            properties:
+              source:
+                type: string
+              target:
+                type: string
+              relationship:
+                type: string
+        metadata:
+          type: object
+
+    ComplianceMappingResponse:
+      type: object
+      properties:
+        mappings:
+          type: array
+          items:
+            type: object
+        checklist:
+          type: array
+          items:
+            type: object
+        summary:
+          type: object
+
+    # =========================================================================
+    # AI Detection - Repository Schemas
+    # =========================================================================
+
+    Repository:
+      type: object
+      properties:
+        id:
+          type: integer
+        repository_url:
+          type: string
+        repository_owner:
+          type: string
+        repository_name:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        default_branch:
+          type: string
+        github_token_id:
+          type: integer
+          nullable: true
+        schedule_enabled:
+          type: boolean
+        schedule_frequency:
+          type: string
+          enum: [daily, weekly, monthly]
+          nullable: true
+        schedule_day_of_week:
+          type: integer
+          minimum: 0
+          maximum: 6
+          nullable: true
+        schedule_day_of_month:
+          type: integer
+          minimum: 1
+          maximum: 31
+          nullable: true
+        schedule_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+        schedule_minute:
+          type: integer
+          minimum: 0
+          maximum: 59
+        webhook_secret:
+          type: string
+          nullable: true
+        ci_enabled:
+          type: boolean
+        ci_min_score:
+          type: number
+        ci_max_critical:
+          type: integer
+        ci_post_comments:
+          type: boolean
+        ci_status_checks:
+          type: boolean
+        last_scan_id:
+          type: integer
+          nullable: true
+        last_scan_status:
+          type: string
+          nullable: true
+        last_scan_at:
+          type: string
+          format: date-time
+          nullable: true
+        next_scan_at:
+          type: string
+          format: date-time
+          nullable: true
+        is_enabled:
+          type: boolean
+        created_by:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateRepositoryRequest:
+      type: object
+      required: [repository_url]
+      properties:
+        repository_url:
+          type: string
+          description: GitHub repository URL
+          example: https://github.com/owner/repo
+        display_name:
+          type: string
+          nullable: true
+        default_branch:
+          type: string
+          default: main
+        github_token_id:
+          type: integer
+          nullable: true
+        schedule_enabled:
+          type: boolean
+          default: false
+        schedule_frequency:
+          type: string
+          enum: [daily, weekly, monthly]
+          description: Required when schedule_enabled is true
+        schedule_day_of_week:
+          type: integer
+          minimum: 0
+          maximum: 6
+          description: Required for weekly schedule (0=Sunday)
+        schedule_day_of_month:
+          type: integer
+          minimum: 1
+          maximum: 31
+          description: Required for monthly schedule
+        schedule_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+          default: 2
+        schedule_minute:
+          type: integer
+          minimum: 0
+          maximum: 59
+          default: 0
+
+    UpdateRepositoryRequest:
+      type: object
+      properties:
+        display_name:
+          type: string
+          nullable: true
+        default_branch:
+          type: string
+        github_token_id:
+          type: integer
+          nullable: true
+        schedule_enabled:
+          type: boolean
+        schedule_frequency:
+          type: string
+          enum: [daily, weekly, monthly]
+        schedule_day_of_week:
+          type: integer
+          minimum: 0
+          maximum: 6
+        schedule_day_of_month:
+          type: integer
+          minimum: 1
+          maximum: 31
+        schedule_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+        schedule_minute:
+          type: integer
+          minimum: 0
+          maximum: 59
+        is_enabled:
+          type: boolean
+        ci_enabled:
+          type: boolean
+        ci_min_score:
+          type: number
+        ci_max_critical:
+          type: integer
+        ci_post_comments:
+          type: boolean
+        ci_status_checks:
+          type: boolean
+
+    RepositoryListResponse:
+      type: object
+      properties:
+        repositories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Repository'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    # =========================================================================
+    # AI Trust Centre Schemas
+    # =========================================================================
+
+    AITrustCentreOverview:
+      type: object
+      description: Full overview with all sections
+      properties:
+        intro:
+          type: object
+          properties:
+            id:
+              type: integer
+            purpose_visible:
+              type: boolean
+            purpose_text:
+              type: string
+            our_statement_visible:
+              type: boolean
+            our_statement_text:
+              type: string
+            our_mission_visible:
+              type: boolean
+            our_mission_text:
+              type: string
+        compliance_badges:
+          type: object
+          properties:
+            id:
+              type: integer
+            soc2_type_i:
+              type: boolean
+            soc2_type_ii:
+              type: boolean
+            iso_27001:
+              type: boolean
+            iso_42001:
+              type: boolean
+            ccpa:
+              type: boolean
+            gdpr:
+              type: boolean
+            hipaa:
+              type: boolean
+            eu_ai_act:
+              type: boolean
+        company_description:
+          type: object
+          properties:
+            id:
+              type: integer
+            background_visible:
+              type: boolean
+            background_text:
+              type: string
+            core_benefits_visible:
+              type: boolean
+            core_benefits_text:
+              type: string
+            compliance_doc_visible:
+              type: boolean
+            compliance_doc_text:
+              type: string
+        terms_and_contact:
+          type: object
+          properties:
+            id:
+              type: integer
+            terms_visible:
+              type: boolean
+            terms_text:
+              type: string
+            privacy_visible:
+              type: boolean
+            privacy_text:
+              type: string
+            email_visible:
+              type: boolean
+            email_text:
+              type: string
+        info:
+          type: object
+          properties:
+            id:
+              type: integer
+            title:
+              type: string
+            header_color:
+              type: string
+            visible:
+              type: boolean
+            intro_visible:
+              type: boolean
+            compliance_badges_visible:
+              type: boolean
+            company_description_visible:
+              type: boolean
+            terms_and_contact_visible:
+              type: boolean
+            resources_visible:
+              type: boolean
+            subprocessor_visible:
+              type: boolean
+            updated_at:
+              type: string
+              format: date-time
+
+    AITrustCentreResource:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        file_id:
+          type: integer
+        visible:
+          type: boolean
+        filename:
+          type: string
+
+    AITrustCentreSubprocessor:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        name:
+          type: string
+        purpose:
+          type: string
+        location:
+          type: string
+        url:
+          type: string
+
+    CreateSubprocessorRequest:
+      type: object
+      required: [name, purpose, location]
+      properties:
+        name:
+          type: string
+        purpose:
+          type: string
+        location:
+          type: string
+        url:
+          type: string
+
+    UpdateSubprocessorRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        purpose:
+          type: string
+        location:
+          type: string
+        url:
+          type: string
+
+    AITrustCentrePublicPage:
+      type: object
+      description: Conditionally includes sections based on visibility settings
+      properties:
+        info:
+          type: object
+          properties:
+            title:
+              type: string
+            header_color:
+              type: string
+            logo:
+              type: integer
+              nullable: true
+        intro:
+          type: object
+          nullable: true
+          properties:
+            purpose:
+              type: string
+              nullable: true
+            statement:
+              type: string
+              nullable: true
+            mission:
+              type: string
+              nullable: true
+        compliance_badges:
+          type: object
+          nullable: true
+          properties:
+            soc2_type_i:
+              type: boolean
+            soc2_type_ii:
+              type: boolean
+            iso_27001:
+              type: boolean
+            iso_42001:
+              type: boolean
+            ccpa:
+              type: boolean
+            gdpr:
+              type: boolean
+            hipaa:
+              type: boolean
+            eu_ai_act:
+              type: boolean
+        company_description:
+          type: object
+          nullable: true
+          properties:
+            background:
+              type: string
+              nullable: true
+            core_benefits:
+              type: string
+              nullable: true
+            compliance_doc:
+              type: string
+              nullable: true
+        terms_and_contact:
+          type: object
+          nullable: true
+          properties:
+            terms:
+              type: string
+              nullable: true
+            privacy:
+              type: string
+              nullable: true
+            email:
+              type: string
+              nullable: true
+        resources:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              description:
+                type: string
+              file_id:
+                type: integer
+              visible:
+                type: boolean
+        subprocessors:
+          type: array
+          nullable: true
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              purpose:
+                type: string
+              location:
+                type: string
+              url:
+                type: string
+
+    # =========================================================================
+    # AI Incident Management Schemas
+    # =========================================================================
+
+    IncidentType:
+      type: string
+      enum:
+        - Malfunction
+        - Unexpected behavior
+        - Model drift
+        - Misuse
+        - Data corruption
+        - Security breach
+        - Performance degradation
+
+    IncidentSeverity:
+      type: string
+      enum:
+        - Minor
+        - Serious
+        - Very serious
+
+    IncidentStatus:
+      type: string
+      enum:
+        - Open
+        - Investigating
+        - Mitigated
+        - Closed
+
+    IncidentApprovalStatus:
+      type: string
+      enum:
+        - Approved
+        - Rejected
+        - Pending
+        - Not required
+
+    Incident:
+      type: object
+      properties:
+        id:
+          type: integer
+        incident_id:
+          type: string
+          nullable: true
+        ai_project:
+          type: string
+        type:
+          $ref: '#/components/schemas/IncidentType'
+        severity:
+          $ref: '#/components/schemas/IncidentSeverity'
+        status:
+          $ref: '#/components/schemas/IncidentStatus'
+        occurred_date:
+          type: string
+          format: date-time
+        date_detected:
+          type: string
+          format: date-time
+        reporter:
+          type: string
+        categories_of_harm:
+          type: array
+          items:
+            type: string
+        affected_persons_groups:
+          type: string
+          nullable: true
+        description:
+          type: string
+        relationship_causality:
+          type: string
+          nullable: true
+        immediate_mitigations:
+          type: string
+          nullable: true
+        planned_corrective_actions:
+          type: string
+          nullable: true
+        model_system_version:
+          type: string
+          nullable: true
+        interim_report:
+          type: boolean
+        archived:
+          type: boolean
+        approval_status:
+          $ref: '#/components/schemas/IncidentApprovalStatus'
+        approved_by:
+          type: string
+          nullable: true
+        approval_date:
+          type: string
+          format: date-time
+          nullable: true
+        approval_notes:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateIncidentRequest:
+      type: object
+      required:
+        - ai_project
+        - type
+        - severity
+        - status
+        - occurred_date
+        - date_detected
+        - reporter
+        - approval_status
+        - categories_of_harm
+        - description
+        - relationship_causality
+      properties:
+        ai_project:
+          type: string
+        type:
+          $ref: '#/components/schemas/IncidentType'
+        severity:
+          $ref: '#/components/schemas/IncidentSeverity'
+        status:
+          $ref: '#/components/schemas/IncidentStatus'
+        occurred_date:
+          type: string
+          format: date-time
+        date_detected:
+          type: string
+          format: date-time
+        reporter:
+          type: string
+        approval_status:
+          $ref: '#/components/schemas/IncidentApprovalStatus'
+        approved_by:
+          type: string
+        categories_of_harm:
+          oneOf:
+            - type: array
+              items:
+                type: string
+            - type: string
+              description: Comma-separated string (will be split)
+        affected_persons_groups:
+          type: string
+        description:
+          type: string
+        relationship_causality:
+          type: string
+        immediate_mitigations:
+          type: string
+        planned_corrective_actions:
+          type: string
+        model_system_version:
+          type: string
+        interim_report:
+          type: boolean
+          default: false
+        archived:
+          type: boolean
+          default: false
+        approval_date:
+          type: string
+          format: date-time
+        approval_notes:
+          type: string
+
+    UpdateIncidentRequest:
+      type: object
+      description: All fields are optional; only provided fields are updated.
+      properties:
+        ai_project:
+          type: string
+        type:
+          $ref: '#/components/schemas/IncidentType'
+        severity:
+          $ref: '#/components/schemas/IncidentSeverity'
+        status:
+          $ref: '#/components/schemas/IncidentStatus'
+        occurred_date:
+          type: string
+          format: date-time
+        date_detected:
+          type: string
+          format: date-time
+        reporter:
+          type: string
+        approval_status:
+          $ref: '#/components/schemas/IncidentApprovalStatus'
+        approved_by:
+          type: string
+        categories_of_harm:
+          oneOf:
+            - type: array
+              items:
+                type: string
+            - type: string
+        affected_persons_groups:
+          type: string
+        description:
+          type: string
+        relationship_causality:
+          type: string
+        immediate_mitigations:
+          type: string
+        planned_corrective_actions:
+          type: string
+        model_system_version:
+          type: string
+        interim_report:
+          type: boolean
+        archived:
+          type: boolean
+        approval_date:
+          type: string
+          format: date-time
+        approval_notes:
+          type: string
+    # ---- Generic response wrappers ----
+
+    Framework:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        organization_id:
+          type: integer
+
+    # ---- ISO 27001 ----
+
+    ISO27001Clause:
+      type: object
+      properties:
+        id:
+          type: integer
+        arrangement:
+          type: integer
+        title:
+          type: string
+
+    ISO27001ClauseWithSubClauses:
+      type: object
+      properties:
+        id:
+          type: integer
+        arrangement:
+          type: integer
+        title:
+          type: string
+        subClauses:
+          type: array
+          items:
+            $ref: "#/components/schemas/ISO27001SubClause"
+
+    ISO27001SubClause:
+      type: object
+      properties:
+        id:
+          type: integer
+        subclause_meta_id:
+          type: integer
+        projects_frameworks_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    ISO27001Annex:
+      type: object
+      properties:
+        id:
+          type: integer
+        arrangement:
+          type: string
+        order_no:
+          type: integer
+        title:
+          type: string
+
+    ISO27001AnnexWithControls:
+      type: object
+      properties:
+        id:
+          type: integer
+        arrangement:
+          type: string
+        order_no:
+          type: integer
+        title:
+          type: string
+        controls:
+          type: array
+          items:
+            $ref: "#/components/schemas/ISO27001AnnexControl"
+
+    ISO27001AnnexControl:
+      type: object
+      properties:
+        id:
+          type: integer
+        annexcontrol_meta_id:
+          type: integer
+        projects_frameworks_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    ISO27001SaveClauseRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: User ID for file upload attribution
+        project_id:
+          type: string
+          description: Project ID for file upload association
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+          description: Evidence files to upload
+
+    ISO27001SaveAnnexRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: User ID for file upload attribution
+        project_id:
+          type: string
+          description: Project ID for file upload association
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+          description: Evidence files to upload
+
+    # ---- ISO 42001 ----
+
+    ISO42001Clause:
+      type: object
+      properties:
+        id:
+          type: integer
+        clause_no:
+          type: integer
+        title:
+          type: string
+
+    ISO42001ClauseWithSubClauses:
+      type: object
+      properties:
+        id:
+          type: integer
+        clause_no:
+          type: integer
+        title:
+          type: string
+        subClauses:
+          type: array
+          items:
+            $ref: "#/components/schemas/ISO42001SubClause"
+
+    ISO42001SubClause:
+      type: object
+      properties:
+        id:
+          type: integer
+        subclause_meta_id:
+          type: integer
+        projects_frameworks_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    ISO42001Annex:
+      type: object
+      properties:
+        id:
+          type: integer
+        annex_no:
+          type: integer
+        title:
+          type: string
+
+    ISO42001AnnexWithCategories:
+      type: object
+      properties:
+        id:
+          type: integer
+        annex_no:
+          type: integer
+        title:
+          type: string
+        categories:
+          type: array
+          items:
+            $ref: "#/components/schemas/ISO42001AnnexCategory"
+
+    ISO42001AnnexCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        annexcategory_meta_id:
+          type: integer
+        projects_frameworks_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    ISO42001SaveClauseRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+        project_id:
+          type: string
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+
+    ISO42001SaveAnnexRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+        project_id:
+          type: string
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+
+    # ---- NIST AI RMF ----
+
+    NISTFunction:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+          example: GOVERN
+        description:
+          type: string
+        organization_id:
+          type: integer
+
+    NISTCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+        function_id:
+          type: integer
+        organization_id:
+          type: integer
+
+    NISTSubcategory:
+      type: object
+      properties:
+        id:
+          type: integer
+        subcategory_meta_id:
+          type: integer
+        organization_id:
+          type: integer
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+          nullable: true
+        evidence_links:
+          type: array
+          items:
+            type: object
+        risks_mitigated:
+          type: array
+          items:
+            type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    NISTSubcategoryUpdateRequest:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: User ID for file upload attribution
+        project_id:
+          type: string
+          description: Project ID for file upload association
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+        owner:
+          type: integer
+          nullable: true
+        reviewer:
+          type: integer
+          nullable: true
+        approver:
+          type: integer
+          nullable: true
+        implementation_details:
+          type: string
+        tags:
+          type: string
+          description: JSON-encoded array of tag strings
+        delete:
+          type: string
+          description: JSON-encoded array of file IDs to unlink
+        risksDelete:
+          type: string
+          description: JSON-encoded array of risk IDs to remove
+        risksMitigated:
+          type: string
+          description: JSON-encoded array of risk IDs to add
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+          description: Evidence files to upload
+
+    NISTSubcategoryStatusUpdate:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum: [Not started, Draft, In review, Done]
+          description: New status value
+
+    NISTProgress:
+      type: object
+      properties:
+        totalSubcategories:
+          type: integer
+        doneSubcategories:
+          type: integer
+
+    NISTAssignments:
+      type: object
+      properties:
+        totalSubcategories:
+          type: integer
+        assignedSubcategories:
+          type: integer
+
+    # ---- Compliance Score ----
+
+    ComplianceScore:
+      type: object
+      properties:
+        organizationId:
+          type: integer
+        overallScore:
+          type: integer
+          minimum: 0
+          maximum: 100
+        calculatedAt:
+          type: string
+          format: date-time
+        modules:
+          type: object
+          properties:
+            riskManagement:
+              $ref: "#/components/schemas/ModuleScore"
+            vendorManagement:
+              $ref: "#/components/schemas/ModuleScore"
+            projectGovernance:
+              $ref: "#/components/schemas/ModuleScore"
+            modelLifecycle:
+              $ref: "#/components/schemas/ModuleScore"
+            policyDocumentation:
+              $ref: "#/components/schemas/ModuleScore"
+        metadata:
+          $ref: "#/components/schemas/ComplianceMetadata"
+
+    ModuleScore:
+      type: object
+      properties:
+        score:
+          type: number
+          minimum: 0
+          maximum: 100
+        weight:
+          type: number
+          description: Module weight (sums to 1.0 across all modules)
+        components:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComponentScore"
+        totalDataPoints:
+          type: integer
+        qualityScore:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Data completeness indicator
+
+    ComponentScore:
+      type: object
+      properties:
+        name:
+          type: string
+        score:
+          type: number
+        weight:
+          type: number
+        dataPoints:
+          type: integer
+        details:
+          type: object
+          description: Module-specific details
+
+    ComplianceMetadata:
+      type: object
+      properties:
+        totalProjects:
+          type: integer
+        applicableProjects:
+          type: integer
+        lastUpdated:
+          type: string
+          format: date-time
+        dataFreshness:
+          type: object
+          properties:
+            risks:
+              type: string
+              format: date-time
+            vendors:
+              type: string
+              format: date-time
+            projects:
+              type: string
+              format: date-time
+            models:
+              type: string
+              format: date-time
+            policies:
+              type: string
+              format: date-time
+        calculationMethod:
+          type: string
+          enum: [balanced_weighted_average]
+        version:
+          type: string
+
+    ComplianceDetails:
+      allOf:
+        - $ref: "#/components/schemas/ComplianceScore"
+        - type: object
+          properties:
+            insights:
+              type: object
+              properties:
+                strongestModule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    score:
+                      type: number
+                weakestModule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    score:
+                      type: number
+                improvementPriority:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      module:
+                        type: string
+                      score:
+                        type: number
+                      weight:
+                        type: number
+                      impact:
+                        type: number
+                        description: "(100 - score) * weight"
+                overallTrend:
+                  type: string
+                  enum: [up, down, stable]
+                dataQuality:
+                  type: object
+                  properties:
+                    riskManagement:
+                      type: number
+                    vendorManagement:
+                      type: number
+                    projectGovernance:
+                      type: number
+                    modelLifecycle:
+                      type: number
+                    policyDocumentation:
+                      type: number
+
+    # ---- Shared ----
+
+    AssignmentResponse:
+      type: object
+      properties:
+        total:
+          type: integer
+        assigned:
+          type: integer
+
+    RisksResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Risk"
+
+    Risk:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+        risk_level:
+          type: string
+        status:
+          type: string
+        organization_id:
+          type: integer
+    # ─── Generic wrapper ────────────────────────────────────────────────────────
+
+    StatusCodeWrapper:
+      type: object
+      properties:
+        code:
+          type: integer
+        data:
+          description: Response payload
+
+    # ─── Share Links ────────────────────────────────────────────────────────────
+
+    ShareLinkSettings:
+      type: object
+      properties:
+        shareAllFields:
+          type: boolean
+          default: false
+        allowDataExport:
+          type: boolean
+          default: true
+        allowViewersToOpenRecords:
+          type: boolean
+          default: false
+        displayToolbar:
+          type: boolean
+          default: true
+
+    ShareLinkCreateRequest:
+      type: object
+      required: [resource_type, resource_id]
+      properties:
+        resource_type:
+          type: string
+          enum: [model, vendor, project, policy, risk]
+        resource_id:
+          type: integer
+          minimum: 0
+          description: Use 0 for sharing the entire table/list view
+        settings:
+          $ref: "#/components/schemas/ShareLinkSettings"
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    ShareLinkUpdateRequest:
+      type: object
+      properties:
+        settings:
+          $ref: "#/components/schemas/ShareLinkSettings"
+        is_enabled:
+          type: boolean
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    ShareLinkResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        share_token:
+          type: string
+        resource_type:
+          type: string
+        resource_id:
+          type: integer
+        settings:
+          $ref: "#/components/schemas/ShareLinkSettings"
+        is_enabled:
+          type: boolean
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        shareable_url:
+          type: string
+          format: uri
+
+    ShareLinkListItem:
+      allOf:
+        - $ref: "#/components/schemas/ShareLinkResponse"
+        - properties:
+            is_valid:
+              type: boolean
+              description: Whether the link is currently active and not expired
+
+    ShareLinkMetadata:
+      type: object
+      properties:
+        id:
+          type: integer
+        share_token:
+          type: string
+        resource_type:
+          type: string
+        resource_id:
+          type: integer
+        settings:
+          $ref: "#/components/schemas/ShareLinkSettings"
+        is_enabled:
+          type: boolean
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        is_valid:
+          type: boolean
+
+    SharedDataResponse:
+      type: object
+      properties:
+        share_link:
+          type: object
+          properties:
+            resource_type:
+              type: string
+            settings:
+              $ref: "#/components/schemas/ShareLinkSettings"
+        data:
+          description: Resource data (object for single record, array for table view)
+          oneOf:
+            - type: object
+            - type: array
+              items:
+                type: object
+        permissions:
+          type: object
+          properties:
+            allowDataExport:
+              type: boolean
+            allowViewersToOpenRecords:
+              type: boolean
+
+    # ─── Notes ──────────────────────────────────────────────────────────────────
+
+    NoteCreateRequest:
+      type: object
+      required: [content, attached_to, attached_to_id]
+      properties:
+        content:
+          type: string
+          maxLength: 5000
+        attached_to:
+          type: string
+          enum: [project, vendor, model, risk, policy, task, incident]
+        attached_to_id:
+          type: string
+
+    Note:
+      type: object
+      properties:
+        id:
+          type: integer
+        content:
+          type: string
+        author_id:
+          type: integer
+        attached_to:
+          type: string
+        attached_to_id:
+          type: string
+        organization_id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    # ─── Search ─────────────────────────────────────────────────────────────────
+
+    SearchResponse:
+      type: object
+      properties:
+        results:
+          type: object
+          description: Results grouped by entity type (projects, vendors, models, etc.)
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: Entity-specific result object
+        totalCount:
+          type: integer
+        query:
+          type: string
+        message:
+          type: string
+          description: Present when query is too short
+
+    # ─── Reporting ──────────────────────────────────────────────────────────────
+
+    ReportGenerateRequest:
+      type: object
+      required: [projectId, frameworkId, projectFrameworkId, reportType]
+      properties:
+        projectId:
+          type: integer
+        frameworkId:
+          type: integer
+        projectFrameworkId:
+          type: integer
+        reportType:
+          oneOf:
+            - type: string
+              enum:
+                - projectRisks
+                - vendorRisks
+                - modelRisks
+                - compliance
+                - assessment
+                - clausesAndAnnexes
+                - nistSubcategories
+                - vendors
+                - models
+                - trainingRegistry
+                - policyManager
+                - incidentManagement
+                - all
+            - type: array
+              items:
+                type: string
+        reportName:
+          type: string
+        format:
+          type: string
+          enum: [pdf, docx]
+          default: docx
+        aiEnhanced:
+          type: boolean
+          default: false
+        llmKeyId:
+          type: integer
+          description: LLM key ID for AI-enhanced reports
+
+    GeneratedReport:
+      type: object
+      properties:
+        id:
+          type: integer
+        filename:
+          type: string
+        project_id:
+          type: integer
+        report_type:
+          type: string
+        created_by:
+          type: integer
+        organization_id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    # ─── Dashboard ──────────────────────────────────────────────────────────────
+
+    DashboardData:
+      type: object
+      properties:
+        projects:
+          type: integer
+          description: Total project count
+        trainings:
+          type: integer
+          description: Total training records
+        models:
+          type: integer
+          description: Total model count
+        reports:
+          type: integer
+          description: Total report count
+        task_radar:
+          type: object
+          properties:
+            overdue:
+              type: integer
+            due:
+              type: integer
+            upcoming:
+              type: integer
+        projects_list:
+          type: array
+          items:
+            type: object
+            description: Project summary objects
+
+    # ─── CE Marking ────────────────────────────────────────────────────────────
+
+    ConformityStep:
+      type: object
+      properties:
+        id:
+          type: integer
+        step:
+          type: string
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [Not started, In progress, Completed, Not needed]
+        owner:
+          type: string
+          nullable: true
+        dueDate:
+          type: string
+          format: date
+          nullable: true
+        completedDate:
+          type: string
+          format: date
+          nullable: true
+
+    CEMarkingResponse:
+      type: object
+      properties:
+        isHighRiskAISystem:
+          type: boolean
+        roleInProduct:
+          type: string
+          enum: [standalone, safety_component, product_itself]
+        annexIIICategory:
+          type: string
+        controlsCompleted:
+          type: integer
+        controlsTotal:
+          type: integer
+        assessmentsCompleted:
+          type: integer
+        assessmentsTotal:
+          type: integer
+        conformitySteps:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConformityStep"
+        completedStepsCount:
+          type: integer
+        totalStepsCount:
+          type: integer
+        declarationStatus:
+          type: string
+          enum: [draft, ready, signed]
+        signedOn:
+          type: string
+          format: date
+          nullable: true
+        signatory:
+          type: string
+          nullable: true
+        declarationDocument:
+          type: string
+          nullable: true
+        registrationStatus:
+          type: string
+          enum: [not_registered, pending, registered]
+        euRegistrationId:
+          type: string
+          nullable: true
+        registrationDate:
+          type: string
+          format: date
+          nullable: true
+        euRecordUrl:
+          type: string
+          format: uri
+          nullable: true
+        policiesLinked:
+          type: integer
+        evidenceLinked:
+          type: integer
+        linkedPolicies:
+          type: array
+          items:
+            type: integer
+        linkedEvidences:
+          type: array
+          items:
+            type: integer
+        totalIncidents:
+          type: integer
+        aiActReportableIncidents:
+          type: integer
+        lastIncident:
+          type: string
+          format: date-time
+          nullable: true
+        linkedIncidents:
+          type: array
+          items:
+            type: integer
+
+    CEMarkingUpdateRequest:
+      type: object
+      properties:
+        isHighRiskAISystem:
+          type: boolean
+        roleInProduct:
+          type: string
+        annexIIICategory:
+          type: string
+        declarationStatus:
+          type: string
+        signedOn:
+          type: string
+          format: date
+        signatory:
+          type: string
+        declarationDocument:
+          type: string
+        registrationStatus:
+          type: string
+        euRegistrationId:
+          type: string
+        registrationDate:
+          type: string
+          format: date
+        euRecordUrl:
+          type: string
+        linkedPolicies:
+          type: array
+          items:
+            type: integer
+        linkedEvidences:
+          type: array
+          items:
+            type: integer
+        linkedIncidents:
+          type: array
+          items:
+            type: integer
+        conformitySteps:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              description:
+                type: string
+              status:
+                type: string
+                enum: [Not started, In progress, Completed, Not needed]
+              owner:
+                type: string
+              dueDate:
+                type: string
+                format: date
+              completedDate:
+                type: string
+                format: date
+
+    # ─── Roles ──────────────────────────────────────────────────────────────────
+
+    Role:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          enum: [Admin, Reviewer, Editor, Auditor]
+        description:
+          type: string
+
+    # ─── Subscriptions ──────────────────────────────────────────────────────────
+
+    SubscriptionCreateRequest:
+      type: object
+      required: [organization_id, tier_id, status, start_date]
+      properties:
+        organization_id:
+          type: integer
+        tier_id:
+          type: integer
+        stripe_sub_id:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [active, cancelled, past_due, trialing]
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+
+    SubscriptionUpdateRequest:
+      type: object
+      properties:
+        tier_id:
+          type: integer
+        stripe_sub_id:
+          type: string
+        status:
+          type: string
+          enum: [active, cancelled, past_due, trialing]
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+
+    Subscription:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        tier_id:
+          type: integer
+        stripe_sub_id:
+          type: string
+          nullable: true
+        status:
+          type: string
+        start_date:
+          type: string
+          format: date-time
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    # ─── Tiers ──────────────────────────────────────────────────────────────────
+
+    TierFeatures:
+      type: object
+      description: Tier details with associated feature flags
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        features:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              enabled:
+                type: boolean
+
+    # ─── API Tokens ─────────────────────────────────────────────────────────────
+
+    ApiTokenCreateRequest:
+      type: object
+      required: [name, expires_in_days]
+      properties:
+        name:
+          type: string
+          description: Descriptive name for the token
+        expires_in_days:
+          type: integer
+          minimum: 1
+          description: Number of days until token expires
+
+    ApiToken:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        expires_at:
+          type: string
+          format: date-time
+        created_by:
+          type: integer
+        organization_id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    ApiTokenCreated:
+      allOf:
+        - $ref: "#/components/schemas/ApiToken"
+        - properties:
+            token:
+              type: string
+              description: Full JWT token value (only shown on creation)
+
+    # ─── LLM Keys ──────────────────────────────────────────────────────────────
+
+    LLMKeyCreateRequest:
+      type: object
+      required: [name, key]
+      properties:
+        name:
+          type: string
+          enum: [Anthropic, OpenAI, OpenRouter, Custom]
+          description: LLM provider name
+        key:
+          type: string
+          description: API key value
+        model:
+          type: string
+          description: Default model to use with this key
+        url:
+          type: string
+          format: uri
+          description: Required for Custom provider; auto-populated for others
+        custom_headers:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+          description: Optional custom headers (string key-value pairs)
+
+    LLMKeyUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          enum: [Anthropic, OpenAI, OpenRouter, Custom]
+        key:
+          type: string
+        model:
+          type: string
+        url:
+          type: string
+          format: uri
+        custom_headers:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+
+    LLMKey:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        key:
+          type: string
+          description: Masked key value
+        url:
+          type: string
+        model:
+          type: string
+          nullable: true
+        custom_headers:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+        organization_id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    LLMKeyStatus:
+      type: object
+      properties:
+        hasKeys:
+          type: boolean
+        keyCount:
+          type: integer
+        providers:
+          type: array
+          items:
+            type: string
+
+    # ─── User Preferences ───────────────────────────────────────────────────────
+
+    UserPreferenceCreateRequest:
+      type: object
+      required: [user_id, date_format]
+      properties:
+        user_id:
+          type: integer
+          minimum: 1
+        date_format:
+          type: string
+          description: "Preferred date format (e.g., YYYY-MM-DD, DD/MM/YYYY)"
+
+    UserPreferenceUpdateRequest:
+      type: object
+      properties:
+        date_format:
+          type: string
+
+    UserPreference:
+      type: object
+      properties:
+        id:
+          type: integer
+        user_id:
+          type: integer
+        date_format:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    FileUploadResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        filename:
+          type: string
+        size:
+          type: integer
+        mimetype:
+          type: string
+        upload_date:
+          type: string
+          format: date-time
+        uploaded_by:
+          type: integer
+        modelId:
+          type: integer
+          nullable: true
+        review_status:
+          type: string
+          enum: [draft, pending_review]
+        approval_workflow_id:
+          type: integer
+          nullable: true
+        approval_request_id:
+          type: integer
+          nullable: true
+
+    FileListResponse:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/FileListItem'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    FileListItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        filename:
+          type: string
+        size:
+          type: integer
+        formattedSize:
+          type: string
+        mimetype:
+          type: string
+        upload_date:
+          type: string
+          format: date-time
+        uploaded_by:
+          type: integer
+        uploader_name:
+          type: string
+        uploader_surname:
+          type: string
+        review_status:
+          type: string
+        approval_workflow_id:
+          type: integer
+          nullable: true
+
+    FileSearchResponse:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              filename:
+                type: string
+              snippet:
+                type: string
+                description: Highlighted text snippet matching the query
+              rank:
+                type: number
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    FileMetadata:
+      type: object
+      properties:
+        id:
+          type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        review_status:
+          type: string
+          enum: [draft, pending_review, approved, rejected, expired]
+        version:
+          type: string
+        expiry_date:
+          type: string
+          format: date-time
+          nullable: true
+        description:
+          type: string
+          nullable: true
+
+    UpdateFileMetadataRequest:
+      type: object
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+          maxItems: 50
+          description: Each tag max 100 chars, alphanumeric/spaces/hyphens/underscores only
+        review_status:
+          type: string
+          enum: [draft, pending_review, approved, rejected, expired]
+        version:
+          type: string
+        expiry_date:
+          type: string
+          format: date-time
+        description:
+          type: string
+
+    HighlightedFiles:
+      type: object
+      properties:
+        due_for_update:
+          type: array
+          items:
+            type: integer
+        pending_approval:
+          type: array
+          items:
+            type: integer
+        recently_modified:
+          type: array
+          items:
+            type: integer
+
+    VirtualFolder:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        parent_id:
+          type: integer
+          nullable: true
+        color:
+          type: string
+          nullable: true
+        icon:
+          type: string
+          nullable: true
+        is_system:
+          type: boolean
+        file_count:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateFolderRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        parent_id:
+          type: integer
+          nullable: true
+          description: Parent folder ID (null for root)
+        color:
+          type: string
+          description: Hex color code
+        icon:
+          type: string
+          description: Icon identifier
+
+    UpdateFolderRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        parent_id:
+          type: integer
+          nullable: true
+          description: New parent (null to move to root). Cannot create circular refs.
+        color:
+          type: string
+        icon:
+          type: string
+
+    AssignFilesRequest:
+      type: object
+      required: [file_ids]
+      properties:
+        file_ids:
+          type: array
+          items:
+            type: integer
+          minItems: 1
+
+    # ─── Plugin Schemas ─────────────────────────────────────────────────────
+
+    Plugin:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        version:
+          type: string
+        author:
+          type: string
+        icon_url:
+          type: string
+        documentation_url:
+          type: string
+
+    PluginInstallation:
+      type: object
+      properties:
+        id:
+          type: integer
+        plugin_key:
+          type: string
+        organization_id:
+          type: integer
+        installed_by:
+          type: integer
+        installed_at:
+          type: string
+          format: date-time
+        configuration:
+          type: object
+          additionalProperties: true
+        status:
+          type: string
+
+    ConnectionTestResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        details:
+          type: object
+
+    # ─── Shadow AI Schemas ──────────────────────────────────────────────────
+
+    ShadowAiToolStatus:
+      type: string
+      enum: [detected, under_review, approved, restricted, blocked, dismissed]
+
+    ApiKeyCreateResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        key:
+          type: string
+          description: Full API key (shown only on creation)
+        key_prefix:
+          type: string
+        label:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    ApiKeyRecord:
+      type: object
+      properties:
+        id:
+          type: integer
+        key_prefix:
+          type: string
+        label:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        revoked_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    InsightsSummary:
+      type: object
+      properties:
+        total_events:
+          type: integer
+        total_users:
+          type: integer
+        total_tools:
+          type: integer
+        total_departments:
+          type: integer
+
+    UserDetail:
+      type: object
+      properties:
+        email:
+          type: string
+        department:
+          type: string
+        tools:
+          type: array
+          items:
+            type: object
+            properties:
+              tool_name:
+                type: string
+              event_count:
+                type: integer
+        total_prompts:
+          type: integer
+
+    ShadowAiToolDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        domain:
+          type: string
+        status:
+          $ref: '#/components/schemas/ShadowAiToolStatus'
+        first_seen:
+          type: string
+          format: date-time
+        last_seen:
+          type: string
+          format: date-time
+        event_count:
+          type: integer
+        user_count:
+          type: integer
+        departments:
+          type: array
+          items:
+            type: object
+            properties:
+              department:
+                type: string
+              user_count:
+                type: integer
+        top_users:
+          type: array
+          items:
+            type: object
+            properties:
+              email:
+                type: string
+              event_count:
+                type: integer
+
+    StartGovernanceRequest:
+      type: object
+      required: [model_inventory, governance_owner_id]
+      properties:
+        model_inventory:
+          type: object
+          required: [provider, model]
+          properties:
+            provider:
+              type: string
+            model:
+              type: string
+            version:
+              type: string
+            status:
+              type: string
+              enum: [Approved, Restricted, Pending, Blocked]
+        governance_owner_id:
+          type: integer
+          minimum: 1
+        start_lifecycle:
+          type: boolean
+          default: false
+
+    StartGovernanceResponse:
+      type: object
+      properties:
+        model_inventory_id:
+          type: integer
+        tool_id:
+          type: integer
+        lifecycle_initialized:
+          type: boolean
+
+    ShadowAiRule:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+        trigger_type:
+          type: string
+        trigger_config:
+          type: object
+        actions:
+          type: array
+          items:
+            type: object
+        cooldown_minutes:
+          type: integer
+          nullable: true
+        notification_user_ids:
+          type: array
+          items:
+            type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    CreateRuleRequest:
+      type: object
+      required: [name, trigger_type, actions]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        is_active:
+          type: boolean
+          default: true
+        trigger_type:
+          type: string
+        trigger_config:
+          type: object
+          default: {}
+        actions:
+          type: array
+          items:
+            type: object
+        cooldown_minutes:
+          type: integer
+        notification_user_ids:
+          type: array
+          items:
+            type: integer
+
+    UpdateRuleRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        is_active:
+          type: boolean
+        trigger_type:
+          type: string
+        trigger_config:
+          type: object
+        actions:
+          type: array
+          items:
+            type: object
+        cooldown_minutes:
+          type: integer
+        notification_user_ids:
+          type: array
+          items:
+            type: integer
+
+    SyslogConfig:
+      type: object
+      properties:
+        id:
+          type: integer
+        source_identifier:
+          type: string
+        parser_type:
+          type: string
+          enum: [zscaler, netskope, squid, generic_kv]
+        is_active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    CreateSyslogConfigRequest:
+      type: object
+      required: [source_identifier, parser_type]
+      properties:
+        source_identifier:
+          type: string
+        parser_type:
+          type: string
+          enum: [zscaler, netskope, squid, generic_kv]
+        is_active:
+          type: boolean
+          default: true
+
+    UpdateSyslogConfigRequest:
+      type: object
+      properties:
+        source_identifier:
+          type: string
+        parser_type:
+          type: string
+          enum: [zscaler, netskope, squid, generic_kv]
+        is_active:
+          type: boolean
+
+    ShadowAiSettings:
+      type: object
+      properties:
+        rate_limit_max_events_per_hour:
+          type: integer
+        retention_events_days:
+          type: integer
+        retention_daily_rollups_days:
+          type: integer
+        retention_alert_history_days:
+          type: integer
+
+    UpdateSettingsRequest:
+      type: object
+      properties:
+        rate_limit_max_events_per_hour:
+          type: integer
+        retention_events_days:
+          type: integer
+        retention_daily_rollups_days:
+          type: integer
+        retention_alert_history_days:
+          type: integer
+
+    # ─── Post-Market Monitoring Schemas ─────────────────────────────────────
+
+    PMMConfig:
+      type: object
+      properties:
+        id:
+          type: integer
+        project_id:
+          type: integer
+        frequency:
+          type: string
+          description: Monitoring frequency (e.g., "monthly", "quarterly")
+        stakeholder_id:
+          type: integer
+          nullable: true
+        is_active:
+          type: boolean
+        questions_count:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    PMMConfigCreateRequest:
+      type: object
+      required: [project_id]
+      properties:
+        project_id:
+          type: integer
+        frequency:
+          type: string
+        stakeholder_id:
+          type: integer
+        is_active:
+          type: boolean
+          default: true
+
+    PMMConfigUpdateRequest:
+      type: object
+      properties:
+        frequency:
+          type: string
+        stakeholder_id:
+          type: integer
+        is_active:
+          type: boolean
+
+    PMMQuestion:
+      type: object
+      properties:
+        id:
+          type: integer
+        config_id:
+          type: integer
+          nullable: true
+        question_text:
+          type: string
+        question_type:
+          type: string
+          enum: [yes_no, multi_select, multi_line_text]
+        options:
+          type: array
+          items:
+            type: string
+          nullable: true
+        is_required:
+          type: boolean
+        is_default:
+          type: boolean
+        display_order:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+
+    PMMQuestionCreate:
+      type: object
+      required: [question_text, question_type]
+      properties:
+        config_id:
+          type: integer
+          nullable: true
+        question_text:
+          type: string
+        question_type:
+          type: string
+          enum: [yes_no, multi_select, multi_line_text]
+        options:
+          type: array
+          items:
+            type: string
+        is_required:
+          type: boolean
+          default: false
+        display_order:
+          type: integer
+
+    PMMQuestionUpdate:
+      type: object
+      properties:
+        question_text:
+          type: string
+        question_type:
+          type: string
+          enum: [yes_no, multi_select, multi_line_text]
+        options:
+          type: array
+          items:
+            type: string
+        is_required:
+          type: boolean
+        display_order:
+          type: integer
+
+    PMMCycle:
+      type: object
+      properties:
+        id:
+          type: integer
+        config_id:
+          type: integer
+        project_id:
+          type: integer
+        project_title:
+          type: string
+        cycle_number:
+          type: integer
+        status:
+          type: string
+          enum: [active, completed]
+        assigned_stakeholder_id:
+          type: integer
+          nullable: true
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    PMMResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+        cycle_id:
+          type: integer
+        question_id:
+          type: integer
+        response_value:
+          type: string
+        is_flagged:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    PMMSaveResponsesRequest:
+      type: object
+      required: [responses]
+      properties:
+        responses:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required: [question_id, response_value]
+            properties:
+              question_id:
+                type: integer
+              response_value:
+                type: string
+              is_flagged:
+                type: boolean
+                default: false
+
+    PMMSubmitCycleResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        report_generated:
+          type: boolean
+        report_filename:
+          type: string
+          nullable: true
+
+    PMMReportsResponse:
+      type: object
+      properties:
+        reports:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              cycle_id:
+                type: integer
+              file_id:
+                type: integer
+                nullable: true
+              completed_by:
+                type: integer
+              created_at:
+                type: string
+                format: date-time
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+
+    # ===== Tasks schemas =====
+    TaskPriority:
+      type: string
+      enum: [Low, Medium, High]
+      description: Task priority level.
+    TaskStatus:
+      type: string
+      enum: [Open, In Progress, Completed, Overdue, Deleted]
+      description: Task lifecycle status. "Deleted" represents a soft-deleted (archived) task.
+    EntityType:
+      type: string
+      enum:
+        - vendor
+        - model
+        - policy
+        - nist_subcategory
+        - iso42001_subclause
+        - iso42001_annexcategory
+        - iso27001_subclause
+        - iso27001_annexcontrol
+        - eu_control
+        - eu_subcontrol
+      description: Type of entity that can be linked to a task.
+    CreateTaskRequest:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+          example: Review vendor risk assessment
+        description:
+          type: string
+          nullable: true
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
+          example: "2026-05-15T00:00:00.000Z"
+        priority:
+          $ref: "#/components/schemas/TaskPriority"
+        status:
+          $ref: "#/components/schemas/TaskStatus"
+        categories:
+          type: array
+          items:
+            type: string
+          example: ["compliance", "vendor"]
+        assignees:
+          type: array
+          items:
+            oneOf:
+              - type: integer
+              - type: object
+                properties:
+                  user_id:
+                    type: integer
+                required:
+                  - user_id
+          example: [1, 2, 3]
+        entity_links:
+          type: array
+          items:
+            type: object
+            properties:
+              entity_id:
+                type: integer
+              entity_type:
+                $ref: "#/components/schemas/EntityType"
+              entity_name:
+                type: string
+    UpdateTaskRequest:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+          nullable: true
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
+        priority:
+          $ref: "#/components/schemas/TaskPriority"
+        status:
+          $ref: "#/components/schemas/TaskStatus"
+        categories:
+          type: array
+          items:
+            type: string
+        assignees:
+          type: array
+          items:
+            type: integer
+        entity_links:
+          type: array
+          items:
+            type: object
+            properties:
+              entity_id:
+                type: integer
+              entity_type:
+                $ref: "#/components/schemas/EntityType"
+              entity_name:
+                type: string
+    AddEntityLinkRequest:
+      type: object
+      required:
+        - entity_id
+        - entity_type
+      properties:
+        entity_id:
+          type: integer
+          example: 42
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        entity_name:
+          type: string
+          example: Acme Corp
+    Task:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        title:
+          type: string
+          example: Review vendor risk assessment
+        description:
+          type: string
+          nullable: true
+        creator_id:
+          type: integer
+        organization_id:
+          type: integer
+        due_date:
+          type: string
+          format: date-time
+          nullable: true
+        priority:
+          $ref: "#/components/schemas/TaskPriority"
+        status:
+          $ref: "#/components/schemas/TaskStatus"
+        categories:
+          type: array
+          items:
+            type: string
+        is_demo:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    TaskWithAssignees:
+      allOf:
+        - $ref: "#/components/schemas/Task"
+        - type: object
+          properties:
+            assignees:
+              type: array
+              items:
+                type: integer
+    TaskWithRelations:
+      allOf:
+        - $ref: "#/components/schemas/Task"
+        - type: object
+          properties:
+            assignees:
+              type: array
+              items:
+                type: integer
+            entity_links:
+              type: array
+              items:
+                $ref: "#/components/schemas/EntityLinkSummary"
+    TaskDetail:
+      allOf:
+        - $ref: "#/components/schemas/Task"
+        - type: object
+          properties:
+            assignees:
+              type: array
+              items:
+                type: integer
+            creator_name:
+              type: string
+              example: Jane Smith
+            assignee_names:
+              type: array
+              items:
+                type: string
+              example: ["John Doe", "Alice Johnson"]
+            entity_links:
+              type: array
+              items:
+                $ref: "#/components/schemas/EntityLinkSummary"
+    EntityLinkSummary:
+      type: object
+      properties:
+        id:
+          type: integer
+        entity_id:
+          type: integer
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        entity_name:
+          type: string
+    TaskEntityLink:
+      type: object
+      properties:
+        id:
+          type: integer
+        task_id:
+          type: integer
+        entity_id:
+          type: integer
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        entity_name:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    # ===== Training schemas =====
+    EnvelopeBase:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
+    EnvelopeEmpty:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: No Content
+            data:
+              type: array
+              items: {}
+              example: []
+    EnvelopeNotFound:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: Not Found
+            data:
+              nullable: true
+              example: null
+    EnvelopeBadRequest:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: Bad Request
+            data:
+              type: string
+              example: Invalid training ID
+    EnvelopeError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Internal Server Error
+        error:
+          type: string
+      required:
+        - message
+        - error
+    Training:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 42
+        training_name:
+          type: string
+          example: AI Governance Fundamentals
+        duration:
+          type: string
+          example: 2 hours
+        provider:
+          type: string
+          example: Internal
+        department:
+          type: string
+          example: Compliance
+        status:
+          type: string
+          enum: [Planned, In Progress, Completed]
+          example: Planned
+        numberOfPeople:
+          type: integer
+          example: 25
+        description:
+          type: string
+          example: Introductory course on EU AI Act compliance
+        progressPercentage:
+          type: integer
+          enum: [0, 50, 100]
+          example: 0
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - training_name
+        - duration
+        - provider
+        - department
+        - status
+        - numberOfPeople
+        - description
+        - progressPercentage
+    TrainingCreateRequest:
+      type: object
+      required:
+        - training_name
+        - duration
+        - provider
+        - department
+        - status
+        - numberOfPeople
+      properties:
+        training_name:
+          type: string
+          example: AI Governance Fundamentals
+        duration:
+          type: string
+          example: 2 hours
+        provider:
+          type: string
+          example: Internal
+        department:
+          type: string
+          example: Compliance
+        status:
+          type: string
+          enum: [Planned, In Progress, Completed]
+          example: Planned
+        numberOfPeople:
+          type: integer
+          example: 25
+        description:
+          type: string
+          example: Introductory course on EU AI Act compliance
+        is_demo:
+          type: boolean
+          default: false
+    TrainingUpdateRequest:
+      type: object
+      properties:
+        training_name:
+          type: string
+          example: Advanced AI Risk Management
+        duration:
+          type: string
+          example: 3 days
+        provider:
+          type: string
+          example: External
+        department:
+          type: string
+          example: Engineering
+        status:
+          type: string
+          enum: [Planned, In Progress, Completed]
+          example: In Progress
+        numberOfPeople:
+          type: integer
+          example: 30
+        description:
+          type: string
+          example: Updated scope to cover ISO 42001
+    TrainingListResponse:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: OK
+            data:
+              type: array
+              items:
+                $ref: "#/components/schemas/Training"
+    TrainingSingleResponse:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: OK
+            data:
+              $ref: "#/components/schemas/Training"
+    ChangeHistoryEntry:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 101
+        entity_type:
+          type: string
+          example: training
+        entity_id:
+          type: integer
+          example: 42
+        field_name:
+          type: string
+          example: status
+        old_value:
+          type: string
+          nullable: true
+          example: Planned
+        new_value:
+          type: string
+          nullable: true
+          example: In Progress
+        change_type:
+          type: string
+          enum: [created, updated, deleted]
+          example: updated
+        changed_by:
+          type: integer
+          example: 5
+        user_name:
+          type: string
+          example: Gorkem
+        user_surname:
+          type: string
+          example: Cetin
+        organization_id:
+          type: integer
+          example: 1
+        created_at:
+          type: string
+          format: date-time
+    ChangeHistoryData:
+      type: object
+      required:
+        - data
+        - hasMore
+        - total
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChangeHistoryEntry"
+        hasMore:
+          type: boolean
+          example: false
+        total:
+          type: integer
+          example: 5
+    ChangeHistoryResponse:
+      allOf:
+        - $ref: "#/components/schemas/EnvelopeBase"
+        - type: object
+          properties:
+            message:
+              example: OK
+            data:
+              $ref: "#/components/schemas/ChangeHistoryData"
+
+    # ===== Organizations schemas =====
+    CreateOrganizationRequest:
+      type: object
+      required:
+        - name
+        - userEmail
+        - userName
+        - userSurname
+        - userPassword
+      properties:
+        name:
+          type: string
+          example: Acme Corp
+        logo:
+          type: string
+          format: uri
+          nullable: true
+          example: https://example.com/logo.png
+        userEmail:
+          type: string
+          format: email
+          example: admin@acme.com
+        userName:
+          type: string
+          example: John
+        userSurname:
+          type: string
+          example: Doe
+        userPassword:
+          type: string
+          format: password
+          example: SecurePassword123!
+    UpdateOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          example: Acme Corporation
+        logo:
+          type: string
+          format: uri
+          nullable: true
+          example: https://example.com/new-logo.png
+    Organization:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Acme Corp
+        logo:
+          type: string
+          nullable: true
+          example: https://example.com/logo.png
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        onboarding_status:
+          type: string
+          enum: [pending, completed]
+          example: pending
+        tenant_id:
+          type: string
+          nullable: true
+          example: a1b2c3d4e5
+        risk_assessment_mode:
+          type: string
+          enum: [qualitative, quantitative]
+          example: qualitative
+        ageInDays:
+          type: integer
+          example: 45
+    OrganizationExistsResult:
+      type: object
+      properties:
+        exists:
+          type: boolean
+          example: true
+    CreateOrganizationResponse:
+      type: object
+      properties:
+        user:
+          $ref: "#/components/schemas/SafeUser"
+        organization:
+          type: object
+          properties:
+            id:
+              type: integer
+              example: 1
+            name:
+              type: string
+              example: Acme Corp
+        token:
+          type: string
+          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    SafeUser:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        email:
+          type: string
+          format: email
+          example: admin@acme.com
+        name:
+          type: string
+          example: John
+        surname:
+          type: string
+          example: Doe
+        role_id:
+          type: integer
+          example: 1
+        organization_id:
+          type: integer
+          example: 1
+    OnboardingStatusResponse:
+      type: object
+      properties:
+        onboarding_status:
+          type: string
+          enum: [completed]
+          example: completed
+
+    # ===== Notifications schemas =====
+    NotificationType:
+      type: string
+      enum:
+        - task_assigned
+        - task_updated
+        - task_completed
+        - review_requested
+        - review_approved
+        - review_rejected
+        - approval_requested
+        - approval_approved
+        - approval_rejected
+        - approval_complete
+        - policy_due_soon
+        - policy_overdue
+        - training_assigned
+        - training_completed
+        - vendor_review_due
+        - file_uploaded
+        - comment_added
+        - mention
+        - shadow_ai_alert
+        - ai_gateway_budget_warning
+        - ai_gateway_budget_exhausted
+        - ai_gateway_guardrail_spike
+        - ai_gateway_config_change
+        - ai_gateway_virtual_key_budget_exhausted
+        - system
+        - assignment_owner
+        - assignment_reviewer
+        - assignment_approver
+        - assignment_member
+        - assignment_assignee
+        - assignment_action_owner
+    NotificationEntityType:
+      type: string
+      enum:
+        - project
+        - task
+        - policy
+        - vendor
+        - model
+        - training
+        - file
+        - use_case
+        - risk
+        - assessment
+        - comment
+        - user
+        - shadow_ai_tool
+        - ai_gateway
+    NotificationJSON:
+      type: object
+      required:
+        - id
+        - user_id
+        - type
+        - title
+        - message
+        - is_read
+        - created_at
+      properties:
+        id:
+          type: integer
+          example: 42
+        user_id:
+          type: integer
+          example: 7
+        type:
+          $ref: "#/components/schemas/NotificationType"
+        title:
+          type: string
+          example: "Task assigned to you"
+        message:
+          type: string
+          example: "You have been assigned to task 'Review vendor contract'."
+        entity_type:
+          allOf:
+            - $ref: "#/components/schemas/NotificationEntityType"
+          nullable: true
+        entity_id:
+          type: integer
+          nullable: true
+          example: 15
+        entity_name:
+          type: string
+          nullable: true
+          example: "Review vendor contract"
+        action_url:
+          type: string
+          nullable: true
+          example: "/projects/3/tasks/15"
+        is_read:
+          type: boolean
+          example: false
+        read_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          example: "2026-04-20T10:00:00.000Z"
+        created_by:
+          type: integer
+          nullable: true
+          example: 3
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties: true
+    NotificationSummary:
+      type: object
+      required:
+        - unread_count
+        - total_count
+        - recent_notifications
+      properties:
+        unread_count:
+          type: integer
+          example: 3
+        total_count:
+          type: integer
+          example: 47
+        recent_notifications:
+          type: array
+          maxItems: 10
+          items:
+            $ref: "#/components/schemas/NotificationJSON"
+    RealtimeNotification:
+      type: object
+      required:
+        - type
+        - data
+      properties:
+        type:
+          type: string
+          enum: [notification]
+        data:
+          $ref: "#/components/schemas/NotificationJSON"
+
+    # ===== FRIA schemas =====
+    ApiEnvelope:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 200
+        data:
+          description: Response payload (varies per endpoint)
+    FriaErrorEnvelope:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 400
+        data:
+          type: string
+          example: "Invalid project ID"
+    DeletedResponse:
+      type: object
+      properties:
+        deleted:
+          type: boolean
+          example: true
+    FriaStatus:
+      type: string
+      enum: [draft, submitted, approved, rejected]
+    FriaRiskLevel:
+      type: string
+      enum: [Low, Medium, High]
+    FriaLikelihood:
+      type: string
+      enum: [Low, Medium, High]
+    FriaSeverity:
+      type: string
+      enum: [Low, Medium, High]
+    FriaAssessment:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        project_id:
+          type: integer
+        version:
+          type: integer
+        status:
+          $ref: "#/components/schemas/FriaStatus"
+        assessment_owner:
+          type: string
+          nullable: true
+        assessment_date:
+          type: string
+          nullable: true
+        operational_context:
+          type: string
+          nullable: true
+        is_high_risk:
+          type: string
+          nullable: true
+        high_risk_basis:
+          type: string
+          nullable: true
+        deployer_type:
+          type: string
+          nullable: true
+        annex_iii_category:
+          type: string
+          nullable: true
+        first_use_date:
+          type: string
+          nullable: true
+        review_cycle:
+          type: string
+          nullable: true
+        period_frequency:
+          type: string
+          nullable: true
+        fria_rationale:
+          type: string
+          nullable: true
+        affected_groups:
+          type: string
+          nullable: true
+        vulnerability_context:
+          type: string
+          nullable: true
+        group_flags:
+          type: array
+          items:
+            type: string
+          nullable: true
+        risk_scenarios:
+          type: string
+          nullable: true
+        provider_info_used:
+          type: string
+          nullable: true
+        human_oversight:
+          type: string
+          nullable: true
+        transparency_measures:
+          type: string
+          nullable: true
+        redress_process:
+          type: string
+          nullable: true
+        data_governance:
+          type: string
+          nullable: true
+        legal_review:
+          type: string
+          nullable: true
+        dpo_review:
+          type: string
+          nullable: true
+        owner_approval:
+          type: string
+          nullable: true
+        stakeholders_consulted:
+          type: string
+          nullable: true
+        consultation_notes:
+          type: string
+          nullable: true
+        deployment_decision:
+          type: string
+          nullable: true
+        decision_conditions:
+          type: string
+          nullable: true
+        completion_pct:
+          type: integer
+        risk_score:
+          type: integer
+        risk_level:
+          $ref: "#/components/schemas/FriaRiskLevel"
+        rights_flagged:
+          type: integer
+        created_by:
+          type: integer
+        updated_by:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        project_title:
+          type: string
+          nullable: true
+        organization_name:
+          type: string
+          nullable: true
+        created_by_name:
+          type: string
+          nullable: true
+        updated_by_name:
+          type: string
+          nullable: true
+    FriaUpdateRequest:
+      type: object
+      properties:
+        status:
+          $ref: "#/components/schemas/FriaStatus"
+        assessment_owner:
+          type: string
+        assessment_date:
+          type: string
+        operational_context:
+          type: string
+        is_high_risk:
+          type: string
+        high_risk_basis:
+          type: string
+        deployer_type:
+          type: string
+        annex_iii_category:
+          type: string
+        first_use_date:
+          type: string
+        review_cycle:
+          type: string
+        period_frequency:
+          type: string
+        fria_rationale:
+          type: string
+        affected_groups:
+          type: string
+        vulnerability_context:
+          type: string
+        group_flags:
+          type: array
+          items:
+            type: string
+        risk_scenarios:
+          type: string
+        provider_info_used:
+          type: string
+        human_oversight:
+          type: string
+        transparency_measures:
+          type: string
+        redress_process:
+          type: string
+        data_governance:
+          type: string
+        legal_review:
+          type: string
+        dpo_review:
+          type: string
+        owner_approval:
+          type: string
+        stakeholders_consulted:
+          type: string
+        consultation_notes:
+          type: string
+        deployment_decision:
+          type: string
+        decision_conditions:
+          type: string
+    FriaFullResponse:
+      type: object
+      properties:
+        assessment:
+          $ref: "#/components/schemas/FriaAssessment"
+        rights:
+          type: array
+          items:
+            $ref: "#/components/schemas/FriaRight"
+        riskItems:
+          type: array
+          items:
+            $ref: "#/components/schemas/FriaRiskItem"
+        modelLinks:
+          type: array
+          items:
+            $ref: "#/components/schemas/FriaModelLink"
+    FriaRight:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        fria_id:
+          type: integer
+        right_key:
+          type: string
+        right_title:
+          type: string
+        charter_ref:
+          type: string
+        flagged:
+          type: boolean
+        severity:
+          type: integer
+        confidence:
+          type: integer
+        impact_pathway:
+          type: string
+          nullable: true
+        mitigation:
+          type: string
+          nullable: true
+    FriaRightsUpdateRequest:
+      type: object
+      required:
+        - rights
+      properties:
+        rights:
+          type: array
+          items:
+            type: object
+            required:
+              - right_key
+            properties:
+              right_key:
+                type: string
+              flagged:
+                type: boolean
+              severity:
+                type: integer
+              confidence:
+                type: integer
+              impact_pathway:
+                type: string
+              mitigation:
+                type: string
+    FriaRiskItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        fria_id:
+          type: integer
+        risk_description:
+          type: string
+        likelihood:
+          $ref: "#/components/schemas/FriaLikelihood"
+        severity:
+          $ref: "#/components/schemas/FriaSeverity"
+        existing_controls:
+          type: string
+          nullable: true
+        further_action:
+          type: string
+          nullable: true
+        linked_project_risk_id:
+          type: integer
+          nullable: true
+        sort_order:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        linked_risk_name:
+          type: string
+          nullable: true
+        linked_risk_description:
+          type: string
+          nullable: true
+    FriaRiskItemCreateRequest:
+      type: object
+      required:
+        - risk_description
+      properties:
+        risk_description:
+          type: string
+        likelihood:
+          $ref: "#/components/schemas/FriaLikelihood"
+        severity:
+          $ref: "#/components/schemas/FriaSeverity"
+        existing_controls:
+          type: string
+        further_action:
+          type: string
+        linked_project_risk_id:
+          type: integer
+        sort_order:
+          type: integer
+    FriaRiskItemUpdateRequest:
+      type: object
+      properties:
+        risk_description:
+          type: string
+        likelihood:
+          $ref: "#/components/schemas/FriaLikelihood"
+        severity:
+          $ref: "#/components/schemas/FriaSeverity"
+        existing_controls:
+          type: string
+        further_action:
+          type: string
+        linked_project_risk_id:
+          type: integer
+        sort_order:
+          type: integer
+    FriaModelLink:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        fria_id:
+          type: integer
+        model_id:
+          type: integer
+        provider:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        version:
+          type: string
+          nullable: true
+        model_status:
+          type: string
+          nullable: true
+    FriaEvidenceLinkRequest:
+      type: object
+      required:
+        - file_id
+        - entity_type
+      properties:
+        file_id:
+          type: integer
+        entity_type:
+          type: string
+    FriaSnapshot:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        fria_id:
+          type: integer
+        version:
+          type: integer
+        snapshot_data:
+          type: object
+          properties:
+            assessment:
+              $ref: "#/components/schemas/FriaAssessment"
+            rights:
+              type: array
+              items:
+                $ref: "#/components/schemas/FriaRight"
+            riskItems:
+              type: array
+              items:
+                $ref: "#/components/schemas/FriaRiskItem"
+            modelLinks:
+              type: array
+              items:
+                $ref: "#/components/schemas/FriaModelLink"
+        snapshot_reason:
+          type: string
+          nullable: true
+        created_by:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        created_by_name:
+          type: string
+          nullable: true
+    FriaSubmitRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+
+    # ===== Integrations schemas =====
+    StandardResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        data:
+          description: Response payload (present on 1xx-4xx)
+        error:
+          type: string
+    ErrorResponse400:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Bad Request"
+        data:
+          type: string
+          example: "userId query parameter is required"
+    ErrorResponse401:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Unauthorized"
+        data:
+          type: string
+    ErrorResponse403:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Forbidden"
+        data:
+          type: string
+    ErrorResponse404:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Not Found"
+        data:
+          type: string
+    ErrorResponse500:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Internal Server Error"
+        error:
+          type: string
+    SlackNotificationRoutingType:
+      type: string
+      enum:
+        - "Membership and roles"
+        - "Projects and organizations"
+        - "Policy reminders and status"
+        - "Evidence and task alerts"
+        - "Control or policy changes"
+    SlackWebhookFull:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        access_token:
+          type: string
+        access_token_iv:
+          type: string
+        scope:
+          type: string
+          example: "incoming-webhook,chat:write"
+        user_id:
+          type: integer
+          example: 5
+        team_name:
+          type: string
+          example: "Acme Corp"
+        team_id:
+          type: string
+          example: "T01234ABC"
+        channel:
+          type: string
+          example: "#general"
+        channel_id:
+          type: string
+          example: "C01234ABC"
+        configuration_url:
+          type: string
+          format: uri
+        url:
+          type: string
+        url_iv:
+          type: string
+        is_active:
+          type: boolean
+          example: true
+        routing_type:
+          type: array
+          items:
+            $ref: "#/components/schemas/SlackNotificationRoutingType"
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    SlackWebhookJSON:
+      type: object
+      properties:
+        id:
+          type: integer
+        scope:
+          type: string
+        user_id:
+          type: integer
+        team_name:
+          type: string
+        team_id:
+          type: string
+        channel:
+          type: string
+        channel_id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        is_active:
+          type: boolean
+        routing_type:
+          type: array
+          items:
+            $ref: "#/components/schemas/SlackNotificationRoutingType"
+          nullable: true
+    CreateSlackWebhookRequest:
+      type: object
+      required:
+        - code
+        - userId
+      properties:
+        code:
+          type: string
+          example: "1234567890.abcdef"
+        userId:
+          type: integer
+          example: 5
+    UpdateSlackWebhookRequest:
+      type: object
+      properties:
+        is_active:
+          type: boolean
+          example: false
+        routing_type:
+          type: array
+          items:
+            $ref: "#/components/schemas/SlackNotificationRoutingType"
+    SendSlackMessageRequest:
+      type: object
+      required:
+        - title
+        - message
+      properties:
+        title:
+          type: string
+          example: "New policy update"
+        message:
+          type: string
+          example: "Policy *Data Retention* has been updated."
+    SlackMessageSentResult:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        messageId:
+          type: string
+          example: "1234567890.123456"
+        channel:
+          type: string
+          example: "C01234ABC"
+    GitHubTokenStatus:
+      type: object
+      properties:
+        configured:
+          type: boolean
+          example: true
+        token_name:
+          type: string
+          example: "GitHub Personal Access Token"
+        last_used_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+    SaveGitHubTokenRequest:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          example: "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        token_name:
+          type: string
+          default: "GitHub Personal Access Token"
+          example: "CI/CD Scanner Token"
+    TestGitHubTokenRequest:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          example: "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    GitHubTokenTestResult:
+      type: object
+      properties:
+        valid:
+          type: boolean
+          example: true
+        scopes:
+          type: array
+          items:
+            type: string
+          example: ["repo", "read:org"]
+        rate_limit:
+          type: object
+          properties:
+            limit:
+              type: integer
+              example: 5000
+            remaining:
+              type: integer
+              example: 4999
+            reset:
+              type: string
+              format: date-time
+        error:
+          type: string
+          example: "Invalid or expired token"
+    GitHubWebhookPayload:
+      type: object
+      required:
+        - repository
+      properties:
+        repository:
+          type: object
+          required:
+            - owner
+            - name
+          properties:
+            owner:
+              type: object
+              required:
+                - login
+              properties:
+                login:
+                  type: string
+                  example: "verifywise-ai"
+            name:
+              type: string
+              example: "verifywise"
+        ref:
+          type: string
+          example: "refs/heads/main"
+        action:
+          type: string
+          example: "opened"
+        pull_request:
+          type: object
+    GitHubWebhookResult:
+      type: object
+      properties:
+        triggered:
+          type: boolean
+        reason:
+          type: string
+          example: "Scan triggered for push to main"
+    GitHubWebhookPong:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "pong"
+    GitHubWebhookSkipped:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Repository not registered or CI not enabled"
+    SuccessResponse_SlackWebhookArray:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/SlackWebhookFull"
+    SuccessResponse_SlackWebhookJSON:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          $ref: "#/components/schemas/SlackWebhookJSON"
+    CreatedResponse_SlackWebhookFull:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Created"
+        data:
+          $ref: "#/components/schemas/SlackWebhookFull"
+    AcceptedResponse_SlackWebhookFull:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Accepted"
+        data:
+          $ref: "#/components/schemas/SlackWebhookFull"
+    SuccessResponse_SlackMessageSent:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          $ref: "#/components/schemas/SlackMessageSentResult"
+    SuccessResponse_GitHubTokenStatus:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          $ref: "#/components/schemas/GitHubTokenStatus"
+    CreatedResponse_GitHubTokenStatus:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Created"
+        data:
+          $ref: "#/components/schemas/GitHubTokenStatus"
+    SuccessResponse_GitHubTokenDeleted:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          type: object
+          properties:
+            message:
+              type: string
+              example: "GitHub token deleted successfully"
+    SuccessResponse_GitHubTokenTest:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "OK"
+        data:
+          $ref: "#/components/schemas/GitHubTokenTestResult"
 
 tags:
   - name: AI Advisor
@@ -3201,8 +10611,8 @@ paths:
     post:
       tags:
         - Files
-      summary: Handle Multer Error
-      operationId: file_manager_handleMulterError
+      summary: Upload File
+      operationId: uploadFile
       security:
         - bearerAuth: []
       description: "Requires role: Admin or Reviewer or Editor"
@@ -3451,39 +10861,6 @@ paths:
           description: Unauthorized
         "500":
           description: Internal server error
-    get:
-      tags:
-        - Files
-      summary: Get All Folders
-      operationId: getAllFolders
-      security:
-        - bearerAuth: []
-      responses:
-        "200":
-          description: Success
-        "401":
-          description: Unauthorized
-        "500":
-          description: Internal server error
-    post:
-      tags:
-        - Files
-      summary: Create Folder
-      operationId: createFolder
-      security:
-        - bearerAuth: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "201":
-          description: Created successfully
-        "401":
-          description: Unauthorized
-        "500":
-          description: Internal server error
   /files/attach:
     post:
       tags:
@@ -3643,26 +11020,6 @@ paths:
           description: Unauthorized
         "403":
           description: Forbidden - insufficient role
-        "500":
-          description: Internal server error
-    get:
-      tags:
-        - Files
-      summary: Get Folder By Id
-      operationId: getFolderById
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: Success
-        "401":
-          description: Unauthorized
         "500":
           description: Internal server error
     patch:
@@ -6025,8 +13382,81 @@ paths:
     get:
       tags:
         - Model Inventory
-      summary: Get All Model Inventories
+      summary: Get all model inventories
+      description: >
+        Returns every model inventory record belonging to the caller's organization,
+        ordered by created_at DESC, id ASC. Each record includes its associated
+        project and framework IDs.
       operationId: getAllModelInventories
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of model inventories (may be empty)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ModelInventoryResponse"
+        "401":
+          description: Missing or invalid JWT
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+    post:
+      tags:
+        - Model Inventory
+      summary: Create a new model inventory
+      description: >
+        Creates a model inventory record, links it to the supplied project and
+        framework IDs, records a change-history entry, fires any "model_added"
+        automations, and notifies the approver (if set).
+      operationId: createNewModelInventory
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ModelInventoryCreateRequest"
+      responses:
+        "201":
+          description: Model inventory created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Created
+                  data:
+                    $ref: "#/components/schemas/ModelInventoryResponse"
+        "401":
+          description: Missing or invalid JWT
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+  /modelInventory/evaluations:
+    get:
+      tags:
+        - Model Inventory
+      summary: Get All Model Evaluations
+      operationId: getAllModelEvaluations
       security:
         - bearerAuth: []
       responses:
@@ -6036,21 +13466,23 @@ paths:
           description: Unauthorized
         "500":
           description: Internal server error
-    post:
+  /modelInventory/{id}/evaluations:
+    get:
       tags:
         - Model Inventory
-      summary: Create New Model Inventory
-      operationId: createNewModelInventory
+      summary: Get Model Evaluations
+      operationId: getModelEvaluations
       security:
         - bearerAuth: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
       responses:
-        "201":
-          description: Created successfully
+        "200":
+          description: Success
         "401":
           description: Unauthorized
         "500":
@@ -6059,7 +13491,10 @@ paths:
     get:
       tags:
         - Model Inventory
-      summary: Get Model By Framework Id
+      summary: Get model inventories by framework ID
+      description: >
+        Returns all model inventories associated with a framework (via the
+        model_inventories_projects_frameworks join table where framework_id matches).
       operationId: getModelByFrameworkId
       security:
         - bearerAuth: []
@@ -6067,20 +13502,41 @@ paths:
         - name: frameworkId
           in: path
           required: true
+          description: Framework ID
           schema:
             type: integer
       responses:
         "200":
-          description: Success
+          description: List of model inventories for the framework (may be empty)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ModelInventoryResponse"
         "401":
-          description: Unauthorized
+          description: Missing or invalid JWT
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /modelInventory/by-projectId/{projectId}:
     get:
       tags:
         - Model Inventory
-      summary: Get Model By Project Id
+      summary: Get model inventories by project ID
+      description: >
+        Returns all model inventories associated with a project (via the
+        model_inventories_projects_frameworks join table where framework_id IS NULL).
+        Non-numeric project IDs (e.g. plugin-sourced) return an empty array.
       operationId: getModelByProjectId
       security:
         - bearerAuth: []
@@ -6088,20 +13544,40 @@ paths:
         - name: projectId
           in: path
           required: true
+          description: Project ID (integer). Non-numeric values return an empty array.
           schema:
             type: integer
       responses:
         "200":
-          description: Success
+          description: List of model inventories for the project (may be empty)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ModelInventoryResponse"
         "401":
-          description: Unauthorized
+          description: Missing or invalid JWT
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /modelInventory/{id}:
     get:
       tags:
         - Model Inventory
-      summary: Get Model Inventory By Id
+      summary: Get a model inventory by ID
+      description: >
+        Returns a single model inventory record with its associated project and
+        framework IDs. Returns 204 if the record does not exist.
       operationId: getModelInventoryById
       security:
         - bearerAuth: []
@@ -6109,19 +13585,51 @@ paths:
         - name: id
           in: path
           required: true
+          description: Model inventory ID
           schema:
             type: integer
       responses:
         "200":
-          description: Success
+          description: Model inventory found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ModelInventoryResponse"
+        "204":
+          description: No model inventory found for the given ID
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: No Content
+                  data:
+                    nullable: true
         "401":
-          description: Unauthorized
+          description: Missing or invalid JWT
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
     patch:
       tags:
         - Model Inventory
-      summary: Update Model Inventory By Id
+      summary: Update a model inventory by ID
+      description: >
+        Partially updates a model inventory record. All body fields are optional;
+        only provided fields are changed. Project and framework associations can be
+        replaced or cleared. Fires "model_updated" automations and notifies a new
+        approver if changed.
       operationId: updateModelInventoryById
       security:
         - bearerAuth: []
@@ -6129,24 +13637,57 @@ paths:
         - name: id
           in: path
           required: true
+          description: Model inventory ID
           schema:
             type: integer
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/ModelInventoryUpdateRequest"
       responses:
         "200":
-          description: Success
+          description: Model inventory updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ModelInventoryResponse"
         "401":
-          description: Unauthorized
+          description: Missing or invalid JWT
+        "404":
+          description: Model inventory not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                  data:
+                    type: string
+                    example: Model inventory not found
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
     delete:
       tags:
         - Model Inventory
-      summary: Delete Model Inventory By Id
+      summary: Delete a model inventory by ID
+      description: >
+        Deletes a model inventory record and its project/framework associations.
+        Optionally deletes linked model risks when deleteRisks=true.
+        Records deletion in change history and fires "model_deleted" automations.
       operationId: deleteModelInventoryById
       security:
         - bearerAuth: []
@@ -6154,15 +13695,55 @@ paths:
         - name: id
           in: path
           required: true
+          description: Model inventory ID
           schema:
             type: integer
+        - name: deleteRisks
+          in: query
+          required: false
+          description: >
+            When "true", also deletes associated rows from the model_risks table.
+          schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+            default: "false"
       responses:
         "200":
-          description: Deleted successfully
+          description: Model inventory deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: string
+                    example: Model inventory deleted successfully
         "401":
-          description: Unauthorized
+          description: Missing or invalid JWT
+        "404":
+          description: Model inventory not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                  data:
+                    type: string
+                    example: Model inventory not found
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /modelInventoryHistory/current-counts:
     get:
       tags:
@@ -6221,9 +13802,28 @@ paths:
       operationId: getAllModelRisks
       security:
         - bearerAuth: []
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ModelRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -6236,13 +13836,23 @@ paths:
       security:
         - bearerAuth: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/ModelRiskInput"
       responses:
         "201":
           description: Created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/ModelRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -6264,6 +13874,15 @@ paths:
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/ModelRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -6282,13 +13901,23 @@ paths:
           schema:
             type: integer
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/ModelRiskInput"
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/ModelRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -6307,13 +13936,23 @@ paths:
           schema:
             type: integer
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/ModelRiskInput"
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/ModelRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -7577,6 +15216,484 @@ paths:
           description: Unauthorized
         "500":
           description: Internal server error
+  /policies:
+    get:
+      tags:
+        - Policies
+      summary: Get all policies
+      description: Returns all policies for the authenticated user's organization, including assigned reviewer IDs.
+      operationId: getAllPolicies
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of policies retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PolicyWithReviewers"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    post:
+      tags:
+        - Policies
+      summary: Create a new policy
+      description: Creates a new policy. The author_id and last_updated_by are set from the JWT token automatically.
+      operationId: createPolicy
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PolicyCreateRequest"
+      responses:
+        "201":
+          description: Policy created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Created
+                  data:
+                    $ref: "#/components/schemas/PolicyWithReviewers"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          description: Service unavailable — policy creation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /policies/tags:
+    get:
+      tags:
+        - Policies
+      summary: Get available policy tags
+      description: Returns the static list of allowed policy tags.
+      operationId: getPolicyTags
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of available tags
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - AI ethics
+                        - Fairness
+                        - Transparency
+                        - Explainability
+                        - Bias mitigation
+                        - Privacy
+                        - Data governance
+                        - Model risk
+                        - Accountability
+                        - Security
+                        - LLM
+                        - Human oversight
+                        - EU AI Act
+                        - ISO 42001
+                        - NIST RMF
+                        - Red teaming
+                        - Audit
+                        - Monitoring
+                        - Vendor management
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /policies/import/docx:
+    post:
+      tags:
+        - Policies
+      summary: Import DOCX and convert to HTML
+      description: >
+        Uploads a .docx file (max 10 MB) and converts it to HTML suitable for
+        the policy content editor. Returns the converted HTML and any conversion warnings.
+      operationId: importDocx
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: A .docx file (max 10 MB).
+      responses:
+        "200":
+          description: DOCX converted to HTML successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: object
+                    properties:
+                      html:
+                        type: string
+                        description: The converted HTML content
+                      warnings:
+                        type: array
+                        items:
+                          type: string
+                        description: Conversion warnings (e.g., unsupported formatting)
+        "400":
+          description: Bad request — no file uploaded or invalid file type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /policies/{id}:
+    get:
+      tags:
+        - Policies
+      summary: Get policy by ID
+      description: Returns a single policy by its ID, including assigned reviewer IDs.
+      operationId: getPolicyById
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/PolicyId"
+      responses:
+        "200":
+          description: Policy retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/PolicyWithReviewers"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    put:
+      tags:
+        - Policies
+      summary: Update a policy
+      description: >
+        Updates an existing policy. Only provided fields are updated.
+        The last_updated_by and last_updated_at are set automatically from the JWT token.
+        If assigned_reviewer_ids is provided, the reviewer list is fully replaced.
+      operationId: updatePolicy
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/PolicyId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PolicyUpdateRequest"
+      responses:
+        "202":
+          description: Policy updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    $ref: "#/components/schemas/PolicyWithReviewers"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - Policies
+      summary: Delete a policy by ID
+      description: Permanently deletes a policy and its associated reviewer mappings (via CASCADE).
+      operationId: deletePolicyById
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/PolicyId"
+      responses:
+        "202":
+          description: Policy deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    type: boolean
+                    example: true
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /policies/{id}/export/pdf:
+    get:
+      tags:
+        - Policies
+      summary: Export policy as PDF
+      description: Generates and downloads the policy as a PDF file.
+      operationId: exportPolicyPDF
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/PolicyId"
+      responses:
+        "200":
+          description: PDF file stream
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: 'attachment; filename="AI_Ethics_Policy.pdf"'
+            Content-Length:
+              schema:
+                type: integer
+        "400":
+          description: Invalid policy ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /policies/{id}/export/docx:
+    get:
+      tags:
+        - Policies
+      summary: Export policy as DOCX
+      description: Generates and downloads the policy as a DOCX file.
+      operationId: exportPolicyDOCX
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/PolicyId"
+      responses:
+        "200":
+          description: DOCX file stream
+          content:
+            application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+              schema:
+                type: string
+                format: binary
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: 'attachment; filename="AI_Ethics_Policy.docx"'
+            Content-Length:
+              schema:
+                type: integer
+        "400":
+          description: Invalid policy ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /policies/{id}/review/request:
+    post:
+      tags:
+        - Policies
+      summary: Request review for a policy
+      description: >
+        Sets the policy review status to pending_review and sends in-app
+        notifications to each specified reviewer.
+      operationId: requestPolicyReview
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/PolicyId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reviewer_ids
+              properties:
+                reviewer_ids:
+                  type: array
+                  items:
+                    type: integer
+                  description: List of user IDs to request review from
+                  example: [2, 5, 8]
+                message:
+                  type: string
+                  description: Optional message to include in the review request notification
+                  example: "Please review the updated data governance section."
+      responses:
+        "200":
+          description: Review requested successfully; returns the updated policy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/PolicyWithReviewers"
+        "400":
+          description: Invalid policy ID or missing reviewer_ids
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /policies/{id}/review/approve:
+    put:
+      tags:
+        - Policies
+      summary: Approve a policy review
+      description: >
+        Sets the policy review status to approved and sends an in-app
+        notification to the policy author.
+      operationId: approvePolicyReview
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/PolicyId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                comment:
+                  type: string
+                  description: Optional approval comment
+                  example: "Looks good, approved."
+      responses:
+        "200":
+          description: Policy review approved; returns the updated policy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/PolicyWithReviewers"
+        "400":
+          description: Invalid policy ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /policies/{id}/review/reject:
+    put:
+      tags:
+        - Policies
+      summary: Reject a policy review (request changes)
+      description: >
+        Sets the policy review status to changes_requested and sends an in-app
+        notification to the policy author. A comment is required.
+      operationId: rejectPolicyReview
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/PolicyId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - comment
+              properties:
+                comment:
+                  type: string
+                  description: Reason for requesting changes (required)
+                  example: "Section 3 needs more detail on bias mitigation procedures."
+      responses:
+        "200":
+          description: Policy review rejected; returns the updated policy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/PolicyWithReviewers"
+        "400":
+          description: Invalid policy ID or missing comment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /policies/folders/{folderId}/policies:
     get:
       tags:
@@ -7673,9 +15790,29 @@ paths:
       operationId: getAllRisks
       security:
         - bearerAuth: []
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
+          description: Filter by soft-delete state.
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -7688,13 +15825,23 @@ paths:
       security:
         - bearerAuth: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/ProjectRiskInput"
       responses:
         "201":
           description: Created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/ProjectRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -7713,9 +15860,27 @@ paths:
           required: true
           schema:
             type: integer
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -7733,10 +15898,28 @@ paths:
           in: path
           required: true
           schema:
-            type: integer
+            type: string
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -7758,6 +15941,15 @@ paths:
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/ProjectRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -7776,13 +15968,23 @@ paths:
           schema:
             type: integer
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/ProjectRiskInput"
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/ProjectRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -7803,179 +16005,385 @@ paths:
       responses:
         "200":
           description: Deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/ProjectRiskResponse"
         "401":
           description: Unauthorized
         "500":
           description: Internal server error
   /projects:
     get:
-      tags:
-        - Projects
-      summary: Get All Projects
+      summary: Get all projects
+      description: >
+        Returns all projects visible to the authenticated user. Admins and SuperAdmins
+        see all projects in the organization; other roles see only projects they own or
+        are members of.
       operationId: getAllProjects
+      tags: [Projects]
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Success
+          description: List of projects retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectListItem"
         "401":
-          description: Unauthorized
+          description: Unauthorized — missing or invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
     post:
-      tags:
-        - Projects
-      summary: Create Project
+      summary: Create a new project (use case)
+      description: >
+        Creates a new project with associated members and frameworks. If an
+        approval_workflow_id is provided, framework creation is deferred until
+        the approval request is approved.
       operationId: createProject
+      tags: [Projects]
       security:
         - bearerAuth: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/CreateProjectRequest"
       responses:
         "201":
-          description: Created successfully
-        "401":
-          description: Unauthorized
+          description: Project created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Created
+                  data:
+                    type: object
+                    properties:
+                      project:
+                        $ref: "#/components/schemas/Project"
+                      frameworks:
+                        type: object
+                        additionalProperties: true
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Business logic error (e.g. framework not allowed)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
+        "503":
+          description: Service unavailable — project creation returned null
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /projects/all/assessment/progress:
     get:
-      tags:
-        - Projects
-      summary: All Projects Assessment Progress
+      summary: Get assessment progress across all projects
       operationId: allProjectsAssessmentProgress
+      tags: [Projects]
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Success
+          description: Aggregated assessment progress returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/AssessmentProgress"
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No projects found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/all/compliance/progress:
     get:
-      tags:
-        - Projects
-      summary: All Projects Compliance Progress
+      summary: Get compliance progress across all projects
       operationId: allProjectsComplianceProgress
+      tags: [Projects]
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Success
+          description: Aggregated compliance progress returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ComplianceProgress"
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: No projects found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/assessment/progress/{id}:
     get:
-      tags:
-        - Projects
-      summary: Project Assessment Progress
+      summary: Get assessment progress for a single project
       operationId: projectAssessmentProgress
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Assessment progress returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/AssessmentProgress"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/calculateProjectRisks/{id}:
     get:
-      tags:
-        - Projects
-      summary: Get Project Risks Calculations
+      summary: Calculate project risk distribution
       operationId: getProjectRisksCalculations
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Risk calculations returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectRiskCount"
+        "204":
+          description: No risk data available
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: No Content
+                  data:
+                    nullable: true
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/calculateVendorRisks/{id}:
     get:
-      tags:
-        - Projects
-      summary: Get Vendor Risks Calculations
+      summary: Calculate vendor risk distribution
       operationId: getVendorRisksCalculations
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Vendor risk calculations returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/VendorRiskCount"
+        "204":
+          description: No vendor risk data available
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: No Content
+                  data:
+                    nullable: true
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/complainces/{projid}:
     get:
-      tags:
-        - Projects
-      summary: Get Compliances
+      summary: Get compliance data for a project
       operationId: getCompliances
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
         - name: projid
           in: path
           required: true
+          description: The project ID
           schema:
             type: integer
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Compliance data returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ControlCategory"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/compliance/progress/{id}:
     get:
-      tags:
-        - Projects
-      summary: Project Compliance Progress
+      summary: Get compliance progress for a single project
       operationId: projectComplianceProgress
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Compliance progress returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ComplianceProgress"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/saveControls:
     post:
       tags:
@@ -7998,117 +16406,204 @@ paths:
           description: Internal server error
   /projects/stats/{id}:
     get:
-      tags:
-        - Projects
-      summary: Get Project Stats By Id
+      summary: Get project statistics by ID
       operationId: getProjectStatsById
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       responses:
-        "200":
-          description: Success
-        "401":
-          description: Unauthorized
+        "202":
+          description: Project stats retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    $ref: "#/components/schemas/ProjectStats"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/{id}:
     get:
-      tags:
-        - Projects
-      summary: Get Project By Id
+      summary: Get a project by ID
+      description: Returns a single project with its frameworks, owner name, members, and approval status.
       operationId: getProjectById
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Project found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ProjectDetail"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
     patch:
-      tags:
-        - Projects
-      summary: Update Project By Id
+      summary: Update a project by ID
+      description: Partially updates a project and its member list. Only provided fields are updated.
       operationId: updateProjectById
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/UpdateProjectRequest"
       responses:
-        "200":
-          description: Success
+        "202":
+          description: Project updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    $ref: "#/components/schemas/ProjectWithMembers"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Business logic error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
     delete:
-      tags:
-        - Projects
-      summary: Delete Project By Id
+      summary: Delete a project by ID
+      description: Deletes a project and all dependent entities (files, risks, members, framework data).
       operationId: deleteProjectById
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       responses:
-        "200":
-          description: Deleted successfully
-        "401":
-          description: Unauthorized
+        "202":
+          description: Project deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    type: boolean
+                    example: true
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /projects/{id}/status:
     patch:
-      tags:
-        - Projects
-      summary: Update Project Status
+      summary: Update project status
       operationId: updateProjectStatus
+      tags: [Projects]
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
+        - $ref: "#/components/parameters/ProjectId"
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              required: [status]
+              properties:
+                status:
+                  $ref: "#/components/schemas/ProjectStatus"
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Project status updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/ProjectWithMembers"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerError"
   /quantitative-risks/assessment-mode:
     get:
       tags:
@@ -9659,6 +18154,24 @@ paths:
           description: Forbidden - insufficient role
         "500":
           description: Internal server error
+  /super-admin/users/count:
+    get:
+      tags:
+        - Super Admin
+      summary: Get User Count
+      operationId: getUserCount
+      security:
+        - bearerAuth: []
+      description: "Requires role: Super Admin"
+      responses:
+        "200":
+          description: Success
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden - insufficient role
+        "500":
+          description: Internal server error
   /super-admin/users/{id}:
     delete:
       tags:
@@ -10210,17 +18723,31 @@ paths:
           description: Internal server error
   /users:
     get:
+      summary: List all users in organization
+      description: |
+        Returns all users belonging to the authenticated user's organization,
+        ordered by created_at DESC, id ASC. Password hashes are excluded.
       tags:
-        - Users
-      summary: Get All Users
-      operationId: getAllUsers
+        - Users - CRUD
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Users found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/UserSafe"
+        "204":
+          description: No users found (empty organization)
         "500":
           description: Internal server error
   /users/by-email/{email}:
@@ -10242,260 +18769,664 @@ paths:
           description: Internal server error
   /users/check/exists:
     get:
+      summary: Check if any user exists
+      description: |
+        Returns a boolean indicating whether any user record exists in the database.
+        Used during initial setup flow to determine if onboarding is needed.
       tags:
-        - Users
-      summary: Check User Exists
-      operationId: checkUserExists
+        - Users - Utility
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Check result
+          content:
+            application/json:
+              schema:
+                type: boolean
+                example: true
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Internal server error"
   /users/chng-pass/{id}:
     patch:
+      summary: Change password (authenticated)
+      description: |
+        Changes the password for the authenticated user. Requires the current
+        password for verification. Protected by selfOnly middleware (users can
+        only change their own password). Rate-limited.
       tags:
-        - Users
-      summary: Change Password
-      operationId: ChangePassword
+        - Users - Password
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           required: true
           schema:
             type: integer
+          description: User ID (must match authenticated user via selfOnly middleware)
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              required: [id, currentPassword, newPassword]
+              properties:
+                id:
+                  type: integer
+                  description: User ID (must match path parameter)
+                  example: 1
+                currentPassword:
+                  type: string
+                  format: password
+                  description: Current password for verification
+                  example: "OldPassword123!"
+                newPassword:
+                  type: string
+                  format: password
+                  description: "Must be 8+ chars with uppercase, lowercase, and digit"
+                  example: "NewPassword456!"
       responses:
-        "200":
-          description: Success
-        "401":
-          description: Unauthorized
+        "202":
+          description: Password changed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Password updated successfully"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "400":
+          description: Validation error (weak password, missing fields)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "403":
+          description: Business logic error (wrong current password)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "User not found"
         "500":
           description: Internal server error
   /users/login:
     post:
+      summary: Authenticate user
+      description: |
+        Validates email/password credentials via bcrypt. Returns a JWT access token
+        in the response body and sets a refresh token in an HTTP-only cookie.
+        Rate-limited to 5 requests per minute per IP.
       tags:
-        - Users
-      summary: Login User
-      operationId: loginUser
+        - Users - Authentication
+      security: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: "user@example.com"
+                password:
+                  type: string
+                  format: password
+                  example: "SecurePassword123!"
       responses:
-        "201":
-          description: Created successfully
+        "202":
+          description: Authentication successful
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+              description: "refresh_token=<jwt>; Path=/api/users; HttpOnly; Secure (prod); SameSite=none (prod) / lax (dev)"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Accepted"
+                  data:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                        description: JWT access token
+                      isSuperAdmin:
+                        type: boolean
+                        description: Only present when user is super-admin (role_id=5)
+                      onboarding_status:
+                        type: string
+                        description: Organization onboarding status (not present for super-admin)
+                        example: "completed"
+                      is_org_creator:
+                        type: boolean
+                        description: Whether user is the first admin of the org (not present for super-admin)
+        "401":
+          description: Invalid email or password
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "429":
+          description: Too many login attempts
         "500":
           description: Internal server error
   /users/refresh-token:
     post:
+      summary: Refresh access token
+      description: |
+        Reads the refresh_token from an HTTP-only cookie and issues a new
+        JWT access token if the refresh token is still valid.
       tags:
-        - Users
-      summary: Refresh Access Token
-      operationId: refreshAccessToken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
+        - Users - Authentication
+      security: []
+      parameters:
+        - in: cookie
+          name: refresh_token
+          required: true
+          schema:
+            type: string
+          description: JWT refresh token set during login
       responses:
-        "201":
-          description: Created successfully
+        "200":
+          description: New access token issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                        description: New JWT access token
+        "400":
+          description: Refresh token missing from cookie
+        "401":
+          description: Invalid refresh token
+        "406":
+          description: Refresh token expired
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        example: "Token expired"
         "500":
           description: Internal server error
   /users/register:
     post:
+      summary: Register a new user
+      description: |
+        Creates a new user account. Requires a valid registration JWT (set by registerJWT middleware).
+        Validates email uniqueness, password strength, and required fields.
+        Marks any pending invitation as accepted after successful creation.
       tags:
-        - Users
-      summary: Create New User
-      operationId: createNewUser
+        - Users - Registration
+      security:
+        - bearerAuth: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              required: [name, surname, email, password, roleId, organizationId]
+              properties:
+                name:
+                  type: string
+                  description: User's first name
+                  example: "John"
+                surname:
+                  type: string
+                  description: User's last name
+                  example: "Doe"
+                email:
+                  type: string
+                  format: email
+                  example: "john@example.com"
+                password:
+                  type: string
+                  format: password
+                  description: "Must be 8+ chars with uppercase, lowercase, and digit"
+                  example: "SecurePassword123!"
+                roleId:
+                  type: integer
+                  description: "1=Admin, 2=Reviewer, 3=Editor, 4=Auditor"
+                  example: 3
+                organizationId:
+                  type: integer
+                  description: Organization to assign the user to
+                  example: 1
       responses:
         "201":
-          description: Created successfully
+          description: User created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Created"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "400":
+          description: Validation error (missing fields, weak password, invalid email)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          description: Business logic error
+        "409":
+          description: User with this email already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
         "500":
           description: Internal server error
   /users/reset-password:
     post:
+      summary: Reset user password
+      description: |
+        Resets the password for a user identified by email. Protected by
+        resetPasswordMiddleware (validates reset token/permission).
+        Password is hashed via bcrypt before storage.
       tags:
-        - Users
-      summary: Reset Password
-      operationId: resetPassword
+        - Users - Password
+      security: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              required: [email, newPassword]
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: "user@example.com"
+                newPassword:
+                  type: string
+                  format: password
+                  description: "Must be 8+ chars with uppercase, lowercase, and digit"
+                  example: "NewSecure123!"
       responses:
-        "201":
-          description: Created successfully
+        "202":
+          description: Password reset successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Accepted"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "400":
+          description: Validation error (weak password)
+        "403":
+          description: Business logic error
+        "404":
+          description: User not found
         "500":
           description: Internal server error
   /users/{id}:
     get:
+      summary: Get user by ID
+      description: |
+        Retrieves a single user by their numeric ID. Super-admins can access
+        any user; regular users can only access users within their organization
+        (or their own record).
       tags:
-        - Users
-      summary: Get User By Id
-      operationId: getUserById
+        - Users - CRUD
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           required: true
           schema:
             type: integer
+          description: User ID
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: User found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "403":
+          description: Access denied (user belongs to different organization)
+        "404":
+          description: User not found
         "500":
           description: Internal server error
     patch:
+      summary: Update user by ID
+      description: |
+        Updates user fields (name, surname, email, roleId, last_login).
+        Only provided fields are updated. Organization isolation enforced.
+        Sends Slack notification on role change. Sends email notification
+        when role changes from Editor (3) to Admin (1).
       tags:
-        - Users
-      summary: Update User By Id
-      operationId: updateUserById
+        - Users - CRUD
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           required: true
           schema:
             type: integer
+          description: User ID to update
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              properties:
+                name:
+                  type: string
+                  description: First name
+                  example: "Jane"
+                surname:
+                  type: string
+                  description: Last name
+                  example: "Smith"
+                email:
+                  type: string
+                  format: email
+                  example: "jane@example.com"
+                roleId:
+                  type: integer
+                  description: "New role ID (1=Admin, 2=Reviewer, 3=Editor, 4=Auditor). Can be sent as string."
+                  example: 1
+                last_login:
+                  type: string
+                  format: date-time
+                  description: Override last login timestamp
+              description: All fields are optional; only provided fields are updated
       responses:
-        "200":
-          description: Success
-        "401":
-          description: Unauthorized
+        "202":
+          description: User updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Accepted"
+                  data:
+                    $ref: "#/components/schemas/UserSafe"
+        "400":
+          description: Validation error
+        "403":
+          description: Access denied or business logic error
+        "404":
+          description: User not found
         "500":
           description: Internal server error
     delete:
+      summary: Delete user by ID
+      description: |
+        Deletes a user and nullifies all their foreign key references across
+        projects, vendors, risks, vendor risks, files, automations, and invitations.
+        Also removes the user from projects_members. Demo users and super-admins
+        cannot be deleted.
       tags:
-        - Users
-      summary: Delete User By Id
-      operationId: deleteUserById
+        - Users - CRUD
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           required: true
           schema:
             type: integer
+          description: User ID to delete
       responses:
-        "200":
-          description: Deleted successfully
-        "401":
-          description: Unauthorized
+        "202":
+          description: User deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Accepted"
+                  data:
+                    type: boolean
+                    description: true if deletion succeeded
+        "403":
+          description: "Forbidden: demo user, super-admin, or wrong organization"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: User not found
         "500":
           description: Internal server error
   /users/{id}/calculate-progress:
     get:
+      summary: Calculate user project progress
+      description: |
+        Computes completion metrics across all projects the user is a member of.
+        Calculates subcontrol completion (status="Done") and assessment question
+        completion (has answer) per project and as aggregated totals.
       tags:
-        - Users
-      summary: Calculate Progress
-      operationId: calculateProgress
+        - Users - Analytics
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           required: true
           schema:
             type: integer
+          description: User ID to calculate progress for
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Progress calculated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProgressResponse"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Internal server error"
   /users/{id}/profile-photo:
     post:
+      summary: Upload profile photo
+      description: |
+        Uploads a profile photo for the specified user. The file is stored in the
+        tenant-scoped files table. If the user already has a profile photo, the old
+        one is deleted and replaced. Uses multer for multipart file handling.
       tags:
-        - Users
-      summary: Upload user profile photo
-      operationId: uploadUserProfilePhoto
+        - Users - Profile Photo
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           required: true
           schema:
             type: integer
+          description: User ID
       requestBody:
+        required: true
         content:
-          application/json:
+          multipart/form-data:
             schema:
               type: object
+              required: [photo]
+              properties:
+                photo:
+                  type: string
+                  format: binary
+                  description: Image file (JPEG, PNG, etc.)
       responses:
-        "201":
-          description: Created successfully
-        "401":
-          description: Unauthorized
+        "200":
+          description: Profile photo uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: object
+                    properties:
+                      profile_photo_id:
+                        type: integer
+                        description: ID of the new file record
+        "400":
+          description: No file provided
+        "403":
+          description: Access denied (wrong organization)
         "500":
           description: Internal server error
     get:
+      summary: Get profile photo
+      description: |
+        Returns the profile photo binary content for the specified user.
+        The response includes the raw file content and its MIME type.
       tags:
-        - Users
-      summary: Get User Profile Photo
-      operationId: getUserProfilePhoto
+        - Users - Profile Photo
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           required: true
           schema:
             type: integer
+          description: User ID
       responses:
         "200":
-          description: Success
-        "401":
-          description: Unauthorized
+          description: Profile photo returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: object
+                    properties:
+                      content:
+                        type: string
+                        format: byte
+                        description: Base64-encoded file content
+                      type:
+                        type: string
+                        description: MIME type
+                        example: "image/png"
+        "404":
+          description: No profile photo found
         "500":
           description: Internal server error
     delete:
+      summary: Delete profile photo
+      description: |
+        Removes the profile photo from the user record and deletes the associated
+        file from the files table.
       tags:
-        - Users
-      summary: Delete User Profile Photo
-      operationId: deleteUserProfilePhoto
+        - Users - Profile Photo
       security:
         - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           required: true
           schema:
             type: integer
+          description: User ID
       responses:
         "200":
-          description: Deleted successfully
-        "401":
-          description: Unauthorized
+          description: Profile photo deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "OK"
+                  data:
+                    type: boolean
+                    description: true if photo was deleted
         "500":
           description: Internal server error
   /v1/shadow-ai/events:
@@ -10565,13 +19496,23 @@ paths:
       security:
         - bearerAuth: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/VendorRiskInput"
       responses:
         "201":
           description: Created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/VendorRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -10584,9 +19525,28 @@ paths:
       operationId: getAllVendorRisksAllProjects
       security:
         - bearerAuth: []
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/VendorRiskAllProjectsResponse"
         "401":
           description: Unauthorized
         "500":
@@ -10604,10 +19564,28 @@ paths:
           in: path
           required: true
           schema:
-            type: integer
+            type: string
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/VendorRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -10626,9 +19604,27 @@ paths:
           required: true
           schema:
             type: integer
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [active, deleted, all]
+            default: active
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/VendorRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -10650,6 +19646,15 @@ paths:
       responses:
         "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/VendorRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -10668,13 +19673,23 @@ paths:
           schema:
             type: integer
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/VendorRiskInput"
       responses:
-        "200":
-          description: Success
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/VendorRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -10693,8 +19708,17 @@ paths:
           schema:
             type: integer
       responses:
-        "200":
-          description: Deleted successfully
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/VendorRiskResponse"
         "401":
           description: Unauthorized
         "500":
@@ -10703,42 +19727,139 @@ paths:
     get:
       tags:
         - Vendors
-      summary: Get All Vendors
-      operationId: getAllVendors
+      summary: Get all vendors
+      description: Retrieves all vendors for the authenticated user's organization, ordered by creation date descending. Each vendor includes its associated project IDs and the reviewer's full name.
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Success
+          description: Vendors retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/VendorWithReviewerName"
+        "204":
+          description: No vendors found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: No Content
+                  data:
+                    type: "null"
         "401":
-          description: Unauthorized
+          description: Unauthorized - missing or invalid JWT
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Internal Server Error
+                  error:
+                    type: string
     post:
       tags:
         - Vendors
-      summary: Create Vendor
-      operationId: createVendor
+      summary: Create a vendor
+      description: |
+        Creates a new vendor in the authenticated user's organization.
+        Validates required fields, checks demo restrictions, associates
+        projects via the vendors_projects join table, records creation
+        in change history, fires automation triggers (vendor_added),
+        and sends in-app assignment notifications to assignee and reviewer.
       security:
         - bearerAuth: []
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/VendorInput"
       responses:
         "201":
-          description: Created successfully
+          description: Vendor created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Created
+                  data:
+                    $ref: "#/components/schemas/Vendor"
+        "400":
+          description: Validation error (missing or invalid required fields)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Bad Request
+                  data:
+                    type: string
+                    description: Validation error message
         "401":
-          description: Unauthorized
+          description: Unauthorized - missing or invalid JWT
+        "403":
+          description: Business logic error (e.g. demo vendor restriction)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                  data:
+                    type: string
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Internal Server Error
+                  error:
+                    type: string
+        "503":
+          description: Service unavailable - vendor creation returned null
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Service Unavailable
+                  error:
+                    type: object
   /vendors/project-id/{id}:
     get:
       tags:
         - Vendors
-      summary: Get Vendor By Project Id
-      operationId: getVendorByProjectId
+      summary: Get vendors by project ID
+      description: Retrieves all vendors associated with a specific project. Returns 404 if the project does not exist.
       security:
         - bearerAuth: []
       parameters:
@@ -10747,19 +19868,55 @@ paths:
           required: true
           schema:
             type: integer
+          description: Project ID
       responses:
         "200":
-          description: Success
+          description: Vendors retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Vendor"
         "401":
-          description: Unauthorized
+          description: Unauthorized - missing or invalid JWT
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                  data:
+                    type: array
+                    items: {}
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Internal Server Error
+                  error:
+                    type: string
   /vendors/{id}:
     get:
       tags:
         - Vendors
-      summary: Get Vendor By Id
-      operationId: getVendorById
+      summary: Get vendor by ID
+      description: Retrieves a single vendor by its ID, including associated project IDs.
       security:
         - bearerAuth: []
       parameters:
@@ -10768,18 +19925,57 @@ paths:
           required: true
           schema:
             type: integer
+          description: Vendor ID
       responses:
         "200":
-          description: Success
+          description: Vendor retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: OK
+                  data:
+                    $ref: "#/components/schemas/Vendor"
         "401":
-          description: Unauthorized
+          description: Unauthorized - missing or invalid JWT
+        "404":
+          description: Vendor not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                  data:
+                    type: "null"
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Internal Server Error
+                  error:
+                    type: string
     patch:
       tags:
         - Vendors
-      summary: Update Vendor By Id
-      operationId: updateVendorById
+      summary: Update a vendor
+      description: |
+        Partially updates an existing vendor. Only provided fields are updated.
+        Review and scorecard fields can be explicitly set to null to clear them.
+        Required fields (vendor_name, vendor_provides, website, vendor_contact_person)
+        are only updated if they have a non-empty value.
+        Records field-level changes in change history, fires automation triggers
+        (vendor_updated), and sends in-app notifications when assignee or reviewer changes.
       security:
         - bearerAuth: []
       parameters:
@@ -10788,23 +19984,94 @@ paths:
           required: true
           schema:
             type: integer
+          description: Vendor ID
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/VendorUpdate"
       responses:
-        "200":
-          description: Success
+        "202":
+          description: Vendor updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    $ref: "#/components/schemas/Vendor"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Bad Request
+                  data:
+                    type: string
         "401":
-          description: Unauthorized
+          description: Unauthorized - missing or invalid JWT, or missing userId/role
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+        "403":
+          description: Business logic error (e.g. demo vendor restriction)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                  data:
+                    type: string
+        "404":
+          description: Vendor not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                  data:
+                    type: object
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Internal Server Error
+                  error:
+                    type: string
     delete:
       tags:
         - Vendors
-      summary: Delete Vendor By Id
-      operationId: deleteVendorById
+      summary: Delete a vendor
+      description: |
+        Deletes a vendor and all associated data in a transaction:
+        1. Deletes vendor risks (vendor_risks table)
+        2. Deletes project associations (vendors_projects table)
+        3. Deletes the vendor record itself
+        Fires automation triggers (vendor_deleted).
       security:
         - bearerAuth: []
       parameters:
@@ -10813,13 +20080,47 @@ paths:
           required: true
           schema:
             type: integer
+          description: Vendor ID
       responses:
-        "200":
-          description: Deleted successfully
+        "202":
+          description: Vendor deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Accepted
+                  data:
+                    type: boolean
+                    example: true
         "401":
-          description: Unauthorized
+          description: Unauthorized - missing or invalid JWT
+        "404":
+          description: Vendor not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                  data:
+                    type: object
         "500":
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Internal Server Error
+                  error:
+                    type: string
   /version:
     get:
       tags:

--- a/docs/api-docs-audit-report.md
+++ b/docs/api-docs-audit-report.md
@@ -1,0 +1,179 @@
+# API Documentation Audit Report
+
+**Date:** 2026-04-20  
+**Scope:** All 3 API documentation sources — `swagger.yaml`, `swagger.generated.yaml`, `endpoints.ts`  
+**Method:** Systematic comparison of every documented endpoint against actual route implementations
+
+---
+
+## Executive Summary
+
+| Metric | Value |
+|--------|-------|
+| **Total actual endpoints in codebase** | 560 |
+| **Documented in swagger.yaml** | ~280 |
+| **Documented in endpoints.ts** | 187 |
+| **Documentation coverage** | ~50% |
+| **Accuracy of documented endpoints** | ~92% |
+| **Critical issues found** | 7 |
+
+---
+
+## Issue #1: Low Documentation Coverage (CRITICAL)
+
+**560 endpoints exist** in the codebase, but swagger.yaml only documents ~280 of them (~50% coverage). The `endpoints.ts` frontend docs app covers only 187.
+
+**Major undocumented areas include:**
+- 18 AI Detection endpoints (scans, risk scoring, scheduling)
+- 4 Approval Request endpoints (pending-approvals, approve, reject, withdraw)
+- Many File Manager sub-routes
+- FRIA public endpoints
+- Shadow AI endpoints
+- Super Admin endpoints
+- Internal endpoints
+- Plugin system endpoints
+- Webhook endpoints
+- Various newer features (Policy Radar, Quantitative Risks, etc.)
+
+---
+
+## Issue #2: Missing Security/Auth Specifications (CRITICAL)
+
+**26 endpoints** in swagger.yaml (lines 1000-1500) are documented WITHOUT `bearerAuth` security specification, but the actual code enforces `authenticateJWT` on all of them:
+
+- `/ai-detection/scans/{scanId}/status`
+- All `/ai-incident-managements/*` endpoints (6)
+- All `/aiTrustCentre/*` endpoints (12+)
+- All `/approval-requests/*` endpoints (4+)
+
+**Impact:** API consumers may attempt unauthenticated requests and receive confusing 401 errors.
+
+---
+
+## Issue #3: Documented Endpoints That Don't Work (CRITICAL)
+
+**4 assessment endpoints** are documented in swagger.yaml but are **commented out** in the actual route file (`assessment.route.ts`):
+
+| Endpoint | Method | Status |
+|----------|--------|--------|
+| `/assessments` | POST | Commented out |
+| `/assessments/{id}` | PUT | Commented out |
+| `/assessments/{id}` | DELETE | Commented out |
+| `/assessments/saveAnswers` | POST | Commented out |
+
+Only the 3 GET endpoints for assessments are active.
+
+---
+
+## Issue #4: Misleading Endpoint Description
+
+**`POST /file-manager`** is documented with:
+- Summary: "Handle Multer Error"  
+- OperationId: `file_manager_handleMulterError`
+
+**Actual behavior:** This endpoint **uploads a file**. The summary completely misrepresents its purpose.
+
+---
+
+## Issue #5: swagger.generated.yaml Out of Sync
+
+The auto-generated file (`swagger.generated.yaml`) is **14 days stale** (Apr 6 vs Apr 20) with 6 operationId issues:
+
+| Endpoint | Generated (wrong) | Manual (correct) |
+|----------|-------------------|-----------------|
+| Upload company logo | `Unknown` | `uploadCompanyLogo` |
+| Withdraw approval request | `approval_requests_unknown` | `withdrawApprovalRequest` |
+| AI Gateway notification | `internal_unknown` | `aiGatewayNotify` |
+| Serve plugin UI assets | `plugins_unknown` | `servePluginUI` |
+| Upload user profile photo | `users_unknown` | `uploadUserProfilePhoto` |
+| Get application version | `version_unknown` | `getAppVersion` |
+
+**Root cause:** The `generateSwagger.ts` script fails to extract operationIds from handlers using multer middleware or non-standard patterns.
+
+---
+
+## Issue #6: endpoints.ts Divergence from swagger.yaml
+
+The `docs/api-docs/src/config/endpoints.ts` (187 endpoints) documents a **different subset** than swagger.yaml (~280 endpoints). Neither is a subset of the other:
+
+- **endpoints.ts has but swagger.yaml lacks:** Bias and Fairness, Logger, Tiers, User Preferences
+- **swagger.yaml has but endpoints.ts lacks:** Agent Discovery, Entity Graph, AI Detection (full), FRIA, Feature Settings, many newer modules
+
+These two documentation sources are maintained independently with no synchronization mechanism.
+
+---
+
+## Issue #7: Missing Query Parameters and Request/Response Schemas
+
+Most endpoints in swagger.yaml are documented with minimal schemas:
+- Request bodies often just say `type: object` with no properties defined
+- Response schemas rarely specify the actual data structure
+- Query parameters (pagination, filters, search) are largely undocumented
+- Path parameters are correctly documented
+
+---
+
+## Verified Accurate Sections
+
+The following sections were verified as **100% accurate** (routes exist, methods match, auth correct):
+
+| Section | Endpoints | Status |
+|---------|-----------|--------|
+| AI Advisor | 5 | ✓ Accurate |
+| Agent Discovery | 13 | ✓ Accurate |
+| AI Detection Repositories | 5 | ✓ Accurate |
+| AI Detection (documented subset) | 26 | ✓ Accurate |
+| Automations | 8 | ✓ Accurate |
+| CE Marking | 2 | ✓ Accurate |
+| Compliance | 3 | ✓ Accurate |
+| Dashboard | 1 | ✓ Accurate |
+| Datasets | 7 | ✓ Accurate |
+| Dataset Bulk Upload | 1 | ✓ Accurate |
+| Dataset Change History | 1 | ✓ Accurate |
+| Entity Graph | 14 | ✓ Accurate |
+| EU AI Act | 14 | ✓ Accurate |
+| Evidence Hub | 4 | ✓ Accurate |
+| Feature Settings | 2 | ✓ Accurate |
+| File Change History | 1 | ✓ Accurate |
+| File Manager (most) | 8 | ✓ Accurate |
+| FRIA | 10+ | ✓ Accurate |
+| Approval Workflows | 5 | ✓ Accurate |
+| Audit Ledger | 2 | ✓ Accurate |
+| AutoDrivers | 2 | ✓ Accurate |
+| Assessments (GET only) | 3 | ✓ Accurate |
+
+---
+
+## Recommendations
+
+### Immediate Fixes (Low Effort)
+
+1. **Add `security: [bearerAuth: []]`** to the 26 endpoints missing it
+2. **Remove or mark as deprecated** the 4 commented-out assessment endpoints
+3. **Fix `POST /file-manager` summary** from "Handle Multer Error" to "Upload File"
+4. **Regenerate swagger.generated.yaml** and fix the script's operationId extraction
+
+### Medium-Term (High Value)
+
+5. **Document the remaining ~280 undocumented endpoints** — focus on user-facing ones first (Projects, Vendors, Users, Policies, Risks, Model Inventory)
+6. **Add request/response schemas** with actual property definitions
+7. **Synchronize endpoints.ts with swagger.yaml** or generate one from the other
+
+### Long-Term
+
+8. **Add JSDoc/swagger annotations to route files** and generate swagger.yaml from code (single source of truth)
+9. **Set up CI validation** — fail builds when routes exist without swagger documentation
+10. **Deprecate endpoints.ts** in favor of serving swagger.yaml directly via Swagger UI (already partially set up at `/api/docs`)
+
+---
+
+## Files Audited
+
+| File | Role |
+|------|------|
+| `Servers/swagger.yaml` | Primary API documentation (manual, 11,072 lines) |
+| `Servers/swagger.generated.yaml` | Auto-generated copy (14 days stale) |
+| `docs/api-docs/src/config/endpoints.ts` | Frontend docs app config (187 endpoints) |
+| `Servers/index.ts` | Route registration (85 route files) |
+| `Servers/routes/*.ts` | All 85 route files |
+| `Servers/scripts/generateSwagger.ts` | Swagger generation script |


### PR DESCRIPTION
## Summary

- Audited all 560 backend API endpoints against existing swagger.yaml documentation
- Enriched swagger.yaml from 1 minimal schema to **301 full component schemas** with property types, enums, required fields, and descriptions
- Fixed `generateSwagger.ts` to resolve all handler names (0 unresolved, was 6)
- Fixed misleading `POST /file-manager` summary ("Handle Multer Error" → "Upload File")
- Added 3 missing endpoints (model evaluations, super-admin user count)
- Added 17 per-domain OpenAPI reference files in `Servers/docs/api/`
- Added audit report documenting all findings

**Before:** ~280 paths, 1 schema, minimal `type: object` bodies
**After:** 418 paths, 301 schemas, 59 tags with full request/response definitions