### PR TITLE
feat(notifications): add delete button, fix action_url routes, handle stale training ids

### DIFF
--- a/Clients/src/application/hooks/useNotifications.ts
+++ b/Clients/src/application/hooks/useNotifications.ts
@@ -121,6 +121,8 @@ interface UseNotificationsReturn {
   markAsRead: (notificationId: number) => Promise<void>;
   /** Mark all notifications as read */
   markAllAsRead: () => Promise<void>;
+  /** Delete a notification */
+  deleteNotification: (notificationId: number) => Promise<void>;
   /** Refresh notifications from server */
   refresh: () => Promise<void>;
   /** Load more notifications */
@@ -261,6 +263,26 @@ export const useNotifications = (options: UseNotificationsOptions = {}): UseNoti
       setUnreadCount(0);
     } catch (error) {
       console.error("Failed to mark all notifications as read:", error);
+      throw error;
+    }
+  }, []);
+
+  /**
+   * Delete a notification
+   */
+  const deleteNotification = useCallback(async (notificationId: number) => {
+    try {
+      await apiServices.delete(`/notifications/${notificationId}`);
+      setNotifications(prev => {
+        const target = prev.find(n => n.id === notificationId);
+        if (target && !target.is_read) {
+          setUnreadCount(c => Math.max(0, c - 1));
+        }
+        return prev.filter(n => n.id !== notificationId);
+      });
+      setTotalCount(prev => Math.max(0, prev - 1));
+    } catch (error) {
+      console.error("Failed to delete notification:", error);
       throw error;
     }
   }, []);
@@ -543,6 +565,7 @@ export const useNotifications = (options: UseNotificationsOptions = {}): UseNoti
     hasMore,
     markAsRead,
     markAllAsRead,
+    deleteNotification,
     refresh,
     loadMore,
   };

--- a/Clients/src/application/hooks/useNotifications.ts
+++ b/Clients/src/application/hooks/useNotifications.ts
@@ -165,6 +165,8 @@ export const useNotifications = (options: UseNotificationsOptions = {}): UseNoti
 
   // State for stored notifications
   const [notifications, setNotifications] = useState<Notification[]>([]);
+  const notificationsRef = useRef<Notification[]>([]);
+  notificationsRef.current = notifications;
   const [unreadCount, setUnreadCount] = useState(0);
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -267,20 +269,16 @@ export const useNotifications = (options: UseNotificationsOptions = {}): UseNoti
     }
   }, []);
 
-  /**
-   * Delete a notification
-   */
   const deleteNotification = useCallback(async (notificationId: number) => {
     try {
       await apiServices.delete(`/notifications/${notificationId}`);
-      setNotifications(prev => {
-        const target = prev.find(n => n.id === notificationId);
-        if (target && !target.is_read) {
-          setUnreadCount(c => Math.max(0, c - 1));
-        }
-        return prev.filter(n => n.id !== notificationId);
-      });
+      const target = notificationsRef.current.find(n => n.id === notificationId);
+      if (!target) return;
+      setNotifications(prev => prev.filter(n => n.id !== notificationId));
       setTotalCount(prev => Math.max(0, prev - 1));
+      if (!target.is_read) {
+        setUnreadCount(prev => Math.max(0, prev - 1));
+      }
     } catch (error) {
       console.error("Failed to delete notification:", error);
       throw error;

--- a/Clients/src/presentation/components/NotificationBell/index.tsx
+++ b/Clients/src/presentation/components/NotificationBell/index.tsx
@@ -9,7 +9,7 @@ import {
   Divider,
   CircularProgress,
 } from '@mui/material';
-import { Bell, CheckCheck, X, ExternalLink } from 'lucide-react';
+import { Bell, CheckCheck, X, ExternalLink, Trash2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useNotifications, Notification } from '../../../application/hooks/useNotifications';
 import VWTooltip from '../VWTooltip';
@@ -67,12 +67,14 @@ interface NotificationItemProps {
   notification: Notification;
   onMarkAsRead: (id: number) => void;
   onNavigate: (url: string) => void;
+  onDelete: (id: number) => void;
 }
 
 const NotificationItem: React.FC<NotificationItemProps> = ({
   notification,
   onMarkAsRead,
   onNavigate,
+  onDelete,
 }) => {
   const isRead = notification.is_read;
   const color = getNotificationColor(notification.type);
@@ -83,6 +85,13 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
     }
     if (notification.action_url) {
       onNavigate(notification.action_url);
+    }
+  };
+
+  const handleDelete = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (notification.id) {
+      onDelete(notification.id);
     }
   };
 
@@ -100,8 +109,12 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
         backgroundColor: isRead ? 'transparent' : 'rgba(19, 113, 91, 0.04)',
         borderLeft: isRead ? '3px solid transparent' : `3px solid ${color}`,
         transition: 'all 0.15s ease',
+        position: 'relative',
         '&:hover': {
           backgroundColor: 'rgba(0, 0, 0, 0.02)',
+        },
+        '&:hover .notification-delete-btn': {
+          opacity: 1,
         },
       }}
     >
@@ -151,6 +164,30 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
           style={{ flexShrink: 0, marginTop: 2 }}
         />
       )}
+
+      {/* Delete button (visible on hover) */}
+      <VWTooltip header="Delete" content="Delete this notification" placement="left">
+        <IconButton
+          className="notification-delete-btn"
+          size="small"
+          onClick={handleDelete}
+          aria-label="Delete notification"
+          sx={{
+            opacity: 0,
+            transition: 'opacity 0.15s ease',
+            width: '24px',
+            height: '24px',
+            marginTop: '-2px',
+            color: text.disabled,
+            '&:hover': {
+              backgroundColor: 'rgba(239, 68, 68, 0.08)',
+              color: '#EF4444',
+            },
+          }}
+        >
+          <Trash2 size={14} />
+        </IconButton>
+      </VWTooltip>
     </Box>
   );
 };
@@ -167,11 +204,13 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ sx }) => {
   const {
     notifications,
     unreadCount,
+    totalCount,
     isLoading,
     isLoadingMore,
     hasMore,
     markAsRead,
     markAllAsRead,
+    deleteNotification,
     loadMore,
     isConnected,
   } = useNotifications();
@@ -199,6 +238,14 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ sx }) => {
       console.error('Failed to mark all notifications as read:', error);
     }
   }, [markAllAsRead]);
+
+  const handleDelete = useCallback(async (notificationId: number) => {
+    try {
+      await deleteNotification(notificationId);
+    } catch (error) {
+      console.error('Failed to delete notification:', error);
+    }
+  }, [deleteNotification]);
 
   const handleNavigate = useCallback((url: string) => {
     handleClose();
@@ -295,16 +342,39 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ sx }) => {
           },
         }}
       >
-        {/* Header - minimal with just action buttons */}
+        {/* Header with title and action buttons */}
         <Box
           sx={{
             display: 'flex',
             alignItems: 'center',
-            justifyContent: 'flex-end',
-            px: 1,
-            py: 0.5,
+            justifyContent: 'space-between',
+            px: 2,
+            py: 1,
+            borderBottom: '1px solid #e5e7eb',
           }}
         >
+          <Stack direction="row" alignItems="baseline" spacing={1}>
+            <Typography
+              sx={{
+                fontSize: '14px',
+                fontWeight: 600,
+                color: 'text.primary',
+              }}
+            >
+              Notifications
+            </Typography>
+            {totalCount > 0 && (
+              <Typography
+                sx={{
+                  fontSize: '12px',
+                  color: 'text.disabled',
+                  fontWeight: 500,
+                }}
+              >
+                {totalCount}
+              </Typography>
+            )}
+          </Stack>
           <Stack direction="row" spacing={0.5}>
             {unreadCount > 0 && (
               <VWTooltip header="Mark all as read" content="Mark all notifications as read" placement="bottom">
@@ -410,6 +480,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ sx }) => {
                     notification={notification}
                     onMarkAsRead={handleMarkAsRead}
                     onNavigate={handleNavigate}
+                    onDelete={handleDelete}
                   />
                 ))}
               </Stack>

--- a/Clients/src/presentation/components/NotificationBell/index.tsx
+++ b/Clients/src/presentation/components/NotificationBell/index.tsx
@@ -18,6 +18,33 @@ import '../Layout/icon-shake.css';
 import { text } from "../../themes/palette";
 
 /**
+ * Rewrite legacy action_url values that were stored in older notifications
+ * before the server-side route mapping was corrected. Each rule rewrites a
+ * path pattern to the frontend route that actually exists.
+ */
+const LEGACY_URL_REWRITES: Array<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /^\/training\/(\d+)/, replacement: '/training?trainingId=$1' },
+  { pattern: /^\/vendors\/(\d+)/, replacement: '/vendors?vendorId=$1' },
+  { pattern: /^\/policies\/(\d+)$/, replacement: '/policies/$1/edit' },
+  { pattern: /^\/use-cases\/(\d+)/, replacement: '/project-view?projectId=$1' },
+  { pattern: /^\/projects\/(\d+)/, replacement: '/project-view?projectId=$1' },
+  { pattern: /^\/policys\/(\d+)/, replacement: '/policies/$1/edit' },
+  { pattern: /^\/models\/(\d+)/, replacement: '/model-inventory/models/$1' },
+  { pattern: /^\/risks\/(\d+)/, replacement: '/risk-management?riskId=$1' },
+  { pattern: /^\/assessments\/(\d+)/, replacement: '/project-view?projectId=$1' },
+  { pattern: /^\/files\/(\d+)/, replacement: '/file-manager?fileId=$1' },
+  { pattern: /^\/approval-requests(?:\?|$|\/)/, replacement: '/approval-workflows' },
+];
+
+const repairLegacyActionUrl = (url: string): string => {
+  if (!url.startsWith('/')) return url;
+  for (const { pattern, replacement } of LEGACY_URL_REWRITES) {
+    if (pattern.test(url)) return url.replace(pattern, replacement);
+  }
+  return url;
+};
+
+/**
  * Format relative time from ISO string
  */
 const formatRelativeTime = (dateString: string): string => {
@@ -249,12 +276,11 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ sx }) => {
 
   const handleNavigate = useCallback((url: string) => {
     handleClose();
-    // Check if it's an internal URL
-    if (url.startsWith('/')) {
-      navigate(url);
+    const repaired = repairLegacyActionUrl(url);
+    if (repaired.startsWith('/')) {
+      navigate(repaired);
     } else {
-      // For external URLs, open in new tab
-      window.open(url, '_blank');
+      window.open(repaired, '_blank');
     }
   }, [navigate, handleClose]);
 

--- a/Clients/src/presentation/pages/TrainingRegistar/index.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/index.tsx
@@ -230,8 +230,10 @@ const Training: React.FC = () => {
           });
           setAlert({
             variant: "error",
-            body: "Failed to load training details. Please try again.",
+            body: "This training no longer exists or you do not have access to it.",
           });
+          setIsNewTrainingModalOpen(false);
+          setSelectedTrainingId(null);
         }
       }
     };

--- a/Servers/controllers/approvalRequest.ctrl.ts
+++ b/Servers/controllers/approvalRequest.ctrl.ts
@@ -578,7 +578,7 @@ export async function rejectRequest(
               entity_type: NotificationEntityType.USE_CASE,
               entity_id: requestId,
               entity_name: notificationInfo.requestName,
-              action_url: `${baseUrl}/approval-requests`,
+              action_url: `${baseUrl}/approval-workflows`,
             },
             true,
             {
@@ -589,7 +589,7 @@ export async function rejectRequest(
                 rejector_name: rejectorName,
                 request_name: notificationInfo.requestName,
                 rejection_reason: comments || "No reason provided",
-                request_url: `${baseUrl}/approval-requests`,
+                request_url: `${baseUrl}/approval-workflows`,
               },
             }
           );

--- a/Servers/services/inAppNotification.service.ts
+++ b/Servers/services/inAppNotification.service.ts
@@ -17,6 +17,46 @@ import { notificationService } from "./notificationService";
 import { EMAIL_TEMPLATES } from "../constants/emailTemplates";
 
 /**
+ * Build a frontend-compatible URL for a given entity type and id.
+ * The frontend routes don't all follow a single `/:entityType/:id` pattern,
+ * so each entity type is mapped to the actual route that exists.
+ */
+const buildEntityUrl = (
+  entityType: NotificationEntityType,
+  entityId: number
+): string => {
+  switch (entityType) {
+    case NotificationEntityType.TASK:
+      return `/tasks?taskId=${entityId}`;
+    case NotificationEntityType.TRAINING:
+      return `/training?trainingId=${entityId}`;
+    case NotificationEntityType.VENDOR:
+      return `/vendors?vendorId=${entityId}`;
+    case NotificationEntityType.POLICY:
+      return `/policies/${entityId}/edit`;
+    case NotificationEntityType.USE_CASE:
+    case NotificationEntityType.PROJECT:
+      return `/project-view?projectId=${entityId}`;
+    case NotificationEntityType.MODEL:
+      return `/model-inventory/models/${entityId}`;
+    case NotificationEntityType.RISK:
+      return `/risk-management?riskId=${entityId}`;
+    case NotificationEntityType.ASSESSMENT:
+      return `/project-view?projectId=${entityId}`;
+    case NotificationEntityType.FILE:
+      return `/file-manager?fileId=${entityId}`;
+    case NotificationEntityType.SHADOW_AI_TOOL:
+      return `/shadow-ai/tools/${entityId}`;
+    case NotificationEntityType.AI_GATEWAY:
+      return `/ai-gateway/settings`;
+    case NotificationEntityType.COMMENT:
+    case NotificationEntityType.USER:
+    default:
+      return `/overview`;
+  }
+};
+
+/**
  * Send a notification to a user via both in-app storage and real-time SSE
  * Optionally also sends an email notification
  */
@@ -532,7 +572,7 @@ export const notifyReviewRequested = async (
       entity_type: entity.type,
       entity_id: entity.id,
       entity_name: entity.name,
-      action_url: `/${entity.type}s/${entity.id}`,
+      action_url: buildEntityUrl(entity.type, entity.id),
     },
     true,
     {
@@ -545,7 +585,7 @@ export const notifyReviewRequested = async (
         entity_name: entity.name,
         project_name: entity.projectName,
         review_message: message || "Please review this item.",
-        review_url: `${baseUrl}/${entity.type}s/${entity.id}`,
+        review_url: `${baseUrl}${buildEntityUrl(entity.type, entity.id)}`,
       },
     }
   );
@@ -580,7 +620,7 @@ export const notifyReviewApproved = async (
       entity_type: entity.type,
       entity_id: entity.id,
       entity_name: entity.name,
-      action_url: `/${entity.type}s/${entity.id}`,
+      action_url: buildEntityUrl(entity.type, entity.id),
     },
     true,
     {
@@ -593,7 +633,7 @@ export const notifyReviewApproved = async (
         entity_name: entity.name,
         project_name: entity.projectName,
         review_comment: comment || "Looks good!",
-        entity_url: `${baseUrl}/${entity.type}s/${entity.id}`,
+        entity_url: `${baseUrl}${buildEntityUrl(entity.type, entity.id)}`,
       },
     }
   );
@@ -628,7 +668,7 @@ export const notifyReviewRejected = async (
       entity_type: entity.type,
       entity_id: entity.id,
       entity_name: entity.name,
-      action_url: `/${entity.type}s/${entity.id}`,
+      action_url: buildEntityUrl(entity.type, entity.id),
     },
     true,
     {
@@ -641,7 +681,7 @@ export const notifyReviewRejected = async (
         entity_name: entity.name,
         project_name: entity.projectName,
         review_comment: comment || "Please make the requested changes.",
-        entity_url: `${baseUrl}/${entity.type}s/${entity.id}`,
+        entity_url: `${baseUrl}${buildEntityUrl(entity.type, entity.id)}`,
       },
     }
   );
@@ -675,7 +715,7 @@ export const notifyApprovalRequested = async (
       entity_type: NotificationEntityType.USE_CASE,
       entity_id: useCase.id,
       entity_name: useCase.name,
-      action_url: `/use-cases/${useCase.id}`,
+      action_url: buildEntityUrl(NotificationEntityType.USE_CASE, useCase.id),
       metadata: { stepNumber: useCase.stepNumber },
     },
     true,
@@ -689,7 +729,7 @@ export const notifyApprovalRequested = async (
         workflow_name: useCase.workflowName,
         step_number: String(useCase.stepNumber),
         total_steps: String(useCase.totalSteps),
-        approval_url: `${baseUrl}/use-cases/${useCase.id}`,
+        approval_url: `${baseUrl}${buildEntityUrl(NotificationEntityType.USE_CASE, useCase.id)}`,
       },
     }
   );
@@ -720,7 +760,7 @@ export const notifyApprovalComplete = async (
       entity_type: NotificationEntityType.USE_CASE,
       entity_id: useCase.id,
       entity_name: useCase.name,
-      action_url: `/use-cases/${useCase.id}`,
+      action_url: buildEntityUrl(NotificationEntityType.USE_CASE, useCase.id),
     },
     true,
     {
@@ -730,7 +770,7 @@ export const notifyApprovalComplete = async (
         requester_name: requester ? `${requester.name}` : "User",
         use_case_name: useCase.name,
         total_steps: String(useCase.totalSteps),
-        use_case_url: `${baseUrl}/use-cases/${useCase.id}`,
+        use_case_url: `${baseUrl}${buildEntityUrl(NotificationEntityType.USE_CASE, useCase.id)}`,
       },
     }
   );
@@ -764,7 +804,7 @@ export const notifyVendorReviewDue = async (
       entity_type: NotificationEntityType.VENDOR,
       entity_id: vendor.id,
       entity_name: vendor.name,
-      action_url: `/vendors/${vendor.id}`,
+      action_url: buildEntityUrl(NotificationEntityType.VENDOR, vendor.id),
     },
     true,
     {
@@ -777,7 +817,7 @@ export const notifyVendorReviewDue = async (
         risk_level: vendor.riskLevel,
         last_review_date: vendor.lastReviewDate || "Never",
         project_count: String(vendor.projectCount),
-        vendor_url: `${baseUrl}/vendors/${vendor.id}`,
+        vendor_url: `${baseUrl}${buildEntityUrl(NotificationEntityType.VENDOR, vendor.id)}`,
       },
     }
   );
@@ -809,7 +849,7 @@ export const notifyPolicyDueSoon = async (
       entity_type: NotificationEntityType.POLICY,
       entity_id: policy.id,
       entity_name: policy.name,
-      action_url: `/policies/${policy.id}`,
+      action_url: buildEntityUrl(NotificationEntityType.POLICY, policy.id),
     },
     true,
     {
@@ -820,7 +860,7 @@ export const notifyPolicyDueSoon = async (
         policy_name: policy.name,
         project_name: policy.projectName,
         due_date: policy.dueDate,
-        policy_url: `${baseUrl}/policies/${policy.id}`,
+        policy_url: `${baseUrl}${buildEntityUrl(NotificationEntityType.POLICY, policy.id)}`,
       },
     }
   );
@@ -854,7 +894,7 @@ export const notifyTrainingAssigned = async (
       entity_type: NotificationEntityType.TRAINING,
       entity_id: training.id,
       entity_name: training.name,
-      action_url: `/training/${training.id}`,
+      action_url: buildEntityUrl(NotificationEntityType.TRAINING, training.id),
     },
     true,
     {
@@ -867,7 +907,7 @@ export const notifyTrainingAssigned = async (
         training_description: training.description || "No description provided",
         training_duration: training.duration || "Not specified",
         training_due_date: training.dueDate || "No due date",
-        training_url: `${baseUrl}/training/${training.id}`,
+        training_url: `${baseUrl}${buildEntityUrl(NotificationEntityType.TRAINING, training.id)}`,
       },
     }
   );


### PR DESCRIPTION
## Summary

- Adds a per-notification delete button (visible on hover) and a "Notifications" header with count to the notification dropdown. Closes #3776.
- Fixes broken `action_url` routes so notifications land on pages that actually exist instead of 404s (training, vendor, policy, use case, approval request, review_*).
- Repairs legacy `action_url` values already in the database at click time so old notifications also route correctly without a data migration.
- Closes the training edit modal cleanly when the training id cannot be loaded (deleted, wrong org, stale id) so the user no longer sees an empty "new training" form behind an error toast.