### PR TITLE
Unblock prettier check on OpenAPI yaml files

### DIFF
--- a/Servers/.prettierignore
+++ b/Servers/.prettierignore
@@ -10,3 +10,5 @@ package-lock.json
 .env.*
 SQL_Commands.sql
 swagger.yaml
+swagger.generated.yaml
+swagger.old.yaml

--- a/Servers/docs/api/compliance-frameworks-openapi.yaml
+++ b/Servers/docs/api/compliance-frameworks-openapi.yaml
@@ -210,6 +210,20 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "500":
           $ref: "#/components/responses/InternalError"
+    delete:
+      tags: [ISO 27001]
+      summary: Delete management system clauses by project ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Clauses deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
 
   /iso27001/annexes/byProjectId/{id}:
     get:
@@ -226,6 +240,20 @@ paths:
                 $ref: "#/components/schemas/SuccessResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    delete:
+      tags: [ISO 27001]
+      summary: Delete reference controls by project ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annex controls deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -455,38 +483,6 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  /iso27001/clauses/byProjectId/{id}:
-    delete:
-      tags: [ISO 27001]
-      summary: Delete management system clauses by project ID
-      parameters:
-        - $ref: "#/components/parameters/IdPath"
-      responses:
-        "200":
-          description: Clauses deleted
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SuccessResponse"
-        "500":
-          $ref: "#/components/responses/InternalError"
-
-  /iso27001/annexes/byProjectId/{id}:
-    delete:
-      tags: [ISO 27001]
-      summary: Delete reference controls by project ID
-      parameters:
-        - $ref: "#/components/parameters/IdPath"
-      responses:
-        "200":
-          description: Annex controls deleted
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SuccessResponse"
-        "500":
-          $ref: "#/components/responses/InternalError"
-
   # ==================== ISO 42001 ====================
   /iso42001/clauses:
     get:
@@ -573,6 +569,20 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "500":
           $ref: "#/components/responses/InternalError"
+    delete:
+      tags: [ISO 42001]
+      summary: Delete management system clauses by project ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Clauses deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
 
   /iso42001/annexes/byProjectId/{id}:
     get:
@@ -589,6 +599,20 @@ paths:
                 $ref: "#/components/schemas/SuccessResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    delete:
+      tags: [ISO 42001]
+      summary: Delete reference controls by project ID
+      parameters:
+        - $ref: "#/components/parameters/IdPath"
+      responses:
+        "200":
+          description: Annex controls deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -837,38 +861,6 @@ paths:
       responses:
         "200":
           description: Annex category updated
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SuccessResponse"
-        "500":
-          $ref: "#/components/responses/InternalError"
-
-  /iso42001/clauses/byProjectId/{id}:
-    delete:
-      tags: [ISO 42001]
-      summary: Delete management system clauses by project ID
-      parameters:
-        - $ref: "#/components/parameters/IdPath"
-      responses:
-        "200":
-          description: Clauses deleted
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SuccessResponse"
-        "500":
-          $ref: "#/components/responses/InternalError"
-
-  /iso42001/annexes/byProjectId/{id}:
-    delete:
-      tags: [ISO 42001]
-      summary: Delete reference controls by project ID
-      parameters:
-        - $ref: "#/components/parameters/IdPath"
-      responses:
-        "200":
-          description: Annex controls deleted
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

The Lint and Build CI step has been failing on every PR because of two unrelated yaml issues. This PR unblocks all in-flight branches.

1. `Servers/docs/api/compliance-frameworks-openapi.yaml` — four path keys were declared twice with different HTTP methods (e.g., once with `get`, again with `delete`). OpenAPI 3.x requires all methods for a path under a single path key. Merged the GET and DELETE blocks for `/iso27001/clauses/byProjectId/{id}`, `/iso27001/annexes/byProjectId/{id}`, `/iso42001/clauses/byProjectId/{id}`, `/iso42001/annexes/byProjectId/{id}`.
2. `Servers/swagger.generated.yaml` is build-time output and shouldn't be in the prettier check. Added it to `.prettierignore` next to `swagger.yaml`. Same for `swagger.old.yaml`.

After this lands, every other open PR's format-check should go green automatically.