### PR TITLE
fix(security): bump PyJWT to 2.12.0 to resolve CVE-2026-32597

### DIFF
--- a/EvalServer/requirements.txt
+++ b/EvalServer/requirements.txt
@@ -72,7 +72,7 @@ pydantic==2.12.3
 pydantic-settings==2.11.0
 pydantic_core==2.41.4
 Pygments==2.19.2
-PyJWT==2.10.1
+PyJWT==2.12.0
 pyparsing==3.2.5
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2


### PR DESCRIPTION
## Summary

- Bump `PyJWT` from 2.10.1 to 2.12.0 in EvalServer/requirements.txt
- Resolves Dependabot alert #186 (accepts unknown `crit` header extensions, high severity)
- Transitive dependency — not imported directly in any Python code
- Minor version upgrade, same API