### PR TITLE
Apply tier and role filter to EU AI Act progress counter

### DIFF
--- a/Servers/utils/eu.utils.ts
+++ b/Servers/utils/eu.utils.ts
@@ -87,11 +87,30 @@ export const countSubControlsEUByProjectId = async (
   totalSubcontrols: string;
   doneSubcontrols: string;
 }> => {
+  const visibleCategoryIds = await getVisibleEuCategoryIdsForProject(
+    projectFrameworkId,
+    organizationId,
+  );
+  if (visibleCategoryIds.length === 0) {
+    return { totalSubcontrols: "0", doneSubcontrols: "0" };
+  }
+
   const result = await sequelize.query(
-    `SELECT COUNT(*) AS "totalSubcontrols", COUNT(CASE WHEN sc.status = 'Done' THEN 1 END) AS "doneSubcontrols" FROM
-      controls_eu c JOIN subcontrols_eu sc ON c.organization_id = sc.organization_id AND c.id = sc.control_id WHERE c.organization_id = :organizationId AND c.projects_frameworks_id = :projects_frameworks_id;`,
+    `SELECT COUNT(*) AS "totalSubcontrols",
+            COUNT(CASE WHEN sc.status = 'Done' THEN 1 END) AS "doneSubcontrols"
+     FROM controls_eu c
+     JOIN subcontrols_eu sc
+       ON c.organization_id = sc.organization_id AND c.id = sc.control_id
+     JOIN controls_struct_eu cs ON c.control_meta_id = cs.id
+     WHERE c.organization_id = :organizationId
+       AND c.projects_frameworks_id = :projects_frameworks_id
+       AND cs.control_category_id IN (:visibleCategoryIds);`,
     {
-      replacements: { organizationId, projects_frameworks_id: projectFrameworkId },
+      replacements: {
+        organizationId,
+        projects_frameworks_id: projectFrameworkId,
+        visibleCategoryIds,
+      },
       type: QueryTypes.SELECT,
     },
   );


### PR DESCRIPTION
## Summary

The compliance progress card on the project framework page showed a denominator that ignored the project's tier and role filter. A High risk Deployer project would render "1 of 184" while only 39 subcontrols were actually visible in the controls table.

`countSubControlsEUByProjectId` now applies the same `getVisibleEuCategoryIdsForProject` filter that the controls list view uses, so the progress card and the table agree on the denominator.

## Verified locally

For project 6 (High risk + Deployer):
- Before: total = 184
- After: total = 39
- Visible categories = 4 of 19 (matches the filter rules)