### PR TITLE
feat(ai-trust-center): implement column visibility on Resources and Subprocessors tabs

### DIFF
--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -38,7 +38,10 @@ import { GroupBy } from "../../../components/Table/GroupBy";
 import { useTableGrouping, useGroupByState } from "../../../../application/hooks/useTableGrouping";
 import { GroupedTableView } from "../../../components/Table/GroupedTableView";
 import { ColumnSelector } from "../../../components/Table/ColumnSelector";
-import { useColumnVisibility, ColumnConfig } from "../../../../application/hooks/useColumnVisibility";
+import {
+  useColumnVisibility,
+  ColumnConfig,
+} from "../../../../application/hooks/useColumnVisibility";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { text, background, border as borderPalette } from "../../../themes/palette";
 import { useFormValidation } from "../../../../application/hooks/useFormValidation";
@@ -565,7 +568,7 @@ const TrustCenterResources: React.FC = () => {
 
   const visibleTableColumns = useMemo(
     () => TABLE_COLUMNS.filter((col) => visibleColumns.has(col.id as ResourceColumn)),
-    [visibleColumns]
+    [visibleColumns],
   );
 
   // Show loading state

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -37,10 +37,21 @@ import {
 import { GroupBy } from "../../../components/Table/GroupBy";
 import { useTableGrouping, useGroupByState } from "../../../../application/hooks/useTableGrouping";
 import { GroupedTableView } from "../../../components/Table/GroupedTableView";
+import { ColumnSelector } from "../../../components/Table/ColumnSelector";
+import { useColumnVisibility, ColumnConfig } from "../../../../application/hooks/useColumnVisibility";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { text, background, border as borderPalette } from "../../../themes/palette";
 import { useFormValidation } from "../../../../application/hooks/useFormValidation";
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
+
+type ResourceColumn = "name" | "type" | "visible" | "action";
+
+const RESOURCE_COLUMNS: ColumnConfig<ResourceColumn>[] = [
+  { key: "name", label: "Resource name", defaultVisible: true, alwaysVisible: true },
+  { key: "type", label: "Type or purpose", defaultVisible: true },
+  { key: "visible", label: "Visibility", defaultVisible: true },
+  { key: "action", label: "Action", defaultVisible: true, alwaysVisible: true },
+];
 
 // Helper component for Resource Table Row
 const ResourceTableRow: React.FC<{
@@ -53,7 +64,8 @@ const ResourceTableRow: React.FC<{
     key: string;
     direction: "asc" | "desc" | null;
   };
-}> = ({ resource, onDelete, onEdit, onMakeVisible, onDownload, sortConfig }) => {
+  visibleColumnIds?: Set<ResourceColumn>;
+}> = ({ resource, onDelete, onEdit, onMakeVisible, onDownload, sortConfig, visibleColumnIds }) => {
   const theme = useTheme();
   const styles = useStyles(theme);
 
@@ -65,83 +77,91 @@ const ResourceTableRow: React.FC<{
 
   return (
     <>
-      <TableCell
-        onClick={handleRowClick}
-        sx={{
-          cursor: resource.visible ? "pointer" : "default",
-          textTransform: "none !important",
-          opacity: resource.visible ? 1 : 0.5,
-          backgroundColor:
-            sortConfig?.key && sortConfig.key.toLowerCase().includes("resource name")
-              ? singleTheme.tableColors.sortedColumnFirst
-              : "transparent",
-        }}
-      >
-        <Typography sx={styles.resourceName}>{resource.name}</Typography>
-      </TableCell>
-      <TableCell
-        onClick={handleRowClick}
-        sx={{
-          cursor: resource.visible ? "pointer" : "default",
-          textTransform: "none !important",
-          opacity: resource.visible ? 1 : 0.5,
-          backgroundColor:
-            sortConfig?.key &&
-            sortConfig.key.toLowerCase().includes("type") &&
-            sortConfig.key.toLowerCase().includes("purpose")
-              ? singleTheme.tableColors.sortedColumn
-              : "transparent",
-        }}
-      >
-        <Typography sx={styles.resourceType}>{resource.description}</Typography>
-      </TableCell>
-      <TableCell
-        onClick={() => onMakeVisible(resource.id)}
-        sx={{
-          cursor: resource.visible ? "pointer" : "default",
-          textTransform: "none !important",
-          opacity: resource.visible ? 1 : 0.5,
-          backgroundColor:
-            sortConfig?.key && sortConfig.key.toLowerCase().includes("visibility")
-              ? singleTheme.tableColors.sortedColumn
-              : "transparent",
-        }}
-      >
-        {resource.visible ? (
-          <Tooltip title="Click to make this resource invisible">
-            <Box component="span" sx={{ display: "inline-flex" }}>
-              <VisibilityIcon size={20} />
-            </Box>
-          </Tooltip>
-        ) : (
-          <Tooltip title="Click to make this resource visible">
-            <Box component="span" sx={{ display: "inline-flex" }}>
-              <VisibilityOffIcon size={20} />
-            </Box>
-          </Tooltip>
-        )}
-      </TableCell>
-      <TableCell
-        sx={{
-          backgroundColor:
-            sortConfig?.key && sortConfig.key.toLowerCase().includes("action")
-              ? singleTheme.tableColors.sortedColumn
-              : "transparent",
-        }}
-      >
-        <IconButtonComponent
-          id={resource.id}
-          onDelete={() => onDelete(resource.id)}
-          onEdit={() => onEdit(resource.id)}
-          onMouseEvent={() => {}}
-          onMakeVisible={() => onMakeVisible(resource.id)}
-          onDownload={() => onDownload(resource.id)}
-          isVisible={resource.visible}
-          warningTitle={WARNING_MESSAGES.deleteTitle}
-          warningMessage={WARNING_MESSAGES.deleteMessage}
-          type="Resource"
-        />
-      </TableCell>
+      {(!visibleColumnIds || visibleColumnIds.has("name")) && (
+        <TableCell
+          onClick={handleRowClick}
+          sx={{
+            cursor: resource.visible ? "pointer" : "default",
+            textTransform: "none !important",
+            opacity: resource.visible ? 1 : 0.5,
+            backgroundColor:
+              sortConfig?.key && sortConfig.key.toLowerCase().includes("resource name")
+                ? singleTheme.tableColors.sortedColumnFirst
+                : "transparent",
+          }}
+        >
+          <Typography sx={styles.resourceName}>{resource.name}</Typography>
+        </TableCell>
+      )}
+      {(!visibleColumnIds || visibleColumnIds.has("type")) && (
+        <TableCell
+          onClick={handleRowClick}
+          sx={{
+            cursor: resource.visible ? "pointer" : "default",
+            textTransform: "none !important",
+            opacity: resource.visible ? 1 : 0.5,
+            backgroundColor:
+              sortConfig?.key &&
+              sortConfig.key.toLowerCase().includes("type") &&
+              sortConfig.key.toLowerCase().includes("purpose")
+                ? singleTheme.tableColors.sortedColumn
+                : "transparent",
+          }}
+        >
+          <Typography sx={styles.resourceType}>{resource.description}</Typography>
+        </TableCell>
+      )}
+      {(!visibleColumnIds || visibleColumnIds.has("visible")) && (
+        <TableCell
+          onClick={() => onMakeVisible(resource.id)}
+          sx={{
+            cursor: resource.visible ? "pointer" : "default",
+            textTransform: "none !important",
+            opacity: resource.visible ? 1 : 0.5,
+            backgroundColor:
+              sortConfig?.key && sortConfig.key.toLowerCase().includes("visibility")
+                ? singleTheme.tableColors.sortedColumn
+                : "transparent",
+          }}
+        >
+          {resource.visible ? (
+            <Tooltip title="Click to make this resource invisible">
+              <Box component="span" sx={{ display: "inline-flex" }}>
+                <VisibilityIcon size={20} />
+              </Box>
+            </Tooltip>
+          ) : (
+            <Tooltip title="Click to make this resource visible">
+              <Box component="span" sx={{ display: "inline-flex" }}>
+                <VisibilityOffIcon size={20} />
+              </Box>
+            </Tooltip>
+          )}
+        </TableCell>
+      )}
+      {(!visibleColumnIds || visibleColumnIds.has("action")) && (
+        <TableCell
+          sx={{
+            backgroundColor:
+              sortConfig?.key && sortConfig.key.toLowerCase().includes("action")
+                ? singleTheme.tableColors.sortedColumn
+                : "transparent",
+          }}
+        >
+          <IconButtonComponent
+            id={resource.id}
+            onDelete={() => onDelete(resource.id)}
+            onEdit={() => onEdit(resource.id)}
+            onMouseEvent={() => {}}
+            onMakeVisible={() => onMakeVisible(resource.id)}
+            onDownload={() => onDownload(resource.id)}
+            isVisible={resource.visible}
+            warningTitle={WARNING_MESSAGES.deleteTitle}
+            warningMessage={WARNING_MESSAGES.deleteMessage}
+            type="Resource"
+          />
+        </TableCell>
+      )}
     </>
   );
 };
@@ -213,6 +233,13 @@ const TrustCenterResources: React.FC = () => {
 
   // GroupBy state
   const { groupBy, groupSortOrder, handleGroupChange } = useGroupByState();
+
+  // Column visibility
+  const { visibleColumns, allColumns, toggleColumn, resetToDefaults } =
+    useColumnVisibility<ResourceColumn>({
+      tableId: "resources-table",
+      columns: RESOURCE_COLUMNS,
+    });
 
   // State management
   const [formData, setFormData] = useState<FormData | null>(null);
@@ -536,6 +563,11 @@ const TrustCenterResources: React.FC = () => {
     getGroupKey: getResourceGroupKey,
   });
 
+  const visibleTableColumns = useMemo(
+    () => TABLE_COLUMNS.filter((col) => visibleColumns.has(col.id as ResourceColumn)),
+    [visibleColumns]
+  );
+
   // Show loading state
   if (overviewLoading || resourcesLoading) {
     return (
@@ -583,6 +615,12 @@ const TrustCenterResources: React.FC = () => {
               ]}
               onGroupChange={handleGroupChange}
             />
+            <ColumnSelector
+              columns={allColumns}
+              visibleColumns={visibleColumns}
+              onToggleColumn={toggleColumn}
+              onResetToDefaults={resetToDefaults}
+            />
           </Box>
           <Box sx={{ display: "flex", gap: "8px", alignItems: "center" }}>
             <Box sx={styles.toggleRow}>
@@ -617,7 +655,7 @@ const TrustCenterResources: React.FC = () => {
             renderTable={(data, options) => (
               <AITrustCenterTable
                 data={data}
-                columns={TABLE_COLUMNS}
+                columns={visibleTableColumns}
                 isLoading={resourcesLoading}
                 paginated={true}
                 disabled={!formData?.info?.resources_visible}
@@ -631,6 +669,7 @@ const TrustCenterResources: React.FC = () => {
                     onMakeVisible={handleMakeVisible}
                     onDownload={handleDownload}
                     sortConfig={sortConfig}
+                    visibleColumnIds={visibleColumns}
                   />
                 )}
                 tableId="resources-table"

--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -30,7 +30,10 @@ import { GroupBy } from "../../../components/Table/GroupBy";
 import { useTableGrouping, useGroupByState } from "../../../../application/hooks/useTableGrouping";
 import { GroupedTableView } from "../../../components/Table/GroupedTableView";
 import { ColumnSelector } from "../../../components/Table/ColumnSelector";
-import { useColumnVisibility, ColumnConfig } from "../../../../application/hooks/useColumnVisibility";
+import {
+  useColumnVisibility,
+  ColumnConfig,
+} from "../../../../application/hooks/useColumnVisibility";
 import { background } from "../../../themes/palette";
 
 interface FormData {
@@ -492,7 +495,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
 
   const visibleTableColumns = useMemo(
     () => TABLE_COLUMNS.filter((col) => visibleColumns.has(col.id as SubprocessorColumn)),
-    [visibleColumns]
+    [visibleColumns],
   );
 
   // Show loading state

--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useState, Suspense, useCallback, useEffect, useRef } from "react";
+import React, { useState, Suspense, useCallback, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Box, Typography, TableCell, Stack, CircularProgress } from "@mui/material";
 import Toggle from "../../../components/Inputs/Toggle";
@@ -29,6 +29,8 @@ import { TABLE_COLUMNS, WARNING_MESSAGES } from "./constants";
 import { GroupBy } from "../../../components/Table/GroupBy";
 import { useTableGrouping, useGroupByState } from "../../../../application/hooks/useTableGrouping";
 import { GroupedTableView } from "../../../components/Table/GroupedTableView";
+import { ColumnSelector } from "../../../components/Table/ColumnSelector";
+import { useColumnVisibility, ColumnConfig } from "../../../../application/hooks/useColumnVisibility";
 import { background } from "../../../themes/palette";
 
 interface FormData {
@@ -36,6 +38,16 @@ interface FormData {
     subprocessor_visible?: boolean;
   };
 }
+
+type SubprocessorColumn = "company" | "url" | "purpose" | "location" | "action";
+
+const SUBPROCESSOR_COLUMNS: ColumnConfig<SubprocessorColumn>[] = [
+  { key: "company", label: "Company name", defaultVisible: true, alwaysVisible: true },
+  { key: "url", label: "URL", defaultVisible: true },
+  { key: "purpose", label: "Purpose", defaultVisible: true },
+  { key: "location", label: "Location", defaultVisible: true },
+  { key: "action", label: "Action", defaultVisible: true, alwaysVisible: true },
+];
 
 // Helper component for Subprocessor Table Row
 const SubprocessorTableRow: React.FC<{
@@ -46,7 +58,8 @@ const SubprocessorTableRow: React.FC<{
     key: string;
     direction: "asc" | "desc" | null;
   };
-}> = ({ subprocessor, onDelete, onEdit, sortConfig }) => {
+  visibleColumnIds?: Set<SubprocessorColumn>;
+}> = ({ subprocessor, onDelete, onEdit, sortConfig, visibleColumnIds }) => {
   const theme = useTheme();
   const styles = useStyles(theme);
 
@@ -56,82 +69,92 @@ const SubprocessorTableRow: React.FC<{
 
   return (
     <>
-      <TableCell
-        onClick={handleRowClick}
-        sx={{
-          cursor: "pointer",
-          textTransform: "none !important",
-          backgroundColor:
-            sortConfig?.key && sortConfig.key.toLowerCase().includes("company name")
-              ? "#e8e8e8"
-              : "#fafafa",
-          maxWidth: "200px",
-          width: "200px",
-        }}
-      >
-        <Typography sx={styles.tableDataCell}>{subprocessor.name}</Typography>
-      </TableCell>
-      <TableCell
-        onClick={handleRowClick}
-        sx={{
-          cursor: "pointer",
-          textTransform: "none !important",
-          backgroundColor:
-            sortConfig?.key && sortConfig.key.toLowerCase().includes("url")
-              ? `${background.surface}`
-              : "inherit",
-        }}
-      >
-        <Typography sx={styles.tableDataCell}>
-          {subprocessor.url.replace(/^https?:\/\//, "")}
-        </Typography>
-      </TableCell>
-      <TableCell
-        onClick={handleRowClick}
-        sx={{
-          cursor: "pointer",
-          textTransform: "none !important",
-          backgroundColor:
-            sortConfig?.key && sortConfig.key.toLowerCase().includes("purpose")
-              ? `${background.surface}`
-              : "inherit",
-        }}
-      >
-        <Typography sx={styles.tableDataCell}>{subprocessor.purpose}</Typography>
-      </TableCell>
-      <TableCell
-        onClick={handleRowClick}
-        sx={{
-          cursor: "pointer",
-          textTransform: "none !important",
-          backgroundColor:
-            sortConfig?.key && sortConfig.key.toLowerCase().includes("location")
-              ? `${background.surface}`
-              : "inherit",
-        }}
-      >
-        <Typography sx={styles.tableDataCell}>{subprocessor.location}</Typography>
-      </TableCell>
-      <TableCell
-        sx={{
-          backgroundColor:
-            sortConfig?.key && sortConfig.key.toLowerCase().includes("action")
-              ? `${background.surface}`
-              : "inherit",
-        }}
-      >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <IconButtonComponent
-            id={subprocessor.id}
-            onDelete={() => onDelete(subprocessor.id)}
-            onEdit={() => onEdit(subprocessor.id)}
-            onMouseEvent={() => {}}
-            type=""
-            warningTitle={WARNING_MESSAGES.deleteTitle}
-            warningMessage={WARNING_MESSAGES.deleteMessage}
-          />
-        </Box>
-      </TableCell>
+      {(!visibleColumnIds || visibleColumnIds.has("company")) && (
+        <TableCell
+          onClick={handleRowClick}
+          sx={{
+            cursor: "pointer",
+            textTransform: "none !important",
+            backgroundColor:
+              sortConfig?.key && sortConfig.key.toLowerCase().includes("company name")
+                ? "#e8e8e8"
+                : "#fafafa",
+            maxWidth: "200px",
+            width: "200px",
+          }}
+        >
+          <Typography sx={styles.tableDataCell}>{subprocessor.name}</Typography>
+        </TableCell>
+      )}
+      {(!visibleColumnIds || visibleColumnIds.has("url")) && (
+        <TableCell
+          onClick={handleRowClick}
+          sx={{
+            cursor: "pointer",
+            textTransform: "none !important",
+            backgroundColor:
+              sortConfig?.key && sortConfig.key.toLowerCase().includes("url")
+                ? `${background.surface}`
+                : "inherit",
+          }}
+        >
+          <Typography sx={styles.tableDataCell}>
+            {subprocessor.url.replace(/^https?:\/\//, "")}
+          </Typography>
+        </TableCell>
+      )}
+      {(!visibleColumnIds || visibleColumnIds.has("purpose")) && (
+        <TableCell
+          onClick={handleRowClick}
+          sx={{
+            cursor: "pointer",
+            textTransform: "none !important",
+            backgroundColor:
+              sortConfig?.key && sortConfig.key.toLowerCase().includes("purpose")
+                ? `${background.surface}`
+                : "inherit",
+          }}
+        >
+          <Typography sx={styles.tableDataCell}>{subprocessor.purpose}</Typography>
+        </TableCell>
+      )}
+      {(!visibleColumnIds || visibleColumnIds.has("location")) && (
+        <TableCell
+          onClick={handleRowClick}
+          sx={{
+            cursor: "pointer",
+            textTransform: "none !important",
+            backgroundColor:
+              sortConfig?.key && sortConfig.key.toLowerCase().includes("location")
+                ? `${background.surface}`
+                : "inherit",
+          }}
+        >
+          <Typography sx={styles.tableDataCell}>{subprocessor.location}</Typography>
+        </TableCell>
+      )}
+      {(!visibleColumnIds || visibleColumnIds.has("action")) && (
+        <TableCell
+          sx={{
+            backgroundColor:
+              sortConfig?.key && sortConfig.key.toLowerCase().includes("action")
+                ? `${background.surface}`
+                : "inherit",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <IconButtonComponent
+              id={subprocessor.id}
+              onDelete={() => onDelete(subprocessor.id)}
+              onEdit={() => onEdit(subprocessor.id)}
+              onMouseEvent={() => {}}
+              type=""
+              warningTitle={WARNING_MESSAGES.deleteTitle}
+              warningMessage={WARNING_MESSAGES.deleteMessage}
+            />
+          </Box>
+        </TableCell>
+      )}
     </>
   );
 };
@@ -174,6 +197,13 @@ const AITrustCenterSubprocessors: React.FC = () => {
 
   // GroupBy state
   const { groupBy, groupSortOrder, handleGroupChange } = useGroupByState();
+
+  // Column visibility
+  const { visibleColumns, allColumns, toggleColumn, resetToDefaults } =
+    useColumnVisibility<SubprocessorColumn>({
+      tableId: "subprocessors-table",
+      columns: SUBPROCESSOR_COLUMNS,
+    });
 
   // State management
   const [formData, setFormData] = useState<FormData | null>(null);
@@ -460,6 +490,11 @@ const AITrustCenterSubprocessors: React.FC = () => {
     getGroupKey: getSubprocessorGroupKey,
   });
 
+  const visibleTableColumns = useMemo(
+    () => TABLE_COLUMNS.filter((col) => visibleColumns.has(col.id as SubprocessorColumn)),
+    [visibleColumns]
+  );
+
   // Show loading state
   if (overviewLoading || subprocessorsLoading) {
     return (
@@ -508,6 +543,12 @@ const AITrustCenterSubprocessors: React.FC = () => {
                 ]}
                 onGroupChange={handleGroupChange}
               />
+              <ColumnSelector
+                columns={allColumns}
+                visibleColumns={visibleColumns}
+                onToggleColumn={toggleColumn}
+                onResetToDefaults={resetToDefaults}
+              />
             </Box>
             <Box sx={{ display: "flex", gap: "8px", alignItems: "center" }}>
               <Box sx={styles.toggleRow}>
@@ -548,7 +589,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
             renderTable={(data, options) => (
               <AITrustCenterTable
                 data={data}
-                columns={TABLE_COLUMNS}
+                columns={visibleTableColumns}
                 isLoading={subprocessorsLoading}
                 paginated={true}
                 disabled={!formData?.info?.subprocessor_visible}
@@ -560,6 +601,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
                     onDelete={handleDelete}
                     onEdit={handleEdit}
                     sortConfig={sortConfig}
+                    visibleColumnIds={visibleColumns}
                   />
                 )}
                 tableId="subprocessors-table"


### PR DESCRIPTION
…

## Describe your changes

Added column visibility controls to the AI Trust Center page so users can customize which columns are displayed.

## Write your issue number after "Fixes "

Fixes #3806 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="1286" height="368" alt="Screenshot 2026-04-29 at 5 32 43 PM" src="https://github.com/user-attachments/assets/c7310e0f-c60f-4c87-a453-f8487967f726" />
<img width="1315" height="426" alt="Screenshot 2026-04-29 at 5 32 53 PM" src="https://github.com/user-attachments/assets/480d9294-eca7-452b-addd-0ddc9a9d6b65" />
