### PR TITLE
feat(create-task): replace Autocomplete with AutoCompleteField for assignees

### DIFF
--- a/Clients/src/presentation/components/Modals/CreateTask/index.tsx
+++ b/Clients/src/presentation/components/Modals/CreateTask/index.tsx
@@ -11,8 +11,6 @@ import {
   useTheme,
   Stack,
   Typography,
-  Autocomplete,
-  TextField,
   Box,
 } from "@mui/material";
 import { lazy } from "react";
@@ -37,7 +35,7 @@ import useUsers from "../../../../application/hooks/useUsers";
 import { useModalKeyHandling } from "../../../../application/hooks/useModalKeyHandling";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import { TaskPriority, TaskStatus } from "../../../../domain/enums/task.enum";
-import { getAutocompleteStyles } from "../../../utils/inputStyles";
+import AutoCompleteField from "../../Inputs/Autocomplete";
 import { CustomSelect } from "../../CustomSelect";
 import { PRIORITY_COLOR_MAP, PRIORITY_DISPLAY_MAP, TASK_PRIORITY_OPTIONS } from "../../../constants/priorityOptions";
 
@@ -317,130 +315,51 @@ const CreateTask: FC<ICreateTaskProps> = ({
         </Suspense>
 
         <Suspense fallback={<div>Loading...</div>}>
-          <Stack gap={theme.spacing(2)}>
-            <Typography
-              component="p"
-              variant="body1"
-              color={theme.palette.text.secondary}
-              fontWeight={500}
-              fontSize={"13px"}
-              sx={{ margin: 0, height: "22px" }}
-            >
-              Assignees *
-            </Typography>
-            <Autocomplete
-              multiple
-              id="assignees-input"
-              size="small"
-              value={values.assignees}
-              options={assigneeOptions}
-              onChange={handleAssigneesChange}
-              getOptionLabel={(user) =>
-                `${user.name} ${user.surname}`.trim()
-              }
-              renderOption={(props, option) => {
-                const { key, ...optionProps } = props;
-                const userEmail =
-                  option.email.length > 30
-                    ? `${option.email.slice(0, 30)}...`
-                    : option.email;
-                return (
-                  <Box component="li" key={key} {...optionProps}>
-                    <Typography sx={{ fontSize: "13px" }}>
-                      {option.name} {option.surname}
-                    </Typography>
-                    <Typography
-                      sx={{
-                        fontSize: "11px",
-                        color: "rgb(157, 157, 157)",
-                        position: "absolute",
-                        right: "9px",
-                      }}
-                    >
-                      {userEmail}
-                    </Typography>
-                  </Box>
-                );
-              }}
-              noOptionsText={
-                values.assignees.length === (users?.length ?? 0)
-                  ? "All members selected"
-                  : "No options"
-              }
-              popupIcon={<GreyDownArrowIcon size={16} />}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  placeholder="Select assignees"
-                  error={!!errors.assignees}
-                  aria-describedby={
-                    errors.assignees ? "assignees-error" : undefined
-                  }
-                  sx={{
-                    "& .MuiOutlinedInput-root": {
-                      minHeight: "34px",
-                      paddingTop: "2px !important",
-                      paddingBottom: "2px !important",
-                    },
-                    "& ::placeholder": {
-                      fontSize: "13px",
-                    },
-                  }}
-                />
-              )}
-              sx={{
-                ...getAutocompleteStyles(theme, { hasError: !!errors.assignees }),
-                width: "350px",
-                backgroundColor: theme.palette.background.main,
-                "& .MuiOutlinedInput-root": {
-                  ...getAutocompleteStyles(theme, { hasError: !!errors.assignees })["& .MuiOutlinedInput-root"],
-                  borderRadius: "5px",
-                },
-                "& .MuiChip-root": {
-                  borderRadius: theme.shape.borderRadius,
-                  height: "26px",
-                  margin: "1px 2px",
-                },
-              }}
-              slotProps={{
-                paper: {
-                  sx: {
-                    "& .MuiAutocomplete-listbox": {
-                      "& .MuiAutocomplete-option": {
-                        fontSize: "13px",
-                        color: "#1c2130",
-                        paddingLeft: "9px",
-                        paddingRight: "9px",
-                      },
-                      "& .MuiAutocomplete-option.Mui-focused": {
-                        background: "background.accent",
-                      },
-                    },
-                    "& .MuiAutocomplete-noOptions": {
-                      fontSize: "13px",
-                      paddingLeft: "9px",
-                      paddingRight: "9px",
-                    },
-                  },
-                },
-              }}
-            />
-            {errors.assignees && (
-              <Typography
-                id="assignees-error"
-                color="error"
-                variant="caption"
-                sx={{
-                  mt: theme.spacing(1),
-                  ml: theme.spacing(1),
-                  color: theme.palette.error.main,
-                  fontSize: theme.typography.caption.fontSize,
-                }}
-              >
-                {errors.assignees}
-              </Typography>
-            )}
-          </Stack>
+          <AutoCompleteField
+            multiple
+            id="assignees-input"
+            label="Assignees"
+            isRequired
+            placeholder="Select assignees"
+            error={errors.assignees}
+            value={values.assignees}
+            options={assigneeOptions}
+            onChange={handleAssigneesChange}
+            getOptionLabel={(user) =>
+              `${user.name} ${user.surname}`.trim()
+            }
+            renderOption={(props, option) => {
+              const { key, ...optionProps } = props;
+              const userEmail =
+                option.email.length > 30
+                  ? `${option.email.slice(0, 30)}...`
+                  : option.email;
+              return (
+                <Box component="li" key={key} {...optionProps}>
+                  <Typography sx={{ fontSize: "13px" }}>
+                    {option.name} {option.surname}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: "11px",
+                      color: "rgb(157, 157, 157)",
+                      position: "absolute",
+                      right: "9px",
+                    }}
+                  >
+                    {userEmail}
+                  </Typography>
+                </Box>
+              );
+            }}
+            noOptionsText={
+              values.assignees.length === (users?.length ?? 0)
+                ? "All members selected"
+                : "No options"
+            }
+            popupIcon={<GreyDownArrowIcon size={16} />}
+            sx={{ width: "350px" }}
+          />
         </Suspense>
       </Stack>
 


### PR DESCRIPTION

## Describe your changes

Migrated the assignees field in Modals/CreateTask/index.tsx from the raw MUI Autocomplete component to the shared "AutoCompleteField" wrapper.

## Write your issue number after "Fixes "

Fixes #3759 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="800" height="500" alt="Screenshot 2026-04-21 at 10 57 42 AM" src="https://github.com/user-attachments/assets/2a7a03e3-4a07-4eb1-9450-0ab4765462e3" />

