### PR TITLE
Validate Owner/Reviewer/Approver assignees belong to the organization

### DIFF
--- a/Servers/controllers/eu.ctrl.ts
+++ b/Servers/controllers/eu.ctrl.ts
@@ -13,6 +13,7 @@ import {
   deleteAssessmentEUByProjectIdQuery,
   deleteComplianeEUByProjectIdQuery,
   deriveControlStatus,
+  findUsersNotInOrganization,
   getAllControlCategoriesQuery,
   getAllTopicsQuery,
   getAssessmentsEUByProjectIdQuery,
@@ -404,6 +405,36 @@ export async function saveControls(req: RequestWithFile, res: Response): Promise
       | "Residual risk"
       | "Unacceptable risk"
       | null;
+
+    const candidateAssigneeIds = [newOwner, newReviewer, newApprover].filter(
+      (id): id is number => id !== null,
+    );
+    if (candidateAssigneeIds.length > 0) {
+      const invalidIds = await findUsersNotInOrganization(
+        candidateAssigneeIds,
+        req.organizationId!,
+        transaction,
+      );
+      if (invalidIds.length > 0) {
+        await transaction.rollback();
+        await logFailure({
+          eventType: "Update",
+          description: `Rejected control save: assignee user IDs not in organization — ${invalidIds.join(", ")}`,
+          functionName: "saveControls",
+          fileName: "eu.ctrl.ts",
+          error: new Error("Invalid assignee"),
+          userId: req.userId!,
+          tenantId: req.organizationId!,
+        });
+        return res
+          .status(400)
+          .json(
+            STATUS_CODE[400](
+              `User${invalidIds.length === 1 ? "" : "s"} ${invalidIds.join(", ")} ${invalidIds.length === 1 ? "is" : "are"} not part of this organization and cannot be assigned.`,
+            ),
+          );
+      }
+    }
 
     const filesToUnlink = JSON.parse(Control.delete || "[]") as number[];
 

--- a/Servers/utils/__tests__/eu.utils.test.ts
+++ b/Servers/utils/__tests__/eu.utils.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect } from "@jest/globals";
+import { describe, it, expect, beforeEach } from "@jest/globals";
 
 jest.mock("../../database/db", () => ({
   sequelize: { query: jest.fn() },
 }));
 
-import { deriveControlStatus } from "../eu.utils";
+import { deriveControlStatus, findUsersNotInOrganization } from "../eu.utils";
+import { sequelize } from "../../database/db";
+
+const mockQuery = sequelize.query as jest.MockedFunction<typeof sequelize.query>;
 
 describe("deriveControlStatus", () => {
   it("returns Waiting when there are no subcontrols", () => {
@@ -28,5 +31,33 @@ describe("deriveControlStatus", () => {
     expect(deriveControlStatus(["In progress", "Waiting"])).toBe("In progress");
     expect(deriveControlStatus([null, "Done"])).toBe("In progress");
     expect(deriveControlStatus(["In progress", "Done", "Waiting"])).toBe("In progress");
+  });
+});
+
+describe("findUsersNotInOrganization", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("returns empty when no candidate ids are provided", async () => {
+    expect(await findUsersNotInOrganization([], 1)).toEqual([]);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("filters out non-positive and non-integer ids before querying", async () => {
+    expect(await findUsersNotInOrganization([0, -1, NaN as unknown as number], 1)).toEqual([]);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns ids that are not in the organization", async () => {
+    mockQuery.mockResolvedValueOnce([{ id: 5 }] as any);
+    const missing = await findUsersNotInOrganization([5, 7], 1);
+    expect(missing).toEqual([7]);
+  });
+
+  it("dedupes candidate ids", async () => {
+    mockQuery.mockResolvedValueOnce([{ id: 5 }] as any);
+    const missing = await findUsersNotInOrganization([5, 5, 5], 1);
+    expect(missing).toEqual([]);
   });
 });

--- a/Servers/utils/eu.utils.ts
+++ b/Servers/utils/eu.utils.ts
@@ -173,6 +173,29 @@ export const deriveControlStatus = (
   return "In progress";
 };
 
+export const findUsersNotInOrganization = async (
+  userIds: number[],
+  organizationId: number,
+  transaction: Transaction | null = null,
+): Promise<number[]> => {
+  const unique = Array.from(new Set(userIds.filter((id) => Number.isInteger(id) && id > 0)));
+  if (unique.length === 0) return [];
+
+  const rows = (await sequelize.query(
+    `SELECT id FROM users
+     WHERE organization_id = :organizationId
+       AND id IN (:userIds);`,
+    {
+      replacements: { organizationId, userIds: unique },
+      type: QueryTypes.SELECT,
+      ...(transaction ? { transaction } : {}),
+    },
+  )) as { id: number }[];
+
+  const found = new Set(rows.map((r) => r.id));
+  return unique.filter((id) => !found.has(id));
+};
+
 const getSubControlsCalculations = async (
   controlId: number,
   organizationId: number,


### PR DESCRIPTION
## Summary

Before this change, the EU AI Act control save endpoint accepted any user ID for Owner / Reviewer / Approver — only the foreign-key constraint to `users.id` was enforced. A buggy or stale client could assign a control to a user from a different organization.

Adds a single membership check that runs before any write: any non-null candidate ID must exist in the `users` table for the same `organization_id`. If any ID fails the check, the save is rolled back and the endpoint returns 400 with a descriptive message identifying the invalid IDs.

The frontend dropdown lists all users in the organization, not just project members, so checking against the org boundary matches the actual data model.

## Verified locally

- **Happy path**: legitimate user (Gorkem Cetin) saves successfully via the UI, DB shows owner=1.
- **Sad path**: API call with `owner=99999` returns 400 with body `"User 99999 is not part of this organization and cannot be assigned."` — DB unchanged (transaction rolled back).
- 8 unit tests pass (4 new tests for `findUsersNotInOrganization`).
- `npm run build` and format-check both clean.

Fixes #3828