### PR TITLE
Rename second EU AI Act tab from Controls to Assessments

### DIFF
--- a/Clients/src/presentation/components/Reporting/GenerateReport/constants.ts
+++ b/Clients/src/presentation/components/Reporting/GenerateReport/constants.ts
@@ -196,7 +196,7 @@ export function selectionToBackendFormat(
 export const EUAI_REPORT_TYPES = [
   "Use case risks report",
   "Requirements tracker report",
-  "Controls tracker report",
+  "Assessments tracker report",
   "Vendors and risks report",
   "Training registry report",
   "Policy manager report",

--- a/Clients/src/presentation/pages/Assessment/1.0AssessmentTracker/AssessmentSteps.tsx
+++ b/Clients/src/presentation/pages/Assessment/1.0AssessmentTracker/AssessmentSteps.tsx
@@ -6,16 +6,16 @@ const AssessmentSteps: IPageTourStep[] = [
   {
     target: '[data-joyride-id="assessment-progress-bar"]',
     content: {
-      header: "Controls progress",
-      body: "Track your controls completion status in real-time. This progress indicator shows how many topics have been evaluated and what remains to be addressed.",
+      header: "Assessments progress",
+      body: "Track your assessments completion status in real-time. This progress indicator shows how many topics have been evaluated and what remains to be addressed.",
       icon: <BarChart3 size={20} color={background.main} />,
     },
   },
   {
     target: '[data-joyride-id="assessment-topics"]',
     content: {
-      header: "Controls topics",
-      body: "Navigate through different controls categories and complete the evaluation questions for your AI project. Each topic covers specific aspects of AI risk and governance.",
+      header: "Assessment topics",
+      body: "Navigate through different assessment categories and complete the evaluation questions for your AI project. Each topic covers specific aspects of AI risk and governance.",
       icon: <ClipboardCheck size={20} color={background.main} />,
     },
   },

--- a/Clients/src/presentation/pages/Assessment/1.0AssessmentTracker/index.tsx
+++ b/Clients/src/presentation/pages/Assessment/1.0AssessmentTracker/index.tsx
@@ -245,14 +245,14 @@ const AssessmentTracker = ({
             <StatsCard
               total={assessmentProgress.totalQuestions}
               completed={assessmentProgress.answeredQuestions}
-              title="Controls"
+              title="Assessments"
               progressbarColor={brand.primary}
             />
           ) : (
             <Typography>Unable to fetch statistical values from the server</Typography>
           )}
         </Stack>
-        <Typography sx={{ ...pageHeadingStyle, mt: 4 }}>Controls status overview</Typography>
+        <Typography sx={{ ...pageHeadingStyle, mt: 4 }}>Assessments status overview</Typography>
         <Divider sx={{ marginY: 2 }} />
         <Box
           sx={{
@@ -265,7 +265,7 @@ const AssessmentTracker = ({
         >
           <Stack sx={topicsListStyle}>
             <Typography sx={subHeadingStyle} data-joyride-id="assessment-topics" ref={refs[1]}>
-              High risk conformity controls
+              Conformity assessment topics
             </Typography>
             <List>
               {loadingAssessmentTopics ? (

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -32,7 +32,7 @@ const FRAMEWORK_IDS = {
 
 const TRACKER_TABS = [
   { label: "Requirements", value: "compliance" },
-  { label: "Controls", value: "assessment" },
+  { label: "Assessments", value: "assessment" },
 ] as const;
 
 type TrackerTab = (typeof TRACKER_TABS)[number]["value"];

--- a/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/Overview/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/V1.0ProjectView/Overview/index.tsx
@@ -172,7 +172,7 @@ const VWProjectOverview = ({ project }: { project?: Project }) => {
     assessmentProgress?.totalQuestions ?? 0,
   ];
 
-  const titleEuAct = ["Requirements", "Controls"];
+  const titleEuAct = ["Requirements", "Assessments"];
 
   const completedIso42001Numbers = [
     clausesProgress?.doneSubclauses ?? 0,


### PR DESCRIPTION
## Summary

The second tab on the EU AI Act framework page renders the assessment questionnaire (FRIA / conformity questions), not controls. Calling it "Controls" was misleading and didn't match the regulation's vocabulary.

This PR renames the user-facing labels only. Tab values, route params, and internal field names are unchanged.

| Location | Before | After |
|---|---|---|
| Project framework tab | "Controls" | "Assessments" |
| Project overview sidebar | "Controls" | "Assessments" |
| StatsCard title | "Controls" | "Assessments" |
| Section heading | "Controls status overview" | "Assessments status overview" |
| Topics list heading | "High risk conformity controls" | "Conformity assessment topics" |
| Joyride tooltip 1 | "Controls progress" | "Assessments progress" |
| Joyride tooltip 2 | "Controls topics" | "Assessment topics" |
| Report type label | "Controls tracker report" | "Assessments tracker report" |