### PR TITLE
fix(security): bump Mako to 1.3.11 to resolve path traversal vulnerability

### DIFF
--- a/EvalServer/requirements.txt
+++ b/EvalServer/requirements.txt
@@ -45,7 +45,7 @@ importlib_metadata==8.7.0
 invoke==2.2.1
 Jinja2==3.1.6
 jiter==0.11.1
-Mako==1.3.10
+Mako==1.3.11
 markdown-it-py==4.0.0
 MarkupSafe==3.0.3
 mdurl==0.1.2


### PR DESCRIPTION
## Summary

- Bump `Mako` from 1.3.10 to 1.3.11 in EvalServer/requirements.txt
- Resolves Dependabot alert #266 (path traversal via double-slash URI prefix, medium severity)
- Transitive dependency of Alembic — not imported directly in any Python code
- Patch-level upgrade, same API