### PR TITLE
Add (none) clear option to EU AI Act control selects

### DIFF
--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -158,12 +158,14 @@ const NewControlPane = ({
   };
 
   const memberOptions = useMemo(
-    () =>
-      (projectMembers || []).map((user) => ({
+    () => [
+      { _id: "", name: "(none)" },
+      ...(projectMembers || []).map((user) => ({
         _id: user.id!.toString(),
         name: user.name || "",
         surname: user.surname || "",
       })),
+    ],
     [projectMembers],
   );
 
@@ -1112,6 +1114,7 @@ const NewControlPane = ({
                 )
               }
               items={[
+                { _id: "", name: "(none)" },
                 { _id: "Acceptable risk", name: "Acceptable risk" },
                 { _id: "Residual risk", name: "Residual risk" },
                 { _id: "Unacceptable risk", name: "Unacceptable risk" },


### PR DESCRIPTION
## Summary

Once a value was set on the Owner / Reviewer / Approver / Risk review dropdowns in the EU AI Act control drawer, there was no way to unset it through the UI. Users had to switch to a different person, never back to "no one assigned".

Adds a "(none)" entry at the top of each select. Picking it sends an empty string, which the controller already normalizes to null via `blankToNull` / `toUserIdOrNull`.

## Verified locally

- "(none)" appears at the top of the Owner dropdown.
- Picking "(none)" → save → DB shows `owner = NULL`.
- Reviewer / Approver / Risk review behave the same way.

Fixes #3827